### PR TITLE
Update build schema for native compilation.

### DIFF
--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -185,30 +185,39 @@
             ],
             "description": "can be either a single sourceItem or an array of sourceItems, sourceItem can be either a single string(non nested directory) or an detailed object config"
         },
-        "targetItems": {
-          "type": "object",
-          "properties": {
-            "outputName": {
-              "type": "string",
-              "description": "The name of the target"
-            },
-            "compilationKind": {
-              "enum": [
-                "js",
-                "native",
-                "bytecode"
-              ],
-              "description": "The compiler to use for the target"
-            },
-            "entryPoint": {
-              "type": "string",
-              "description": "Path to file used as entrypoint for this target"
-            }
-          }
+        "targetItem": {
+          "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "js"
+                ],
+                "description": "JS target compiled using BuckleScript"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "native",
+                      "bytecode"
+                    ],
+                    "description": "The compiler to use for the target"
+                  },
+                  "entryPoint": {
+                    "type": "string",
+                    "description": "Path to file used as entrypoint for this target"
+                  }
+                }
+              }
+          ]
         },
         "targets": {
-          "$ref": "#/definitions/targetItems",
-          "description": "(Not implemented yet)"
+          "type": "array",
+          "items": {
+              "$ref": "#/definitions/targetItem"
+          },
+          "description": "A list of target items"
         },
         "bsc-flags": {
             "oneOf": [

--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -185,6 +185,31 @@
             ],
             "description": "can be either a single sourceItem or an array of sourceItems, sourceItem can be either a single string(non nested directory) or an detailed object config"
         },
+        "targetItems": {
+          "type": "object",
+          "properties": {
+            "outputName": {
+              "type": "string",
+              "description": "The name of the target"
+            },
+            "compilationKind": {
+              "enum": [
+                "js",
+                "native",
+                "bytecode"
+              ],
+              "description": "The compiler to use for the target"
+            },
+            "entryPoint": {
+              "type": "string",
+              "description": "Path to file used as entrypoint for this target"
+            }
+          }
+        },
+        "targets": {
+          "$ref": "#/definitions/targetItems",
+          "description": "(Not implemented yet)"
+        },
         "bsc-flags": {
             "oneOf": [
                 {
@@ -196,8 +221,8 @@
                 },
                 {
                     "properties": {
-                        "kind" : 
-                        { 
+                        "kind" :
+                        {
                             "enum": [
                             "reset",
                             "prefix",
@@ -276,6 +301,10 @@
         "sources": {
             "$ref": "#/definitions/sources",
             "description": "specication of where source code is "
+        },
+        "targets": {
+            "$ref": "#/definitions/targets",
+            "description": "specification for compiling to differet targets (native, bytecode, js)"
         },
         "generate-merlin": {
             "type": "boolean",

--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -212,12 +212,12 @@
               }
           ]
         },
-        "targets": {
+        "buildable-targets": {
           "type": "array",
           "items": {
               "$ref": "#/definitions/targetItem"
           },
-          "description": "A list of target items"
+          "description": "A list of buildable targets"
         },
         "bsc-flags": {
             "oneOf": [
@@ -311,9 +311,9 @@
             "$ref": "#/definitions/sources",
             "description": "specication of where source code is "
         },
-        "targets": {
-            "$ref": "#/definitions/targets",
-            "description": "specification for compiling to differet targets (native, bytecode, js)"
+        "buildable-targets": {
+            "$ref": "#/definitions/buildable-targets",
+            "description": "Used by bsb to build to native/bytecode (instead of the default JS)"
         },
         "generate-merlin": {
             "type": "boolean",


### PR DESCRIPTION
Tell me what you think.

I'm basing this off of what ReProcessing needs. We'd also need a way to switch at compile time. You implemented some cppo-like feature but to my understanding it doesn't work with Reason (since it's another -pp?). @Schmavery and I have been using [matchenv](https://github.com/Schmavery/reprocessing/blob/a2f5d567e902b1700147622bdcee2d32b5ae5ea0/src/glloader.re#L2) and for that we need to be able to set an environment variable per target. I'm not sure this that's the best way to do that so I didn't include in this PR the ability to set env-vars per target.