### PR TITLE
Sync in new refmt & jsx ppx from 183fed4

### DIFF
--- a/jscomp/bin/reactjs_ppx.ml
+++ b/jscomp/bin/reactjs_ppx.ml
@@ -25466,14 +25466,15 @@ let jsxMapper () =
     let (children, argsWithLabels) =
       extractChildrenForDOMElements ~loc ~removeLastPositionUnit:true callArguments in
     let argIsKeyRef = function
-      | (Labelled ("key" | "ref") , _) -> true
+      | (Labelled ("key" | "ref"), _) | (Optional ("key" | "ref"), _) -> true
       | _ -> false in
     let (argsKeyRef, argsForMake) = List.partition argIsKeyRef argsWithLabels in
     let childrenExpr =
-      Exp.array (
+      Exp.array ~loc (
         listToArray children |> List.map (fun a -> mapper.expr mapper a)
       ) in
-    let args = argsForMake @ [ (Nolabel, childrenExpr) ] in
+    let recursivelyTransformedArgsForMake = argsForMake |> List.map (fun (label, expression) -> (label, mapper.expr mapper expression)) in
+    let args = recursivelyTransformedArgsForMake @ [ (Nolabel, childrenExpr) ] in
     let wrapWithReasonReactElement e = (* ReasonReact.element ::key ::ref (...) *)
       Exp.apply
         ~loc

--- a/jscomp/bin/reactjs_ppx_2.ml
+++ b/jscomp/bin/reactjs_ppx_2.ml
@@ -25466,14 +25466,15 @@ let jsxMapper () =
     let (children, argsWithLabels) =
       extractChildrenForDOMElements ~loc ~removeLastPositionUnit:true callArguments in
     let argIsKeyRef = function
-      | (Labelled ("key" | "ref") , _) -> true
+      | (Labelled ("key" | "ref"), _) | (Optional ("key" | "ref"), _) -> true
       | _ -> false in
     let (argsKeyRef, argsForMake) = List.partition argIsKeyRef argsWithLabels in
     let childrenExpr =
-      Exp.array (
+      Exp.array ~loc (
         listToArray children |> List.map (fun a -> mapper.expr mapper a)
       ) in
-    let args = argsForMake @ [ (Nolabel, childrenExpr) ] in
+    let recursivelyTransformedArgsForMake = argsForMake |> List.map (fun (label, expression) -> (label, mapper.expr mapper expression)) in
+    let args = recursivelyTransformedArgsForMake @ [ (Nolabel, childrenExpr) ] in
     let wrapWithReasonReactElement e = (* ReasonReact.element ::key ::ref (...) *)
       Exp.apply
         ~loc

--- a/jscomp/bin/refmt_main.ml
+++ b/jscomp/bin/refmt_main.ml
@@ -2705,9 +2705,9 @@ module Package
 = struct
 #1 "package.ml"
 
-let version = "2.0.0"
-let git_version = "84e87c458bc04c92771480641118d95650c08d2a"
-let git_short_version = "84e87c4"
+let version = "1.13.6"
+let git_version = "3cacdcbeec6493573d96db05af29bc47273ff60d"
+let git_short_version = "3cacdcb"
 
 end
 module Ast_404
@@ -35058,8 +35058,7 @@ class printer  ()= object(self:'self)
             ~postSpace:true
             ~sep:";"
             (List.map self#signature_item (List.filter self#shouldDisplaySigItem s))
-      (* Not sure what this is about. *)
-      | Pmty_extension _ -> assert false
+      | Pmty_extension (s, e) -> self#payload "%" s e
       | _ -> makeList ~break:IfNeed ~wrap:("(", ")") [self#module_type x]
 
   method module_type x =
@@ -35068,7 +35067,7 @@ class printer  ()= object(self:'self)
       | Pmty_functor (_, None, mt2) -> (atom "()")::(functorTypeArgs mt2)
       | Pmty_functor (s, Some mt1, mt2) ->
           if s.txt = "_" then
-            (self#module_type mt1)::(functorTypeArgs mt2)
+            (self#non_arrowed_module_type mt1)::(functorTypeArgs mt2)
           else
             let cur =
               makeList ~wrap:("(",")") [
@@ -75781,7 +75780,7 @@ let message =
     | 2680 ->
         "<SYNTAX ERROR>\n"
     | 2676 ->
-        "This is a reserved keyword. Consider using a different one. For BuckleScript, add an underscore at the end (http://bloomberg.github.io/bucklescript/Manual.html#_object_label_translation_convention).\n"
+        "This is a reserved keyword. Consider using a different one. For BuckleScript, add an underscore at the end (http://bucklescript.github.io/bucklescript/Manual.html#_object_label_translation_convention).\n"
     | 2683 ->
         "<SYNTAX ERROR>\n"
     | 2374 ->


### PR DESCRIPTION
From https://github.com/facebook/reason/commit/183fed4decbaf954b469a40044ac85e56ccde37b

At this point, the ppxes:

- Fixes #1721
- Recursively transforms non-children props' jsx
- Correctly transforms explicit optional `ref` and `key`.

Test:
- Scaffold a project through `bsb -theme -init react .`
- Try #1721's snippet in a file (e.g. simpleRoot.re)
- Try
    ```reason
    module Foo = {let make ::bar children => Obj.magic 1};
    <Foo bar=(fun () => <div />) />
    ```
    and see no error
- Try
    ```
    <Foo key=?(Some "1") bar=(fun () => <div />) />
    ```