### PR TITLE
add query info support

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -309,6 +309,7 @@ BSB_SRCS= bsb_config \
 	bsb_regex\
 	bsb_clean\
 	bsb_ninja_regen\
+	bsb_query\
 	bsb_world\
 	oCamlRes\
 	bsb_templates\

--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -756,9 +756,10 @@ bsb/bsb_init.cmx : ext/string_hashtbl.cmx bsb/oCamlRes.cmx \
     common/bs_version.cmx bsb/bsb_init.cmi
 bsb/bsb_log.cmx : ext/ext_string.cmx ext/ext_color.cmx bsb/bsb_log.cmi
 bsb/bsb_main.cmx : ext/ext_sys.cmx ext/ext_string.cmx ext/ext_filename.cmx \
-    ext/ext_array.cmx bsb/bsb_world.cmx bsb/bsb_ninja_regen.cmx \
-    bsb/bsb_log.cmx bsb/bsb_init.cmx bsb/bsb_config.cmx bsb/bsb_clean.cmx \
-    bsb/bsb_build_util.cmx bsb/bsb_main.cmi
+    ext/ext_array.cmx bsb/bsb_world.cmx bsb/bsb_query.cmx \
+    bsb/bsb_ninja_regen.cmx bsb/bsb_log.cmx bsb/bsb_init.cmx \
+    bsb/bsb_config.cmx bsb/bsb_clean.cmx bsb/bsb_build_util.cmx \
+    bsb/bsb_main.cmi
 bsb/bsb_merlin_gen.cmx : ext/literals.cmx ext/ext_string.cmx \
     ext/ext_filename.cmx bsb/bsb_parse_sources.cmx bsb/bsb_config_types.cmx \
     bsb/bsb_config.cmx bsb/bsb_merlin_gen.cmi
@@ -785,6 +786,9 @@ bsb/bsb_parse_sources.cmx : ext/string_vec.cmx ext/string_set.cmx \
     bsb/bsb_parse_sources.cmi
 bsb/bsb_pkg.cmx : ext/string_hashtbl.cmx ext/literals.cmx \
     bsb/bsb_exception.cmx bsb/bsb_pkg.cmi
+bsb/bsb_query.cmx : ext/string_map.cmx ext/ext_json_noloc.cmx \
+    ext/ext_array.cmx bsb/bsb_parse_sources.cmx bsb/bsb_ninja_regen.cmx \
+    bsb/bsb_config_types.cmx bsb/bsb_query.cmi
 bsb/bsb_regex.cmx : bsb/bsb_regex.cmi
 bsb/bsb_rule.cmx : ext/string_set.cmx ext/string_map.cmx ext/ext_sys.cmx \
     bsb/bsb_rule.cmi
@@ -824,6 +828,7 @@ bsb/bsb_ninja_util.cmi : ext/string_map.cmi ext/string_hash_set.cmi \
 bsb/bsb_parse_sources.cmi : ext/string_set.cmi ext/ext_json_types.cmx \
     ext/ext_file_pp.cmi bsb/bsb_dir_index.cmi common/binary_cache.cmi
 bsb/bsb_pkg.cmi :
+bsb/bsb_query.cmi :
 bsb/bsb_regex.cmi :
 bsb/bsb_rule.cmi : ext/string_map.cmi
 bsb/bsb_templates.cmi : bsb/oCamlRes.cmx

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -25,7 +25,8 @@
 
 
 let cwd = Sys.getcwd ()
-
+let bsc_dir = Bsb_build_util.get_bsc_dir cwd 
+let () =  Bsb_log.setup () 
 let (//) = Ext_filename.combine
 let force_regenerate = ref false
 let exec = ref false
@@ -38,6 +39,7 @@ let separator = "--"
 let watch_mode = ref false
 let make_world = ref false 
 let set_make_world () = make_world := true
+
 
 
 let bsb_main_flags : (string * Arg.spec * string) list=
@@ -61,6 +63,8 @@ let bsb_main_flags : (string * Arg.spec * string) list=
     " Init sample project to get started. Note (`bsb -init sample` will create a sample project while `bsb -init .` will resuse current directory)";
     "-theme", Arg.String set_theme,
     " The theme for project initialization, default is basic(https://github.com/bucklescript/bucklescript/tree/master/jscomp/bsb/templates)";
+    "-query", Arg.String (fun s -> Bsb_query.query ~cwd ~bsc_dir s ),
+    " (internal)Query metadata about the build";
     "-themes", Arg.Unit Bsb_init.list_themes,
     " List all available themes"
   ]
@@ -131,8 +135,7 @@ let watch_exit () =
 
 (* see discussion #929, if we catch the exception, we don't have stacktrace... *)
 let () =
-  let () =  Bsb_log.setup () in 
-  let bsc_dir = Bsb_build_util.get_bsc_dir cwd in
+  
   let vendor_ninja = bsc_dir // "ninja.exe" in  
   match Sys.argv with 
   | [| _ |] ->  (* specialize this path [bsb.exe] which is used in watcher *)

--- a/jscomp/bsb/bsb_query.ml
+++ b/jscomp/bsb/bsb_query.ml
@@ -1,0 +1,69 @@
+(* Copyright (C) 2017 Authors of BuckleScript
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+let query_sources ({bs_file_groups} : Bsb_config_types.t) : Ext_json_noloc.t 
+  = 
+  bs_file_groups 
+  |> Ext_array.of_list_map (fun (x : Bsb_parse_sources.file_group) -> 
+    Ext_json_noloc.(
+      kvs [
+        "dir", str x.dir ;
+        "sources" , 
+        (String_map.keys x.sources)
+        |> Ext_array.of_list_map str
+        |> arr 
+      ]
+    )
+  )
+  |> Ext_json_noloc.arr 
+
+
+let query_current_package_sources cwd bsc_dir = 
+    let config_opt  = Bsb_ninja_regen.regenerate_ninja 
+      ~no_dev:false
+      ~override_package_specs:None
+      ~generate_watch_metadata:true
+      ~forced:true  cwd bsc_dir in 
+    match config_opt with   
+    | None -> None
+     
+    | Some config ->
+      Some (query_sources config)
+
+
+let query ~cwd ~bsc_dir str = 
+  match str with 
+  | "sources" -> 
+    begin match query_current_package_sources cwd bsc_dir with 
+    | None -> raise (Arg.Bad "internal error in query")
+    | Some config -> 
+      output_string stdout 
+      (Printf.sprintf "QUERY-INFO-BEGIN(%s)\n" str);
+      Ext_json_noloc.to_channel stdout 
+      ( config );
+      output_string stdout "\nQUERY-INFO-END\n";
+    end
+  | _ -> raise (Arg.Bad "Unsupported query")

--- a/jscomp/bsb/bsb_query.mli
+++ b/jscomp/bsb/bsb_query.mli
@@ -1,0 +1,27 @@
+(* Copyright (C) 2017 Authors of BuckleScript
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+val query: cwd:string -> bsc_dir:string -> string -> unit  


### PR DESCRIPTION
Sample output:
```
bsb -query sources
```
```
reason-react-example>bsb -query sources
BSB check build spec : Bsb forced rebuild
Package bs-platform -> /Users/hongbozhang/git/reason-react-example/node_modules/bs-platform
Package reason-react -> /Users/hongbozhang/git/reason-react-example/node_modules/reason-react
Package reason-js -> /Users/hongbozhang/git/reason-react-example/node_modules/reason-js
QUERY-INFO-BEGIN(sources)
[ { "dir" : "src" , "sources" : [] } , { "dir" : "src/todomvc" , "sources" : [ "App" , "TodoItem" , "TodoFooter" ] } , { \
"dir" : "src/simple" , "sources" : [ "Page" , "SimpleRoot" ] } , { "dir" : "src/logo" , "sources" : [ "Logo" , "LogoRoot"\
 , "Constants" , "LifecycleTester" ] } , { "dir" : "src/interop" , "sources" : [ "PageReason" ] } ]
QUERY-INFO-END
```