### PR TITLE
Introduce [@bs.unwrap] for inline variant as external arg

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 # 1.8.3
-- Features
+Features
 - #1839, #1653, allow in-source build in package-specs , allow single pacakge-spec element in package-specs
+- #1802 introduce [@bs.unwrap] for polymorphic variant as external argument
 
 # 1.8.2
 - Features

--- a/docs/Manual.html
+++ b/docs/Manual.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.4">
+<meta name="generator" content="Asciidoctor 1.5.6.1">
 <meta name="author" content="Hongbo Zhang">
 <title>BuckleScript User Manual</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
@@ -18,7 +18,6 @@ audio:not([controls]){display:none;height:0}
 [hidden],template{display:none}
 script{display:none!important}
 html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-body{margin:0}
 a{background:transparent}
 a:focus{outline:thin dotted}
 a:active,a:hover{outline:0}
@@ -53,7 +52,7 @@ textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
 *,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -65,7 +64,6 @@ img{-ms-interpolation-mode:bicubic}
 .text-center{text-align:center!important}
 .text-justify{text-align:justify!important}
 .hide{display:none}
-body{-webkit-font-smoothing:antialiased}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
@@ -92,13 +90,12 @@ strong,b{font-weight:bold;line-height:inherit}
 small{font-size:60%;line-height:inherit}
 code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
 ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
+ul,ol{margin-left:1.5em}
 ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
 ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
 ul.square{list-style-type:square}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
-ul.no-bullet{list-style:none}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
@@ -120,18 +117,25 @@ table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
 table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-body{tab-size:4}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
 .clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
 .clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
 pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
 kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:rgba(0,0,0,.8)}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
 b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
 b.button:before{content:"[";padding:0 3px 0 2px}
 b.button:after{content:"]";padding:0 2px 0 3px}
@@ -198,7 +202,7 @@ table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
 table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon img{max-width:initial}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
 .admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
@@ -254,13 +258,13 @@ table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
 table.tableblock{max-width:100%;border-collapse:separate}
 table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
-table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
-table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
-table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
-table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
-table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
-table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
 table.frame-all{border-width:1px}
 table.frame-sides{border-width:0 1px}
 table.frame-topbot{border-width:1px 0}
@@ -281,10 +285,12 @@ ul li ol{margin-left:1.5em}
 dl dd{margin-left:1.125em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
 ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
-ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
 ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
 ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
 ul.inline>li>*{display:block}
@@ -301,7 +307,8 @@ ol.lowergreek{list-style-type:lower-greek}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
+.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
+.colist>table tr>td:first-of-type img{max-width:initial}
 .colist>table tr>td:last-of-type{padding:.25em 0}
 .thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
 .imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
@@ -364,6 +371,7 @@ div.unbreakable{page-break-inside:avoid}
 .yellow{color:#bfbf00}
 .yellow-background{background-color:#fafa00}
 span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
 .admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
 .admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
@@ -419,13 +427,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 <style>
 .listingblock .pygments .hll { background-color: #ffffcc }
-.listingblock .pygments  { background: #f8f8f8; }
+.listingblock .pygments, .listingblock .pygments code { background: #f8f8f8; }
 .listingblock .pygments .tok-c { color: #408080; font-style: italic } /* Comment */
 .listingblock .pygments .tok-err { border: 1px solid #FF0000 } /* Error */
 .listingblock .pygments .tok-k { color: #008000; font-weight: bold } /* Keyword */
 .listingblock .pygments .tok-o { color: #666666 } /* Operator */
+.listingblock .pygments .tok-ch { color: #408080; font-style: italic } /* Comment.Hashbang */
 .listingblock .pygments .tok-cm { color: #408080; font-style: italic } /* Comment.Multiline */
 .listingblock .pygments .tok-cp { color: #BC7A00 } /* Comment.Preproc */
+.listingblock .pygments .tok-cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
 .listingblock .pygments .tok-c1 { color: #408080; font-style: italic } /* Comment.Single */
 .listingblock .pygments .tok-cs { color: #408080; font-style: italic } /* Comment.Special */
 .listingblock .pygments .tok-gd { color: #A00000 } /* Generic.Deleted */
@@ -465,8 +475,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .listingblock .pygments .tok-mh { color: #666666 } /* Literal.Number.Hex */
 .listingblock .pygments .tok-mi { color: #666666 } /* Literal.Number.Integer */
 .listingblock .pygments .tok-mo { color: #666666 } /* Literal.Number.Oct */
+.listingblock .pygments .tok-sa { color: #BA2121 } /* Literal.String.Affix */
 .listingblock .pygments .tok-sb { color: #BA2121 } /* Literal.String.Backtick */
 .listingblock .pygments .tok-sc { color: #BA2121 } /* Literal.String.Char */
+.listingblock .pygments .tok-dl { color: #BA2121 } /* Literal.String.Delimiter */
 .listingblock .pygments .tok-sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
 .listingblock .pygments .tok-s2 { color: #BA2121 } /* Literal.String.Double */
 .listingblock .pygments .tok-se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
@@ -477,9 +489,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .listingblock .pygments .tok-s1 { color: #BA2121 } /* Literal.String.Single */
 .listingblock .pygments .tok-ss { color: #19177C } /* Literal.String.Symbol */
 .listingblock .pygments .tok-bp { color: #008000 } /* Name.Builtin.Pseudo */
+.listingblock .pygments .tok-fm { color: #0000FF } /* Name.Function.Magic */
 .listingblock .pygments .tok-vc { color: #19177C } /* Name.Variable.Class */
 .listingblock .pygments .tok-vg { color: #19177C } /* Name.Variable.Global */
 .listingblock .pygments .tok-vi { color: #19177C } /* Name.Variable.Instance */
+.listingblock .pygments .tok-vm { color: #19177C } /* Name.Variable.Magic */
 .listingblock .pygments .tok-il { color: #666666 } /* Literal.Number.Integer.Long */
 </style>
 </head>
@@ -502,8 +516,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_installation">Installation</a>
 <ul class="sectlevel2">
 <li><a href="#_windows_installation">Windows Installation</a></li>
-<li><a href="#__nix_installation">*nix installation</a></li>
-<li><a href="#__strong_recommended_strong_installation_with_opam"><strong>Recommended</strong> installation with OPAM</a></li>
+<li><a href="#_nix_installation">*nix installation</a></li>
+<li><a href="#_strong_recommended_strong_installation_with_opam"><strong>Recommended</strong> installation with OPAM</a></li>
 <li><a href="#_install_from_source">Install from source</a>
 <ul class="sectlevel3">
 <li><a href="#_using_npm">using NPM</a></li>
@@ -549,20 +563,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </ul>
 </li>
 <li><a href="#_splice_calling_convention_bs_splice">Splice calling convention: bs.splice</a></li>
-<li><a href="#_special_types_on_external_declarations_bs_string_bs_int_bs_ignore_bs_as">Special types on external declarations: bs.string, bs.int, bs.ignore, bs.as</a>
+<li><a href="#_special_types_on_external_declarations_code_bs_string_code_code_bs_int_code_code_bs_ignore_code_code_bs_as_code_code_bs_unwrap_code">Special types on external declarations: <code>bs.string</code>, <code>bs.int</code>, <code>bs.ignore</code>, <code>bs.as</code>, <code>bs.unwrap</code></a>
 <ul class="sectlevel3">
 <li><a href="#_using_polymorphic_variant_to_model_enums_and_string_types">Using polymorphic variant to model enums and string types</a></li>
 <li><a href="#_using_polymorphic_variant_to_model_event_listener">Using polymorphic variant to model event listener</a></li>
+<li><a href="#_using_polymorphic_variant_to_model_arguments_of_multiple_possible_types_since_1_8_3">Using polymorphic variant to model arguments of multiple possible types (@since 1.8.3)</a></li>
 <li><a href="#_phantom_arguments_and_ad_hoc_polymorphism">Phantom Arguments and ad-hoc polymorphism</a></li>
-</ul>
-</li>
 <li><a href="#_fixed_arguments">Fixed Arguments</a></li>
 <li><a href="#_fixed_arguments_with_arbitrary_json_literal_since_1_7_0">Fixed Arguments with arbitrary JSON literal (@since 1.7.0)</a></li>
+</ul>
+</li>
 <li><a href="#_binding_to_nodejs_special_variables_bs_node">Binding to NodeJS special variables: bs.node</a></li>
 <li><a href="#_binding_to_callbacks_high_order_function">Binding to callbacks (high-order function)</a>
 <ul class="sectlevel3">
-<li><a href="#__bs_for_explicit_uncurried_callback">[@bs] for explicit uncurried callback</a></li>
-<li><a href="#__bs_uncurry_for_implicit_uncurried_callback_since_1_5_0">[@bs.uncurry] for implicit uncurried callback (@since 1.5.0)</a></li>
+<li><a href="#_bs_for_explicit_uncurried_callback">[@bs] for explicit uncurried callback</a></li>
+<li><a href="#_bs_uncurry_for_implicit_uncurried_callback_since_1_5_0">[@bs.uncurry] for implicit uncurried callback (@since 1.5.0)</a></li>
 <li><a href="#_uncurried_calling_convention_as_an_optimization">Uncurried calling convention as an optimization</a>
 <ul class="sectlevel4">
 <li><a href="#_callback_optimization">Callback optimization</a></li>
@@ -613,7 +628,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_raise_js_style_exception">Raise JS style exception</a></li>
 </ul>
 </li>
-<li><a href="#__code_bs_open_code_type_safe_external_data_source_handling_since_1_7_0"><code>bs.open</code>: Type safe external data-source handling (@@since 1.7.0)</a>
+<li><a href="#_code_bs_open_code_type_safe_external_data_source_handling_since_1_7_0"><code>bs.open</code>: Type safe external data-source handling (@@since 1.7.0)</a>
 <ul class="sectlevel2">
 <li><a href="#_use_cases">Use cases</a></li>
 </ul>
@@ -634,15 +649,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_extended_compiler_options">Extended compiler options</a>
 <ul class="sectlevel2">
-<li><a href="#__bs_main_single_directory_build">-bs-main (single directory build)</a></li>
-<li><a href="#__bs_files">-bs-files</a></li>
-<li><a href="#__bs_package_name">-bs-package-name</a></li>
-<li><a href="#__bs_packge_output">-bs-packge-output</a></li>
-<li><a href="#__bs_gen_tds">-bs-gen-tds</a></li>
-<li><a href="#__bs_no_warn_ffi_type">-bs-no-warn-ffi-type</a></li>
-<li><a href="#__bs_eval">-bs-eval</a></li>
-<li><a href="#__bs_no_builtin_ppx_ml_bs_no_builtin_ppx_mli">-bs-no-builtin-ppx-ml, -bs-no-builtin-ppx-mli</a></li>
-<li><a href="#__bs_no_version_header">-bs-no-version-header</a></li>
+<li><a href="#_bs_main_single_directory_build">-bs-main (single directory build)</a></li>
+<li><a href="#_bs_files">-bs-files</a></li>
+<li><a href="#_bs_package_name">-bs-package-name</a></li>
+<li><a href="#_bs_packge_output">-bs-packge-output</a></li>
+<li><a href="#_bs_gen_tds">-bs-gen-tds</a></li>
+<li><a href="#_bs_no_warn_ffi_type">-bs-no-warn-ffi-type</a></li>
+<li><a href="#_bs_eval">-bs-eval</a></li>
+<li><a href="#_bs_no_builtin_ppx_ml_bs_no_builtin_ppx_mli">-bs-no-builtin-ppx-ml, -bs-no-builtin-ppx-mli</a></li>
+<li><a href="#_bs_no_version_header">-bs-no-version-header</a></li>
 </ul>
 </li>
 <li><a href="#_semantic_differences_from_other_backends">Semantic differences from other backends</a>
@@ -771,10 +786,10 @@ hesitate to submit an issue, sources are <a href="https://github.com/bucklescrip
 </div>
 </div>
 <div class="sect1">
-<h2 id="_why_bucklescript"><a class="anchor" href="#_why_bucklescript"></a>Why BuckleScript</h2>
+<h2 id="_why_bucklescript"><a class="anchor" href="#_why_bucklescript"></a><a class="link" href="#_why_bucklescript">Why BuckleScript</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_benefits_of_javascript_platform"><a class="anchor" href="#_benefits_of_javascript_platform"></a>Benefits of JavaScript platform</h3>
+<h3 id="_benefits_of_javascript_platform"><a class="anchor" href="#_benefits_of_javascript_platform"></a><a class="link" href="#_benefits_of_javascript_platform">Benefits of JavaScript platform</a></h3>
 <div class="paragraph">
 <p>JavaScript is not just <em>the</em> browser language, it&#8217;s also the <em>only</em>
 existing cross platform language. It is truly everywhere: users don&#8217;t
@@ -788,7 +803,7 @@ increasingly capable of supporting large applications.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_problems_of_javascript_how_bucklescript_solves_them"><a class="anchor" href="#_problems_of_javascript_how_bucklescript_solves_them"></a>Problems of JavaScript &amp;&amp; how BuckleScript solves them</h3>
+<h3 id="_problems_of_javascript_how_bucklescript_solves_them"><a class="anchor" href="#_problems_of_javascript_how_bucklescript_solves_them"></a><a class="link" href="#_problems_of_javascript_how_bucklescript_solves_them">Problems of JavaScript &amp;&amp; how BuckleScript solves them</a></h3>
 <div class="paragraph">
 <p>BuckleScript is mainly designed to solve the problems of <em>large scale</em> JavaScript programming:</p>
 </div>
@@ -900,21 +915,21 @@ runtime libraries are only needed when user actually calls it.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_installation"><a class="anchor" href="#_installation"></a>Installation</h2>
+<h2 id="_installation"><a class="anchor" href="#_installation"></a><a class="link" href="#_installation">Installation</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Below is a list of different ways to install BuckleScript:</p>
 </div>
 <div class="sect2">
-<h3 id="_windows_installation"><a class="anchor" href="#_windows_installation"></a>Windows Installation</h3>
+<h3 id="_windows_installation"><a class="anchor" href="#_windows_installation"></a><a class="link" href="#_windows_installation">Windows Installation</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm install bs-platform</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>npm install bs-platform</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="__nix_installation"><a class="anchor" href="#__nix_installation"></a>*nix installation</h3>
+<h3 id="_nix_installation"><a class="anchor" href="#_nix_installation"></a><a class="link" href="#_nix_installation">*nix installation</a></h3>
 <div class="ulist">
 <div class="title">Prerequisites</div>
 <ul>
@@ -935,7 +950,7 @@ is installed, run the following command:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm install --save bs-platform</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>npm install --save bs-platform</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -943,12 +958,12 @@ is installed, run the following command:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm install -g bs-platform</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>npm install -g bs-platform</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="__strong_recommended_strong_installation_with_opam"><a class="anchor" href="#__strong_recommended_strong_installation_with_opam"></a><strong>Recommended</strong> installation with OPAM</h3>
+<h3 id="_strong_recommended_strong_installation_with_opam"><a class="anchor" href="#_strong_recommended_strong_installation_with_opam"></a><a class="link" href="#_strong_recommended_strong_installation_with_opam"><strong>Recommended</strong> installation with OPAM</a></h3>
 <div class="paragraph">
 <p>When working with OCaml we also recommend using <a href="https://opam.ocaml.org">opam</a>
 package manager to install OCaml toolchains, available
@@ -961,8 +976,8 @@ version of the compiler:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">opam update
-opam switch 4.02.3+buckle-master
+<pre class="pygments highlight"><code data-lang="sh"><span></span>opam update
+opam switch <span class="tok-m">4</span>.02.3+buckle-master
 <span class="tok-nb">eval</span> <span class="tok-sb">`</span>opam config env<span class="tok-sb">`</span>
 npm install bs-platform</code></pre>
 </div>
@@ -972,9 +987,9 @@ npm install bs-platform</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_install_from_source"><a class="anchor" href="#_install_from_source"></a>Install from source</h3>
+<h3 id="_install_from_source"><a class="anchor" href="#_install_from_source"></a><a class="link" href="#_install_from_source">Install from source</a></h3>
 <div class="sect3">
-<h4 id="_using_npm"><a class="anchor" href="#_using_npm"></a>using NPM</h4>
+<h4 id="_using_npm"><a class="anchor" href="#_using_npm"></a><a class="link" href="#_using_npm">using NPM</a></h4>
 <div class="olist arabic">
 <div class="title">Prerequisites:</div>
 <ol class="arabic">
@@ -989,14 +1004,14 @@ npm install bs-platform</code></pre>
 <div class="listingblock">
 <div class="title">Instructions:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">git clone https://github.com/bucklescript/bucklescript
-<span class="tok-nb">cd </span>bucklescript
+<pre class="pygments highlight"><code data-lang="sh"><span></span>git clone https://github.com/bucklescript/bucklescript
+<span class="tok-nb">cd</span> bucklescript
 npm install</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_minimal_dependencies"><a class="anchor" href="#_minimal_dependencies"></a>Minimal dependencies</h4>
+<h4 id="_minimal_dependencies"><a class="anchor" href="#_minimal_dependencies"></a><a class="link" href="#_minimal_dependencies">Minimal dependencies</a></h4>
 <div class="olist arabic">
 <div class="title">Prerequisites:</div>
 <ol class="arabic">
@@ -1012,9 +1027,9 @@ easily be done.</p>
 <div class="listingblock">
 <div class="title">Build OCaml compiler</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">git clone https://github.com/bucklescript/bucklescript
-<span class="tok-nb">cd </span>bucklescript/vendor/ocaml
-./configure -prefix <span class="tok-sb">`</span><span class="tok-nb">pwd</span><span class="tok-sb">`</span> <span class="tok-c"># put your preferred directory</span>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>git clone https://github.com/bucklescript/bucklescript
+<span class="tok-nb">cd</span> bucklescript/vendor/ocaml
+./configure -prefix <span class="tok-sb">`</span><span class="tok-nb">pwd</span><span class="tok-sb">`</span> <span class="tok-c1"># put your preferred directory</span>
 make world.opt
 make install</code></pre>
 </div>
@@ -1033,7 +1048,7 @@ the previous section.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh"><span class="tok-nb">cd</span> ../../jscomp
+<pre class="pygments highlight"><code data-lang="sh"><span></span><span class="tok-nb">cd</span> ../../jscomp
 make world</code></pre>
 </div>
 </div>
@@ -1062,16 +1077,16 @@ The built compiler is not <em>relocatable</em> out of box, please don&#8217;t mo
 </div>
 </div>
 <div class="sect1">
-<h2 id="_get_started"><a class="anchor" href="#_get_started"></a>Get Started</h2>
+<h2 id="_get_started"><a class="anchor" href="#_get_started"></a><a class="link" href="#_get_started">Get Started</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_using_existing_templates_since_1_7_4"><a class="anchor" href="#_using_existing_templates_since_1_7_4"></a>Using existing templates (@since 1.7.4 )</h3>
+<h3 id="_using_existing_templates_since_1_7_4"><a class="anchor" href="#_using_existing_templates_since_1_7_4"></a><a class="link" href="#_using_existing_templates_since_1_7_4">Using existing templates (@since 1.7.4 )</a></h3>
 <div class="paragraph">
 <p>BuckleScript provide some project templates, to help people get started on board as fast as possible.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm install -g bs-platform <span class="tok-o">&amp;&amp;</span> bsb -init hello <span class="tok-o">&amp;&amp;</span> <span class="tok-nb">cd </span>hello <span class="tok-o">&amp;&amp;</span> npm run build</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>npm install -g bs-platform <span class="tok-o">&amp;&amp;</span> bsb -init hello <span class="tok-o">&amp;&amp;</span> <span class="tok-nb">cd</span> hello <span class="tok-o">&amp;&amp;</span> npm run build</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1082,7 +1097,7 @@ The built compiler is not <em>relocatable</em> out of box, please don&#8217;t mo
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">hello&gt;tree -d .
+<pre class="pygments highlight"><code data-lang="sh"><span></span>hello&gt;tree -d .
 .
 <span class="tok-p">|</span>---.vscode
 ├── lib
@@ -1108,7 +1123,7 @@ a <code>Problems</code> panel which has a much nicer UI.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_first_example_by_hand_without_samples"><a class="anchor" href="#_first_example_by_hand_without_samples"></a>First example by hand without samples</h3>
+<h3 id="_first_example_by_hand_without_samples"><a class="anchor" href="#_first_example_by_hand_without_samples"></a><a class="link" href="#_first_example_by_hand_without_samples">First example by hand without samples</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -1117,7 +1132,7 @@ as below:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;hello&quot;</span><span class="tok-p">,</span>
     <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">}</span>
 <span class="tok-p">}</span></code></pre>
@@ -1126,7 +1141,7 @@ as below:</p>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
         <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;1.7.0&quot;</span> <b class="conum">(1)</b>
     <span class="tok-p">},</span>
@@ -1153,7 +1168,7 @@ as below:</p>
 <div class="listingblock">
 <div class="title">src/main_entry.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
   <span class="tok-n">print_endline</span> <span class="tok-s2">&quot;hello world&quot;</span></code></pre>
 </div>
 </div>
@@ -1162,7 +1177,7 @@ as below:</p>
 <p>Build the app</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm run build</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>npm run build</code></pre>
 </div>
 </div>
 </li>
@@ -1174,7 +1189,7 @@ as below:</p>
 <div class="listingblock">
 <div class="title">lib/js/src/main_entry.js</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-c1">// GENERATED CODE BY BUCKLESCRIPT VERSION 1.0.1 , PLEASE EDIT WITH CARE</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-c1">// GENERATED CODE BY BUCKLESCRIPT VERSION 1.0.1 , PLEASE EDIT WITH CARE</span>
 <span class="tok-s1">&#39;use strict&#39;</span><span class="tok-p">;</span>
 
 
@@ -1195,7 +1210,7 @@ as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm run watch</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>npm run watch</code></pre>
 </div>
 </div>
 <div class="admonitionblock tip">
@@ -1212,7 +1227,7 @@ The working code is available <a href="https://github.com/bucklescript/bucklescr
 </div>
 </div>
 <div class="sect2">
-<h3 id="_an_example_with_multiple_modules"><a class="anchor" href="#_an_example_with_multiple_modules"></a>An example with multiple modules</h3>
+<h3 id="_an_example_with_multiple_modules"><a class="anchor" href="#_an_example_with_multiple_modules"></a><a class="link" href="#_an_example_with_multiple_modules">An example with multiple modules</a></h3>
 <div class="paragraph">
 <p>Now we want to create two modules, one file called <code>fib.ml</code> which
 exports <code>fib</code> function, the other module called <code>main_entry.ml</code> which
@@ -1225,7 +1240,7 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;helo&quot;</span><span class="tok-p">,</span>
     <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">}</span>
 <span class="tok-p">}</span></code></pre>
@@ -1234,7 +1249,7 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
         <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;1.7.0&quot;</span>
     <span class="tok-p">},</span>
@@ -1251,7 +1266,7 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">src/fib.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">fib</span> <span class="tok-n">n</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">fib</span> <span class="tok-n">n</span> <span class="tok-o">=</span>
   <span class="tok-k">let</span> <span class="tok-k">rec</span> <span class="tok-n">aux</span> <span class="tok-n">n</span> <span class="tok-n">a</span> <span class="tok-n">b</span> <span class="tok-o">=</span>
     <span class="tok-k">if</span> <span class="tok-n">n</span> <span class="tok-o">=</span> <span class="tok-mi">0</span> <span class="tok-k">then</span> <span class="tok-n">a</span>
     <span class="tok-k">else</span>
@@ -1262,7 +1277,7 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">src/main_entry.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
   <span class="tok-k">for</span> <span class="tok-n">i</span> <span class="tok-o">=</span> <span class="tok-mi">0</span> <span class="tok-k">to</span> <span class="tok-mi">10</span> <span class="tok-k">do</span>
     <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-nn">Fib</span><span class="tok-p">.</span><span class="tok-n">fib</span> <span class="tok-n">i</span><span class="tok-o">)</span> <b class="conum">(1)</b>
   <span class="tok-k">done</span></code></pre>
@@ -1280,7 +1295,7 @@ will call <code>fib</code>.</p>
 <p>Build the app</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm install
+<pre class="pygments highlight"><code data-lang="sh"><span></span>npm install
 npm run build
 node lib/js/src/main_entry.js</code></pre>
 </div>
@@ -1293,27 +1308,27 @@ node lib/js/src/main_entry.js</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">1
-1
-2
-3
-5
-8
-13
-21
-34
-55
-89</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span><span class="tok-m">1</span>
+<span class="tok-m">1</span>
+<span class="tok-m">2</span>
+<span class="tok-m">3</span>
+<span class="tok-m">5</span>
+<span class="tok-m">8</span>
+<span class="tok-m">13</span>
+<span class="tok-m">21</span>
+<span class="tok-m">34</span>
+<span class="tok-m">55</span>
+<span class="tok-m">89</span></code></pre>
 </div>
 </div>
 </div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_built_in_npm_support"><a class="anchor" href="#_built_in_npm_support"></a>Built in NPM support</h2>
+<h2 id="_built_in_npm_support"><a class="anchor" href="#_built_in_npm_support"></a><a class="link" href="#_built_in_npm_support">Built in NPM support</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_build_an_ocaml_library_as_a_npm_package"><a class="anchor" href="#_build_an_ocaml_library_as_a_npm_package"></a>Build an OCaml library as a npm package</h3>
+<h3 id="_build_an_ocaml_library_as_a_npm_package"><a class="anchor" href="#_build_an_ocaml_library_as_a_npm_package"></a><a class="link" href="#_build_an_ocaml_library_as_a_npm_package">Build an OCaml library as a npm package</a></h3>
 <div class="paragraph">
 <p>BuckleScript build system has built in support for NPM packages,
 please checkout the section about the bsb for NPM support.</p>
@@ -1348,7 +1363,7 @@ directories, we have a flag</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output modulesystem:path/to/your/js/dir -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsc.exe -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output modulesystem:path/to/your/js/dir -c a.ml</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1367,30 +1382,30 @@ and Javascript files in a <em>hierachical</em> directory like <code>package.json
 </div>
 </div>
 <div class="sect2">
-<h3 id="_to_use_ocaml_library_as_a_npm_package"><a class="anchor" href="#_to_use_ocaml_library_as_a_npm_package"></a>To use OCaml library as a npm package</h3>
+<h3 id="_to_use_ocaml_library_as_a_npm_package"><a class="anchor" href="#_to_use_ocaml_library_as_a_npm_package"></a><a class="link" href="#_to_use_ocaml_library_as_a_npm_package">To use OCaml library as a npm package</a></h3>
 <div class="paragraph">
 <p>If you follow the layout convention above, using an OCaml package is
 pretty straightforward:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -I path/to/ocaml/package/installed -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsc.exe -I path/to/ocaml/package/installed -c a.ml</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_together"><a class="anchor" href="#_together"></a>Together</h3>
+<h3 id="_together"><a class="anchor" href="#_together"></a><a class="link" href="#_together">Together</a></h3>
 <div class="paragraph">
 <p>Your command line would be like this:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -I path/to/ocaml/package1/installed -I path/to/ocaml/package2/installed  -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output commonjs:path/to/lib/js/ -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsc.exe -I path/to/ocaml/package1/installed -I path/to/ocaml/package2/installed  -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output commonjs:path/to/lib/js/ -c a.ml</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_examples"><a class="anchor" href="#_examples"></a>Examples</h3>
+<h3 id="_examples"><a class="anchor" href="#_examples"></a><a class="link" href="#_examples">Examples</a></h3>
 <div class="paragraph">
 <p>Please visit <a href="https://github.com/bucklescript/bucklescript-addons" class="bare">https://github.com/bucklescript/bucklescript-addons</a> for more examples.</p>
 </div>
@@ -1398,7 +1413,7 @@ pretty straightforward:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_js_calling_ocaml"><a class="anchor" href="#_js_calling_ocaml"></a>JS Calling OCaml</h2>
+<h2 id="_js_calling_ocaml"><a class="anchor" href="#_js_calling_ocaml"></a><a class="link" href="#_js_calling_ocaml">JS Calling OCaml</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Since BuckleScript guarantees that all OCaml functions are exported as
@@ -1437,7 +1452,7 @@ we recommend users to export it as functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">  <span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span>  <span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
     <span class="tok-o">|</span> <span class="tok-nc">Cons</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-n">t</span>
     <span class="tok-o">|</span> <span class="tok-nc">Nil</span></code></pre>
 </div>
@@ -1448,7 +1463,7 @@ so that it can be constructed from the JS side.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">cons</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-nc">Cons</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">cons</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-nc">Cons</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
 <span class="tok-k">let</span> <span class="tok-n">nil</span> <span class="tok-o">=</span> <span class="tok-nc">Nil</span></code></pre>
 </div>
 </div>
@@ -1470,7 +1485,7 @@ automate this process.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_bucklescript_annotations_for_unicode_and_js_ffi_support"><a class="anchor" href="#_bucklescript_annotations_for_unicode_and_js_ffi_support"></a>BuckleScript annotations for Unicode and JS FFI support</h2>
+<h2 id="_bucklescript_annotations_for_unicode_and_js_ffi_support"><a class="anchor" href="#_bucklescript_annotations_for_unicode_and_js_ffi_support"></a><a class="link" href="#_bucklescript_annotations_for_unicode_and_js_ffi_support">BuckleScript annotations for Unicode and JS FFI support</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>To make OCaml work smoothly with JavaScript, we introduced several
@@ -1479,7 +1494,7 @@ facilitate the integration of native JavaScript code and
 improve the generated code.</p>
 </div>
 <div class="sect2">
-<h3 id="_unicode_support_since_1_5_1"><a class="anchor" href="#_unicode_support_since_1_5_1"></a>Unicode support (@since 1.5.1)</h3>
+<h3 id="_unicode_support_since_1_5_1"><a class="anchor" href="#_unicode_support_since_1_5_1"></a><a class="link" href="#_unicode_support_since_1_5_1">Unicode support (@since 1.5.1)</a></h3>
 <div class="admonitionblock warning">
 <table>
 <tr>
@@ -1499,7 +1514,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;你好&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;你好&quot;</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1507,7 +1522,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;\xe4\xbd\xa0\xe5\xa5\xbd&quot;</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;\xe4\xbd\xa0\xe5\xa5\xbd&quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1515,14 +1530,14 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">{</span><span class="tok-n">js</span><span class="tok-o">|</span><span class="tok-err">你好，</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">{</span><span class="tok-n">js</span><span class="tok-o">|</span><span class="tok-err">你好，</span>
 <span class="tok-err">世界</span><span class="tok-o">|</span><span class="tok-n">js</span><span class="tok-o">}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;你好，\n世界&quot;</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;你好，\n世界&quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1530,17 +1545,17 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">{</span><span class="tok-n">js</span><span class="tok-o">|</span><span class="tok-err">\</span><span class="tok-n">x3f</span><span class="tok-err">\</span><span class="tok-n">u003f</span><span class="tok-err">\</span><span class="tok-n">b</span><span class="tok-err">\</span><span class="tok-n">t</span><span class="tok-err">\</span><span class="tok-n">n</span><span class="tok-err">\</span><span class="tok-n">v</span><span class="tok-err">\</span><span class="tok-n">f</span><span class="tok-err">\</span><span class="tok-n">r</span><span class="tok-err">\</span><span class="tok-mi">0</span><span class="tok-s2">&quot;&#39;|js}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">{</span><span class="tok-n">js</span><span class="tok-o">|</span><span class="tok-err">\</span><span class="tok-n">x3f</span><span class="tok-err">\</span><span class="tok-n">u003f</span><span class="tok-err">\</span><span class="tok-n">b</span><span class="tok-err">\</span><span class="tok-n">t</span><span class="tok-err">\</span><span class="tok-n">n</span><span class="tok-err">\</span><span class="tok-n">v</span><span class="tok-err">\</span><span class="tok-n">f</span><span class="tok-err">\</span><span class="tok-n">r</span><span class="tok-err">\</span><span class="tok-mi">0</span><span class="tok-s2">&quot;&#39;|js}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;\x3f\u003f\b\t\n\v\f\r\0\&quot;\&#39;&quot;</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;\x3f\u003f\b\t\n\v\f\r\0\&quot;\&#39;&quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_unicode_support_with_string_interpolation_since_1_7_0"><a class="anchor" href="#_unicode_support_with_string_interpolation_since_1_7_0"></a>Unicode support with string interpolation (@since 1.7.0)</h4>
+<h4 id="_unicode_support_with_string_interpolation_since_1_7_0"><a class="anchor" href="#_unicode_support_with_string_interpolation_since_1_7_0"></a><a class="link" href="#_unicode_support_with_string_interpolation_since_1_7_0">Unicode support with string interpolation (@since 1.7.0)</a></h4>
 <div class="paragraph">
 <p>Like <code>{js||js}</code>, <code>{j||j}</code> not only allow unicode point, but also variable interpolation.</p>
 </div>
@@ -1549,7 +1564,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">世界</span><span class="tok-o">|</span><span class="tok-n">j</span><span class="tok-o">}</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">世界</span><span class="tok-o">|</span><span class="tok-n">j</span><span class="tok-o">}</span>
 <span class="tok-k">let</span> <span class="tok-n">hello_world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">你好，</span><span class="tok-o">$</span><span class="tok-n">world</span><span class="tok-o">|</span><span class="tok-n">j</span><span class="tok-o">}</span></code></pre>
 </div>
 </div>
@@ -1558,7 +1573,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">hello_world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">你好，</span><span class="tok-o">$(</span><span class="tok-n">world</span><span class="tok-o">)|</span><span class="tok-n">j</span><span class="tok-o">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">hello_world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">你好，</span><span class="tok-o">$(</span><span class="tok-n">world</span><span class="tok-o">)|</span><span class="tok-n">j</span><span class="tok-o">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1567,7 +1582,7 @@ Its lexical convention is as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="bnf">identifier := leading_identifier_char identifier_chars
+<pre class="pygments highlight"><code data-lang="bnf"><span></span>identifier := leading_identifier_char identifier_chars
 leading_identifier_char := &#39;a&#39; .. &#39;z&#39; | &#39;_&#39;
 identifier_chars := &#39;a&#39; .. &#39;z&#39; | &#39;A&#39; .. &#39;Z&#39; | &#39;0&#39; .. &#39;9&#39; | &#39;_&#39; | &#39;\&#39;</code></pre>
 </div>
@@ -1575,7 +1590,7 @@ identifier_chars := &#39;a&#39; .. &#39;z&#39; | &#39;A&#39; .. &#39;Z&#39; | &#
 </div>
 </div>
 <div class="sect2">
-<h3 id="_ffi"><a class="anchor" href="#_ffi"></a>FFI</h3>
+<h3 id="_ffi"><a class="anchor" href="#_ffi"></a><a class="link" href="#_ffi">FFI</a></h3>
 <div class="paragraph">
 <p>Like TypeScript, when building type-safe bindings from JS to OCaml,
 users have to write type declarations.
@@ -1608,14 +1623,14 @@ code</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_binding_to_simple_js_functions_values"><a class="anchor" href="#_binding_to_simple_js_functions_values"></a>Binding to simple JS functions values</h3>
+<h3 id="_binding_to_simple_js_functions_values"><a class="anchor" href="#_binding_to_simple_js_functions_values"></a><a class="link" href="#_binding_to_simple_js_functions_values">Binding to simple JS functions values</a></h3>
 <div class="paragraph">
 <p>This part is similar to <a href="http://caml.inria.fr/pub/docs/manual-ocaml-4.02/intfc.html">traditional FFI</a>,
 with syntax as described below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-k">value</span><span class="tok-o">-</span><span class="tok-n">name</span> <span class="tok-o">:</span> <span class="tok-n">typexpr</span> <span class="tok-o">=</span> <span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span> <span class="tok-n">attributes</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-k">value</span><span class="tok-o">-</span><span class="tok-n">name</span> <span class="tok-o">:</span> <span class="tok-n">typexpr</span> <span class="tok-o">=</span> <span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span> <span class="tok-n">attributes</span>
 <span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span> <span class="tok-o">:=</span> <span class="tok-kt">string</span><span class="tok-o">-</span><span class="tok-n">literal</span></code></pre>
 </div>
 </div>
@@ -1625,10 +1640,10 @@ with syntax as described below:</p>
 and provide customized <code>attributes</code>.</p>
 </div>
 <div class="sect3">
-<h4 id="_binding_to_global_value_bs_val"><a class="anchor" href="#_binding_to_global_value_bs_val"></a>Binding to global value: bs.val</h4>
+<h4 id="_binding_to_global_value_bs_val"><a class="anchor" href="#_binding_to_global_value_bs_val"></a><a class="link" href="#_binding_to_global_value_bs_val">Binding to global value: bs.val</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Math.imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Math.imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 <span class="tok-k">type</span> <span class="tok-n">dom</span>
 <span class="tok-c">(* Abstract type for the DOM *)</span>
 <span class="tok-k">external</span> <span class="tok-n">dom</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;document&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
@@ -1652,7 +1667,7 @@ it can be a function or plain value.</p>
 For example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">document</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">document</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </li>
@@ -1662,7 +1677,7 @@ JavaScript functions, you can
 give the JavaScript foreign function a different name:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span>
   <span class="tok-s2">&quot;c_imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span> <span class="tok-s2">&quot;Math.imul&quot;</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
@@ -1675,7 +1690,7 @@ give the JavaScript foreign function a different name:</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_scoped_values_bs_scope_since_1_7_2"><a class="anchor" href="#_scoped_values_bs_scope_since_1_7_2"></a>Scoped values: bs.scope (@since 1.7.2)</h4>
+<h4 id="_scoped_values_bs_scope_since_1_7_2"><a class="anchor" href="#_scoped_values_bs_scope_since_1_7_2"></a><a class="link" href="#_scoped_values_bs_scope_since_1_7_2">Scoped values: bs.scope (@since 1.7.2)</a></h4>
 <div class="paragraph">
 <p>In JS library, it is quite common to use a name as namespace,
 for example, if the user want to write a binding to
@@ -1685,7 +1700,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">param</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">param</span>
 <span class="tok-k">external</span> <span class="tok-n">executeCommands</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">param</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
 <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;commands&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;vscode&quot;</span><span class="tok-o">][@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
 
@@ -1696,7 +1711,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Vscode</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;vscode&quot;</span><span class="tok-p">);</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">Vscode</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;vscode&quot;</span><span class="tok-p">);</span>
 <span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">c</span><span class="tok-p">)</span> <span class="tok-p">{</span>
   <span class="tok-nx">Vscode</span><span class="tok-p">.</span><span class="tok-nx">commands</span><span class="tok-p">.</span><span class="tok-nx">executeCommands</span><span class="tok-p">(</span><span class="tok-s2">&quot;hi&quot;</span><span class="tok-p">,</span> <span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">c</span><span class="tok-p">);</span>
   <span class="tok-k">return</span> <span class="tok-nx">process</span><span class="tok-p">.</span><span class="tok-nx">env</span><span class="tok-p">;</span>
@@ -1709,7 +1724,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Exmaple</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">makeBuffer</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">buffer</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Buffer&quot;</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">makeBuffer</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">buffer</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Buffer&quot;</span>
 <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;global&quot;</span><span class="tok-o">]</span>
 <span class="tok-k">external</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
 <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;z&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;a0&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;a1&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;a2&quot;</span><span class="tok-o">]</span>
@@ -1724,7 +1739,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Z</span>      <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;z&quot;</span><span class="tok-p">);</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">Z</span>      <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;z&quot;</span><span class="tok-p">);</span>
 <span class="tok-kd">function</span> <span class="tok-nx">f2</span><span class="tok-p">()</span> <span class="tok-p">{</span>
   <span class="tok-k">return</span> <span class="tok-cm">/* tuple */</span><span class="tok-p">[</span>
           <span class="tok-k">new</span> <span class="tok-p">(</span><span class="tok-nx">global</span><span class="tok-p">.</span><span class="tok-nx">Buffer</span><span class="tok-p">)(</span><span class="tok-mi">20</span><span class="tok-p">),</span>
@@ -1737,29 +1752,29 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_binding_to_javascript_constructor_bs_new"><a class="anchor" href="#_binding_to_javascript_constructor_bs_new"></a>Binding to JavaScript constructor: bs.new</h4>
+<h4 id="_binding_to_javascript_constructor_bs_new"><a class="anchor" href="#_binding_to_javascript_constructor_bs_new"></a><a class="link" href="#_binding_to_javascript_constructor_bs_new">Binding to JavaScript constructor: bs.new</a></h4>
 <div class="paragraph">
 <p><code>bs.new</code> is used to create a JavaScript object.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">create_date</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Date&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">create_date</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Date&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-n">date</span> <span class="tok-o">=</span> <span class="tok-n">create_date</span> <span class="tok-bp">()</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">date</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Date</span><span class="tok-p">();</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">date</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Date</span><span class="tok-p">();</span></code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_binding_to_a_value_from_a_module_bs_module"><a class="anchor" href="#_binding_to_a_value_from_a_module_bs_module"></a>Binding to a value from a module: bs.module</h4>
+<h4 id="_binding_to_a_value_from_a_module_bs_module"><a class="anchor" href="#_binding_to_a_value_from_a_module_bs_module"></a><a class="link" href="#_binding_to_a_value_from_a_module_bs_module">Binding to a value from a module: bs.module</a></h4>
 <div class="listingblock">
 <div class="title">Input:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span>
 <span class="tok-k">external</span> <span class="tok-n">add2</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add2&quot;</span><span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;y&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;U&quot;</span><span class="tok-o">]</span> <b class="conum">(1)</b>
 <span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-n">add</span> <span class="tok-mi">3</span> <span class="tok-mi">4</span>
 <span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-o">=</span> <span class="tok-n">add2</span> <span class="tok-mi">3</span> <span class="tok-mi">4</span></code></pre>
@@ -1775,7 +1790,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">U</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;y&quot;</span><span class="tok-p">);</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">U</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;y&quot;</span><span class="tok-p">);</span>
 <span class="tok-kd">var</span> <span class="tok-nx">X</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;x&quot;</span><span class="tok-p">);</span>
 <span class="tok-kd">var</span> <span class="tok-nx">f</span> <span class="tok-o">=</span> <span class="tok-nx">X</span><span class="tok-p">.</span><span class="tok-nx">add</span><span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span>
 <span class="tok-kd">var</span> <span class="tok-nx">g</span> <span class="tok-o">=</span> <span class="tok-nx">U</span><span class="tok-p">.</span><span class="tok-nx">add2</span><span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span></code></pre>
@@ -1794,7 +1809,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example,</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </li>
@@ -1806,10 +1821,10 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_binding_the_whole_module_as_a_value_or_function"><a class="anchor" href="#_binding_the_whole_module_as_a_value_or_function"></a>Binding the whole module as a value or function</h4>
+<h4 id="_binding_the_whole_module_as_a_value_or_function"><a class="anchor" href="#_binding_the_whole_module_as_a_value_or_function"></a><a class="link" href="#_binding_the_whole_module_as_a_value_or_function">Binding the whole module as a value or function</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">http</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">http</span>
 <span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;http&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
@@ -1833,7 +1848,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </li>
@@ -1845,13 +1860,13 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_binding_to_method_bs_send_bs_send_pipe"><a class="anchor" href="#_binding_to_method_bs_send_bs_send_pipe"></a>Binding to method: bs.send, bs.send.pipe</h4>
+<h4 id="_binding_to_method_bs_send_bs_send_pipe"><a class="anchor" href="#_binding_to_method_bs_send_bs_send_pipe"></a><a class="link" href="#_binding_to_method_bs_send_bs_send_pipe">Binding to method: bs.send, bs.send.pipe</a></h4>
 <div class="paragraph">
 <p><code>bs.send</code> helps the user send a message to a JS object.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">id</span> <span class="tok-c">(** Abstract type for id object *)</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">id</span> <span class="tok-c">(** Abstract type for id object *)</span>
 <span class="tok-k">external</span> <span class="tok-n">get_by_id</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
   <span class="tok-s2">&quot;getElementById&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span></code></pre>
 </div>
@@ -1862,13 +1877,13 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Input:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">get_by_id</span> <span class="tok-n">dom</span> <span class="tok-s2">&quot;xx&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-n">get_by_id</span> <span class="tok-n">dom</span> <span class="tok-s2">&quot;xx&quot;</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">dom</span><span class="tok-p">.</span><span class="tok-nx">getElementById</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx&quot;</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">dom</span><span class="tok-p">.</span><span class="tok-nx">getElementById</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx&quot;</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1877,7 +1892,7 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
   <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span><span class="tok-o">]</span> <b class="conum">(1)</b>
 <span class="tok-k">external</span> <span class="tok-n">forEach</span><span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
   <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span><span class="tok-o">]</span>
@@ -1907,7 +1922,7 @@ is put in the position of last argument to help user write in a <em>chaining sty
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">getElementById</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">getElementById</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
   <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
@@ -1920,13 +1935,13 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 </div>
 <div class="sect3">
-<h4 id="_binding_to_dynamic_key_access_set_bs_set_index_bs_get_index"><a class="anchor" href="#_binding_to_dynamic_key_access_set_bs_set_index_bs_get_index"></a>Binding to dynamic key access/set: bs.set_index, bs.get_index</h4>
+<h4 id="_binding_to_dynamic_key_access_set_bs_set_index_bs_get_index"><a class="anchor" href="#_binding_to_dynamic_key_access_set_bs_set_index_bs_get_index"></a><a class="link" href="#_binding_to_dynamic_key_access_set_bs_set_index_bs_get_index">Binding to dynamic key access/set: bs.set_index, bs.get_index</a></h4>
 <div class="paragraph">
 <p>This attribute allows dynamic access to a JavaScript property</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">t</span>
 <span class="tok-k">external</span> <span class="tok-n">create</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Int32Array&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
 <span class="tok-k">external</span> <span class="tok-n">get</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get_index</span><span class="tok-o">]</span>
 <span class="tok-k">external</span> <span class="tok-n">set</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set_index</span><span class="tok-o">]</span></code></pre>
@@ -1934,13 +1949,13 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 </div>
 <div class="sect3">
-<h4 id="_binding_to_getter_setter_bs_get_bs_set"><a class="anchor" href="#_binding_to_getter_setter_bs_get_bs_set"></a>Binding to Getter/Setter: bs.get, bs.set</h4>
+<h4 id="_binding_to_getter_setter_bs_get_bs_set"><a class="anchor" href="#_binding_to_getter_setter_bs_get_bs_set"></a><a class="link" href="#_binding_to_getter_setter_bs_get_bs_set">Binding to Getter/Setter: bs.get, bs.set</a></h4>
 <div class="paragraph">
 <p>This attribute helps get and set the property of a JavaScript object.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">textarea</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">textarea</span>
 <span class="tok-k">external</span> <span class="tok-n">set_name</span> <span class="tok-o">:</span> <span class="tok-n">textarea</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span>
 <span class="tok-k">external</span> <span class="tok-n">get_name</span> <span class="tok-o">:</span> <span class="tok-n">textarea</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span><span class="tok-o">]</span></code></pre>
 </div>
@@ -1948,21 +1963,21 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 </div>
 <div class="sect2">
-<h3 id="_splice_calling_convention_bs_splice"><a class="anchor" href="#_splice_calling_convention_bs_splice"></a>Splice calling convention: bs.splice</h3>
+<h3 id="_splice_calling_convention_bs_splice"><a class="anchor" href="#_splice_calling_convention_bs_splice"></a><a class="link" href="#_splice_calling_convention_bs_splice">Splice calling convention: bs.splice</a></h3>
 <div class="paragraph">
 <p>In JS, it is quite common to have a function take variadic arguments.
 BuckleScript supports typing homogeneous variadic arguments. For example,</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">join</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;path&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">join</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;path&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">join</span> <span class="tok-o">[|</span> <span class="tok-s2">&quot;a&quot;</span><span class="tok-o">;</span> <span class="tok-s2">&quot;b&quot;</span><span class="tok-o">|]</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Path</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;path&quot;</span><span class="tok-p">)</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">Path</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;path&quot;</span><span class="tok-p">)</span>
 <span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-nx">Path</span><span class="tok-p">.</span><span class="tok-nx">join</span><span class="tok-p">(</span><span class="tok-s2">&quot;a&quot;</span><span class="tok-p">,</span><span class="tok-s2">&quot;b&quot;</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
@@ -1983,9 +1998,9 @@ the compiler will emit an error message.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_special_types_on_external_declarations_bs_string_bs_int_bs_ignore_bs_as"><a class="anchor" href="#_special_types_on_external_declarations_bs_string_bs_int_bs_ignore_bs_as"></a>Special types on external declarations: bs.string, bs.int, bs.ignore, bs.as</h3>
+<h3 id="_special_types_on_external_declarations_code_bs_string_code_code_bs_int_code_code_bs_ignore_code_code_bs_as_code_code_bs_unwrap_code"><a class="anchor" href="#_special_types_on_external_declarations_code_bs_string_code_code_bs_int_code_code_bs_ignore_code_code_bs_as_code_code_bs_unwrap_code"></a><a class="link" href="#_special_types_on_external_declarations_code_bs_string_code_code_bs_int_code_code_bs_ignore_code_code_bs_as_code_code_bs_unwrap_code">Special types on external declarations: <code>bs.string</code>, <code>bs.int</code>, <code>bs.ignore</code>, <code>bs.as</code>, <code>bs.unwrap</code></a></h3>
 <div class="sect3">
-<h4 id="_using_polymorphic_variant_to_model_enums_and_string_types"><a class="anchor" href="#_using_polymorphic_variant_to_model_enums_and_string_types"></a>Using polymorphic variant to model enums and string types</h4>
+<h4 id="_using_polymorphic_variant_to_model_enums_and_string_types"><a class="anchor" href="#_using_polymorphic_variant_to_model_enums_and_string_types"></a><a class="link" href="#_using_polymorphic_variant_to_model_enums_and_string_types">Using polymorphic variant to model enums and string types</a></h4>
 <div class="paragraph">
 <p>There are several patterns heavily used in existing JavaScript codebases, for example,
 the string type is used a lot. BuckleScript FFI allows the user to model string type in a safe
@@ -1993,7 +2008,7 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">readFileSync</span> <span class="tok-o">:</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">readFileSync</span> <span class="tok-o">:</span>
   <span class="tok-n">name</span><span class="tok-o">:</span><span class="tok-kt">string</span> <span class="tok-o">-&gt;</span>
   <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-n">utf8</span>
    <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">my_name</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;ascii&quot;</span><span class="tok-o">]</span> <b class="conum">(1)</b>
@@ -2017,7 +2032,7 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Fs</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;fs&quot;</span><span class="tok-p">);</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">Fs</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;fs&quot;</span><span class="tok-p">);</span>
 <span class="tok-nx">Fs</span><span class="tok-p">.</span><span class="tok-nx">readFileSync</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx.txt&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;ascii&quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
@@ -2026,7 +2041,7 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">test_int_type</span> <span class="tok-o">:</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">test_int_type</span> <span class="tok-o">:</span>
   <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-n">on_closed</span> <b class="conum">(1)</b>
    <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">on_open</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-mi">3</span><span class="tok-o">]</span> <b class="conum">(2)</b>
    <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">in_bin</span> <b class="conum">(3)</b>
@@ -2050,13 +2065,13 @@ way by using annotated polymorphic variant.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_using_polymorphic_variant_to_model_event_listener"><a class="anchor" href="#_using_polymorphic_variant_to_model_event_listener"></a>Using polymorphic variant to model event listener</h4>
+<h4 id="_using_polymorphic_variant_to_model_event_listener"><a class="anchor" href="#_using_polymorphic_variant_to_model_event_listener"></a><a class="link" href="#_using_polymorphic_variant_to_model_event_listener">Using polymorphic variant to model event listener</a></h4>
 <div class="paragraph">
 <p>BuckleScript models this in a type-safe way by using annotated polymorphic variants.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">readline</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">readline</span>
 <span class="tok-k">external</span> <span class="tok-n">on</span> <span class="tok-o">:</span>
     <span class="tok-o">(</span>
     <span class="tok-o">[</span> <span class="tok-o">`</span><span class="tok-n">close</span> <span class="tok-k">of</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
@@ -2080,7 +2095,7 @@ way by using annotated polymorphic variant.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">rl</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">rl</span><span class="tok-p">)</span> <span class="tok-p">{</span>
   <span class="tok-k">return</span> <span class="tok-nx">rl</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;close&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
                 <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
               <span class="tok-p">})</span>
@@ -2089,6 +2104,57 @@ way by using annotated polymorphic variant.</p>
               <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
             <span class="tok-p">});</span>
 <span class="tok-p">}</span></code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_using_polymorphic_variant_to_model_arguments_of_multiple_possible_types_since_1_8_3"><a class="anchor" href="#_using_polymorphic_variant_to_model_arguments_of_multiple_possible_types_since_1_8_3"></a><a class="link" href="#_using_polymorphic_variant_to_model_arguments_of_multiple_possible_types_since_1_8_3">Using polymorphic variant to model arguments of multiple possible types (@since 1.8.3)</a></h4>
+<div class="paragraph">
+<p>Sometimes a JavaScript function will accept an argument that could have different types depending upon how it&#8217;s used.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">padLeft</span><span class="tok-p">(</span><span class="tok-nx">string</span><span class="tok-p">,</span> <span class="tok-nx">padding</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+  <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-k">typeof</span> <span class="tok-nx">padding</span> <span class="tok-o">===</span> <span class="tok-s2">&quot;number&quot;</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+    <span class="tok-k">return</span> <span class="tok-nb">Array</span><span class="tok-p">(</span><span class="tok-nx">padding</span> <span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-p">).</span><span class="tok-nx">join</span><span class="tok-p">(</span><span class="tok-s2">&quot; &quot;</span><span class="tok-p">)</span> <span class="tok-o">+</span> <span class="tok-nx">value</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+  <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-k">typeof</span> <span class="tok-nx">padding</span> <span class="tok-o">===</span> <span class="tok-s2">&quot;string&quot;</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+    <span class="tok-k">return</span> <span class="tok-nx">padding</span> <span class="tok-o">+</span> <span class="tok-nx">value</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+  <span class="tok-k">throw</span> <span class="tok-k">new</span> <span class="tok-nb">Error</span><span class="tok-p">(</span><span class="tok-sb">`Expected string or number, got &#39;</span><span class="tok-si">${</span><span class="tok-nx">padding</span><span class="tok-si">}</span><span class="tok-sb">&#39;.`</span><span class="tok-p">);</span>
+<span class="tok-p">}</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>You can model such a function in BuckleScript using <code>[@bs.unwrap]</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">padLeft</span> <span class="tok-o">:</span>
+  <span class="tok-kt">string</span>
+  <span class="tok-o">-&gt;</span> <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-nc">String</span> <span class="tok-k">of</span> <span class="tok-kt">string</span>
+      <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-nc">Int</span> <span class="tok-k">of</span> <span class="tok-kt">int</span>
+      <span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">unwrap</span><span class="tok-o">])</span>
+  <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span>
+  <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Polymorphic variants with <code>[@bs.unwrap]</code> will "unwrap" the variant at the call site so that the JavaScript function is called with the underlying value.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-n">padLeft</span> <span class="tok-s2">&quot;Hello World&quot;</span> <span class="tok-o">(`</span><span class="tok-nc">Int</span> <span class="tok-mi">4</span><span class="tok-o">)</span>
+<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-n">padLeft</span> <span class="tok-s2">&quot;Hello World&quot;</span> <span class="tok-o">(`</span><span class="tok-nc">String</span> <span class="tok-s2">&quot;bs: &quot;</span><span class="tok-o">)</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Output:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">padLeft</span><span class="tok-p">(</span><span class="tok-s2">&quot;Hello World&quot;</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span>
+<span class="tok-nx">padLeft</span><span class="tok-p">(</span><span class="tok-s2">&quot;Hello World&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;bs: &quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -2101,15 +2167,15 @@ way by using annotated polymorphic variant.</p>
 <div class="ulist">
 <ul>
 <li>
-<p>These annotations will only have effect in <code>external</code> declarations.</p>
+<p>These <code>[@bs.string]</code>, <code>[@bs.int]</code>, and <code>[@bs.unwrap]</code> annotations will only have effect in <code>external</code> declarations.</p>
 </li>
 <li>
 <p>The runtime encoding of using polymorphic variant is internal to the compiler.</p>
 </li>
 <li>
 <p>With these annotations mentioned above, BuckleScript will automatically
- transform the internal encoding to the designated encoding for FFI.
- BuckleScript will try to do such conversion at compile time if it can, otherwise, it
+transform the internal encoding to the designated encoding for FFI.
+BuckleScript will try to do such conversion at compile time if it can, otherwise, it
 will do such conversion in the runtime, but it should be always correct.</p>
 </li>
 </ul>
@@ -2120,7 +2186,7 @@ will do such conversion in the runtime, but it should be always correct.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_phantom_arguments_and_ad_hoc_polymorphism"><a class="anchor" href="#_phantom_arguments_and_ad_hoc_polymorphism"></a>Phantom Arguments and ad-hoc polymorphism</h4>
+<h4 id="_phantom_arguments_and_ad_hoc_polymorphism"><a class="anchor" href="#_phantom_arguments_and_ad_hoc_polymorphism"></a><a class="link" href="#_phantom_arguments_and_ad_hoc_polymorphism">Phantom Arguments and ad-hoc polymorphism</a></h4>
 <div class="paragraph">
 <p><code>bs.ignore</code> allows arguments to be erased after passing to JS functional call, the side effect will
 still be recorded.</p>
@@ -2130,7 +2196,7 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
 <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">add</span> <span class="tok-mi">0</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <b class="conum">(1)</b></code></pre>
 </div>
@@ -2145,7 +2211,7 @@ still be recorded.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="javascript"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-nx">add</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="javascript"><span></span><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-nx">add</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2153,7 +2219,7 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-o">_</span> <span class="tok-n">kind</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-o">_</span> <span class="tok-n">kind</span> <span class="tok-o">=</span>
   <span class="tok-o">|</span> <span class="tok-nc">Float</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-n">kind</span>
   <span class="tok-o">|</span> <span class="tok-nc">String</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">kind</span>
 <span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">kind</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
@@ -2168,7 +2234,7 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">string_of_kind</span> <span class="tok-o">(</span><span class="tok-k">type</span> <span class="tok-n">t</span><span class="tok-o">)</span> <span class="tok-o">(</span><span class="tok-n">kind</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-n">kind</span><span class="tok-o">)</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">string_of_kind</span> <span class="tok-o">(</span><span class="tok-k">type</span> <span class="tok-n">t</span><span class="tok-o">)</span> <span class="tok-o">(</span><span class="tok-n">kind</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-n">kind</span><span class="tok-o">)</span> <span class="tok-o">=</span>
   <span class="tok-k">match</span> <span class="tok-n">kind</span> <span class="tok-k">with</span>
   <span class="tok-o">|</span> <span class="tok-nc">Float</span> <span class="tok-o">-&gt;</span> <span class="tok-s2">&quot;float&quot;</span>
   <span class="tok-o">|</span> <span class="tok-nc">String</span> <span class="tok-o">-&gt;</span> <span class="tok-s2">&quot;string&quot;</span>
@@ -2180,10 +2246,23 @@ still be recorded.</p>
   <span class="tok-n">add_dyn</span> <span class="tok-n">k</span> <span class="tok-o">(</span><span class="tok-n">string_of_kind</span> <span class="tok-n">k</span><span class="tok-o">)</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Using a GADT as a <code>[@bs.ignore]</code> argument as described to achieve a single polymorphic argument can now also be accomplished with <code>[@bs.unwrap]</code> above. The GADT + <code>[@bs.ignore]</code> approach is slightly more flexible and is always guaranteed to have no runtime overhead, where <code>[@bs.unwrap]</code> could incur slight runtime overhead in some cases but could be a more intuitive API for end users.</p>
+</div>
+</td>
+</tr>
+</table>
 </div>
 </div>
-<div class="sect2">
-<h3 id="_fixed_arguments"><a class="anchor" href="#_fixed_arguments"></a>Fixed Arguments</h3>
+<div class="sect3">
+<h4 id="_fixed_arguments"><a class="anchor" href="#_fixed_arguments"></a><a class="link" href="#_fixed_arguments">Fixed Arguments</a></h4>
 <div class="paragraph">
 <p>Contrary to the Phantom arguments, <code>_[@bs.as]</code> is introduced to attach the const
 data.</p>
@@ -2193,7 +2272,7 @@ data.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">process_on_exit</span> <span class="tok-o">:</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;exit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">process_on_exit</span> <span class="tok-o">:</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;exit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span>
   <span class="tok-s2">&quot;process.on&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 
 <span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
@@ -2204,7 +2283,7 @@ data.</p>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">process</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;exit&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">exit_code</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">process</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;exit&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">exit_code</span><span class="tok-p">)</span> <span class="tok-p">{</span>
       <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;error code: &quot;</span> <span class="tok-o">+</span> <span class="tok-nx">exit_code</span><span class="tok-p">);</span>
       <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
     <span class="tok-p">});</span></code></pre>
@@ -2215,7 +2294,7 @@ data.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">process</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">process</span>
 
 <span class="tok-k">external</span> <span class="tok-n">on_exit</span> <span class="tok-o">:</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;exit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span>
     <span class="tok-s2">&quot;on&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-n">process</span><span class="tok-o">]</span>
@@ -2226,7 +2305,7 @@ data.</p>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">p</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">p</span><span class="tok-p">)</span> <span class="tok-p">{</span>
   <span class="tok-k">return</span> <span class="tok-nx">p</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;exit&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">)</span> <span class="tok-p">{</span>
               <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">);</span>
               <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
@@ -2237,7 +2316,7 @@ data.</p>
 <div class="listingblock">
 <div class="title">Input</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">io_config</span> <span class="tok-o">:</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">io_config</span> <span class="tok-o">:</span>
     <span class="tok-n">stdio</span><span class="tok-o">:(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;inherit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-n">cwd</span><span class="tok-o">:</span><span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span>
 
 <span class="tok-k">let</span> <span class="tok-n">config</span> <span class="tok-o">=</span> <span class="tok-n">io_config</span> <span class="tok-o">~</span><span class="tok-n">cwd</span><span class="tok-o">:</span><span class="tok-s2">&quot;.&quot;</span> <span class="tok-bp">()</span></code></pre>
@@ -2246,21 +2325,21 @@ data.</p>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">config</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">config</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
   <span class="tok-nx">stdio</span><span class="tok-o">:</span> <span class="tok-s2">&quot;inherit&quot;</span><span class="tok-p">,</span>
   <span class="tok-nx">cwd</span><span class="tok-o">:</span> <span class="tok-s2">&quot;.&quot;</span>
 <span class="tok-p">};</span></code></pre>
 </div>
 </div>
 </div>
-<div class="sect2">
-<h3 id="_fixed_arguments_with_arbitrary_json_literal_since_1_7_0"><a class="anchor" href="#_fixed_arguments_with_arbitrary_json_literal_since_1_7_0"></a>Fixed Arguments with arbitrary JSON literal (@since 1.7.0)</h3>
+<div class="sect3">
+<h4 id="_fixed_arguments_with_arbitrary_json_literal_since_1_7_0"><a class="anchor" href="#_fixed_arguments_with_arbitrary_json_literal_since_1_7_0"></a><a class="link" href="#_fixed_arguments_with_arbitrary_json_literal_since_1_7_0">Fixed Arguments with arbitrary JSON literal (@since 1.7.0)</a></h4>
 <div class="paragraph">
 <p>So the payload can be more flexiblie with JSON literal support</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">on_exit_slice5</span> <span class="tok-o">:</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">on_exit_slice5</span> <span class="tok-o">:</span>
     <span class="tok-kt">int</span>
     <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-mi">3</span><span class="tok-o">])</span>
     <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span><span class="tok-bp">true</span><span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
@@ -2284,12 +2363,13 @@ data.</p>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">xx</span><span class="tok-p">(</span><span class="tok-mi">114</span><span class="tok-p">,</span> <span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-kc">true</span><span class="tok-p">,</span> <span class="tok-kc">false</span><span class="tok-p">,</span> <span class="tok-p">(</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">]</span> <span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-p">}]</span> <span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-p">}]</span> <span class="tok-p">),</span> <span class="tok-s2">&quot;xxx&quot;</span><span class="tok-p">,</span> <span class="tok-mi">0</span><span class="tok-p">,</span> <span class="tok-s2">&quot;yyy&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;b&quot;</span><span class="tok-p">,</span> <span class="tok-mi">1</span><span class="tok-p">,</span> <span class="tok-mi">2</span><span class="tok-p">,</span> <span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">,</span> <span class="tok-mi">5</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">xx</span><span class="tok-p">(</span><span class="tok-mi">114</span><span class="tok-p">,</span> <span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-kc">true</span><span class="tok-p">,</span> <span class="tok-kc">false</span><span class="tok-p">,</span> <span class="tok-p">(</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">]</span> <span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-p">}]</span> <span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-p">}]</span> <span class="tok-p">),</span> <span class="tok-s2">&quot;xxx&quot;</span><span class="tok-p">,</span> <span class="tok-mi">0</span><span class="tok-p">,</span> <span class="tok-s2">&quot;yyy&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;b&quot;</span><span class="tok-p">,</span> <span class="tok-mi">1</span><span class="tok-p">,</span> <span class="tok-mi">2</span><span class="tok-p">,</span> <span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">,</span> <span class="tok-mi">5</span><span class="tok-p">)</span></code></pre>
+</div>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_binding_to_nodejs_special_variables_bs_node"><a class="anchor" href="#_binding_to_nodejs_special_variables_bs_node"></a>Binding to NodeJS special variables: bs.node</h3>
+<h3 id="_binding_to_nodejs_special_variables_bs_node"><a class="anchor" href="#_binding_to_nodejs_special_variables_bs_node"></a><a class="link" href="#_binding_to_nodejs_special_variables_bs_node">Binding to NodeJS special variables: bs.node</a></h3>
 <div class="paragraph">
 <p>NodeJS has several file local variables: <code><em>dirname</code>, <code></em>filename</code>, <code>_module</code>, and <code>require</code>.
 Their semantics are more like macros instead of functions.</p>
@@ -2299,7 +2379,7 @@ Their semantics are more like macros instead of functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">dirname</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">dirname</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">dirname</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">dirname</span><span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-n">filename</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">filename</span><span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-o">_</span><span class="tok-n">module</span> <span class="tok-o">:</span> <span class="tok-nn">Node</span><span class="tok-p">.</span><span class="tok-n">node_module</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">_</span><span class="tok-n">module</span><span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-n">require</span> <span class="tok-o">:</span> <span class="tok-nn">Node</span><span class="tok-p">.</span><span class="tok-n">node_require</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-n">require</span><span class="tok-o">]</span></code></pre>
@@ -2307,7 +2387,7 @@ Their semantics are more like macros instead of functions.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_binding_to_callbacks_high_order_function"><a class="anchor" href="#_binding_to_callbacks_high_order_function"></a>Binding to callbacks (high-order function)</h3>
+<h3 id="_binding_to_callbacks_high_order_function"><a class="anchor" href="#_binding_to_callbacks_high_order_function"></a><a class="link" href="#_binding_to_callbacks_high_order_function">Binding to callbacks (high-order function)</a></h3>
 <div class="paragraph">
 <p>High order functions are functions where the callback can be another
 function. For example, suppose
@@ -2315,7 +2395,7 @@ JS has a map function as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">map</span> <span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">f</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">map</span> <span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">f</span><span class="tok-p">){</span>
   <span class="tok-kd">var</span> <span class="tok-nx">i</span> <span class="tok-o">=</span> <span class="tok-nb">Math</span><span class="tok-p">.</span><span class="tok-nx">min</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">.</span><span class="tok-nx">length</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">.</span><span class="tok-nx">length</span><span class="tok-p">);</span>
   <span class="tok-kd">var</span> <span class="tok-nx">c</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Array</span><span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">);</span>
   <span class="tok-k">for</span><span class="tok-p">(</span><span class="tok-kd">var</span> <span class="tok-nx">j</span> <span class="tok-o">=</span> <span class="tok-mi">0</span><span class="tok-p">;</span> <span class="tok-nx">j</span> <span class="tok-o">&lt;</span> <span class="tok-nx">i</span><span class="tok-p">;</span> <span class="tok-o">++</span><span class="tok-nx">j</span><span class="tok-p">){</span>
@@ -2330,7 +2410,7 @@ JS has a map function as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2339,12 +2419,12 @@ reading the type <code>'a &#8594; 'b &#8594; 'c</code>, it can be in several cas
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-k">let</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span> <span class="tok-k">in</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">z</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-k">let</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span> <span class="tok-k">in</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">z</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2357,12 +2437,12 @@ different arities.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
   <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
     <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
   <span class="tok-p">}</span>
@@ -2384,7 +2464,7 @@ however, we expect <em>its arity to be 2</em>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">){</span>
   <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-p">;</span>
 <span class="tok-p">}</span></code></pre>
 </div>
@@ -2394,14 +2474,14 @@ however, we expect <em>its arity to be 2</em>.</p>
 guarantee a function of type <code>'a &#8594; 'b &#8594; 'c</code> will have arity 2.</strong></p>
 </div>
 <div class="sect3">
-<h4 id="__bs_for_explicit_uncurried_callback"><a class="anchor" href="#__bs_for_explicit_uncurried_callback"></a>[@bs] for explicit uncurried callback</h4>
+<h4 id="_bs_for_explicit_uncurried_callback"><a class="anchor" href="#_bs_for_explicit_uncurried_callback"></a><a class="link" href="#_bs_for_explicit_uncurried_callback">[@bs] for explicit uncurried callback</a></h4>
 <div class="paragraph">
 <p>To solve this problem introduced by OCaml&#8217;s curried calling convention,
 we support a special attribute <code>[@bs]</code> at the type level.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span>
 <span class="tok-o">=</span> <span class="tok-s2">&quot;map&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
@@ -2418,7 +2498,7 @@ unknown.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a1</span> <span class="tok-o">-&gt;</span> <span class="tok-o">..</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a1</span> <span class="tok-o">-&gt;</span> <span class="tok-o">..</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span>
   <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">a0</span> <span class="tok-n">a1</span> <span class="tok-o">..</span> <span class="tok-n">aN</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
 <span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">a0</span> <span class="tok-n">a1</span> <span class="tok-n">a2</span> <span class="tok-o">..</span> <span class="tok-n">aN</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
@@ -2428,7 +2508,7 @@ unknown.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
 <span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-bp">()</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
@@ -2443,7 +2523,7 @@ will complain.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span>
 <span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u0</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(1)</b>
 <span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u1</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(2)</b>
 <span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u2</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(3)</b></code></pre>
@@ -2465,7 +2545,7 @@ with arity 1</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="__bs_uncurry_for_implicit_uncurried_callback_since_1_5_0"><a class="anchor" href="#__bs_uncurry_for_implicit_uncurried_callback_since_1_5_0"></a>[@bs.uncurry] for implicit uncurried callback (@since 1.5.0)</h4>
+<h4 id="_bs_uncurry_for_implicit_uncurried_callback_since_1_5_0"><a class="anchor" href="#_bs_uncurry_for_implicit_uncurried_callback_since_1_5_0"></a><a class="link" href="#_bs_uncurry_for_implicit_uncurried_callback_since_1_5_0">[@bs.uncurry] for implicit uncurried callback (@since 1.5.0)</a></h4>
 <div class="paragraph">
 <p>Note the <code>[@bs]</code> annotation already solved the problem completely, but it has a drawback
 that it requires users to write <code>[@bs]</code> both in definition site and call site.</p>
@@ -2475,7 +2555,7 @@ that it requires users to write <code>[@bs]</code> both in definition site and c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span><span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span><span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span> <b class="conum">(1)</b>
 <span class="tok-n">map</span> <span class="tok-o">[|</span><span class="tok-mi">1</span><span class="tok-o">;</span><span class="tok-mi">2</span><span class="tok-o">;</span><span class="tok-mi">3</span><span class="tok-o">|]</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <b class="conum">(2)</b></code></pre>
 </div>
 </div>
@@ -2495,7 +2575,7 @@ only once.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">uncurry</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">uncurry</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span> <b class="conum">(1)</b>
 <span class="tok-n">map</span> <span class="tok-o">[|</span><span class="tok-mi">1</span><span class="tok-o">;</span><span class="tok-mi">2</span><span class="tok-o">;</span><span class="tok-mi">3</span><span class="tok-o">|]</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span><span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <b class="conum">(2)</b></code></pre>
 </div>
 </div>
@@ -2528,7 +2608,7 @@ only once.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_uncurried_calling_convention_as_an_optimization"><a class="anchor" href="#_uncurried_calling_convention_as_an_optimization"></a>Uncurried calling convention as an optimization</h4>
+<h4 id="_uncurried_calling_convention_as_an_optimization"><a class="anchor" href="#_uncurried_calling_convention_as_an_optimization"></a><a class="link" href="#_uncurried_calling_convention_as_an_optimization">Uncurried calling convention as an optimization</a></h4>
 <div class="paragraph">
 <div class="title">Background:</div>
 <p>As we discussed before, we can compile any OCaml function as arity 1
@@ -2541,7 +2621,7 @@ the native compilation is very slow and expensive for all functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span> <span class="tok-o">+</span> <span class="tok-n">z</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span> <span class="tok-o">+</span> <span class="tok-n">z</span>
 <span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-mi">3</span>
 <span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
 </div>
@@ -2551,7 +2631,7 @@ the native compilation is very slow and expensive for all functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
   <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
     <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">z</span><span class="tok-p">){</span>
       <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span>
@@ -2568,7 +2648,7 @@ already <em>saw the source definition</em> of <code>f</code>, it can be optimize
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span><span class="tok-p">}</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span><span class="tok-p">}</span>
 <span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">)</span>
 <span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">z</span><span class="tok-p">){</span><span class="tok-k">return</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)}</span></code></pre>
 </div>
@@ -2578,7 +2658,7 @@ already <em>saw the source definition</em> of <code>f</code>, it can be optimize
 to infer the arity as much as it can.</p>
 </div>
 <div class="sect4">
-<h5 id="_callback_optimization"><a class="anchor" href="#_callback_optimization"></a>Callback optimization</h5>
+<h5 id="_callback_optimization"><a class="anchor" href="#_callback_optimization"></a><a class="link" href="#_callback_optimization">Callback optimization</a></h5>
 <div class="paragraph">
 <p>However, such optimization will not work with <em>high-order</em> functions,
 i.e, callbacks.</p>
@@ -2588,7 +2668,7 @@ i.e, callbacks.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2598,7 +2678,7 @@ have to generate code as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
   <span class="tok-k">return</span> <span class="tok-nx">Curry</span><span class="tok-p">.</span><span class="tok-nx">_1</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">);</span>
 <span class="tok-p">}</span></code></pre>
 </div>
@@ -2613,7 +2693,7 @@ as below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2622,7 +2702,7 @@ as below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
   <span class="tok-k">return</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span>
 <span class="tok-p">}</span></code></pre>
 </div>
@@ -2647,14 +2727,14 @@ not need the <code>[@bs]</code> annotation.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_bindings_to_code_this_code_based_callbacks_bs_this"><a class="anchor" href="#_bindings_to_code_this_code_based_callbacks_bs_this"></a>Bindings to <code>this</code> based callbacks: bs.this</h4>
+<h4 id="_bindings_to_code_this_code_based_callbacks_bs_this"><a class="anchor" href="#_bindings_to_code_this_code_based_callbacks_bs_this"></a><a class="link" href="#_bindings_to_code_this_code_based_callbacks_bs_this">Bindings to <code>this</code> based callbacks: bs.this</a></h4>
 <div class="paragraph">
 <p>Many JS libraries have callbacks which rely on <code>this</code> (the source), for
 example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
   <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-k">this</span><span class="tok-p">.</span><span class="tok-nx">response</span> <span class="tok-o">+</span> <span class="tok-nx">v</span> <span class="tok-p">)</span>
 <span class="tok-p">}</span></code></pre>
 </div>
@@ -2668,7 +2748,7 @@ Instead, we introduced a special attribute
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">x</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">x</span>
 <span class="tok-k">external</span> <span class="tok-n">set_onload</span> <span class="tok-o">:</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;onload&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span>
 <span class="tok-k">external</span> <span class="tok-n">resp</span> <span class="tok-o">:</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;response&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span><span class="tok-o">]</span>
 <span class="tok-n">set_onload</span> <span class="tok-n">x</span> <span class="tok-k">begin</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">o</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span>
@@ -2679,7 +2759,7 @@ Instead, we introduced a special attribute
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
   <span class="tok-kd">var</span> <span class="tok-nx">o</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span> <b class="conum">(1)</b>
   <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">o</span><span class="tok-p">.</span><span class="tok-nx">response</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">);</span>
 <span class="tok-p">}</span></code></pre>
@@ -2698,7 +2778,7 @@ reserved for <code>this</code> and for arity of 0, there is no need for a redund
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
   <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-o">....</span>
 <span class="tok-k">let</span> <span class="tok-n">f1</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
   <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">obj</span> <span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-o">...</span></code></pre>
@@ -2727,7 +2807,7 @@ User can also type <code>x</code> as a JS class too (see later)</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_binding_to_js_objects"><a class="anchor" href="#_binding_to_js_objects"></a>Binding to JS objects</h3>
+<h3 id="_binding_to_js_objects"><a class="anchor" href="#_binding_to_js_objects"></a><a class="link" href="#_binding_to_js_objects">Binding to JS objects</a></h3>
 <div class="paragraph">
 <div class="title">Convention:</div>
 <p>All JS objects of type <code>'a</code> are lifted to type <code>'a Js.t</code> to avoid
@@ -2748,7 +2828,7 @@ share the same type system, all JS objects of type <code>'a</code> are typed as 
 (supporting inheritance) but more verbose.</p>
 </div>
 <div class="sect3">
-<h4 id="_simple_object_type"><a class="anchor" href="#_simple_object_type"></a>Simple object type</h4>
+<h4 id="_simple_object_type"><a class="anchor" href="#_simple_object_type"></a><a class="link" href="#_simple_object_type">Simple object type</a></h4>
 <div class="paragraph">
 <p>Suppose we have a JS file <code>demo.js</code>
 which exports two properties: <code>height</code> and <code>width</code>:</p>
@@ -2756,7 +2836,7 @@ which exports two properties: <code>height</code> and <code>width</code>:</p>
 <div class="listingblock">
 <div class="title">demo.js</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">height</span> <span class="tok-o">=</span> <span class="tok-mi">3</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">height</span> <span class="tok-o">=</span> <span class="tok-mi">3</span>
 <span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">width</span>  <span class="tok-o">=</span> <span class="tok-mi">3</span></code></pre>
 </div>
 </div>
@@ -2766,7 +2846,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">demo</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">demo</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2778,7 +2858,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 <p>normal type</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
 <span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
 <span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]&gt;</span>
 <span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]&gt;</span></code></pre>
@@ -2789,7 +2869,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 <p>method</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span></code></pre>
 </div>
 </div>
 </li>
@@ -2804,7 +2884,7 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
   <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-mi">1</span> <b class="conum">(1)</b>
 <span class="tok-k">let</span> <span class="tok-n">test2</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
   <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-k">in</span>
@@ -2826,7 +2906,7 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <b class="conum">(1)</b>
 <span class="tok-k">val</span> <span class="tok-n">test2</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">;</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
 <span class="tok-k">val</span> <span class="tok-n">test3</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span></code></pre>
 </div>
@@ -2840,13 +2920,13 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 </div>
 <div class="sect3">
-<h4 id="_complex_object_type"><a class="anchor" href="#_complex_object_type"></a>Complex object type</h4>
+<h4 id="_complex_object_type"><a class="anchor" href="#_complex_object_type"></a><a class="link" href="#_complex_object_type">Complex object type</a></h4>
 <div class="paragraph">
 <p>Below is an example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">class</span> <span class="tok-k">type</span> <span class="tok-o">_</span><span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-k">object</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">class</span> <span class="tok-k">type</span> <span class="tok-o">_</span><span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-k">object</span>
   <span class="tok-k">method</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
   <span class="tok-k">method</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
   <span class="tok-k">method</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
@@ -2873,18 +2953,18 @@ are treated as properties.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">wdith</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">wdith</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_how_to_consume_js_property_and_methods"><a class="anchor" href="#_how_to_consume_js_property_and_methods"></a>How to consume JS property and methods</h4>
+<h4 id="_how_to_consume_js_property_and_methods"><a class="anchor" href="#_how_to_consume_js_property_and_methods"></a><a class="link" href="#_how_to_consume_js_property_and_methods">How to consume JS property and methods</a></h4>
 <div class="paragraph">
 <p>As we said: <code>##</code> is used in both object method dispatch and field access.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span> <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span> <b class="conum">(1)</b>
 <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span> <span class="tok-o">#=</span> <span class="tok-n">v</span>
 <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">js_method</span> <span class="tok-n">args0</span> <span class="tok-n">args1</span> <span class="tok-n">args2</span> <b class="conum">(2)</b></code></pre>
 </div>
@@ -2912,7 +2992,7 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span>
 <span class="tok-kd">var</span> <span class="tok-nx">log</span> <span class="tok-o">=</span> <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">;</span>
 <span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span> <b class="conum">(1)</b></code></pre>
 </div>
@@ -2933,7 +3013,7 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-n">f0</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-k">in</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-n">f0</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-k">in</span>
 <span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">fn</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span>
 <span class="tok-c">(* f##field a b would think `field` as a method *)</span></code></pre>
 </div>
@@ -2943,7 +3023,7 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f1</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f1</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2951,7 +3031,7 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">f0</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">val</span> <span class="tok-n">f0</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
 <span class="tok-k">val</span> <span class="tok-n">f1</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
@@ -2960,7 +3040,7 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span> <span class="tok-s2">&quot;fine&quot;</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span> <span class="tok-s2">&quot;fine&quot;</span>
 <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span>
 <span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-n">u</span> <span class="tok-s2">&quot;fine&quot;</span> <b class="conum">(1)</b></code></pre>
 </div>
@@ -2989,7 +3069,7 @@ function instead, so it is still sound and type safe.</p>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_getter_setter_annotation_to_js_properties"><a class="anchor" href="#_getter_setter_annotation_to_js_properties"></a>getter/setter annotation to JS properties</h5>
+<h5 id="_getter_setter_annotation_to_js_properties"><a class="anchor" href="#_getter_setter_annotation_to_js_properties"></a><a class="link" href="#_getter_setter_annotation_to_js_properties">getter/setter annotation to JS properties</a></h5>
 <div class="paragraph">
 <p>Since OCaml&#8217;s object system does not have getters/setters, we introduced two
 attributes <code>bs.get</code> and <code>bs.set</code> to help inform BuckleScript to compile
@@ -2997,7 +3077,7 @@ them as property getters/setters.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
   <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span> <span class="tok-o">{</span><span class="tok-n">no_get</span><span class="tok-o">}]</span> <b class="conum">(1)</b>
 <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
 <span class="tok-k">type</span> <span class="tok-n">y0</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
@@ -3048,14 +3128,14 @@ Getter/Setter also applies to class type label
 </div>
 </div>
 <div class="sect3">
-<h4 id="_create_js_objects_using_bs_obj"><a class="anchor" href="#_create_js_objects_using_bs_obj"></a>Create JS objects using bs.obj</h4>
+<h4 id="_create_js_objects_using_bs_obj"><a class="anchor" href="#_create_js_objects_using_bs_obj"></a><a class="link" href="#_create_js_objects_using_bs_obj">Create JS objects using bs.obj</a></h4>
 <div class="paragraph">
 <p>Not only can we create bindings to JS objects, but also we can
 create JS objects in a type safe way on the OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">}}}</span> <span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">}}}</span> <span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3068,7 +3148,7 @@ create JS objects in a type safe way on the OCaml side:</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}}}}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}}}}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3076,7 +3156,7 @@ create JS objects in a type safe way on the OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3085,7 +3165,7 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3093,7 +3173,7 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">(</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}}}</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">(</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}}}</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3101,33 +3181,33 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">xs</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">;</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-kt">array</span> <span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">xs</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">;</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-kt">array</span> <span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-n">ys</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">;</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">4</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">xs</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">,</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">]</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">xs</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">,</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">]</span>
 <span class="tok-kd">var</span> <span class="tok-nx">ys</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">,</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">4</span> <span class="tok-p">}</span> <span class="tok-p">]</span></code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_create_js_objects_using_external"><a class="anchor" href="#_create_js_objects_using_external"></a>Create JS objects using external</h4>
+<h4 id="_create_js_objects_using_external"><a class="anchor" href="#_create_js_objects_using_external"></a><a class="link" href="#_create_js_objects_using_external">Create JS objects using external</a></h4>
 <div class="paragraph">
 <p><code>bs.obj</code> can also be used as an attribute in external declarations, as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">2</span> <span class="tok-o">~</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-mi">3</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">2</span> <span class="tok-p">,</span> <span class="tok-nx">lo</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">2</span> <span class="tok-p">,</span> <span class="tok-nx">lo</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3135,7 +3215,7 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-o">?</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-o">?</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span> <b class="conum">(1)</b>
 <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">3</span> <span class="tok-bp">()</span>
 <span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-mi">2</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">3</span> <span class="tok-bp">()</span></code></pre>
 </div>
@@ -3152,7 +3232,7 @@ are fulfilled (including optional arguments), it is common to have a <code>unit<
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span><span class="tok-p">}</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span><span class="tok-p">}</span>
 <span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">,</span> <span class="tok-nx">lo</span><span class="tok-o">:</span> <span class="tok-mi">2</span><span class="tok-p">}</span></code></pre>
 </div>
 </div>
@@ -3161,7 +3241,7 @@ are fulfilled (including optional arguments), it is common to have a <code>unit<
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span>
   <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">};</span>
   <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">u</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span> <span class="tok-n">u</span> <span class="tok-o">+</span> <span class="tok-n">v</span> <b class="conum">(1)</b>
   <span class="tok-o">}</span> <span class="tok-o">]</span>
@@ -3181,7 +3261,8 @@ We will show how to create JS method in OCaml later.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">},</span> <span class="tok-nx">fn</span> <span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">,</span> <span class="tok-nx">v</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">u</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">}}</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span>
+<span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">},</span> <span class="tok-nx">fn</span> <span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">,</span> <span class="tok-nx">v</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">u</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">}}</span>
 <span class="tok-kd">var</span> <span class="tok-nx">h</span> <span class="tok-o">=</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">y</span><span class="tok-p">.</span><span class="tok-nx">z</span>
 <span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">fn</span>
 <span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-nx">a</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
@@ -3200,12 +3281,12 @@ is available:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">h</span> <span class="tok-o">=</span> <span class="tok-n">h</span><span class="tok-o">#@</span><span class="tok-n">fn</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">h</span> <span class="tok-o">=</span> <span class="tok-n">h</span><span class="tok-o">#@</span><span class="tok-n">fn</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">b</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">h</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">b</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">h</span><span class="tok-p">){</span>
   <span class="tok-k">return</span> <span class="tok-nx">h</span><span class="tok-p">.</span><span class="tok-nx">fn</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span>
 <span class="tok-p">}</span></code></pre>
 </div>
@@ -3215,7 +3296,7 @@ is available:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-o">&lt;</span> <span class="tok-n">fn</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-o">&lt;</span> <span class="tok-n">fn</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span></code></pre>
 </div>
 </div>
 </td>
@@ -3224,14 +3305,14 @@ is available:</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_create_js_objects_with_code_this_code_semantics"><a class="anchor" href="#_create_js_objects_with_code_this_code_semantics"></a>Create JS objects with <code>this</code> semantics</h4>
+<h4 id="_create_js_objects_with_code_this_code_semantics"><a class="anchor" href="#_create_js_objects_with_code_this_code_semantics"></a><a class="link" href="#_create_js_objects_with_code_this_code_semantics">Create JS objects with <code>this</code> semantics</a></h4>
 <div class="paragraph">
 <p>The objects created above can not use <code>this</code> in the method, this is supported in
 BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">v2</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">v2</span> <span class="tok-o">=</span>
   <span class="tok-k">let</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">.</span> <span class="tok-k">in</span>
   <span class="tok-k">object</span> <span class="tok-o">(</span><span class="tok-n">self</span><span class="tok-o">)</span> <b class="conum">(1)</b>
     <span class="tok-k">method</span> <span class="tok-n">hi</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">self</span><span class="tok-o">##</span><span class="tok-n">say</span> <span class="tok-n">x</span> <span class="tok-o">+.</span> <span class="tok-n">y</span>
@@ -3253,7 +3334,7 @@ BuckleScript too.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v2</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">v2</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
   <span class="tok-nx">hi</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span> <span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
     <span class="tok-kd">var</span> <span class="tok-nx">self</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span>
     <span class="tok-k">return</span> <span class="tok-nx">self</span><span class="tok-p">.</span><span class="tok-nx">say</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
@@ -3273,7 +3354,7 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">v2</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">val</span> <span class="tok-n">v2</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span>
   <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span>
   <span class="tok-n">say</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span>
   <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span>
@@ -3285,7 +3366,7 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">(</span><span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-n">rect</span><span class="tok-o">)</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">(</span><span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-n">rect</span><span class="tok-o">)</span> <span class="tok-o">=</span>
   <span class="tok-c">(* the type annotation is un-necessary,</span>
 <span class="tok-c">     but it gives better error message</span>
 <span class="tok-c">  *)</span>
@@ -3299,7 +3380,7 @@ BuckleScript too.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">){</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">){</span>
   <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">height</span><span class="tok-p">);</span>
   <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">width</span><span class="tok-p">);</span>
   <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">width</span> <span class="tok-o">=</span> <span class="tok-mi">30</span><span class="tok-p">;</span>
@@ -3309,10 +3390,10 @@ BuckleScript too.</p>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_method_chaining"><a class="anchor" href="#_method_chaining"></a>Method chaining</h5>
+<h5 id="_method_chaining"><a class="anchor" href="#_method_chaining"></a><a class="link" href="#_method_chaining">Method chaining</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-n">f</span>
 <span class="tok-o">##(</span><span class="tok-n">meth0</span> <span class="tok-bp">()</span><span class="tok-o">)</span>
 <span class="tok-o">##(</span><span class="tok-n">meth1</span> <span class="tok-n">a</span><span class="tok-o">)</span>
 <span class="tok-o">##(</span><span class="tok-n">meth2</span> <span class="tok-n">a</span> <span class="tok-n">b</span><span class="tok-o">)</span></code></pre>
@@ -3321,7 +3402,7 @@ BuckleScript too.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_object_label_translation_convention"><a class="anchor" href="#_object_label_translation_convention"></a>Object label translation convention</h4>
+<h4 id="_object_label_translation_convention"><a class="anchor" href="#_object_label_translation_convention"></a><a class="link" href="#_object_label_translation_convention">Object label translation convention</a></h4>
 <div class="paragraph">
 <p>There are two cases, where we might want to do name mangling for a JS object method name.</p>
 </div>
@@ -3332,14 +3413,14 @@ error.</p>
 <div class="listingblock">
 <div class="title">Key-word method:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##_</span><span class="tok-n">open</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-n">f</span><span class="tok-o">##_</span><span class="tok-n">open</span>
 <span class="tok-n">f</span><span class="tok-o">##_</span><span class="tok-n">MAX_LENGTH</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">OUTPUT:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">open</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">open</span>
 <span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">MAX_LENGTH</span></code></pre>
 </div>
 </div>
@@ -3351,14 +3432,14 @@ object labels, which is <em>occasionally</em> useful as below</p>
 <div class="listingblock">
 <div class="title">Ad-hoc polymorphism</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">draw__cat</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">draw__cat</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
 <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">draw__dog</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">OUTPUT:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-c1">// f.draw in JS can accept different types</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-c1">// f.draw in JS can accept different types</span>
 <span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
@@ -3412,7 +3493,7 @@ drop the first '_'</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_return_value_checking_since_1_5_1"><a class="anchor" href="#_return_value_checking_since_1_5_1"></a>Return value checking (@since 1.5.1)</h3>
+<h3 id="_return_value_checking_since_1_5_1"><a class="anchor" href="#_return_value_checking_since_1_5_1"></a><a class="link" href="#_return_value_checking_since_1_5_1">Return value checking (@since 1.5.1)</a></h3>
 <div class="paragraph">
 <p>In general, the FFI code is error prone, and potentially will leak in
 <code>undefined</code> or <code>null</code> values.</p>
@@ -3435,7 +3516,7 @@ drop the first '_'</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">element</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">element</span>
 <span class="tok-k">type</span> <span class="tok-n">dom</span>
 <span class="tok-k">external</span> <span class="tok-n">getElementById</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">element</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
 <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span><span class="tok-n">dom</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">return</span> <span class="tok-n">null_to_opt</span><span class="tok-o">]</span> <b class="conum">(1)</b>
@@ -3457,7 +3538,7 @@ drop the first '_'</p>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test</span><span class="tok-p">(</span><span class="tok-nx">dom</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">test</span><span class="tok-p">(</span><span class="tok-nx">dom</span><span class="tok-p">)</span> <span class="tok-p">{</span>
   <span class="tok-kd">var</span> <span class="tok-nx">elem</span> <span class="tok-o">=</span> <span class="tok-nx">dom</span><span class="tok-p">.</span><span class="tok-nx">getElementById</span><span class="tok-p">(</span><span class="tok-s2">&quot;haha&quot;</span><span class="tok-p">);</span>
   <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">elem</span> <span class="tok-o">!==</span> <span class="tok-kc">null</span><span class="tok-p">)</span> <span class="tok-p">{</span> <b class="conum">(1)</b>
     <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">elem</span><span class="tok-p">);</span>
@@ -3519,7 +3600,7 @@ is rarely used, but introduced here for debugging purpose.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_embedding_untyped_javascript_code"><a class="anchor" href="#_embedding_untyped_javascript_code"></a>Embedding untyped Javascript code</h3>
+<h3 id="_embedding_untyped_javascript_code"><a class="anchor" href="#_embedding_untyped_javascript_code"></a><a class="link" href="#_embedding_untyped_javascript_code">Embedding untyped Javascript code</a></h3>
 <div class="admonitionblock warning">
 <table>
 <tr>
@@ -3538,14 +3619,14 @@ get the job done.</p>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_detect_global_variable_existence_code_bs_external_code_since_1_5_1"><a class="anchor" href="#_detect_global_variable_existence_code_bs_external_code_since_1_5_1"></a>Detect global variable existence <code>bs.external</code> (@since 1.5.1)</h4>
+<h4 id="_detect_global_variable_existence_code_bs_external_code_since_1_5_1"><a class="anchor" href="#_detect_global_variable_existence_code_bs_external_code_since_1_5_1"></a><a class="link" href="#_detect_global_variable_existence_code_bs_external_code_since_1_5_1">Detect global variable existence <code>bs.external</code> (@since 1.5.1)</a></h4>
 <div class="paragraph">
 <p>Before we dive into embedding arbitrary JS code, a quite common use case of embedding untyped JS code is detect a global variable (feature detection), Bucklescript provides a relatively type safe approach for such use case: <code>bs.external</code> (or <code>external</code>),
  <code>[%bs.external a_single_identifier]</code> is a value of <code>_ option</code> type, see examples below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
   <span class="tok-k">match</span> <span class="tok-o">[%</span><span class="tok-k">external</span> <span class="tok-o">__</span><span class="tok-n">DEV__</span><span class="tok-o">]</span> <span class="tok-k">with</span>
   <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;dev mode&quot;</span>
   <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;production mode&quot;</span></code></pre>
@@ -3554,7 +3635,7 @@ get the job done.</p>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test</span><span class="tok-p">()</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">test</span><span class="tok-p">()</span> <span class="tok-p">{</span>
   <span class="tok-kd">var</span> <span class="tok-nx">match</span> <span class="tok-o">=</span> <span class="tok-k">typeof</span> <span class="tok-p">(</span><span class="tok-nx">__DEV__</span><span class="tok-p">)</span> <span class="tok-o">===</span> <span class="tok-s2">&quot;undefined&quot;</span> <span class="tok-o">?</span> <span class="tok-kc">undefined</span> <span class="tok-o">:</span> <span class="tok-p">(</span><span class="tok-nx">__DEV__</span><span class="tok-p">);</span>
   <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">match</span> <span class="tok-o">!==</span> <span class="tok-kc">undefined</span><span class="tok-p">)</span> <span class="tok-p">{</span>
     <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;dev mode&quot;</span><span class="tok-p">);</span>
@@ -3569,7 +3650,7 @@ get the job done.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test2</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">test2</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
   <span class="tok-k">match</span> <span class="tok-o">[%</span><span class="tok-k">external</span> <span class="tok-o">__</span><span class="tok-n">filename</span><span class="tok-o">]</span> <span class="tok-k">with</span>
   <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-n">f</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">f</span>
   <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;non node environment&quot;</span></code></pre>
@@ -3578,7 +3659,7 @@ get the job done.</p>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test2</span><span class="tok-p">()</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">function</span> <span class="tok-nx">test2</span><span class="tok-p">()</span> <span class="tok-p">{</span>
   <span class="tok-kd">var</span> <span class="tok-nx">match</span> <span class="tok-o">=</span> <span class="tok-k">typeof</span> <span class="tok-p">(</span><span class="tok-nx">__filename</span><span class="tok-p">)</span> <span class="tok-o">===</span> <span class="tok-s2">&quot;undefined&quot;</span> <span class="tok-o">?</span> <span class="tok-kc">undefined</span> <span class="tok-o">:</span> <span class="tok-p">(</span><span class="tok-nx">__filename</span><span class="tok-p">);</span>
   <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">match</span> <span class="tok-o">!==</span> <span class="tok-kc">undefined</span><span class="tok-p">)</span> <span class="tok-p">{</span>
     <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">match</span><span class="tok-p">);</span>
@@ -3593,10 +3674,10 @@ get the job done.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedding_arbitrary_js_code_as_an_expression"><a class="anchor" href="#_embedding_arbitrary_js_code_as_an_expression"></a>Embedding arbitrary JS code as an expression</h4>
+<h4 id="_embedding_arbitrary_js_code_as_an_expression"><a class="anchor" href="#_embedding_arbitrary_js_code_as_an_expression"></a><a class="link" href="#_embedding_arbitrary_js_code_as_an_expression">Embedding arbitrary JS code as an expression</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">keys</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span> <span class="tok-s2">&quot;Object.keys&quot;</span> <span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">keys</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span> <span class="tok-s2">&quot;Object.keys&quot;</span> <span class="tok-o">]</span>
 <span class="tok-k">let</span> <span class="tok-n">unsafe_lt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">boolean</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-k">function</span><span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">){</span><span class="tok-n">return</span> <span class="tok-n">x</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span><span class="tok-o">}|}]</span></code></pre>
 </div>
 </div>
@@ -3607,10 +3688,10 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedding_raw_js_code_as_statements"><a class="anchor" href="#_embedding_raw_js_code_as_statements"></a>Embedding raw JS code as statements</h4>
+<h4 id="_embedding_raw_js_code_as_statements"><a class="anchor" href="#_embedding_raw_js_code_as_statements"></a><a class="link" href="#_embedding_raw_js_code_as_statements">Embedding raw JS code as statements</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">[</span><span class="tok-o">%%</span><span class="tok-nx">bs</span><span class="tok-p">.</span><span class="tok-nx">raw</span><span class="tok-p">{</span><span class="tok-o">|</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">[</span><span class="tok-o">%%</span><span class="tok-nx">bs</span><span class="tok-p">.</span><span class="tok-nx">raw</span><span class="tok-p">{</span><span class="tok-o">|</span>
   <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span> <span class="tok-p">(</span><span class="tok-s2">&quot;hey&quot;</span><span class="tok-p">);</span>
 <span class="tok-o">|</span><span class="tok-p">}]</span></code></pre>
 </div>
@@ -3620,7 +3701,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-s2">&quot;</span><span class="tok-se">\x01\x02</span><span class="tok-s2">&quot;</span><span class="tok-o">|}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-s2">&quot;</span><span class="tok-se">\x01\x02</span><span class="tok-s2">&quot;</span><span class="tok-o">|}]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3628,7 +3709,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">x</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;\x01\x02&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">x</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;\x01\x02&quot;</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3636,7 +3717,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">   <span class="tok-o">[%%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span>   <span class="tok-o">[%%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span>
    <span class="tok-o">//</span> <span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span> <span class="tok-n">polyfill</span>
    <span class="tok-k">if</span> <span class="tok-o">(!</span><span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span><span class="tok-o">){</span>
        <span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">(..)</span> <span class="tok-o">{..}</span>
@@ -3670,13 +3751,13 @@ that the order is correct.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_debugger_support"><a class="anchor" href="#_debugger_support"></a>Debugger support</h3>
+<h3 id="_debugger_support"><a class="anchor" href="#_debugger_support"></a><a class="link" href="#_debugger_support">Debugger support</a></h3>
 <div class="paragraph">
 <p>We introduced the extension <code>bs.debugger</code>, for example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">  <span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span>  <span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span>
     <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">debugger</span><span class="tok-o">];</span>
     <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
 </div>
@@ -3686,7 +3767,8 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">  <span class="tok-kd">function</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span>
+  <span class="tok-kd">function</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
      <span class="tok-kr">debugger</span><span class="tok-p">;</span> <span class="tok-c1">// JavaScript developer tools will set an breakpoint and stop here</span>
      <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
   <span class="tok-p">}</span></code></pre>
@@ -3694,13 +3776,13 @@ that the order is correct.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_regex_support"><a class="anchor" href="#_regex_support"></a>Regex support</h3>
+<h3 id="_regex_support"><a class="anchor" href="#_regex_support"></a><a class="link" href="#_regex_support">Regex support</a></h3>
 <div class="paragraph">
 <p>We introduced <code>bs.re</code> for Javascript regex expressions:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">re</span> <span class="tok-s2">&quot;/b/g&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">re</span> <span class="tok-s2">&quot;/b/g&quot;</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3726,21 +3808,21 @@ below:</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_examples_2"><a class="anchor" href="#_examples_2"></a>Examples</h3>
+<h3 id="_examples_2"><a class="anchor" href="#_examples_2"></a><a class="link" href="#_examples_2">Examples</a></h3>
 <div class="paragraph">
 <p>Below is a simple example for the <a href="https://mochajs.org/">mocha</a> library. For
 more examples, please visit
 <a href="https://github.com/bucklescript/bucklescript-addons" class="bare">https://github.com/bucklescript/bucklescript-addons</a></p>
 </div>
 <div class="sect3">
-<h4 id="_a_simple_example_binding_to_mocha_unit_test_library"><a class="anchor" href="#_a_simple_example_binding_to_mocha_unit_test_library"></a>A simple example: binding to mocha unit test library</h4>
+<h4 id="_a_simple_example_binding_to_mocha_unit_test_library"><a class="anchor" href="#_a_simple_example_binding_to_mocha_unit_test_library"></a><a class="link" href="#_a_simple_example_binding_to_mocha_unit_test_library">A simple example: binding to mocha unit test library</a></h4>
 <div class="paragraph">
 <p>This is an example showing how to provide bindings to the
 <a href="https://mochajs.org/">mochajs</a> unit test framework.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">describe</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">describe</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 <span class="tok-k">external</span> <span class="tok-n">it</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
@@ -3751,7 +3833,7 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">eq</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;deepEqual&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;assert&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">eq</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;deepEqual&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;assert&quot;</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3759,7 +3841,7 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">assert_equal</span> <span class="tok-o">=</span> <span class="tok-n">eq</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">assert_equal</span> <span class="tok-o">=</span> <span class="tok-n">eq</span>
 <span class="tok-k">let</span> <span class="tok-n">from_suites</span> <span class="tok-n">name</span> <span class="tok-n">suite</span> <span class="tok-o">=</span>
     <span class="tok-n">describe</span> <span class="tok-n">name</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span>
          <span class="tok-nn">List</span><span class="tok-p">.</span><span class="tok-n">iter</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">(</span><span class="tok-n">name</span><span class="tok-o">,</span> <span class="tok-n">code</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-n">it</span> <span class="tok-n">name</span> <span class="tok-n">code</span><span class="tok-o">)</span> <span class="tok-n">suite</span>
@@ -3771,7 +3853,7 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"> <span class="tok-kd">var</span> <span class="tok-nx">Assert</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;assert&quot;</span><span class="tok-p">);</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span> <span class="tok-kd">var</span> <span class="tok-nx">Assert</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;assert&quot;</span><span class="tok-p">);</span>
  <span class="tok-kd">var</span> <span class="tok-nx">List</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;bs-platform/lib/js/list&quot;</span><span class="tok-p">);</span>
 
 <span class="tok-kd">function</span> <span class="tok-nx">assert_equal</span><span class="tok-p">(</span><span class="tok-nx">prim</span><span class="tok-p">,</span> <span class="tok-nx">prim$1</span><span class="tok-p">)</span> <span class="tok-p">{</span>
@@ -3792,19 +3874,19 @@ more examples, please visit
 </div>
 </div>
 <div class="sect1">
-<h2 id="_exception_handling_between_ocaml_and_js_since_1_7_0"><a class="anchor" href="#_exception_handling_between_ocaml_and_js_since_1_7_0"></a>Exception handling between OCaml and JS (@since 1.7.0)</h2>
+<h2 id="_exception_handling_between_ocaml_and_js_since_1_7_0"><a class="anchor" href="#_exception_handling_between_ocaml_and_js_since_1_7_0"></a><a class="link" href="#_exception_handling_between_ocaml_and_js_since_1_7_0">Exception handling between OCaml and JS (@since 1.7.0)</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>In Js world, exception could be any data, while OCaml exception is structured data format and supports pattern match, catch OCaml exception on JS side is no-op.</p>
 </div>
 <div class="sect2">
-<h3 id="_catch_js_exception"><a class="anchor" href="#_catch_js_exception"></a>Catch JS exception</h3>
+<h3 id="_catch_js_exception"><a class="anchor" href="#_catch_js_exception"></a><a class="link" href="#_catch_js_exception">Catch JS exception</a></h3>
 <div class="paragraph">
 <p>To catch Js exception on OCaml side, we categorize all JS exceptions to belong to <code>Js.Exn.Error</code>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">example1</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">example1</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
     <span class="tok-k">match</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Json</span><span class="tok-p">.</span><span class="tok-n">exnParse</span> <span class="tok-o">{|</span> <span class="tok-o">{</span><span class="tok-s2">&quot;x&quot;</span> <span class="tok-o">}|}</span> <span class="tok-k">with</span>
     <span class="tok-o">|</span> <span class="tok-k">exception</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Exn</span><span class="tok-p">.</span><span class="tok-nc">Error</span> <span class="tok-n">err</span> <span class="tok-o">-&gt;</span>
         <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">@@</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Exn</span><span class="tok-p">.</span><span class="tok-n">stack</span> <span class="tok-n">err</span><span class="tok-o">;</span>
@@ -3821,7 +3903,7 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
   <span class="tok-o">&lt;</span> <span class="tok-n">stack</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">;</span>
     <span class="tok-n">message</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">;</span>
     <span class="tok-n">name</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span><span class="tok-o">;</span>
@@ -3833,13 +3915,13 @@ more examples, please visit
 </div>
 </div>
 <div class="sect2">
-<h3 id="_raise_js_style_exception"><a class="anchor" href="#_raise_js_style_exception"></a>Raise JS style exception</h3>
+<h3 id="_raise_js_style_exception"><a class="anchor" href="#_raise_js_style_exception"></a><a class="link" href="#_raise_js_style_exception">Raise JS style exception</a></h3>
 <div class="paragraph">
 <p>We provide such functions</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-c">(** Raise Js exception Error object with stacktrace *)</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-c">(** Raise Js exception Error object with stacktrace *)</span>
 <span class="tok-k">val</span> <span class="tok-n">error</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
 <span class="tok-k">val</span> <span class="tok-n">evalError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
 <span class="tok-k">val</span> <span class="tok-n">rangeError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
@@ -3856,7 +3938,7 @@ more examples, please visit
 </div>
 </div>
 <div class="sect1">
-<h2 id="__code_bs_open_code_type_safe_external_data_source_handling_since_1_7_0"><a class="anchor" href="#__code_bs_open_code_type_safe_external_data_source_handling_since_1_7_0"></a><code>bs.open</code>: Type safe external data-source handling (@@since 1.7.0)</h2>
+<h2 id="_code_bs_open_code_type_safe_external_data_source_handling_since_1_7_0"><a class="anchor" href="#_code_bs_open_code_type_safe_external_data_source_handling_since_1_7_0"></a><a class="link" href="#_code_bs_open_code_type_safe_external_data_source_handling_since_1_7_0"><code>bs.open</code>: Type safe external data-source handling (@@since 1.7.0)</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>There are some cases, the data-source could either come from JS land or OCaml land, it is very hard to give precise type information.
@@ -3872,7 +3954,7 @@ it preserves the type safety while allow users to deal with mixed source.</p>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">handleData</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">open</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">handleData</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">open</span><span class="tok-o">]</span>
    <span class="tok-o">|</span> <span class="tok-nc">Invalid_argument</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">0</span>
    <span class="tok-o">|</span> <span class="tok-nc">Not_found</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">1</span>
    <span class="tok-o">|</span> <span class="tok-nc">Sys_error</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">2</span>
@@ -3888,13 +3970,13 @@ it preserves the type safety while allow users to deal with mixed source.</p>
 </ol>
 </div>
 <div class="sect2">
-<h3 id="_use_cases"><a class="anchor" href="#_use_cases"></a>Use cases</h3>
+<h3 id="_use_cases"><a class="anchor" href="#_use_cases"></a><a class="link" href="#_use_cases">Use cases</a></h3>
 <div class="paragraph">
 <p>Take promise for example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">reject</span> <span class="tok-nc">Not_found</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">reject</span> <span class="tok-nc">Not_found</span>
 <span class="tok-k">let</span> <span class="tok-n">handlePromiseFaiure</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">open</span><span class="tok-o">]</span>
    <span class="tok-o">|</span> <span class="tok-nc">Not_found</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;Not found&quot;</span><span class="tok-o">;</span> <span class="tok-o">(</span><span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">resolve</span> <span class="tok-bp">()</span><span class="tok-o">)</span>
 
@@ -3911,7 +3993,7 @@ it preserves the type safety while allow users to deal with mixed source.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_js_module"><a class="anchor" href="#_js_module"></a>Js module</h2>
+<h2 id="_js_module"><a class="anchor" href="#_js_module"></a><a class="link" href="#_js_module">Js module</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p><a href="https://bucklescript.github.io/bucklescript/api/Js.html">API reference</a></p>
@@ -3920,7 +4002,7 @@ it preserves the type safety while allow users to deal with mixed source.</p>
 <p>Js module is shipped with BuckleScript, both the namespace <code>Js</code> and <code>Node</code> are preserved.</p>
 </div>
 <div class="sect2">
-<h3 id="_null_and_undefined"><a class="anchor" href="#_null_and_undefined"></a>Null and Undefined</h3>
+<h3 id="_null_and_undefined"><a class="anchor" href="#_null_and_undefined"></a><a class="link" href="#_null_and_undefined">Null and Undefined</a></h3>
 <div class="paragraph">
 <p>BuckleScript does not deal with <code>null</code> and <code>undefined</code> on the language level.
 Instead they are defined on the library level, represented by <code>Js.Null.empty</code>
@@ -3937,7 +4019,7 @@ want to use them with. For this purpose BuckleScript defines the type <code>'a J
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">get_prop_name_maybe</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">get_prop_name_maybe</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 <span class="tok-k">external</span> <span class="tok-n">set_or_unset_prop</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 
 <span class="tok-c">(* unset property if fond *)</span>
@@ -3955,7 +4037,7 @@ to maintain:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">try_some_thing</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-o">...</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">external</span> <span class="tok-n">try_some_thing</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-o">...</span>
 
 <span class="tok-k">let</span> <span class="tok-n">try_some_thing_maybe</span> <span class="tok-o">(</span> <span class="tok-n">v</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span><span class="tok-o">)</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-n">option</span> <span class="tok-o">=</span>
   <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">to_opt</span> <span class="tok-o">(</span><span class="tok-n">try_some_thing</span> <span class="tok-o">(</span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">from_opt</span> <span class="tok-n">v</span><span class="tok-o">))</span></code></pre>
@@ -3963,7 +4045,7 @@ to maintain:</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_boolean"><a class="anchor" href="#_boolean"></a>Boolean</h3>
+<h3 id="_boolean"><a class="anchor" href="#_boolean"></a><a class="link" href="#_boolean">Boolean</a></h3>
 <div class="paragraph">
 <p>"Native" <code>bool</code> is for Bob-ish reasons not represented as <code>true</code> and <code>false</code>
 literals in JavaScript. For interop you therefore need to use the <code>Js.boolean</code>
@@ -3972,7 +4054,7 @@ for coercing to and from <code>bool</code>: <code>Js.to_bool</code> and <code>Js
 </div>
 </div>
 <div class="sect2">
-<h3 id="_stable_ish_submodules"><a class="anchor" href="#_stable_ish_submodules"></a>Stable-ish submodules</h3>
+<h3 id="_stable_ish_submodules"><a class="anchor" href="#_stable_ish_submodules"></a><a class="link" href="#_stable_ish_submodules">Stable-ish submodules</a></h3>
 <div class="paragraph">
 <p><em>These APIs might change, but is considered mostly complete</em></p>
 </div>
@@ -4009,7 +4091,7 @@ for coercing to and from <code>bool</code>: <code>Js.to_bool</code> and <code>Js
 </div>
 </div>
 <div class="sect2">
-<h3 id="_experimental_incomplete_submodules"><a class="anchor" href="#_experimental_incomplete_submodules"></a>Experimental/incomplete submodules</h3>
+<h3 id="_experimental_incomplete_submodules"><a class="anchor" href="#_experimental_incomplete_submodules"></a><a class="link" href="#_experimental_incomplete_submodules">Experimental/incomplete submodules</a></h3>
 <div class="paragraph">
 <p><em>Expect these APIs to change drastically, <strong>use only if you accept breakage.</strong></em></p>
 </div>
@@ -4028,7 +4110,7 @@ for coercing to and from <code>bool</code>: <code>Js.to_bool</code> and <code>Js
 </div>
 </div>
 <div class="sect2">
-<h3 id="_very_experimental_internal_submodules"><a class="anchor" href="#_very_experimental_internal_submodules"></a>Very experimental/internal submodules</h3>
+<h3 id="_very_experimental_internal_submodules"><a class="anchor" href="#_very_experimental_internal_submodules"></a><a class="link" href="#_very_experimental_internal_submodules">Very experimental/internal submodules</a></h3>
 <div class="paragraph">
 <p><strong><em>Do not use these APIs unless absolutely necessary, they&#8217;re mostly internal</em></strong></p>
 </div>
@@ -4064,13 +4146,13 @@ for coercing to and from <code>bool</code>: <code>Js.to_bool</code> and <code>Js
 </div>
 </div>
 <div class="sect1">
-<h2 id="_node_module"><a class="anchor" href="#_node_module"></a>Node module</h2>
+<h2 id="_node_module"><a class="anchor" href="#_node_module"></a><a class="link" href="#_node_module">Node module</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p><a href="https://bucklescript.github.io/bucklescript/api/Node.html">Node</a></p>
 </div>
 <div class="sect2">
-<h3 id="_submodules"><a class="anchor" href="#_submodules"></a>Submodules</h3>
+<h3 id="_submodules"><a class="anchor" href="#_submodules"></a><a class="link" href="#_submodules">Submodules</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -4097,7 +4179,7 @@ for coercing to and from <code>bool</code>: <code>Js.to_bool</code> and <code>Js
 </div>
 </div>
 <div class="sect1">
-<h2 id="_extended_compiler_options"><a class="anchor" href="#_extended_compiler_options"></a>Extended compiler options</h2>
+<h2 id="_extended_compiler_options"><a class="anchor" href="#_extended_compiler_options"></a><a class="link" href="#_extended_compiler_options">Extended compiler options</a></h2>
 <div class="sectionbody">
 <div class="exampleblock">
 <div class="content">
@@ -4114,10 +4196,10 @@ It also adds some tips for people who debug the compiler.</p>
 also adds several flags:</p>
 </div>
 <div class="sect2">
-<h3 id="__bs_main_single_directory_build"><a class="anchor" href="#__bs_main_single_directory_build"></a>-bs-main (single directory build)</h3>
+<h3 id="_bs_main_single_directory_build"><a class="anchor" href="#_bs_main_single_directory_build"></a><a class="link" href="#_bs_main_single_directory_build">-bs-main (single directory build)</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -bs-main Main</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsc.exe -bs-main Main</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4126,7 +4208,7 @@ finishes, it will run <code>node main.js</code>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -c -bs-main Main</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsc.exe -c -bs-main Main</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4134,13 +4216,13 @@ finishes, it will run <code>node main.js</code>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="__bs_files"><a class="anchor" href="#__bs_files"></a>-bs-files</h3>
+<h3 id="_bs_files"><a class="anchor" href="#_bs_files"></a><a class="link" href="#_bs_files">-bs-files</a></h3>
 <div class="paragraph">
 <p>So that you can do</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -c -bs-files *.ml *.mli</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsc.exe -c -bs-files *.ml *.mli</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4154,14 +4236,14 @@ mode. In package mode, you have to provide <code>package.json</code> on top and 
 </div>
 </div>
 <div class="sect2">
-<h3 id="__bs_package_name"><a class="anchor" href="#__bs_package_name"></a>-bs-package-name</h3>
+<h3 id="_bs_package_name"><a class="anchor" href="#_bs_package_name"></a><a class="link" href="#_bs_package_name">-bs-package-name</a></h3>
 <div class="paragraph">
 <p>The project name of your project. The user is suggested to make it
 consistent with the <code>name</code> field in <code>package.json</code></p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="__bs_packge_output"><a class="anchor" href="#__bs_packge_output"></a>-bs-packge-output</h3>
+<h3 id="_bs_packge_output"><a class="anchor" href="#_bs_packge_output"></a><a class="link" href="#_bs_packge_output">-bs-packge-output</a></h3>
 <div class="paragraph">
 <p>The format is <code>module_system:oupt/path/relative/to/package.json</code>
 Currently supported module systesms are: <code>commonjs</code>, <code>amdjs</code> and
@@ -4173,7 +4255,7 @@ things like this:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="bash">bsc.exe -bs-package-name your_package -bs-package-output goog:lib/goog -c xx.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="bash"><span></span>bsc.exe -bs-package-name your_package -bs-package-output goog:lib/goog -c xx.ml</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -4193,7 +4275,7 @@ The user can supply multiple <code>-bs-package-output</code> at the same time.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="bash">bsc.exe -bs-package-name name -bs-package-output commonjs:lib/js -bs-package-output goog:lib/goog -bs-package-output amdjs:lib/amdjs -c x.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="bash"><span></span>bsc.exe -bs-package-name name -bs-package-output commonjs:lib/js -bs-package-output goog:lib/goog -bs-package-output amdjs:lib/amdjs -c x.ml</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4206,7 +4288,7 @@ The user can supply multiple <code>-bs-package-output</code> at the same time.
 </div>
 </div>
 <div class="sect2">
-<h3 id="__bs_gen_tds"><a class="anchor" href="#__bs_gen_tds"></a>-bs-gen-tds</h3>
+<h3 id="_bs_gen_tds"><a class="anchor" href="#_bs_gen_tds"></a><a class="link" href="#_bs_gen_tds">-bs-gen-tds</a></h3>
 <div class="paragraph">
 <p>Trigger the generation of TypeScript <code>.d.ts</code> files.
 <code>bsc.exe</code> has the ability to also emit <code>.d.ts</code> for better interaction with
@@ -4217,22 +4299,22 @@ TypeScript. This is still experimental.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="__bs_no_warn_ffi_type"><a class="anchor" href="#__bs_no_warn_ffi_type"></a>-bs-no-warn-ffi-type</h3>
+<h3 id="_bs_no_warn_ffi_type"><a class="anchor" href="#_bs_no_warn_ffi_type"></a><a class="link" href="#_bs_no_warn_ffi_type">-bs-no-warn-ffi-type</a></h3>
 <div class="paragraph">
 <p>Turn off warnings on FFI type declarations.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="__bs_eval"><a class="anchor" href="#__bs_eval"></a>-bs-eval</h3>
+<h3 id="_bs_eval"><a class="anchor" href="#_bs_eval"></a><a class="link" href="#_bs_eval">-bs-eval</a></h3>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -dparsetree -drawlambda -bs-eval <span class="tok-s1">&#39;Js.log &quot;hello&quot;&#39;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsc.exe -dparsetree -drawlambda -bs-eval <span class="tok-s1">&#39;Js.log &quot;hello&quot;&#39;</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">[</span> <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-o">[</span> <b class="conum">(1)</b>
   <span class="tok-n">structure_item</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">14</span><span class="tok-o">])</span>
     <span class="tok-nc">Pstr_eval</span>
     <span class="tok-n">expression</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">14</span><span class="tok-o">])</span>
@@ -4272,19 +4354,19 @@ learning or troubleshooting.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="__bs_no_builtin_ppx_ml_bs_no_builtin_ppx_mli"><a class="anchor" href="#__bs_no_builtin_ppx_ml_bs_no_builtin_ppx_mli"></a>-bs-no-builtin-ppx-ml, -bs-no-builtin-ppx-mli</h3>
+<h3 id="_bs_no_builtin_ppx_ml_bs_no_builtin_ppx_mli"><a class="anchor" href="#_bs_no_builtin_ppx_ml_bs_no_builtin_ppx_mli"></a><a class="link" href="#_bs_no_builtin_ppx_ml_bs_no_builtin_ppx_mli">-bs-no-builtin-ppx-ml, -bs-no-builtin-ppx-mli</a></h3>
 <div class="paragraph">
 <p>If the user doesn&#8217;t use any bs specific annotations, the user can explicitly turn it off.
 Another use case is that users can use <code>-ppx</code> explicitly as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">bsc</span><span class="tok-o">.</span><span class="tok-n">exe</span> <span class="tok-o">-</span><span class="tok-n">c</span> <span class="tok-o">-</span><span class="tok-n">ppx</span> <span class="tok-n">bsppx</span><span class="tok-o">.</span><span class="tok-n">exe</span> <span class="tok-o">-</span><span class="tok-n">bs</span><span class="tok-o">-</span><span class="tok-n">no</span><span class="tok-o">-</span><span class="tok-n">builtin</span><span class="tok-o">-</span><span class="tok-n">ppx</span><span class="tok-o">-</span><span class="tok-n">ml</span> <span class="tok-n">c</span><span class="tok-o">.</span><span class="tok-n">ml</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-n">bsc</span><span class="tok-o">.</span><span class="tok-n">exe</span> <span class="tok-o">-</span><span class="tok-n">c</span> <span class="tok-o">-</span><span class="tok-n">ppx</span> <span class="tok-n">bsppx</span><span class="tok-o">.</span><span class="tok-n">exe</span> <span class="tok-o">-</span><span class="tok-n">bs</span><span class="tok-o">-</span><span class="tok-n">no</span><span class="tok-o">-</span><span class="tok-n">builtin</span><span class="tok-o">-</span><span class="tok-n">ppx</span><span class="tok-o">-</span><span class="tok-n">ml</span> <span class="tok-n">c</span><span class="tok-o">.</span><span class="tok-n">ml</span></code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="__bs_no_version_header"><a class="anchor" href="#__bs_no_version_header"></a>-bs-no-version-header</h3>
+<h3 id="_bs_no_version_header"><a class="anchor" href="#_bs_no_version_header"></a><a class="link" href="#_bs_no_version_header">-bs-no-version-header</a></h3>
 <div class="paragraph">
 <p>Don&#8217;t print version header.</p>
 </div>
@@ -4292,14 +4374,14 @@ Another use case is that users can use <code>-ppx</code> explicitly as below:</p
 </div>
 </div>
 <div class="sect1">
-<h2 id="_semantic_differences_from_other_backends"><a class="anchor" href="#_semantic_differences_from_other_backends"></a>Semantic differences from other backends</h2>
+<h2 id="_semantic_differences_from_other_backends"><a class="anchor" href="#_semantic_differences_from_other_backends"></a><a class="link" href="#_semantic_differences_from_other_backends">Semantic differences from other backends</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>This is particularly important when porting an existing OCaml
 application to JavaScript.</p>
 </div>
 <div class="sect2">
-<h3 id="_custom_data_type"><a class="anchor" href="#_custom_data_type"></a>Custom data type</h3>
+<h3 id="_custom_data_type"><a class="anchor" href="#_custom_data_type"></a><a class="link" href="#_custom_data_type">Custom data type</a></h3>
 <div class="paragraph">
 <p>In OCaml, the C FFI allows the user to define a custom data type and
 customize <code>caml_compare</code>, <code>caml_hash</code> behavior, etc. This is not
@@ -4307,7 +4389,7 @@ available in our backend (since we have no C FFI).</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_physical_in_equality"><a class="anchor" href="#_physical_in_equality"></a>Physical (in)equality</h3>
+<h3 id="_physical_in_equality"><a class="anchor" href="#_physical_in_equality"></a><a class="link" href="#_physical_in_equality">Physical (in)equality</a></h3>
 <div class="paragraph">
 <p>In general, users should only use physical equality as an optimization
 technique, but not rely on its correctness, since it is tightly coupled
@@ -4315,7 +4397,7 @@ with the runtime.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_string_char_range"><a class="anchor" href="#_string_char_range"></a>String char range</h3>
+<h3 id="_string_char_range"><a class="anchor" href="#_string_char_range"></a><a class="link" href="#_string_char_range">String char range</a></h3>
 <div class="paragraph">
 <p>Currently, BuckleScript assumes that the char range is <code>0-255</code>. The user
 should be careful when they pass a JavaScript string to the OCaml side. Note
@@ -4323,14 +4405,14 @@ that we are working on a solution for this problem.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_weak_map"><a class="anchor" href="#_weak_map"></a>Weak map</h3>
+<h3 id="_weak_map"><a class="anchor" href="#_weak_map"></a><a class="link" href="#_weak_map">Weak map</a></h3>
 <div class="paragraph">
 <p>OCaml&#8217;s weak map is not available in BuckleScript. The weak pointer is
 replaced by a strict pointer.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_integers"><a class="anchor" href="#_integers"></a>Integers</h3>
+<h3 id="_integers"><a class="anchor" href="#_integers"></a><a class="link" href="#_integers">Integers</a></h3>
 <div class="paragraph">
 <p>OCaml has <code>int</code>, <code>int32</code>, <code>nativeint</code> and <code>int64</code> types.
 - Both <code>int32</code> and <code>int64</code> in BuckleScript have the exact same semantics as OCaml.
@@ -4357,7 +4439,7 @@ replaced by a strict pointer.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_printf_printf"><a class="anchor" href="#_printf_printf"></a>Printf.printf</h3>
+<h3 id="_printf_printf"><a class="anchor" href="#_printf_printf"></a><a class="link" href="#_printf_printf">Printf.printf</a></h3>
 <div class="paragraph">
 <p>The <code>Printf.print</code> implementation in BuckleScript requires a newline
 (<code>\n</code>) to trigger the printing. This behavior is not consistent with the
@@ -4367,27 +4449,27 @@ will never be printed.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_obj_module"><a class="anchor" href="#_obj_module"></a>Obj module</h3>
+<h3 id="_obj_module"><a class="anchor" href="#_obj_module"></a><a class="link" href="#_obj_module">Obj module</a></h3>
 <div class="paragraph">
 <p>We do our best to mimic the native compiler, but we have no guarantee
 and there are differences.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_hashtbl_hash_algorithm"><a class="anchor" href="#_hashtbl_hash_algorithm"></a>Hashtbl hash algorithm</h3>
+<h3 id="_hashtbl_hash_algorithm"><a class="anchor" href="#_hashtbl_hash_algorithm"></a><a class="link" href="#_hashtbl_hash_algorithm">Hashtbl hash algorithm</a></h3>
 <div class="paragraph">
 <p>BuckleScript uses the same algorithm as native OCaml but the output is
 different due to the runtime representation of int/int64/int32 and float.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_marshall"><a class="anchor" href="#_marshall"></a>Marshall</h3>
+<h3 id="_marshall"><a class="anchor" href="#_marshall"></a><a class="link" href="#_marshall">Marshall</a></h3>
 <div class="paragraph">
 <p>Marshall module is not supported yet.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_sys_argv_sys_max_array_length_sys_max_string_length"><a class="anchor" href="#_sys_argv_sys_max_array_length_sys_max_string_length"></a>Sys.argv, Sys.max_array_length, Sys.max_string_length</h3>
+<h3 id="_sys_argv_sys_max_array_length_sys_max_string_length"><a class="anchor" href="#_sys_argv_sys_max_array_length_sys_max_string_length"></a><a class="link" href="#_sys_argv_sys_max_array_length_sys_max_string_length">Sys.argv, Sys.max_array_length, Sys.max_string_length</a></h3>
 <div class="paragraph">
 <p>Command line arguments are always empty.
 This might be fixed in the near future.
@@ -4396,7 +4478,7 @@ This might be fixed in the near future.
 </div>
 </div>
 <div class="sect2">
-<h3 id="_unsupported_io_primitives"><a class="anchor" href="#_unsupported_io_primitives"></a>Unsupported IO primitives</h3>
+<h3 id="_unsupported_io_primitives"><a class="anchor" href="#_unsupported_io_primitives"></a><a class="link" href="#_unsupported_io_primitives">Unsupported IO primitives</a></h3>
 <div class="paragraph">
 <p>Because of the JavaScript environment limitation, <code>Pervasives.stdin</code> is
 not supported but both <code>Pervasives.stdout</code> and <code>Pervasives.stderr</code> are.</p>
@@ -4405,7 +4487,7 @@ not supported but both <code>Pervasives.stdout</code> and <code>Pervasives.stder
 </div>
 </div>
 <div class="sect1">
-<h2 id="_conditional_compilation_support_static_if"><a class="anchor" href="#_conditional_compilation_support_static_if"></a>Conditional compilation support - static if</h2>
+<h2 id="_conditional_compilation_support_static_if"><a class="anchor" href="#_conditional_compilation_support_static_if"></a><a class="link" href="#_conditional_compilation_support_static_if">Conditional compilation support - static if</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>It is quite common that people want to write code that works with different versions of compilers and libraries.</p>
@@ -4435,10 +4517,10 @@ libs to back-port it to old OCaml compilers.</p>
 </ul>
 </div>
 <div class="sect2">
-<h3 id="_concrete_syntax"><a class="anchor" href="#_concrete_syntax"></a>Concrete syntax</h3>
+<h3 id="_concrete_syntax"><a class="anchor" href="#_concrete_syntax"></a><a class="link" href="#_concrete_syntax">Concrete syntax</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="bnf">static-if
+<pre class="pygments highlight"><code data-lang="bnf"><span></span>static-if
 | HASH-IF-BOL conditional-expression THEN <b class="conum">(1)</b>
    tokens
 (HASH-ELIF-BOL conditional-expression THEN) *
@@ -4471,7 +4553,7 @@ atom
 </div>
 </div>
 <div class="sect2">
-<h3 id="_typing_rules"><a class="anchor" href="#_typing_rules"></a>Typing rules</h3>
+<h3 id="_typing_rules"><a class="anchor" href="#_typing_rules"></a><a class="link" href="#_typing_rules">Typing rules</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -4501,7 +4583,7 @@ it would be string</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;~1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span><span class="tok-o">;;</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;~1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span><span class="tok-o">;;</span>
 <span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;^1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span> <span class="tok-o">;;</span>
 <span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&gt;1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span> <span class="tok-o">;;</span>
 <span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&gt;=1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span> <span class="tok-o">;;</span>
@@ -4512,11 +4594,11 @@ it would be string</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_examples_3"><a class="anchor" href="#_examples_3"></a>Examples</h3>
+<h3 id="_examples_3"><a class="anchor" href="#_examples_3"></a><a class="link" href="#_examples_3">Examples</a></h3>
 <div class="listingblock">
 <div class="title">lwt_unix.mli</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">open_flag</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">open_flag</span> <span class="tok-o">=</span>
     <span class="tok-nn">Unix</span><span class="tok-p">.</span><span class="tok-n">open_flag</span> <span class="tok-o">=</span>
   <span class="tok-o">|</span> <span class="tok-nc">O_RDONLY</span>
   <span class="tok-o">|</span> <span class="tok-nc">O_WRONLY</span>
@@ -4540,23 +4622,23 @@ it would be string</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_built_in_variables_and_custom_variables"><a class="anchor" href="#_built_in_variables_and_custom_variables"></a>Built in variables and custom variables</h3>
+<h3 id="_built_in_variables_and_custom_variables"><a class="anchor" href="#_built_in_variables_and_custom_variables"></a><a class="link" href="#_built_in_variables_and_custom_variables">Built in variables and custom variables</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">ocamlscript&gt;bsc.exe -bs-D <span class="tok-nv">CUSTOM_A</span><span class="tok-o">=</span><span class="tok-s2">&quot;ghsigh&quot;</span> -bs-list-conditionals
+<pre class="pygments highlight"><code data-lang="sh"><span></span>ocamlscript&gt;bsc.exe -bs-D <span class="tok-nv">CUSTOM_A</span><span class="tok-o">=</span><span class="tok-s2">&quot;ghsigh&quot;</span> -bs-list-conditionals
 OCAML_PATCH <span class="tok-s2">&quot;BS&quot;</span>
 BS_VERSION <span class="tok-s2">&quot;1.2.1&quot;</span>
 OS_TYPE <span class="tok-s2">&quot;Unix&quot;</span>
 BS <span class="tok-nb">true</span>
 CUSTOM_A <span class="tok-s2">&quot;ghsigh&quot;</span>
-WORD_SIZE 64
+WORD_SIZE <span class="tok-m">64</span>
 OCAML_VERSION <span class="tok-s2">&quot;4.02.3+BS&quot;</span>
 BIG_ENDIAN <span class="tok-nb">false</span></code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_changes_to_command_line_options"><a class="anchor" href="#_changes_to_command_line_options"></a>Changes to command line options</h3>
+<h3 id="_changes_to_command_line_options"><a class="anchor" href="#_changes_to_command_line_options"></a><a class="link" href="#_changes_to_command_line_options">Changes to command line options</a></h3>
 <div class="paragraph">
 <p>For BuckleScript users, nothing needs to be done (it is baked in the language level).
 For non BuckleScript users, we provide an external pre-processor, so it will work with other OCaml
@@ -4567,7 +4649,7 @@ so that it even works without compilation.</p>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -c lwt_unix.mli
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsc.exe -c lwt_unix.mli
 ocamlc -pp <span class="tok-s1">&#39;bspp.exe&#39;</span> -c lwt_unix.mli
 ocamlc -pp <span class="tok-s1">&#39;ocaml -w -a bspp.ml&#39;</span> -c lwt_unix.mli</code></pre>
 </div>
@@ -4584,7 +4666,7 @@ ocamlc -pp <span class="tok-s1">&#39;ocaml -w -a bspp.ml&#39;</span> -c lwt_unix
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span>
   <span class="tok-n">x</span>
 <span class="tok-o">#</span><span class="tok-n">elif</span> <b class="conum">(1)</b></code></pre>
 </div>
@@ -4604,7 +4686,7 @@ ocamlc -pp <span class="tok-s1">&#39;ocaml -w -a bspp.ml&#39;</span> -c lwt_unix
 </div>
 </div>
 <div class="sect1">
-<h2 id="_build_system_support"><a class="anchor" href="#_build_system_support"></a>Build system support</h2>
+<h2 id="_build_system_support"><a class="anchor" href="#_build_system_support"></a><a class="link" href="#_build_system_support">Build system support</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>The BuckleScript compilation model is similar to OCaml native compiler.
@@ -4628,7 +4710,7 @@ inlining, arity inference and other information.</p>
 </table>
 </div>
 <div class="sect2">
-<h3 id="_bucklescript_build_system_code_bsb_code"><a class="anchor" href="#_bucklescript_build_system_code_bsb_code"></a>BuckleScript build system: <code>bsb</code></h3>
+<h3 id="_bucklescript_build_system_code_bsb_code"><a class="anchor" href="#_bucklescript_build_system_code_bsb_code"></a><a class="link" href="#_bucklescript_build_system_code_bsb_code">BuckleScript build system: <code>bsb</code></a></h3>
 <div class="paragraph">
 <p>BuckleScript provides a native build tool on top of Google&#8217;s <a href="https://github.com/ninja-build/ninja/releases">ninja-build</a>.
 It is designed for a fast feedback loop (typically 100ms feedback loop) and works cross platform.</p>
@@ -4645,7 +4727,7 @@ below is a configuration to help you get auto-completion and validation for free
 <div class="listingblock">
 <div class="title">settings.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;json.schemas&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
         <span class="tok-p">{</span>
             <span class="tok-s2">&quot;fileMatch&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
@@ -4669,7 +4751,7 @@ either <code>bsb</code> (slightly higher latency but symlinked into <code>.bin</
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
   <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;test&quot;</span><span class="tok-p">,</span> <span class="tok-c1">// package name, required </span><b class="conum">(1)</b>
   <span class="tok-s2">&quot;sources&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span> <b class="conum">(2)</b>
 <span class="tok-p">}</span></code></pre>
@@ -4732,7 +4814,7 @@ and delegate the hard work to <code>ninja</code>.</p>
 <div class="listingblock">
 <div class="title">Watch mode</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsb <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsb <b class="conum">(1)</b>
 bsb -w <b class="conum">(2)</b></code></pre>
 </div>
 </div>
@@ -4747,14 +4829,14 @@ bsb -w <b class="conum">(2)</b></code></pre>
 </ol>
 </div>
 <div class="sect3">
-<h4 id="_build_with_other_bucklescript_dependencies"><a class="anchor" href="#_build_with_other_bucklescript_dependencies"></a>Build with other BuckleScript dependencies</h4>
+<h4 id="_build_with_other_bucklescript_dependencies"><a class="anchor" href="#_build_with_other_bucklescript_dependencies"></a><a class="link" href="#_build_with_other_bucklescript_dependencies">Build with other BuckleScript dependencies</a></h4>
 <div class="paragraph">
 <p>List your dependency in <code>bs-dependencies</code> and install it via <code>npm install</code> as below:</p>
 </div>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bs-string&quot;</span><span class="tok-p">,</span>
     <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
     <span class="tok-s2">&quot;bs-dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
@@ -4780,7 +4862,7 @@ bsb -w <b class="conum">(2)</b></code></pre>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
  <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
     <span class="tok-s2">&quot;bs-mocha&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.5&quot;</span>
     <span class="tok-p">},</span>
@@ -4793,7 +4875,7 @@ bsb -w <b class="conum">(2)</b></code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsb -clean-world <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsb -clean-world <b class="conum">(1)</b>
 bsb -make-world <b class="conum">(2)</b>
 bsb -w <b class="conum">(3)</b></code></pre>
 </div>
@@ -4816,12 +4898,12 @@ bsb -w <b class="conum">(3)</b></code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsb -clean-world -make-world -w</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsb -clean-world -make-world -w</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_mark_your_directory_as_dev_only"><a class="anchor" href="#_mark_your_directory_as_dev_only"></a>Mark your directory as dev only</h4>
+<h4 id="_mark_your_directory_as_dev_only"><a class="anchor" href="#_mark_your_directory_as_dev_only"></a><a class="link" href="#_mark_your_directory_as_dev_only">Mark your directory as dev only</a></h4>
 <div class="paragraph">
 <p>Note sometimes, you have directories which are just tests that you don&#8217;t need your dependency
 to build. In that case you can mark it as dev only:</p>
@@ -4829,7 +4911,7 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
         <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
                 <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;test&quot;</span><span class="tok-p">,</span>
                 <span class="tok-s2">&quot;type&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;dev&quot;</span> <b class="conum">(1)</b>
@@ -4847,14 +4929,14 @@ to build. In that case you can mark it as dev only:</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_a_real_world_example_of_using_code_bsb_code"><a class="anchor" href="#_a_real_world_example_of_using_code_bsb_code"></a>A real world example of using <code>bsb</code></h3>
+<h3 id="_a_real_world_example_of_using_code_bsb_code"><a class="anchor" href="#_a_real_world_example_of_using_code_bsb_code"></a><a class="link" href="#_a_real_world_example_of_using_code_bsb_code">A real world example of using <code>bsb</code></a></h3>
 <div class="paragraph">
 <p>Below is a json configuration for the <a href="https://github.com/OvermindDL1/bucklescript-tea">bucklescript-tea</a>: the Elm artchitecture in BuckleScript</p>
 </div>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
   <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span><span class="tok-p">,</span>
   <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
   <span class="tok-s2">&quot;sources&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
@@ -4880,7 +4962,7 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
   <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span><span class="tok-p">,</span>
   <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
   <span class="tok-s2">&quot;description&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;TEA for Bucklescript&quot;</span><span class="tok-p">,</span>
@@ -4908,7 +4990,7 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-have-tea&quot;</span><span class="tok-p">,</span>
     <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">,</span>
     <span class="tok-s2">&quot;bs-dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
@@ -4920,7 +5002,7 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-have-tea&quot;</span><span class="tok-p">,</span>
     <span class="tok-s2">&quot;version&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.0&quot;</span><span class="tok-p">,</span>
     <span class="tok-s2">&quot;dependencies&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;^0.1.2&quot;</span> <span class="tok-p">},</span> <b class="conum">(1)</b>
@@ -4943,7 +5025,7 @@ to build. In that case you can mark it as dev only:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm install <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>npm install <b class="conum">(1)</b>
 npm install bs-platform <b class="conum">(2)</b>
 ./node_modules/.bin/bsb -clean-world -make-world -w <b class="conum">(3)</b></code></pre>
 </div>
@@ -4966,7 +5048,7 @@ npm install bs-platform <b class="conum">(2)</b>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
   <span class="tok-p">...</span> <span class="tok-p">,</span>
   <span class="tok-s2">&quot;package-specs&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;amdjs&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;commonjs&quot;</span><span class="tok-p">],</span>
   <span class="tok-p">...</span>
@@ -4978,7 +5060,7 @@ npm install bs-platform <b class="conum">(2)</b>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsb -clean-world -make-world</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>bsb -clean-world -make-world</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4986,7 +5068,7 @@ npm install bs-platform <b class="conum">(2)</b>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_build_using_make"><a class="anchor" href="#_build_using_make"></a>Build using Make</h3>
+<h3 id="_build_using_make"><a class="anchor" href="#_build_using_make"></a><a class="link" href="#_build_using_make">Build using Make</a></h3>
 <div class="admonitionblock warning">
 <table>
 <tr>
@@ -5011,7 +5093,7 @@ are <em>curious</em> about how the build works.</p>
 <div class="listingblock">
 <div class="title">Makefile</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="make"><span class="tok-nv">OCAMLC</span><span class="tok-o">=</span>bsc.exe <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="make"><span></span><span class="tok-nv">OCAMLC</span><span class="tok-o">=</span>bsc.exe <b class="conum">(1)</b>
 <span class="tok-nv">OCAMLDEP</span><span class="tok-o">=</span>bsdep.exe <b class="conum">(2)</b>
 <span class="tok-nv">SOURCE_LIST</span> <span class="tok-o">:=</span> src_a src_b
 <span class="tok-nv">SOURCE_MLI</span> <span class="tok-o">=</span> <span class="tok-k">$(</span>addsuffix .mli, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
@@ -5020,9 +5102,9 @@ are <em>curious</em> about how the build works.</p>
 <span class="tok-nv">INCLUDES</span><span class="tok-o">=</span>
 <span class="tok-nf">all</span><span class="tok-o">:</span> <span class="tok-k">$(</span><span class="tok-nv">TARGETS</span><span class="tok-k">)</span>
 <span class="tok-nf">.mli</span><span class="tok-o">:</span>.<span class="tok-n">cmi</span>
-        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span> -c <span class="tok-nv">$&lt;</span>
+        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span> -c $&lt;
 <span class="tok-nf">.ml</span><span class="tok-o">:</span>.<span class="tok-n">cmj</span>:
-        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span> -c <span class="tok-nv">$&lt;</span>
+        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span> -c $&lt;
 <span class="tok-cp">-include .depend</span>
 <span class="tok-nf">depend</span><span class="tok-o">:</span>
         <span class="tok-k">$(</span>OCAMLDEP<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>SOURCE_ML<span class="tok-k">)</span> <span class="tok-k">$(</span>SOURCE_MLI<span class="tok-k">)</span> &gt; .depend</code></pre>
@@ -5049,7 +5131,7 @@ such as <a href="https://facebook.github.io/watchman/">watchman</a> for example,
 <div class="listingblock">
 <div class="title">build.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="json"><span class="tok-p">[</span>
+<pre class="pygments highlight"><code data-lang="json"><span></span><span class="tok-p">[</span>
     <span class="tok-s2">&quot;trigger&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;.&quot;</span><span class="tok-p">,</span> <span class="tok-p">{</span>
         <span class="tok-nt">&quot;name&quot;</span><span class="tok-p">:</span> <span class="tok-s2">&quot;build&quot;</span><span class="tok-p">,</span>
         <span class="tok-nt">&quot;expression&quot;</span><span class="tok-p">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;pcre&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;(\\.(ml|mll|mly|mli|sh|sh)$|Makefile)&quot;</span><span class="tok-p">],</span> <b class="conum">(1)</b>
@@ -5069,7 +5151,7 @@ such as <a href="https://facebook.github.io/watchman/">watchman</a> for example,
 <div class="listingblock">
 <div class="title">build.sh</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make -r -j8 all <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>make -r -j8 all <b class="conum">(1)</b>
 make depend <b class="conum">(2)</b></code></pre>
 </div>
 </div>
@@ -5088,7 +5170,7 @@ make depend <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_customize_rules_generators_support_since_1_7_4"><a class="anchor" href="#_customize_rules_generators_support_since_1_7_4"></a>Customize rules (generators support, @since 1.7.4)</h3>
+<h3 id="_customize_rules_generators_support_since_1_7_4"><a class="anchor" href="#_customize_rules_generators_support_since_1_7_4"></a><a class="link" href="#_customize_rules_generators_support_since_1_7_4">Customize rules (generators support, @since 1.7.4)</a></h3>
 <div class="paragraph">
 <p>It is quite common that programmers use some pre-processors to generate some bolierpolate code during developement.</p>
 </div>
@@ -5104,7 +5186,7 @@ make depend <b class="conum">(2)</b></code></pre>
 <div class="listingblock">
 <div class="title">Bsb using ocamlyacc</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-s2">&quot;generators&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span>
         <span class="tok-p">{</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;ocamlyacc&quot;</span> <span class="tok-p">,</span>
           <span class="tok-s2">&quot;command&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;ocamlyacc $in&quot;</span> <span class="tok-p">}</span>
@@ -5132,7 +5214,7 @@ only need the generated <code>test.ml</code>, to help test such behavior in deve
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-p">{</span>
     <span class="tok-p">...,</span>
     <span class="tok-s2">&quot;cut-generators&quot;</span> <span class="tok-o">:</span> <span class="tok-kc">true</span>
 <span class="tok-p">}</span></code></pre>
@@ -5145,7 +5227,7 @@ only need the generated <code>test.ml</code>, to help test such behavior in deve
 </div>
 </div>
 <div class="sect1">
-<h2 id="_faq"><a class="anchor" href="#_faq"></a>FAQ</h2>
+<h2 id="_faq"><a class="anchor" href="#_faq"></a><a class="link" href="#_faq">FAQ</a></h2>
 <div class="sectionbody">
 <div class="qlist qanda">
 <ol>
@@ -5267,7 +5349,7 @@ functions mentioned above, the code will fail at runtime.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_high_level_compiler_workflow"><a class="anchor" href="#_high_level_compiler_workflow"></a>High Level compiler workflow</h2>
+<h2 id="_high_level_compiler_workflow"><a class="anchor" href="#_high_level_compiler_workflow"></a><a class="link" href="#_high_level_compiler_workflow">High Level compiler workflow</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>The high level architecture is illustrated below:</p>
@@ -5319,7 +5401,7 @@ Javascript Code</pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_design_principles"><a class="anchor" href="#_design_principles"></a>Design Principles</h3>
+<h3 id="_design_principles"><a class="anchor" href="#_design_principles"></a><a class="link" href="#_design_principles">Design Principles</a></h3>
 <div class="paragraph">
 <p>The current design of BuckleScript follows several high level
 principles. While those principles might change in the future, they are
@@ -5367,14 +5449,14 @@ would be too large of a change to OCaml compiler.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_soundness"><a class="anchor" href="#_soundness"></a>Soundness</h3>
+<h3 id="_soundness"><a class="anchor" href="#_soundness"></a><a class="link" href="#_soundness">Soundness</a></h3>
 <div class="paragraph">
 <p>BuckleScript preserves the soundness of the OCaml language. Assuming the
 FFI is correctly implemented, the type safety is preserved.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_minimal_new_symbol_creation"><a class="anchor" href="#_minimal_new_symbol_creation"></a>Minimal new symbol creation</h3>
+<h3 id="_minimal_new_symbol_creation"><a class="anchor" href="#_minimal_new_symbol_creation"></a><a class="link" href="#_minimal_new_symbol_creation">Minimal new symbol creation</a></h3>
 <div class="paragraph">
 <p>In order to make the JavaScript generated code as close as possible to
 the original OCaml core we thrive to introduce as few new symbols as
@@ -5384,7 +5466,7 @@ possible.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_runtime_representation"><a class="anchor" href="#_runtime_representation"></a>Runtime representation</h2>
+<h2 id="_runtime_representation"><a class="anchor" href="#_runtime_representation"></a><a class="link" href="#_runtime_representation">Runtime representation</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Below is a description of how OCaml values are encoded in JavaScript,
@@ -5398,7 +5480,7 @@ JavaScript; instead, the OCaml stdlib provides three functions: <code>List.cons<
 <code>List.tl</code>. JavaScript code should only rely on those three functions.</p>
 </div>
 <div class="sect2">
-<h3 id="_simple_ocaml_type"><a class="anchor" href="#_simple_ocaml_type"></a>Simple OCaml type</h3>
+<h3 id="_simple_ocaml_type"><a class="anchor" href="#_simple_ocaml_type"></a><a class="link" href="#_simple_ocaml_type">Simple OCaml type</a></h3>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 50%;">
@@ -5499,7 +5581,7 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span><span class="tok-o">;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">}</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span><span class="tok-o">;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">}</span>
 <span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">1</span><span class="tok-o">;</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-mi">2</span><span class="tok-o">}</span></code></pre>
 </div>
 </div>
@@ -5508,7 +5590,7 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">[</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span></span><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">[</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">]</span></code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5579,7 +5661,7 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">tree</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">tree</span> <span class="tok-o">=</span>
   <span class="tok-o">|</span> <span class="tok-nc">Leaf</span>
   <span class="tok-o">|</span> <span class="tok-nc">Node</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-n">tree</span> <span class="tok-o">*</span> <span class="tok-n">tree</span>
 <span class="tok-c">(* Leaf --&gt; 0 *)</span>
@@ -5591,7 +5673,7 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">u</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">u</span> <span class="tok-o">=</span>
      <span class="tok-o">|</span> <span class="tok-nc">A</span> <span class="tok-k">of</span> <span class="tok-kt">string</span>
      <span class="tok-o">|</span> <span class="tok-nc">B</span> <span class="tok-k">of</span> <span class="tok-kt">int</span>
 <span class="tok-c">(* A a --&gt; [a].tag=0 -- tag 0 assignment is optional *)</span>
@@ -5606,7 +5688,7 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-c">(* 97 *)</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-c">(* 97 *)</span>
 <span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-c">(* [97, [1,2] ]*)</span></code></pre>
 </div>
 </div></div></td>
@@ -5644,7 +5726,7 @@ We might encode it as buffer in NodeJS.
 <div class="listingblock">
 <div class="title">Js module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">boolean</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">boolean</span>
 <span class="tok-k">val</span> <span class="tok-n">to_bool</span><span class="tok-o">:</span> <span class="tok-n">boolean</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
 </div>
 </div>
@@ -5663,7 +5745,7 @@ We might encode it as buffer in NodeJS.
 <div class="listingblock">
 <div class="title">Js.Null module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">to_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">val</span> <span class="tok-n">to_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span>
 <span class="tok-k">val</span> <span class="tok-n">from_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
 <span class="tok-k">val</span> <span class="tok-n">return</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
 <span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
@@ -5727,7 +5809,7 @@ We are working to provide a ppx extension as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
   <span class="tok-o">|</span> <span class="tok-nc">A</span>
   <span class="tok-o">|</span> <span class="tok-nc">B</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span>
   <span class="tok-o">|</span> <span class="tok-nc">C</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span>
@@ -5740,7 +5822,7 @@ We are working to provide a ppx extension as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">a</span> <span class="tok-o">:</span> <span class="tok-n">t</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">val</span> <span class="tok-n">a</span> <span class="tok-o">:</span> <span class="tok-n">t</span>
 <span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span>
 <span class="tok-k">val</span> <span class="tok-n">c</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span>
 <span class="tok-k">val</span> <span class="tok-n">d</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
@@ -5755,7 +5837,7 @@ We are working to provide a ppx extension as below:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_integration_with_reason"><a class="anchor" href="#_integration_with_reason"></a>Integration with Reason</h2>
+<h2 id="_integration_with_reason"><a class="anchor" href="#_integration_with_reason"></a><a class="link" href="#_integration_with_reason">Integration with Reason</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>You can play with Reason using the playground
@@ -5782,7 +5864,7 @@ We are working to provide a ppx extension as below:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_contributions"><a class="anchor" href="#_contributions"></a>Contributions</h2>
+<h2 id="_contributions"><a class="anchor" href="#_contributions"></a><a class="link" href="#_contributions">Contributions</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>First, thanks for your interest in contributing!
@@ -5793,7 +5875,7 @@ open sourcing your libraries using BuckleScript. They are all deeply appreciated
 <p>This section will focus on how to contribute to this repo.</p>
 </div>
 <div class="sect2">
-<h3 id="_development_set_up"><a class="anchor" href="#_development_set_up"></a>Development set-up</h3>
+<h3 id="_development_set_up"><a class="anchor" href="#_development_set_up"></a><a class="link" href="#_development_set_up">Development set-up</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -5825,13 +5907,13 @@ change <code>j.ml</code> (most likely you won&#8217;t), so you probably don&#821
 </div>
 </div>
 <div class="sect2">
-<h3 id="_contributing_to_code_bsb_exe_code"><a class="anchor" href="#_contributing_to_code_bsb_exe_code"></a>Contributing to <code>bsb.exe</code></h3>
+<h3 id="_contributing_to_code_bsb_exe_code"><a class="anchor" href="#_contributing_to_code_bsb_exe_code"></a><a class="link" href="#_contributing_to_code_bsb_exe_code">Contributing to <code>bsb.exe</code></a></h3>
 <div class="paragraph">
 <p>The build target is</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make -C bin bsb.exe</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>make -C bin bsb.exe</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5848,7 +5930,7 @@ so the user does not need install those tools.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make snapshotml <span class="tok-c"># see the diffs in jscomp/bin</span></code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>make snapshotml <span class="tok-c1"># see the diffs in jscomp/bin</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5856,15 +5938,15 @@ so the user does not need install those tools.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_contributing_to_code_bsc_exe_code"><a class="anchor" href="#_contributing_to_code_bsc_exe_code"></a>Contributing to <code>bsc.exe</code></h3>
+<h3 id="_contributing_to_code_bsc_exe_code"><a class="anchor" href="#_contributing_to_code_bsc_exe_code"></a><a class="link" href="#_contributing_to_code_bsc_exe_code">Contributing to <code>bsc.exe</code></a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make -C bin bsc.exe <span class="tok-c"># build the compiler in dev mode</span></code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>make -C bin bsc.exe <span class="tok-c1"># build the compiler in dev mode</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make libs <span class="tok-c"># build all libs using the dev compiler</span></code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>make libs <span class="tok-c1"># build all libs using the dev compiler</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5872,7 +5954,7 @@ so the user does not need install those tools.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make snapshotml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh"><span></span>make snapshotml</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5881,7 +5963,7 @@ But please <strong>don&#8217;t commit</strong> those changes in PR, it will caus
 </div>
 </div>
 <div class="sect2">
-<h3 id="_contributing_to_the_runtime"><a class="anchor" href="#_contributing_to_the_runtime"></a>Contributing to the runtime</h3>
+<h3 id="_contributing_to_the_runtime"><a class="anchor" href="#_contributing_to_the_runtime"></a><a class="link" href="#_contributing_to_the_runtime">Contributing to the runtime</a></h3>
 <div class="paragraph">
 <p>BuckleScript runtime implementation is currently a mix of OCaml and
 JavaScript. (<code>jscomp/runtime</code> directory). The JavaScript code is defined
@@ -5917,7 +5999,7 @@ the compiler you modified.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">suites</span> <span class="tok-o">:</span> <span class="tok-o">_</span> <span class="tok-nn">Mt</span><span class="tok-p">.</span><span class="tok-n">pair_suites</span> <span class="tok-o">=</span>
+<pre class="pygments highlight"><code data-lang="ocaml"><span></span><span class="tok-k">let</span> <span class="tok-n">suites</span> <span class="tok-o">:</span> <span class="tok-o">_</span> <span class="tok-nn">Mt</span><span class="tok-p">.</span><span class="tok-n">pair_suites</span> <span class="tok-o">=</span>
    <span class="tok-o">[</span><span class="tok-s2">&quot;hey&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Eq</span><span class="tok-o">(</span><span class="tok-bp">true</span><span class="tok-o">,</span> <span class="tok-mi">3</span> <span class="tok-o">&gt;</span> <span class="tok-mi">2</span><span class="tok-o">));</span>
        <span class="tok-s2">&quot;hi&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Neq</span><span class="tok-o">(</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">));</span>
        <span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Approx</span><span class="tok-o">(</span><span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">,</span> <span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">));</span>
@@ -5957,7 +6039,7 @@ the compiler you modified.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_contributing_to_the_documentation"><a class="anchor" href="#_contributing_to_the_documentation"></a>Contributing to the documentation</h3>
+<h3 id="_contributing_to_the_documentation"><a class="anchor" href="#_contributing_to_the_documentation"></a><a class="link" href="#_contributing_to_the_documentation">Contributing to the documentation</a></h3>
 <div class="paragraph">
 <p>You&#8217;ll need <a href="http://asciidoctor.org/">Asciidoctor</a> installed and on your <code>PATH</code>.
 Go into <code>site/docsource/</code>, modify the section you want, and run <code>build.sh</code>.
@@ -5965,7 +6047,7 @@ You can check the <code>build.compile</code> file for debug output.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_contributing_to_the_api_reference"><a class="anchor" href="#_contributing_to_the_api_reference"></a>Contributing to the API reference</h3>
+<h3 id="_contributing_to_the_api_reference"><a class="anchor" href="#_contributing_to_the_api_reference"></a><a class="link" href="#_contributing_to_the_api_reference">Contributing to the API reference</a></h3>
 <div class="paragraph">
 <p>The API reference is generated from doc comments in the source code. Here&#8217;s a good example: <a href="https://github.com/bucklescript/bucklescript/blob/master/jscomp/others/js_re.mli#L146-L161" class="bare">https://github.com/bucklescript/bucklescript/blob/master/jscomp/others/js_re.mli#L146-L161</a></p>
 </div>
@@ -6025,10 +6107,10 @@ You can check the <code>build.compile</code> file for debug output.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_comparisons"><a class="anchor" href="#_comparisons"></a>Comparisons</h2>
+<h2 id="_comparisons"><a class="anchor" href="#_comparisons"></a><a class="link" href="#_comparisons">Comparisons</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_difference_from_a_href_https_github_com_ocsigen_js_of_ocaml_js_of_ocaml_a"><a class="anchor" href="#_difference_from_a_href_https_github_com_ocsigen_js_of_ocaml_js_of_ocaml_a"></a>Difference from <a href="https://github.com/ocsigen/js_of_ocaml">js_of_ocaml</a></h3>
+<h3 id="_difference_from_a_href_https_github_com_ocsigen_js_of_ocaml_js_of_ocaml_a"><a class="anchor" href="#_difference_from_a_href_https_github_com_ocsigen_js_of_ocaml_js_of_ocaml_a"></a><a class="link" href="#_difference_from_a_href_https_github_com_ocsigen_js_of_ocaml_js_of_ocaml_a">Difference from <a href="https://github.com/ocsigen/js_of_ocaml">js_of_ocaml</a></a></h3>
 <div class="paragraph">
 <p>Js_of_ocaml is a popular compiler which compiles OCaml&#8217;s bytecode into JavaScript. It is the
 inspiration for this project, and has already been under development for
@@ -6065,7 +6147,7 @@ Array while js_of_ocaml requires its index 0 to be of value 0.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_library_api_documentation"><a class="anchor" href="#_library_api_documentation"></a>Appendix A: Library API documentation</h2>
+<h2 id="_library_api_documentation"><a class="anchor" href="#_library_api_documentation"></a><a class="link" href="#_library_api_documentation">Appendix A: Library API documentation</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>There is a small library that comes with <code>bs-platform</code>, its documentation is
@@ -6074,10 +6156,10 @@ Array while js_of_ocaml requires its index 0 to be of value 0.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_changes"><a class="anchor" href="#_changes"></a>Appendix B: CHANGES</h2>
+<h2 id="_changes"><a class="anchor" href="#_changes"></a><a class="link" href="#_changes">Appendix B: CHANGES</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_1_3_2"><a class="anchor" href="#_1_3_2"></a>1.3.2</h3>
+<h3 id="_1_3_2"><a class="anchor" href="#_1_3_2"></a><a class="link" href="#_1_3_2">1.3.2</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -6094,7 +6176,7 @@ Array while js_of_ocaml requires its index 0 to be of value 0.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_1_2_1_dev"><a class="anchor" href="#_1_2_1_dev"></a>1.2.1 + dev</h3>
+<h3 id="_1_2_1_dev"><a class="anchor" href="#_1_2_1_dev"></a><a class="link" href="#_1_2_1_dev">1.2.1 + dev</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -6121,7 +6203,7 @@ it&#8217;s for deterministic build</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_1_1_2"><a class="anchor" href="#_1_1_2"></a>1.1.2</h3>
+<h3 id="_1_1_2"><a class="anchor" href="#_1_1_2"></a><a class="link" href="#_1_1_2">1.1.2</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -6148,7 +6230,7 @@ it&#8217;s for deterministic build</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_1_1_1"><a class="anchor" href="#_1_1_1"></a>1.1.1</h3>
+<h3 id="_1_1_1"><a class="anchor" href="#_1_1_1"></a><a class="link" href="#_1_1_1">1.1.1</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -6179,7 +6261,7 @@ Note that all attributes will still be qualified</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_1_03"><a class="anchor" href="#_1_03"></a>1.03</h3>
+<h3 id="_1_03"><a class="anchor" href="#_1_03"></a><a class="link" href="#_1_03">1.03</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -6224,7 +6306,7 @@ Note that all attributes will still be qualified</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_1_02"><a class="anchor" href="#_1_02"></a>1.02</h3>
+<h3 id="_1_02"><a class="anchor" href="#_1_02"></a><a class="link" href="#_1_02">1.02</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -6255,7 +6337,7 @@ By default, <code>bsc.exe</code> will warn when it detect some ocaml datatype is
 </div>
 </div>
 <div class="sect2">
-<h3 id="_1_01"><a class="anchor" href="#_1_01"></a>1.01</h3>
+<h3 id="_1_01"><a class="anchor" href="#_1_01"></a><a class="link" href="#_1_01">1.01</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -6287,7 +6369,7 @@ polymorphism <a href="https://github.com/bucklescript/bucklescript/issues/686">#
 </div>
 </div>
 <div class="sect2">
-<h3 id="_1_0"><a class="anchor" href="#_1_0"></a>1.0</h3>
+<h3 id="_1_0"><a class="anchor" href="#_1_0"></a><a class="link" href="#_1_0">1.0</a></h3>
 <div class="paragraph">
 <p>Initial release</p>
 </div>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.4">
+<meta name="generator" content="Asciidoctor 1.5.6.1">
 <title>Bloomberg announcing BuckleScript 1.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -17,7 +17,6 @@ audio:not([controls]){display:none;height:0}
 [hidden],template{display:none}
 script{display:none!important}
 html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-body{margin:0}
 a{background:transparent}
 a:focus{outline:thin dotted}
 a:active,a:hover{outline:0}
@@ -52,7 +51,7 @@ textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
 *,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -64,7 +63,6 @@ img{-ms-interpolation-mode:bicubic}
 .text-center{text-align:center!important}
 .text-justify{text-align:justify!important}
 .hide{display:none}
-body{-webkit-font-smoothing:antialiased}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
@@ -91,13 +89,12 @@ strong,b{font-weight:bold;line-height:inherit}
 small{font-size:60%;line-height:inherit}
 code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
 ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
+ul,ol{margin-left:1.5em}
 ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
 ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
 ul.square{list-style-type:square}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
-ul.no-bullet{list-style:none}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
@@ -119,18 +116,25 @@ table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
 table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-body{tab-size:4}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
 .clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
 .clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
 pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
 kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:rgba(0,0,0,.8)}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
 b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
 b.button:before{content:"[";padding:0 3px 0 2px}
 b.button:after{content:"]";padding:0 2px 0 3px}
@@ -197,7 +201,7 @@ table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
 table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon img{max-width:initial}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
 .admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
@@ -253,13 +257,13 @@ table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
 table.tableblock{max-width:100%;border-collapse:separate}
 table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
-table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
-table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
-table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
-table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
-table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
-table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
 table.frame-all{border-width:1px}
 table.frame-sides{border-width:0 1px}
 table.frame-topbot{border-width:1px 0}
@@ -280,10 +284,12 @@ ul li ol{margin-left:1.5em}
 dl dd{margin-left:1.125em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
 ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
-ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
 ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
 ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
 ul.inline>li>*{display:block}
@@ -300,7 +306,8 @@ ol.lowergreek{list-style-type:lower-greek}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
+.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
+.colist>table tr>td:first-of-type img{max-width:initial}
 .colist>table tr>td:last-of-type{padding:.25em 0}
 .thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
 .imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
@@ -363,6 +370,7 @@ div.unbreakable{page-break-inside:avoid}
 .yellow{color:#bfbf00}
 .yellow-background{background-color:#fafa00}
 span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
 .admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
 .admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.4">
+<meta name="generator" content="Asciidoctor 1.5.6.1">
 <title>Developer experience</title>
 </head>
 <body class="article">

--- a/jscomp/bin/all_ounit_tests.i.ml
+++ b/jscomp/bin/all_ounit_tests.i.ml
@@ -75,7 +75,7 @@ open OUnitTypes
 
 (** Most simple heuristic, just pick the first test. *)
 let simple state =
-  (* 206 *) List.hd state.tests_planned
+  (* 208 *) List.hd state.tests_planned
 
 end
 module OUnitUtils
@@ -98,22 +98,22 @@ let is_success =
 let is_failure = 
   function
     | RFailure _ -> (* 0 *) true
-    | RSuccess _ | RError _  | RSkip _ | RTodo _ -> (* 412 *) false
+    | RSuccess _ | RError _  | RSkip _ | RTodo _ -> (* 416 *) false
 
 let is_error = 
   function 
     | RError _ -> (* 0 *) true
-    | RSuccess _ | RFailure _ | RSkip _ | RTodo _ -> (* 412 *) false
+    | RSuccess _ | RFailure _ | RSkip _ | RTodo _ -> (* 416 *) false
 
 let is_skip = 
   function
     | RSkip _ -> (* 0 *) true
-    | RSuccess _ | RFailure _ | RError _  | RTodo _ -> (* 412 *) false
+    | RSuccess _ | RFailure _ | RError _  | RTodo _ -> (* 416 *) false
 
 let is_todo = 
   function
     | RTodo _ -> (* 0 *) true
-    | RSuccess _ | RFailure _ | RError _  | RSkip _ -> (* 412 *) false
+    | RSuccess _ | RFailure _ | RError _  | RSkip _ -> (* 416 *) false
 
 let result_flavour = 
   function
@@ -145,7 +145,7 @@ let rec was_successful =
     | [] -> (* 3 *) true
     | RSuccess _::t 
     | RSkip _::t -> 
-        (* 618 *) was_successful t
+        (* 624 *) was_successful t
 
     | RFailure _::_
     | RError _::_ 
@@ -155,22 +155,22 @@ let rec was_successful =
 let string_of_node = 
   function
     | ListItem n -> 
-        (* 824 *) string_of_int n
+        (* 832 *) string_of_int n
     | Label s -> 
-        (* 1236 *) s
+        (* 1248 *) s
 
 (* Return the number of available tests *)
 let rec test_case_count = 
   function
-    | TestCase _ -> (* 206 *) 1 
-    | TestLabel (_, t) -> (* 231 *) test_case_count t
+    | TestCase _ -> (* 208 *) 1 
+    | TestLabel (_, t) -> (* 233 *) test_case_count t
     | TestList l -> 
         (* 25 *) List.fold_left 
-          (fun c t -> (* 230 *) c + test_case_count t) 
+          (fun c t -> (* 232 *) c + test_case_count t) 
           0 l
 
 let string_of_path path =
-  (* 412 *) String.concat ":" (List.rev_map string_of_node path)
+  (* 416 *) String.concat ":" (List.rev_map string_of_node path)
 
 let buff_format_printf f = 
   (* 0 *) let buff = Buffer.create 13 in
@@ -194,12 +194,12 @@ let mapi f l =
 
 let fold_lefti f accu l =
   (* 25 *) let rec rfold_lefti cnt accup l = 
-    (* 255 *) match l with
+    (* 257 *) match l with
       | [] -> 
           (* 25 *) accup
 
       | h::t -> 
-          (* 230 *) rfold_lefti (cnt + 1) (f accup h cnt) t
+          (* 232 *) rfold_lefti (cnt + 1) (f accup h cnt) t
   in
     rfold_lefti 0 accu l
 
@@ -217,7 +217,7 @@ open OUnitUtils
 type event_type = GlobalEvent of global_event | TestEvent of test_event
 
 let format_event verbose event_type =
-  (* 1238 *) match event_type with
+  (* 1250 *) match event_type with
     | GlobalEvent e ->
         (* 2 *) begin
           match e with 
@@ -276,31 +276,31 @@ let format_event verbose event_type =
         end
 
     | TestEvent e ->
-        (* 1236 *) begin
+        (* 1248 *) begin
           let string_of_result = 
             if verbose then
-              (* 618 *) function
-                | RSuccess _      -> (* 206 *) "ok\n"
+              (* 624 *) function
+                | RSuccess _      -> (* 208 *) "ok\n"
                 | RFailure (_, _) -> (* 0 *) "FAIL\n"
                 | RError (_, _)   -> (* 0 *) "ERROR\n"
                 | RSkip (_, _)    -> (* 0 *) "SKIP\n"
                 | RTodo (_, _)    -> (* 0 *) "TODO\n"
             else
-              (* 618 *) function
-                | RSuccess _      -> (* 206 *) "."
+              (* 624 *) function
+                | RSuccess _      -> (* 208 *) "."
                 | RFailure (_, _) -> (* 0 *) "F"
                 | RError (_, _)   -> (* 0 *) "E"
                 | RSkip (_, _)    -> (* 0 *) "S"
                 | RTodo (_, _)    -> (* 0 *) "T"
           in
             if verbose then
-              (* 618 *) match e with 
+              (* 624 *) match e with 
                 | EStart p -> 
-                    (* 206 *) Printf.sprintf "%s start\n" (string_of_path p)
+                    (* 208 *) Printf.sprintf "%s start\n" (string_of_path p)
                 | EEnd p -> 
-                    (* 206 *) Printf.sprintf "%s end\n" (string_of_path p)
+                    (* 208 *) Printf.sprintf "%s end\n" (string_of_path p)
                 | EResult result -> 
-                    (* 206 *) string_of_result result
+                    (* 208 *) string_of_result result
                 | ELog (lvl, str) ->
                     (* 0 *) let prefix = 
                       match lvl with 
@@ -312,21 +312,21 @@ let format_event verbose event_type =
                 | ELogRaw str ->
                     (* 0 *) str
             else 
-              (* 618 *) match e with 
-                | EStart _ | EEnd _ | ELog _ | ELogRaw _ -> (* 412 *) ""
-                | EResult result -> (* 206 *) string_of_result result
+              (* 624 *) match e with 
+                | EStart _ | EEnd _ | ELog _ | ELogRaw _ -> (* 416 *) ""
+                | EResult result -> (* 208 *) string_of_result result
         end
 
 let file_logger fn =
   (* 1 *) let chn = open_out fn in
     (fun ev ->
-       (* 619 *) output_string chn (format_event true ev);
+       (* 625 *) output_string chn (format_event true ev);
        flush chn),
     (fun () -> (* 1 *) close_out chn)
 
 let std_logger verbose =
   (* 1 *) (fun ev -> 
-     (* 619 *) print_string (format_event verbose ev);
+     (* 625 *) print_string (format_event verbose ev);
      flush stdout),
   (fun () -> (* 1 *) ())
 
@@ -343,7 +343,7 @@ let create output_file_opt verbose (log,close) =
           (* 0 *) null_logger
   in
     (fun ev ->
-       (* 619 *) std_log ev; file_log ev; log ev),
+       (* 625 *) std_log ev; file_log ev; log ev),
     (fun () ->
        (* 1 *) std_close (); file_close (); close ())
 
@@ -705,7 +705,7 @@ let assert_failure msg =
   (* 0 *) failwith ("OUnit: " ^ msg)
 
 let assert_bool msg b =
-  (* 2009455 *) if not b then (* 0 *) assert_failure msg
+  (* 2009457 *) if not b then (* 0 *) assert_failure msg
 
 let assert_string str =
   (* 0 *) if not (str = "") then (* 0 *) assert_failure str
@@ -951,7 +951,7 @@ let (@?) = assert_bool
 
 (* Some shorthands which allows easy test construction *)
 let (>:) s t = (* 0 *) TestLabel(s, t)             (* infix *)
-let (>::) s f = (* 206 *) TestLabel(s, TestCase(f))  (* infix *)
+let (>::) s f = (* 208 *) TestLabel(s, TestCase(f))  (* infix *)
 let (>:::) s l = (* 25 *) TestLabel(s, TestList(l)) (* infix *)
 
 (* Utility function to manipulate test *)
@@ -1087,7 +1087,7 @@ let maybe_backtrace = ""
 (* Run all tests, report starts, errors, failures, and return the results *)
 let perform_test report test =
   (* 1 *) let run_test_case f path =
-    (* 206 *) try 
+    (* 208 *) try 
       f ();
       RSuccess path
     with
@@ -1106,22 +1106,22 @@ let perform_test report test =
   let rec flatten_test path acc = 
     function
       | TestCase(f) -> 
-          (* 206 *) (path, f) :: acc
+          (* 208 *) (path, f) :: acc
 
       | TestList (tests) ->
           (* 25 *) fold_lefti 
             (fun acc t cnt -> 
-               (* 230 *) flatten_test 
+               (* 232 *) flatten_test 
                  ((ListItem cnt)::path) 
                  acc t)
             acc tests
       
       | TestLabel (label, t) -> 
-          (* 231 *) flatten_test ((Label label)::path) acc t
+          (* 233 *) flatten_test ((Label label)::path) acc t
   in
   let test_cases = List.rev (flatten_test [] [] test) in
   let runner (path, f) = 
-    (* 206 *) let result = 
+    (* 208 *) let result = 
       report (EStart path);
       run_test_case f path 
     in
@@ -1130,18 +1130,18 @@ let perform_test report test =
       result
   in
   let rec iter state = 
-    (* 207 *) match state.tests_planned with 
+    (* 209 *) match state.tests_planned with 
       | [] ->
           (* 1 *) state.results
       | _ ->
-          (* 206 *) let (path, f) = !global_chooser state in            
+          (* 208 *) let (path, f) = !global_chooser state in            
           let result = runner (path, f) in
             iter 
               {
                 results = result :: state.results;
                 tests_planned = 
                   List.filter 
-                    (fun (path', _) -> (* 21321 *) path <> path') state.tests_planned
+                    (fun (path', _) -> (* 21736 *) path <> path') state.tests_planned
               }
   in
     iter {results = []; tests_planned = test_cases}
@@ -1171,7 +1171,7 @@ let run_test_tt ?verbose test =
     time_fun 
       perform_test 
       (fun ev ->
-         (* 618 *) log (OUnitLogger.TestEvent ev))
+         (* 624 *) log (OUnitLogger.TestEvent ev))
       test 
   in
     
@@ -1981,11 +1981,11 @@ let equal (x : string) y  = (* 0 *) x = y
 
 
 let unsafe_is_sub ~sub i s j ~len =
-  (* 987 *) let rec check k =
-    (* 1265 *) if k = len
-    then (* 41 *) true
+  (* 1181 *) let rec check k =
+    (* 1477 *) if k = len
+    then (* 42 *) true
     else 
-      (* 1224 *) String.unsafe_get sub (i+k) = 
+      (* 1435 *) String.unsafe_get sub (i+k) = 
       String.unsafe_get s (j+k) && check (k+1)
   in
   j+len <= String.length s && check 0
@@ -1993,21 +1993,21 @@ let unsafe_is_sub ~sub i s j ~len =
 
 exception Local_exit 
 let find ?(start=0) ~sub s =
-  (* 47 *) let n = String.length sub in
+  (* 48 *) let n = String.length sub in
   let s_len = String.length s in 
   let i = ref start in  
   try
     while !i + n <= s_len do
-      (* 979 *) if unsafe_is_sub ~sub 0 s !i ~len:n then
-        (* 39 *) raise_notrace Local_exit;
+      (* 1173 *) if unsafe_is_sub ~sub 0 s !i ~len:n then
+        (* 40 *) raise_notrace Local_exit;
       incr i
     done;
     -1
   with Local_exit ->
-    (* 39 *) !i
+    (* 40 *) !i
 
 let contain_substring s sub = 
-  (* 17 *) find s ~sub >= 0 
+  (* 18 *) find s ~sub >= 0 
 
 (** TODO: optimize 
     avoid nonterminating when string is empty 
@@ -4124,7 +4124,7 @@ let rec safe_dup fd =
   end
 
 let safe_close fd =
-  (* 52 *) try Unix.close fd with Unix.Unix_error(_,_,_) -> (* 0 *) ()
+  (* 56 *) try Unix.close fd with Unix.Unix_error(_,_,_) -> (* 0 *) ()
 
 
 type output = {
@@ -4134,7 +4134,7 @@ type output = {
 }
 
 let perform command args = 
-  (* 26 *) let new_fd_in, new_fd_out = Unix.pipe () in 
+  (* 28 *) let new_fd_in, new_fd_out = Unix.pipe () in 
   let err_fd_in, err_fd_out = Unix.pipe () in 
   match Unix.fork () with 
   | 0 -> 
@@ -4153,7 +4153,7 @@ let perform command args =
        when all the descriptiors on a pipe's output are closed, a call to 
        [write] on its input kills the writing process (EPIPE).
     *)
-    (* 26 *) safe_close new_fd_out ; 
+    (* 28 *) safe_close new_fd_out ; 
     safe_close err_fd_out ; 
     let in_chan = Unix.in_channel_of_descr new_fd_in in 
     let err_in_chan = Unix.in_channel_of_descr err_fd_in in 
@@ -4161,20 +4161,20 @@ let perform command args =
     let err_buf = Buffer.create 1024 in 
     (try 
        while true do 
-         (* 95 *) Buffer.add_string buf (input_line in_chan );             
+         (* 97 *) Buffer.add_string buf (input_line in_chan );             
          Buffer.add_char buf '\n'
        done;
      with
-       End_of_file -> (* 26 *) ()) ; 
+       End_of_file -> (* 28 *) ()) ; 
     (try 
        while true do 
          (* 168 *) Buffer.add_string err_buf (input_line err_in_chan );
          Buffer.add_char err_buf '\n'
        done;
      with
-       End_of_file -> (* 26 *) ()) ; 
+       End_of_file -> (* 28 *) ()) ; 
     let exit_code = match snd @@ Unix.waitpid [] pid with 
-      | Unix.WEXITED exit_code -> (* 26 *) exit_code 
+      | Unix.WEXITED exit_code -> (* 28 *) exit_code 
       | Unix.WSIGNALED _signal_number 
       | Unix.WSTOPPED _signal_number  -> (* 0 *) 127 in 
     {
@@ -4185,7 +4185,7 @@ let perform command args =
 
 
 let perform_bsc args = 
-  (* 26 *) perform bsc_exe 
+  (* 28 *) perform bsc_exe 
     (Array.append 
        [|bsc_exe ; 
          "-bs-package-name" ; "bs-platform"; 
@@ -4202,7 +4202,7 @@ let perform_bsc args =
        |] args)
 
 let bsc_eval str = 
-  (* 23 *) perform_bsc [|"-bs-eval"; str|]        
+  (* 25 *) perform_bsc [|"-bs-eval"; str|]        
 
   let debug_output o = 
   (* 0 *) Printf.printf "\nexit_code:%d\nstdout:%s\nstderr:%s\n"
@@ -4525,11 +4525,39 @@ external err :
         |} in
         OUnit.assert_bool __LOC__
             (Ext_string.contain_substring output.stderr "hi_should_error")        
+        end;
+
+        __LOC__ >:: begin fun _ ->
+          (**
+             Each [@bs.unwrap] variant constructor requires an argument
+          *)
+          (* 1 *) let output =
+            bsc_eval {|
+              external err :
+              ?hi_should_error:([`a of int | `b] [@bs.unwrap]) -> unit -> unit = "" [@@bs.val]
+            |}
+          in
+          OUnit.assert_bool __LOC__
+            (Ext_string.contain_substring output.stderr "bs.unwrap")
+        end;
+
+        __LOC__ >:: begin fun _ ->
+          (**
+             [@bs.unwrap] args are not supported in [@@bs.obj] functions
+          *)
+          (* 1 *) let output =
+            bsc_eval {|
+              external err :
+              ?hi_should_error:([`a of int] [@bs.unwrap]) -> unit -> _ = "" [@@bs.obj]
+            |}
+          in
+          OUnit.assert_bool __LOC__
+            true
+            (* (Ext_string.contain_substring output.stderr "hi_should_error") *)
         end
 
-        
-
     ]
+
 end
 module Ext_util : sig 
 #1 "ext_util.mli"

--- a/jscomp/bin/all_ounit_tests.ml
+++ b/jscomp/bin/all_ounit_tests.ml
@@ -4525,11 +4525,38 @@ let output = bsc_eval {|
         |} in
         OUnit.assert_bool __LOC__
             (Ext_string.contain_substring output.stderr "hi_should_error")        
+        end;
+
+        __LOC__ >:: begin fun _ ->
+          (**
+             Each [@bs.unwrap] variant constructor requires an argument
+          *)
+          let output =
+            bsc_eval {|
+              external err :
+              ?hi_should_error:([`a of int | `b] [@bs.unwrap]) -> unit -> unit = "" [@@bs.val]
+            |}
+          in
+          OUnit.assert_bool __LOC__
+            (Ext_string.contain_substring output.stderr "bs.unwrap")
+        end;
+
+        __LOC__ >:: begin fun _ ->
+          (**
+             [@bs.unwrap] args are not supported in [@@bs.obj] functions
+          *)
+          let output =
+            bsc_eval {|
+              external err :
+              ?hi_should_error:([`a of int] [@bs.unwrap]) -> unit -> _ = "" [@@bs.obj]
+            |}
+          in
+          OUnit.assert_bool __LOC__
+            (Ext_string.contain_substring output.stderr "hi_should_error")
         end
 
-        
-
     ]
+
 end
 module Ext_util : sig 
 #1 "ext_util.mli"

--- a/jscomp/bin/bsppx.ml
+++ b/jscomp/bin/bsppx.ml
@@ -6664,6 +6664,7 @@ type error
   | Invalid_underscore_type_in_external
   | Invalid_bs_string_type 
   | Invalid_bs_int_type 
+  | Invalid_bs_unwrap_type
   | Conflict_ffi_attribute of string
   | Not_supported_in_bs_deriving
   | Canot_infer_arity_by_syntax
@@ -6724,6 +6725,7 @@ type error
   | Invalid_underscore_type_in_external
   | Invalid_bs_string_type 
   | Invalid_bs_int_type 
+  | Invalid_bs_unwrap_type
   | Conflict_ffi_attribute of string
   | Not_supported_in_bs_deriving
   | Canot_infer_arity_by_syntax
@@ -6794,6 +6796,10 @@ let pp_error fmt err =
   | Invalid_bs_int_type 
     -> 
     "Not a valid  type for [@bs.int]"
+  | Invalid_bs_unwrap_type
+    ->
+    "Not a valid type for [@bs.unwrap]. Type must be an inline variant (closed), and\n\
+     each constructor must have an argument."
   | Conflict_ffi_attribute str
     ->
     "Conflicting FFI attributes found: " ^ str
@@ -8431,8 +8437,8 @@ type derive_attr = {
   explict_nonrec : bool;
   bs_deriving : [`Has_deriving of Ast_payload.action list | `Nothing ]
 }
-val process_bs_string_int_uncurry : 
-  t -> [`Nothing | `String | `Int | `Ignore | `Uncurry of int option ]  * t 
+val process_bs_string_int_unwrap_uncurry :
+  t -> [`Nothing | `String | `Int | `Ignore | `Unwrap | `Uncurry of int option ]  * t
 
 val process_bs_string_as :
   t -> string option * t 
@@ -8619,7 +8625,7 @@ let process_derive_type attrs =
 
 
 
-let process_bs_string_int_uncurry attrs = 
+let process_bs_string_int_unwrap_uncurry attrs =
   List.fold_left 
     (fun (st,attrs)
       (({txt ; loc}, (payload : _ ) ) as attr : attr)  ->
@@ -8630,7 +8636,8 @@ let process_bs_string_int_uncurry attrs =
         ->  `Int, attrs
       | "bs.ignore", (`Nothing | `Ignore)
         -> `Ignore, attrs
-      
+      | "bs.unwrap", (`Nothing | `Unwrap)
+        -> `Unwrap, attrs
       | "bs.uncurry", `Nothing
         ->
           `Uncurry (Ast_payload.is_single_int payload), attrs 
@@ -8640,6 +8647,7 @@ let process_bs_string_int_uncurry attrs =
       | "bs.int", _
       | "bs.string", _
       | "bs.ignore", _
+      | "bs.unwrap", _
         -> 
         Bs_syntaxerr.err loc Conflict_attributes
       | _ , _ -> st, (attr :: attrs )
@@ -11952,6 +11960,7 @@ type ty =
   | Extern_unit
   | Nothing
   | Ignore
+  | Unwrap
 
 type kind = 
   {
@@ -12022,6 +12031,7 @@ type ty =
   | Extern_unit
   | Nothing
   | Ignore
+  | Unwrap
 
 type kind = 
   {
@@ -13268,6 +13278,28 @@ end = struct
 
 
 
+let variant_can_bs_unwrap_fields row_fields =
+  let validity = (List.fold_left
+     begin fun st row ->
+       match st, row with
+       | (* we've seen no fields or only valid fields so far *)
+         (`No_fields | `Valid_fields),
+         (* and this field has one constructor arg that we can unwrap to *)
+         Parsetree.Rtag (label, attrs, false, ([ _ ]))
+         ->
+         `Valid_fields
+       | (* otherwise, this field or a previous field was invalid *)
+         _ ->
+         `Invalid_field
+     end
+     `No_fields
+     row_fields
+  )
+  in
+  match validity with
+  | `Valid_fields -> true
+  | `No_fields
+  | `Invalid_field -> false
 
 (** Given the type of argument, process its [bs.] attribute and new type,
     The new type is currently used to reconstruct the external type 
@@ -13303,7 +13335,7 @@ let get_arg_type ~nolabel optional
 
     end 
   else (* ([`a|`b] [@bs.string]) *)
-    match Ast_attributes.process_bs_string_int_uncurry ptyp.ptyp_attributes, ptyp.ptyp_desc with 
+    match Ast_attributes.process_bs_string_int_unwrap_uncurry ptyp.ptyp_attributes, ptyp.ptyp_desc with
     | (`String, ptyp_attributes),  Ptyp_variant ( row_fields, Closed, None)
       -> 
       let case, result, row_fields  = 
@@ -13369,8 +13401,13 @@ let get_arg_type ~nolabel optional
        ptyp_desc = Ptyp_variant(List.rev rev_row_fields, Closed, None );
        ptyp_attributes
       }
-
     | (`Int, _), _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
+    | (`Unwrap, ptyp_attributes), (Ptyp_variant (row_fields, Closed, _) as ptyp_desc)
+      when variant_can_bs_unwrap_fields row_fields
+      ->
+      Unwrap, {ptyp with ptyp_desc; ptyp_attributes}
+    | (`Unwrap, _), _ ->
+      Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_unwrap_type
     | (`Uncurry opt_arity, ptyp_attributes), ptyp_desc -> 
       let real_arity =  Ast_core_type.get_uncurry_arity ptyp in 
       (begin match opt_arity, real_arity with 
@@ -13735,6 +13772,9 @@ let handle_attributes
                        ->  
                        Location.raise_errorf ~loc 
                          "bs.obj label %s does not support such arg type" name
+                     | Unwrap ->
+                       Location.raise_errorf ~loc
+                         "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
                  | Optional name -> 
                    let arg_type, new_ty_extract = get_arg_type ~nolabel:false true ty in 
@@ -13770,6 +13810,9 @@ let handle_attributes
                        ->  
                        Location.raise_errorf ~loc
                          "bs.obj label %s does not support such arg type" name                        
+                     | Unwrap ->
+                       Location.raise_errorf ~loc
+                         "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
                in     
                (

--- a/jscomp/core/js_of_lam_option.mli
+++ b/jscomp/core/js_of_lam_option.mli
@@ -27,9 +27,12 @@
 
 
 
+type option_unwrap_time =
+  | Static_unwrapped
+  | Runtime_maybe_unwrapped
 
-val get_default_undefined : J.expression -> J.expression
+val get_default_undefined : ?map:(option_unwrap_time -> J.expression -> J.expression) -> J.expression -> J.expression
 
-val none : J.expression 
+val none : J.expression
 
 val some : J.expression -> J.expression

--- a/jscomp/core/js_of_lam_variant.ml
+++ b/jscomp/core/js_of_lam_variant.ml
@@ -84,3 +84,13 @@ let eval_as_int (arg : J.expression) (dispatches : (int * int) list ) : E.t  =
                body = [S.return (E.int (Int32.of_int  r))],
                       false (* FIXME: if true, still print break*)
               }) dispatches))]
+
+let eval_as_unwrap (arg : J.expression) : E.t =
+  if arg == E.undefined then
+    E.undefined
+  else
+    match arg.expression_desc with
+    | Caml_block ([{expression_desc = Number _}; cb], _, _, _) ->
+      cb
+    | _ ->
+      E.index (arg) 1l

--- a/jscomp/core/js_of_lam_variant.ml
+++ b/jscomp/core/js_of_lam_variant.ml
@@ -86,11 +86,8 @@ let eval_as_int (arg : J.expression) (dispatches : (int * int) list ) : E.t  =
               }) dispatches))]
 
 let eval_as_unwrap (arg : J.expression) : E.t =
-  if arg == E.undefined then
-    E.undefined
-  else
-    match arg.expression_desc with
-    | Caml_block ([{expression_desc = Number _}; cb], _, _, _) ->
-      cb
-    | _ ->
-      E.index (arg) 1l
+  match arg.expression_desc with
+  | Caml_block ([{expression_desc = Number _}; cb], _, _, _) ->
+    cb
+  | _ ->
+    E.index (arg) 1l

--- a/jscomp/core/js_of_lam_variant.mli
+++ b/jscomp/core/js_of_lam_variant.mli
@@ -25,3 +25,4 @@
 val eval : J.expression -> (int * string) list -> J.expression
 val eval_as_event : J.expression -> (int * string) list -> J.expression list 
 val eval_as_int : J.expression -> (int * int) list -> J.expression
+val eval_as_unwrap : J.expression -> J.expression

--- a/jscomp/core/lam_compile_external_call.ml
+++ b/jscomp/core/lam_compile_external_call.ml
@@ -79,12 +79,12 @@ let handle_external_opt
 *)
 let ocaml_to_js_eff 
     ({ Ast_arg.arg_label;  arg_type })
-    (arg : J.expression) 
+    (raw_arg : J.expression)
   : E.t list * E.t list  =
   let arg =
     match arg_label with
-    | Optional label -> Js_of_lam_option.get_default_undefined arg 
-    | Label (_, None) | Empty None -> arg 
+    | Optional label -> Js_of_lam_option.get_default_undefined raw_arg
+    | Label (_, None) | Empty None -> raw_arg
     | Label (_, Some _) 
     | Empty ( Some _)
       -> assert false in 
@@ -111,7 +111,31 @@ let ocaml_to_js_eff
   | Int dispatches -> 
     [Js_of_lam_variant.eval_as_int arg dispatches],[]
   | Unwrap ->
-    [Js_of_lam_variant.eval_as_unwrap arg],[]
+    let single_arg =
+      match arg_label with
+      | Optional label ->
+        (**
+           If this is an optional arg (like `?arg`), we have to potentially do
+           2 levels of unwrapping:
+           - if ocaml arg is `None`, let js arg be `undefined` (no unwrapping)
+           - if ocaml arg is `Some x`, unwrap the arg to get the `x`, then
+             unwrap the `x` itself
+        *)
+        Js_of_lam_option.get_default_undefined
+          ~map:(fun opt_unwrapping exp ->
+              match opt_unwrapping with
+              | Static_unwrapped ->
+                (* If we can unwrap the option statically, do `arg[1]` *)
+                E.index exp 1l
+              | Runtime_maybe_unwrapped ->
+                (* If we can't, do Js_primitive.option_get_unwrap(arg) *)
+                E.runtime_call Js_config.js_primitive "option_get_unwrap" [raw_arg]
+            )
+          raw_arg
+      | _ ->
+        Js_of_lam_variant.eval_as_unwrap raw_arg
+    in
+    [single_arg],[]
   | Nothing  | Array ->  [arg], []
 
 

--- a/jscomp/core/lam_compile_external_call.ml
+++ b/jscomp/core/lam_compile_external_call.ml
@@ -110,6 +110,8 @@ let ocaml_to_js_eff
     Js_of_lam_variant.eval_as_event arg dispatches,[]
   | Int dispatches -> 
     [Js_of_lam_variant.eval_as_int arg dispatches],[]
+  | Unwrap ->
+    [Js_of_lam_variant.eval_as_unwrap arg],[]
   | Nothing  | Array ->  [arg], []
 
 

--- a/jscomp/ounit_tests/ounit_ffi_error_debug_test.ml
+++ b/jscomp/ounit_tests/ounit_ffi_error_debug_test.ml
@@ -45,8 +45,34 @@ let output = bsc_eval {|
         |} in
         OUnit.assert_bool __LOC__
             (Ext_string.contain_substring output.stderr "hi_should_error")        
-        end
+        end;
 
-        
+        __LOC__ >:: begin fun _ ->
+          (**
+             Each [@bs.unwrap] variant constructor requires an argument
+          *)
+          let output =
+            bsc_eval {|
+              external err :
+              ?hi_should_error:([`a of int | `b] [@bs.unwrap]) -> unit -> unit = "" [@@bs.val]
+            |}
+          in
+          OUnit.assert_bool __LOC__
+            (Ext_string.contain_substring output.stderr "bs.unwrap")
+        end;
+
+        __LOC__ >:: begin fun _ ->
+          (**
+             [@bs.unwrap] args are not supported in [@@bs.obj] functions
+          *)
+          let output =
+            bsc_eval {|
+              external err :
+              ?hi_should_error:([`a of int] [@bs.unwrap]) -> unit -> _ = "" [@@bs.obj]
+            |}
+          in
+          OUnit.assert_bool __LOC__
+            (Ext_string.contain_substring output.stderr "hi_should_error")
+        end
 
     ]

--- a/jscomp/runtime/js_primitive.ml
+++ b/jscomp/runtime/js_primitive.ml
@@ -48,3 +48,9 @@ let option_get (x : 'a option) : 'a Js_undefined.t =
   match x with 
   | None -> Js_undefined.empty
   | Some x -> Js_undefined.return x 
+
+let option_get_unwrap (x : 'a option) : 'b Js_undefined.t =
+  match x with
+  | None -> Js_undefined.empty
+  | Some x -> Js_undefined.return ((Obj.magic x).(1))
+

--- a/jscomp/runtime/js_primitive.mli
+++ b/jscomp/runtime/js_primitive.mli
@@ -34,3 +34,5 @@ val undefined_to_opt : 'a Js.undefined -> 'a option
 val null_to_opt : 'a Js.null -> 'a option
 
 val option_get : 'a option -> 'a Js_undefined.t 
+
+val option_get_unwrap : 'a option -> 'b Js_undefined.t

--- a/jscomp/syntax/ast_arg.ml
+++ b/jscomp/syntax/ast_arg.ml
@@ -49,6 +49,7 @@ type ty =
   | Extern_unit
   | Nothing
   | Ignore
+  | Unwrap
 
 type kind = 
   {

--- a/jscomp/syntax/ast_arg.mli
+++ b/jscomp/syntax/ast_arg.mli
@@ -48,6 +48,7 @@ type ty =
   | Extern_unit
   | Nothing
   | Ignore
+  | Unwrap
 
 type kind = 
   {

--- a/jscomp/syntax/ast_attributes.ml
+++ b/jscomp/syntax/ast_attributes.ml
@@ -156,7 +156,7 @@ let process_derive_type attrs =
 
 
 
-let process_bs_string_int_uncurry attrs = 
+let process_bs_string_int_unwrap_uncurry attrs =
   List.fold_left 
     (fun (st,attrs)
       (({txt ; loc}, (payload : _ ) ) as attr : attr)  ->
@@ -167,7 +167,8 @@ let process_bs_string_int_uncurry attrs =
         ->  `Int, attrs
       | "bs.ignore", (`Nothing | `Ignore)
         -> `Ignore, attrs
-      
+      | "bs.unwrap", (`Nothing | `Unwrap)
+        -> `Unwrap, attrs
       | "bs.uncurry", `Nothing
         ->
           `Uncurry (Ast_payload.is_single_int payload), attrs 
@@ -177,6 +178,7 @@ let process_bs_string_int_uncurry attrs =
       | "bs.int", _
       | "bs.string", _
       | "bs.ignore", _
+      | "bs.unwrap", _
         -> 
         Bs_syntaxerr.err loc Conflict_attributes
       | _ , _ -> st, (attr :: attrs )

--- a/jscomp/syntax/ast_attributes.mli
+++ b/jscomp/syntax/ast_attributes.mli
@@ -46,8 +46,8 @@ type derive_attr = {
   explict_nonrec : bool;
   bs_deriving : [`Has_deriving of Ast_payload.action list | `Nothing ]
 }
-val process_bs_string_int_uncurry : 
-  t -> [`Nothing | `String | `Int | `Ignore | `Uncurry of int option ]  * t 
+val process_bs_string_int_unwrap_uncurry :
+  t -> [`Nothing | `String | `Int | `Ignore | `Unwrap | `Uncurry of int option ]  * t
 
 val process_bs_string_as :
   t -> string option * t 

--- a/jscomp/syntax/ast_external_attributes.ml
+++ b/jscomp/syntax/ast_external_attributes.ml
@@ -62,7 +62,7 @@ let get_arg_type ~nolabel optional
 
     end 
   else (* ([`a|`b] [@bs.string]) *)
-    match Ast_attributes.process_bs_string_int_uncurry ptyp.ptyp_attributes, ptyp.ptyp_desc with 
+    match Ast_attributes.process_bs_string_int_unwrap_uncurry ptyp.ptyp_attributes, ptyp.ptyp_desc with
     | (`String, ptyp_attributes),  Ptyp_variant ( row_fields, Closed, None)
       -> 
       let case, result, row_fields  = 
@@ -128,8 +128,35 @@ let get_arg_type ~nolabel optional
        ptyp_desc = Ptyp_variant(List.rev rev_row_fields, Closed, None );
        ptyp_attributes
       }
-
     | (`Int, _), _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
+    | (`Unwrap, ptyp_attributes), (Ptyp_variant (row_fields, Closed, _) as ptyp_desc) ->
+      let validity =
+        (List.fold_left
+          begin fun st row ->
+            match st, row with
+            | (`No_fields | `Some_fields),
+              Parsetree.Rtag (label, attrs, false, ([ _ ]))
+              ->
+              `Some_fields
+            | _ ->
+              `Invalid_field
+          end
+          `No_fields
+          row_fields
+        ) in
+      (match validity with
+       | `Some_fields ->
+         Unwrap,
+         {ptyp with
+          ptyp_desc;
+          ptyp_attributes
+         }
+       | `No_fields
+       | `Invalid_field ->
+         Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_unwrap_type
+      )
+    | (`Unwrap, _), _ ->
+      Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_unwrap_type
     | (`Uncurry opt_arity, ptyp_attributes), ptyp_desc -> 
       let real_arity =  Ast_core_type.get_uncurry_arity ptyp in 
       (begin match opt_arity, real_arity with 
@@ -494,6 +521,9 @@ let handle_attributes
                        ->  
                        Location.raise_errorf ~loc 
                          "bs.obj label %s does not support such arg type" name
+                     | Unwrap ->
+                       Location.raise_errorf ~loc
+                         "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
                  | Optional name -> 
                    let arg_type, new_ty_extract = get_arg_type ~nolabel:false true ty in 
@@ -529,6 +559,9 @@ let handle_attributes
                        ->  
                        Location.raise_errorf ~loc
                          "bs.obj label %s does not support such arg type" name                        
+                     | Unwrap ->
+                       Location.raise_errorf ~loc
+                         "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
                in     
                (

--- a/jscomp/syntax/bs_syntaxerr.ml
+++ b/jscomp/syntax/bs_syntaxerr.ml
@@ -39,6 +39,7 @@ type error
   | Invalid_underscore_type_in_external
   | Invalid_bs_string_type 
   | Invalid_bs_int_type 
+  | Invalid_bs_unwrap_type
   | Conflict_ffi_attribute of string
   | Not_supported_in_bs_deriving
   | Canot_infer_arity_by_syntax
@@ -109,6 +110,10 @@ let pp_error fmt err =
   | Invalid_bs_int_type 
     -> 
     "Not a valid  type for [@bs.int]"
+  | Invalid_bs_unwrap_type
+    ->
+    "Not a valid type for [@bs.unwrap]. Type must be an inline variant (closed), and\n\
+     each constructor must have an argument."
   | Conflict_ffi_attribute str
     ->
     "Conflicting FFI attributes found: " ^ str

--- a/jscomp/syntax/bs_syntaxerr.mli
+++ b/jscomp/syntax/bs_syntaxerr.mli
@@ -37,6 +37,7 @@ type error
   | Invalid_underscore_type_in_external
   | Invalid_bs_string_type 
   | Invalid_bs_int_type 
+  | Invalid_bs_unwrap_type
   | Conflict_ffi_attribute of string
   | Not_supported_in_bs_deriving
   | Canot_infer_arity_by_syntax

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -177,7 +177,8 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	inner_call\
 	default_export_test\
 	gpr_1817_test\
-	gpr_1822_test
+	gpr_1822_test\
+	bs_unwrap_test
 
 # bs_uncurry_test
 # needs Lam to get rid of Uncurry arity first

--- a/jscomp/test/bs_unwrap_test.js
+++ b/jscomp/test/bs_unwrap_test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+
+console.log(/* tuple */[
+      "hello world",
+      1
+    ]);
+
+console.log(1337);
+
+console.log("hello world");
+
+var arg_string = /* `String */[
+  -976970511,
+  "hi runtime"
+];
+
+console.log(arg_string[1]);
+
+var arg_pair = /* `Pair */[
+  892012602,
+  /* tuple */[
+    "hi",
+    1
+  ]
+];
+
+console.log(arg_pair[1]);
+
+console.log(/* () */0);
+
+console.log(undefined);
+
+console.log("hi");
+
+console.log("foo");
+
+console.log({
+      foo: 1
+    });
+
+exports.arg_string = arg_string;
+exports.arg_pair   = arg_pair;
+/*  Not a pure module */

--- a/jscomp/test/bs_unwrap_test.js
+++ b/jscomp/test/bs_unwrap_test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Js_primitive = require("../../lib/js/js_primitive.js");
 
 console.log(/* tuple */[
       "hello world",
@@ -31,7 +32,35 @@ console.log(/* () */0);
 
 console.log(1, undefined);
 
-console.log(1, "hi");
+console.log(2, "hi");
+
+console.log(3, "hi");
+
+console.log(4, undefined);
+
+var some_arg = /* Some */[/* `Bool */[
+    737456202,
+    true
+  ]];
+
+console.log(5, some_arg ? some_arg[0][1] : undefined);
+
+console.log(6, undefined);
+
+console.log(7, Js_primitive.option_get_unwrap((console.log("trace"), /* None */0)));
+
+function dyn_log3(prim, prim$1, _) {
+  console.log(prim[1], prim$1 ? prim$1[0][1] : undefined);
+  return /* () */0;
+}
+
+dyn_log3(/* `Int */[
+      3654863,
+      8
+    ], /* Some */[/* `Bool */[
+        737456202,
+        true
+      ]], /* () */0);
 
 console.log("foo");
 
@@ -39,6 +68,21 @@ console.log({
       foo: 1
     });
 
+function dyn_log4(prim) {
+  console.log(prim[1]);
+  return /* () */0;
+}
+
+console.log({
+      foo: 2
+    });
+
+var none_arg = /* None */0;
+
 exports.arg_string = arg_string;
 exports.arg_pair   = arg_pair;
+exports.some_arg   = some_arg;
+exports.none_arg   = none_arg;
+exports.dyn_log3   = dyn_log3;
+exports.dyn_log4   = dyn_log4;
 /*  Not a pure module */

--- a/jscomp/test/bs_unwrap_test.js
+++ b/jscomp/test/bs_unwrap_test.js
@@ -29,9 +29,9 @@ console.log(arg_pair[1]);
 
 console.log(/* () */0);
 
-console.log(undefined);
+console.log(1, undefined);
 
-console.log("hi");
+console.log(1, "hi");
 
 console.log("foo");
 

--- a/jscomp/test/bs_unwrap_test.ml
+++ b/jscomp/test/bs_unwrap_test.ml
@@ -27,22 +27,21 @@ external log2 :
 let _ = log2 (`Unit ())
 
 external log3 :
-  ?arg:(
-    [ `String of string
-    ] [@bs.unwrap]
-  )
+  req:([ `String of string
+       | `Int of int
+       ] [@bs.unwrap])
+  -> ?opt:([ `String of string
+           ] [@bs.unwrap])
   -> unit
   -> unit = "console.log" [@@bs.val]
 
-let _ = log3 ()
-let _ = log3 ~arg:(`String "hi") ()
+let _ = log3 ~req:(`Int 1) ()
+let _ = log3 ~req:(`Int 1) ~opt:(`String "hi") ()
 
 external log4 :
-  (
-    [ `String of string
-    | `Options of < foo : int > Js.t
-    ] [@bs.unwrap]
-  )
+  ([ `String of string
+   | `Options of [%bs.obj: < foo : int > ]
+   ] [@bs.unwrap])
   -> unit = "console.log" [@@bs.val]
 
 let _ = log4 (`String "foo")

--- a/jscomp/test/bs_unwrap_test.ml
+++ b/jscomp/test/bs_unwrap_test.ml
@@ -1,0 +1,49 @@
+external log1 :
+  (
+    [ `Pair of string * int
+    | `Int of int
+    | `String of string
+    ] [@bs.unwrap]
+  )
+  -> unit = "console.log" [@@bs.val]
+
+let _ = log1 (`Pair ("hello world", 1))
+let _ = log1 (`Int 1337)
+let _ = log1 (`String "hello world")
+
+let arg_string = `String "hi runtime"
+let _ = log1 arg_string
+
+let arg_pair = `Pair ("hi", 1)
+let _ = log1 arg_pair
+
+external log2 :
+  (
+    [ `Unit of unit
+    ] [@bs.unwrap]
+  )
+  -> unit = "console.log" [@@bs.val]
+
+let _ = log2 (`Unit ())
+
+external log3 :
+  ?arg:(
+    [ `String of string
+    ] [@bs.unwrap]
+  )
+  -> unit
+  -> unit = "console.log" [@@bs.val]
+
+let _ = log3 ()
+let _ = log3 ~arg:(`String "hi") ()
+
+external log4 :
+  (
+    [ `String of string
+    | `Options of < foo : int > Js.t
+    ] [@bs.unwrap]
+  )
+  -> unit = "console.log" [@@bs.val]
+
+let _ = log4 (`String "foo")
+let _ = log4 (`Options [%bs.obj { foo = 1 }])

--- a/jscomp/test/bs_unwrap_test.ml
+++ b/jscomp/test/bs_unwrap_test.ml
@@ -31,12 +31,41 @@ external log3 :
        | `Int of int
        ] [@bs.unwrap])
   -> ?opt:([ `String of string
+           | `Bool of Js.boolean
            ] [@bs.unwrap])
   -> unit
   -> unit = "console.log" [@@bs.val]
 
 let _ = log3 ~req:(`Int 1) ()
-let _ = log3 ~req:(`Int 1) ~opt:(`String "hi") ()
+let _ = log3 ~req:(`Int 2) ~opt:(`String "hi") ()
+let _ = log3 ~req:(`Int 3) ?opt:(Some (`String "hi")) ()
+let _ = log3 ~req:(`Int 4) ?opt:None ()
+
+(* static optional arg as variable *)
+let some_arg = Some (`Bool Js.true_)
+let _ = log3 ~req:(`Int 5) ?opt:some_arg ()
+
+let none_arg = None
+let _ = log3 ~req:(`Int 6) ?opt:none_arg ()
+
+(* static optional arg as complex side-effectful expression *)
+let _ = log3
+    ~req:(`Int 7)
+    ?opt:(
+      ((fun _ ->
+           print_endline "trace";
+           None
+        )
+         ()
+      )
+    )
+    ()
+
+(* expose the external as a function in generated module*)
+let dyn_log3 = log3
+
+(* call the dynamically reassigned external *)
+let _ = dyn_log3 ~req:(`Int 8) ~opt:(`Bool Js.true_) ()
 
 external log4 :
   ([ `String of string
@@ -44,5 +73,9 @@ external log4 :
    ] [@bs.unwrap])
   -> unit = "console.log" [@@bs.val]
 
+(* Make sure [@bs.unwrap] plays nicely with [%bs.obj] *)
 let _ = log4 (`String "foo")
 let _ = log4 (`Options [%bs.obj { foo = 1 }])
+
+let dyn_log4 = log4
+let _ = dyn_log4 (`Options [%bs.obj { foo = 2 }])

--- a/lib/js/js_primitive.js
+++ b/lib/js/js_primitive.js
@@ -41,9 +41,18 @@ function option_get(x) {
   }
 }
 
+function option_get_unwrap(x) {
+  if (x) {
+    return x[0][1];
+  } else {
+    return undefined;
+  }
+}
+
 exports.is_nil_undef          = is_nil_undef;
 exports.null_undefined_to_opt = null_undefined_to_opt;
 exports.undefined_to_opt      = undefined_to_opt;
 exports.null_to_opt           = null_to_opt;
 exports.option_get            = option_get;
+exports.option_get_unwrap     = option_get_unwrap;
 /* No side effect */

--- a/site/docsource/OCaml-call-JS.adoc
+++ b/site/docsource/OCaml-call-JS.adoc
@@ -463,7 +463,7 @@ function register(rl) {
 }
 ----------
 
-#### Using polymorphic variant to model arguments of multiple possible types (@since master)
+#### Using polymorphic variant to model arguments of multiple possible types (@since 1.8.3)
 
 Sometimes a JavaScript function will accept an argument that could have different types depending upon how it's used.
 

--- a/site/docsource/OCaml-call-JS.adoc
+++ b/site/docsource/OCaml-call-JS.adoc
@@ -383,7 +383,7 @@ the compiler will emit an error message.
 ======
 
 
-### Special types on external declarations: bs.string, bs.int, bs.ignore, bs.as
+### Special types on external declarations: `bs.string`, `bs.int`, `bs.ignore`, `bs.as`, `bs.unwrap`
 
 #### Using polymorphic variant to model enums and string types
 There are several patterns heavily used in existing JavaScript codebases, for example,
@@ -463,14 +463,59 @@ function register(rl) {
 }
 ----------
 
+#### Using polymorphic variant to model arguments of multiple possible types (@since master)
+
+Sometimes a JavaScript function will accept an argument that could have different types depending upon how it's used.
+
+[source,js]
+----
+function padLeft(string, padding) {
+  if (typeof padding === "number") {
+    return Array(padding + 1).join(" ") + value;
+  }
+  if (typeof padding === "string") {
+    return padding + value;
+  }
+  throw new Error(`Expected string or number, got '${padding}'.`);
+}
+----
+
+You can model such a function in BuckleScript using `[@bs.unwrap]`.
+
+[source,ocaml]
+----
+external padLeft :
+  string
+  -> ([ `String of string
+      | `Int of int
+      ] [@bs.unwrap])
+  -> string
+  = "" [@@bs.val]
+----
+
+Polymorphic variants with `[@bs.unwrap]` will "unwrap" the variant at the call site so that the JavaScript function is called with the underlying value.
+
+[source,ocaml]
+----
+let _ = padLeft "Hello World" (`Int 4)
+let _ = padLeft "Hello World" (`String "bs: ")
+----
+
+Output:
+[source,js]
+----
+padLeft("Hello World", 4);
+padLeft("Hello World", "bs: ");
+----
+
 [WARNING]
 =========
-- These annotations will only have effect in `external` declarations.
+- These `[@bs.string]`, `[@bs.int]`, and `[@bs.unwrap]` annotations will only have effect in `external` declarations.
 - The runtime encoding of using polymorphic variant is internal to the compiler.
 - With these annotations mentioned above, BuckleScript will automatically
   transform the internal encoding to the designated encoding for FFI.
   BuckleScript will try to do such conversion at compile time if it can, otherwise, it
- will do such conversion in the runtime, but it should be always correct.
+  will do such conversion in the runtime, but it should be always correct.
 =========
 
 #### Phantom Arguments and ad-hoc polymorphism
@@ -522,7 +567,12 @@ let add2 k x y =
   add_dyn k (string_of_kind k) x y
 -------------
 
-### Fixed Arguments
+[NOTE]
+====
+Using a GADT as a `[@bs.ignore]` argument as described to achieve a single polymorphic argument can now also be accomplished with `[@bs.unwrap]` above. The GADT + `[@bs.ignore]` approach is slightly more flexible and is always guaranteed to have no runtime overhead, where `[@bs.unwrap]` could incur slight runtime overhead in some cases but could be a more intuitive API for end users.
+====
+
+#### Fixed Arguments
 
 Contrary to the Phantom arguments, `_[@bs.as]` is introduced to attach the const
 data.
@@ -590,7 +640,7 @@ var config = {
 };
 -----------
 
-### Fixed Arguments with arbitrary JSON literal (@since 1.7.0)
+#### Fixed Arguments with arbitrary JSON literal (@since 1.7.0)
 
 So the payload can be more flexiblie with JSON literal support
 

--- a/site/docsource/build.sh
+++ b/site/docsource/build.sh
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 echo "Building" >build.compile
 asciidoctor -a reproducible -D ../../docs/ ./Manual.adoc  2>> build.compile
 asciidoctor -a reproducible -D ../../docs/blog ./blog/index.adoc 2>> build.compile
 asciidoctor -a reproducible -a linkcss -a stylesheet!  -D ../../docs/ ./index.adoc 2>> build.compile
 echo "Finished" >> build.compile
-reload
+if type reload >/dev/null 2>&1; then
+  reload
+fi
 # wkhtmltopdf -B 20 -T 20 ../../docs/Manual.html ../../docs/Manual.pdf &


### PR DESCRIPTION
Closes #1736 

---

This introduces a `[@bs.unwrap]` attribute as described in #1736 which can be added to an argument to an external, if that argument has an inline anonymous variant as its type, and will have the effect of the boxed value being "unwrapped" from the tagged tuple that bucklescript usually creates for variants at codegen callsites.

For example, this ocaml:

```ocaml
external log :
  (
    [ `String of string
    | `Options of < foo : int > Js.t
    ] [@bs.unwrap]
  )
  -> unit = "console.log" [@@bs.val]

let _ = log (`String "foo")
let _ = log (`Options [%bs.obj { foo = 1 }])
```

will compile to this js:

```js
console.log("foo");

console.log({
      foo: 1
    });
```

One intention is that we can guarantee that if the variant is constructed inline at the callsite, as in ``log (`String "foo")``, then the codegen will produce `log("foo")` without any intermediate boxing/unboxing at all. I _think_ I've done this correctly, and have some basic tests, but definitely need a review. In any case, if the arg isn't constructed directly at the callsite, the emitted js will create an intermediate tuple (js array) and the callsite will index into it to get the wrapped arg, as in:

```js
var arg_string = /* `String */[
  -976970511,
  "hi runtime"
];
console.log(arg_string[1]);
```

I don't know if there are other opportunities to avoid this intermediate boxing that I haven't taken, but none were obvious to me.

As a side note, hi 👋 ! This is my first PR to bucklescript and first time writing OCaml in a little while, so please pick my code apart and let me know what other checks/docs/tests/etc. should be included.

#### TODO

- [x] Document `[@bs.unwrap]` usage & examples
- [ ] Decide on name:  `[@bs.unwrap]` or `[@bs.unbox]`?