### PR TITLE
Feature/relative ppx merlin

### DIFF
--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -451,10 +451,9 @@ core/lam_compile_const.cmx : core/lam_compile_util.cmx core/lam.cmx \
     syntax/ast_arg.cmx core/lam_compile_const.cmi
 core/lam_inner.cmx : core/lam.cmx core/lam_inner.cmi
 core/lam_util.cmx : core/lam_stats.cmx core/lam_print.cmx \
-    core/lam_id_kind.cmx core/lam_analysis.cmx core/lam.cmx \
-    common/js_config.cmx ext/ident_set.cmx ext/ident_map.cmx \
-    ext/ident_hashtbl.cmx common/ext_log.cmx ext/ext_filename.cmx \
-    ext/ext_array.cmx core/lam_util.cmi
+    core/lam_id_kind.cmx core/lam_analysis.cmx core/lam.cmx ext/ident_set.cmx \
+    ext/ident_map.cmx ext/ident_hashtbl.cmx ext/ext_array.cmx \
+    core/lam_util.cmi
 core/lam_eta_conversion.cmx : ext/literals.cmx core/lam.cmx ext/ext_list.cmx \
     ext/ext_ident.cmx core/lam_eta_conversion.cmi
 core/lam_group.cmx : core/lam_print.cmx core/lam.cmx core/lam_group.cmi
@@ -517,9 +516,7 @@ core/js_dump.cmx : ext/literals.cmx core/lam_module_ident.cmx \
     core/js_exp_make.cmx common/js_config.cmx core/js_closure.cmx core/j.cmx \
     ext/ident_set.cmx ext/ext_string.cmx ext/ext_pp_scope.cmx ext/ext_pp.cmx \
     ext/ext_list.cmx ext/ext_ident.cmx common/bs_version.cmx core/js_dump.cmi
-core/js_pass_debug.cmx : core/js_dump.cmx common/js_config.cmx core/j.cmx \
-    ext/ext_pervasives.cmx common/ext_log.cmx ext/ext_filename.cmx \
-    core/js_pass_debug.cmi
+core/js_pass_debug.cmx : core/j.cmx core/js_pass_debug.cmi
 core/js_of_lam_option.cmx : core/js_exp_make.cmx common/js_config.cmx \
     core/js_analyzer.cmx core/j.cmx core/js_of_lam_option.cmi
 core/js_output.cmx : core/lam_compile_defs.cmx core/lam_analysis.cmx \
@@ -585,8 +582,7 @@ core/lam_pass_eliminate_ref.cmx : core/lam.cmx ext/ident_set.cmx \
 core/lam_pass_lets_dce.cmx : core/lam_util.cmx \
     core/lam_pass_eliminate_ref.cmx core/lam_pass_count.cmx \
     core/lam_beta_reduce.cmx core/lam_analysis.cmx core/lam.cmx \
-    ext/ident_hashtbl.cmx common/ext_log.cmx ext/ext_list.cmx \
-    core/lam_pass_lets_dce.cmi
+    ext/ident_hashtbl.cmx ext/ext_list.cmx core/lam_pass_lets_dce.cmi
 core/lam_pass_remove_alias.cmx : core/lam_util.cmx core/lam_stats.cmx \
     core/lam_inline_util.cmx core/lam_compile_env.cmx core/lam_closure.cmx \
     core/lam_beta_reduce.cmx core/lam_analysis.cmx core/lam.cmx \
@@ -609,9 +605,8 @@ core/lam_compile_group.cmx : core/lam_util.cmx core/lam_stats_export.cmx \
     core/js_pass_flatten.cmx core/js_pass_debug.cmx core/js_output.cmx \
     core/js_fold_basic.cmx core/js_exp_make.cmx core/js_dump.cmx \
     common/js_config.cmx core/js_cmj_format.cmx core/j.cmx ext/ident_set.cmx \
-    ext/ext_string.cmx ext/ext_pervasives.cmx common/ext_log.cmx \
-    ext/ext_list.cmx ext/ext_ident.cmx ext/ext_filename.cmx \
-    core/lam_compile_group.cmi
+    ext/ext_string.cmx ext/ext_pervasives.cmx ext/ext_list.cmx \
+    ext/ext_ident.cmx ext/ext_filename.cmx core/lam_compile_group.cmi
 core/js_implementation.cmx : core/ocaml_parse.cmx ext/literals.cmx \
     core/lam_compile_group.cmx core/lam_compile_env.cmx common/js_config.cmx \
     ext/ext_pervasives.cmx common/ext_log.cmx syntax/bs_ast_invariant.cmx \
@@ -726,8 +721,7 @@ bsb/bsb_build_util.cmx : ext/string_map.cmx ext/string_hashtbl.cmx \
     ext/literals.cmx ext/ext_sys.cmx ext/ext_string.cmx ext/ext_list.cmx \
     ext/ext_json_types.cmx ext/ext_json_parse.cmx ext/ext_json.cmx \
     ext/ext_filename.cmx ext/ext_array.cmx bsb/bsb_pkg.cmx \
-    bsb/bsb_exception.cmx bsb/bsb_config.cmx bsb/bsb_build_schemas.cmx \
-    bsb/bsb_build_util.cmi
+    bsb/bsb_exception.cmx bsb/bsb_build_schemas.cmx bsb/bsb_build_util.cmi
 bsb/bsb_clean.cmx : ext/ext_filename.cmx bsb/bsb_unix.cmx bsb/bsb_config.cmx \
     bsb/bsb_build_util.cmx bsb/bsb_clean.cmi
 bsb/bsb_config.cmx : ext/string_set.cmx ext/literals.cmx ext/ext_string.cmx \

--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -35,13 +35,12 @@ let (//) = Ext_filename.combine
 
 
 
-let convert_and_resolve_path = 
-  if Sys.unix then Bsb_config.proj_rel  
-  else 
+let convert_and_resolve_path =
+  if Sys.unix then (//)
+  else fun cwd path ->
   if Ext_sys.is_windows_or_cygwin then 
-    fun (p:string) -> 
-      let p = Ext_string.replace_slash_backward p in
-      Bsb_config.proj_rel p 
+    let p = Ext_string.replace_slash_backward path in
+      cwd // p
   else failwith ("Unknown OS :" ^ Sys.os_type)
 (* we only need convert the path in the beginning *)
 
@@ -81,7 +80,7 @@ let resolve_bsb_magic_file ~cwd ~desc p =
 
   else
     (* relative path [./x/y]*)
-    convert_and_resolve_path p
+    convert_and_resolve_path cwd p
 
 
 

--- a/jscomp/bsb/bsb_build_util.mli
+++ b/jscomp/bsb/bsb_build_util.mli
@@ -36,8 +36,9 @@ val flag_concat : string -> string list -> string
     First, it will convert unix path to windows backward on windows platform.
     Then if it is absolute path, it will do thing
     Else if it is relative path, it will be rebased on project's root directory 
+
+val convert_and_resolve_path : string -> string -> string
 *)
-val convert_and_resolve_path : string -> string
 
 (**
    The difference between [convert_path] is that if the file is [ocamlc.opt] 


### PR DESCRIPTION
Contains code from PR #1810 
Fixes #1752 

at present, the generation of FLG statements in the .merlin file when a
relative ppx is used contains the string $src_root_dir rather than an
absolute path to the ppx file. this PR changes the
`convert_and_resolve_path` function to use the provided cwd from parsing
the bsconfig file as the base against which the ppx is resolved.