### PR TITLE
Expose bsrefmt correctly

### DIFF
--- a/bin/bsrefmt
+++ b/bin/bsrefmt
@@ -2,8 +2,10 @@
 "use strict";
 
 var child_process = require('child_process')
+var path = require('path')
 
-var exe = __filename + ".exe"
+// the underlying binary is called refmt
+var exe = path.join(__dirname, 'refmt.exe')
 var delegate_args = process.argv.slice(2)
 
 try {


### PR DESCRIPTION
Currently it doesn't work because it looks for a bsrefmt.exe. This correct the name

cc @glennsl