### PR TITLE
Explicit tar options

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -37,7 +37,7 @@ var ninja_vendor_dir = path.join(root_dir, 'vendor', 'ninja-build')
 
 function build_ninja() {
     console.log('No prebuilt Ninja, building Ninja now')
-    var build_ninja_command = "tar -xf  ninja-1.7.2.tar.gz  && cd  ninja-1.7.2  && ./configure.py --bootstrap "
+    var build_ninja_command = "tar -xzf  ninja-1.7.2.tar.gz  && cd  ninja-1.7.2  && ./configure.py --bootstrap "
     child_process.execSync(build_ninja_command, { cwd: ninja_vendor_dir })
     fs.renameSync(path.join(ninja_vendor_dir, 'ninja-1.7.2', 'ninja'), ninja_bin_output)
     console.log('ninja binary is ready: ', ninja_bin_output)


### PR DESCRIPTION
This change allows bs-platform installation on systems with non-GNU tar.