### PR TITLE
[bsb] Fix package-specs in-source detection & provide better errors

### DIFF
--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -10,7 +10,7 @@
                 "es6",
                 "es6-global"
             ],
-            "description": "amdjs-global and es6-global will generate relative `require` paths instead of relying on NodeJS' module resolution"
+            "description": "amdjs-global and es6-global generate relative `require` paths instead of relying on NodeJS' module resolution. Default: commonjs."
         },
         "module-format-object": {
             "type": "object",
@@ -20,7 +20,7 @@
                 },
                 "in-source": {
                     "type": "boolean",
-                    "description": "default is false"
+                    "description": "Default: true if package-specs is present, false otherwise."
                 }
             },
             "required": [

--- a/jscomp/bsb/bsb_exception.ml
+++ b/jscomp/bsb/bsb_exception.ml
@@ -55,14 +55,14 @@ let () =
 
 
 let failf ?loc fmt =
-    let prefix = 
-        match loc with 
-        | None -> "Error <bsconfig.json> "
-        | Some x  -> 
-            Format.asprintf "Error <bsconfig.json: %a> " Ext_position.print x  in 
-    Format.ksprintf (fun s -> failwith (prefix ^ s)) fmt 
+    let prefix =
+        match loc with
+        | None -> "bsconfig.json"
+        | Some x  ->
+            Format.asprintf "bsconfig.json %a: " Ext_position.print x  in
+    Format.ksprintf (fun s -> failwith (prefix ^ s)) fmt
 
 let expect_an_array_fmt : _ format = "%s expect an array"
 let failwith_config config fmt =
   let loc = Ext_json.loc_of config in
-  failf ~loc fmt 
+  failf ~loc fmt

--- a/jscomp/ext/ext_position.ml
+++ b/jscomp/ext/ext_position.ml
@@ -31,8 +31,8 @@ type t = Lexing.position = {
 }
 
 
-let print fmt (pos : t) = 
-  Format.fprintf fmt "(%d,%d)" pos.pos_lnum (pos.pos_cnum - pos.pos_bol)
+let print fmt (pos : t) =
+  Format.fprintf fmt "(line %d, column %d)" pos.pos_lnum (pos.pos_cnum - pos.pos_bol)
 
 
 


### PR DESCRIPTION
The detection was broken; 2 `in-source: false` would still error saying that both configs are in-source