### PR TITLE
Remove submodule config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ocaml"]
-	path = ocaml
-	url = https://github.com/bucklescript/ocaml


### PR DESCRIPTION
This was causing a few git fetch warnings. We're not using it anywhere
anymore right?