### PR TITLE
Display error location inline

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -54,7 +54,7 @@ ext/int_vec.ml: ext/vec.cppo.ml
 ext/resize_array.ml: ext/vec.cppo.ml
 	cppo -D TYPE_FUNCTOR $< -o $@
 ext/string_set.ml : ext/set.cppo.ml
-	cppo -D TYPE_STRING $< -o $@	
+	cppo -D TYPE_STRING $< -o $@
 ext/set_int.ml : ext/set.cppo.ml
 	cppo -D TYPE_INT $< -o $@
 ext/ident_set.ml : ext/set.cppo.ml
@@ -89,16 +89,16 @@ ext/ordered_hash_set_ident.ml:ext/ordered_hash_set.cppo.ml
 	cppo -D TYPE_IDENT $< -o $@
 
 ext/string_hashtbl.ml: ext/hashtbl.cppo.ml
-	cppo -D TYPE_STRING $< -o $@	
+	cppo -D TYPE_STRING $< -o $@
 ext/int_hashtbl.ml: ext/hashtbl.cppo.ml
 	cppo -D TYPE_INT $< -o $@
-ext/ident_hashtbl.ml: ext/hashtbl.cppo.ml	
+ext/ident_hashtbl.ml: ext/hashtbl.cppo.ml
 	cppo -D TYPE_IDENT $< -o $@
 ext/hashtbl_make.ml: ext/hashtbl.cppo.ml
 	cppo -D TYPE_FUNCTOR $< -o $@
-## Stubs 
+## Stubs
 .c.o:
-	$(NATIVE) -ccopt -O2 -ccopt -o -ccopt $@ -c $< 
+	$(NATIVE) -ccopt -O2 -ccopt -o -ccopt $@ -c $<
 
 STUBS_OBJS=stubs/ext_basic_hash_stubs.o
 
@@ -253,9 +253,9 @@ SYNTAX_SRCS= \
 	ast_util\
 	ppx_entry\
 	bs_ast_invariant
-# not a good name ast_util	 
+# not a good name ast_util
 SYNTAX_CMXS=$(addprefix syntax/, $(addsuffix .cmx, $(SYNTAX_SRCS)))
-DEPENDS_SRCS=  bs_exception ast_extract binary_ast  
+DEPENDS_SRCS= bs_exception ast_extract binary_ast 
 DEPENDS_CMXS=$(addprefix depends/, $(addsuffix .cmx, $(DEPENDS_SRCS)))
 CORE_SRCS= type_int_to_string type_util  ocaml_stdlib_slots bs_conditional_initial ocaml_options ocaml_parse\
 	js_op\
@@ -337,7 +337,7 @@ BSB_SRCS= bsb_config\
 	oCamlRes\
 	bsb_templates\
 	bsb_init
-SUPER_ERRORS_SRCS=super_warnings super_typecore super_typetexp super_location super_main
+SUPER_ERRORS_SRCS=super_misc super_warnings super_typecore super_typetexp super_location super_main
 
 BSB_CMXS=$(addprefix bsb/, $(addsuffix .cmx, $(BSB_SRCS)))
 BSB_CMOS=$(addprefix bsb/, $(addsuffix .cmo, $(BSB_SRCS)))
@@ -364,9 +364,9 @@ bsb.cmxa:$(BSB_CMXS)
 	ocamlopt.opt -a $^ -o $@
 bsb.cma:$(BSB_CMOS)
 	ocamlc.opt -a $^ -o $@
-super.cmxa:$(SUPER_ERRORS_CMXS)	
+super.cmxa:$(SUPER_ERRORS_CMXS)
 	ocamlopt.opt -a $^ -o $@
-super.cma:$(SUPER_ERRORS_CMOS)	
+super.cma:$(SUPER_ERRORS_CMOS)
 	ocamlc.opt -a $^ -o $@
 
 check: $(EXT_CMXS) $(COMMON_CMXS) $(SYNTAX_CMXS) $(DEPENDS_CMXS) $(CORE_CMXS) $(BSB_CMXS) $(OTHER_CORE_CMXS) $(MAIN_CMXS) $(SUPER_ERRORS_CMXS) $(OUNIT_CMXS) $(OUNIT_TESTS_CMXS)
@@ -377,7 +377,7 @@ bin/bsb.exe: bs_hash.cmxa ext.cmxa common.cmxa  bsb.cmxa bsb/bsb_main.cmx
 # bin/bsc:  ext.cmxa common.cmxa  depends.cmxa syntax.cmxa core.cmxa
 # 	$(NATIVE) -g -linkall -I +compiler-libs ocamlcommon.cmxa $^ -o $@
 
-bin/bsc.exe: bs_hash.cmxa ext.cmxa common.cmxa syntax.cmxa depends.cmxa core.cmxa super.cmxa core/js_main.cmx 
+bin/bsc.exe: bs_hash.cmxa ext.cmxa common.cmxa syntax.cmxa depends.cmxa core.cmxa super.cmxa core/js_main.cmx
 	@echo "Linking"
 	$(NATIVE) -g -linkall -I +compiler-libs ocamlcommon.cmxa $^ -o $@
 
@@ -464,7 +464,7 @@ SNAPSHOT_DEPS=$(SNAPSHOT_SRCS:.ml=.d)
 # Actually we can not make it correct by including..
 # if we force it, then the initial build will fail
 # if we don't force it, then if we remove bin/bsb.d
-# The build will never be re-triggered -- ninja seems to have special support for this semantics 
+# The build will never be re-triggered -- ninja seems to have special support for this semantics
 # if we move files around, it will cause file failure
 # Note the currently snapshot mode means if we don't
 # generate ml files it will not be included
@@ -591,9 +591,9 @@ travis-world-test:
 DEST=../lib/ocaml
 DEST_BIN=../bin
 
-# TODO: sync up with 
-# scripts/build_uitil.js 
-# function install 
+# TODO: sync up with
+# scripts/build_uitil.js
+# function install
 # scripts/build_util.install
 install:
 	@echo "copy exe"
@@ -623,7 +623,7 @@ clean:
 DOCS_SOURCES+=$(shell ls runtime/*.ml*)
 DOCS_SOURCES+=$(shell ls others/*.ml*)
 
-# 
+#
 ../odoc_gen/generator.cmxs : ../odoc_gen/generator.mli ../odoc_gen/generator.ml
 	ocamlopt.opt -I +compiler-libs -I +ocamldoc -shared -I ../odoc_gen  -o $@ $^
 
@@ -634,5 +634,5 @@ docs: ../odoc_gen/generator.cmxs
 
 top: bs_hash.cma ext.cma bsb.cma
 repl: top
-	rlwrap ocaml	
+	rlwrap ocaml
 .PHONY: release   releasebuild libs snapshotml force-snapshotml toplevel

--- a/jscomp/ext/ext_color.ml
+++ b/jscomp/ext/ext_color.ml
@@ -39,6 +39,7 @@ type style
   = FG of color 
   | BG of color 
   | Bold
+  | Dim
 
 
 let ansi_of_color = function
@@ -71,6 +72,7 @@ let code_of_style = function
   | BG White -> "47"
 
   | Bold -> "1"
+  | Dim -> "2"
 
 
 
@@ -81,7 +83,7 @@ let style_of_tag s = match s with
   | "info" -> [Bold; FG Yellow]
   | _ -> []
 
-let ansi_of_tag s = 
+let ansi_of_tag ?(style_of_tag=style_of_tag) s = 
   let l = style_of_tag s in
   let s =  String.concat ";" (List.map code_of_style l) in
   "\x1b[" ^ s ^ "m"

--- a/jscomp/ext/ext_color.ml
+++ b/jscomp/ext/ext_color.ml
@@ -81,9 +81,11 @@ let style_of_tag s = match s with
   | "error" -> [Bold; FG Red]
   | "warning" -> [Bold; FG Magenta]
   | "info" -> [Bold; FG Yellow]
+  | "dim" -> [Dim]
+  | "filename" -> [FG Cyan]
   | _ -> []
 
-let ansi_of_tag ?(style_of_tag=style_of_tag) s = 
+let ansi_of_tag s = 
   let l = style_of_tag s in
   let s =  String.concat ";" (List.map code_of_style l) in
   "\x1b[" ^ s ^ "m"

--- a/jscomp/ext/ext_color.mli
+++ b/jscomp/ext/ext_color.mli
@@ -39,6 +39,6 @@ type style
   | Dim
 
 (** Input is the tag for example `@{<warning>@}` return escape code *)
-val ansi_of_tag : ?style_of_tag:(string -> style list) -> string -> string 
+val ansi_of_tag : string -> string 
 
 val reset_lit : string

--- a/jscomp/ext/ext_color.mli
+++ b/jscomp/ext/ext_color.mli
@@ -22,8 +22,23 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+type color 
+  = Black
+  | Red
+  | Green
+  | Yellow
+  | Blue
+  | Magenta
+  | Cyan
+  | White
+
+type style 
+  = FG of color 
+  | BG of color 
+  | Bold
+  | Dim
 
 (** Input is the tag for example `@{<warning>@}` return escape code *)
-val ansi_of_tag : string -> string 
+val ansi_of_tag : ?style_of_tag:(string -> style list) -> string -> string 
 
 val reset_lit : string

--- a/jscomp/ext/ext_string.mli
+++ b/jscomp/ext/ext_string.mli
@@ -111,7 +111,7 @@ val is_valid_source_name :
    '@angular/core'
    its directory structure is like 
    {[
-     @angualar
+     @angular
      |-------- core
    ]}
 *)

--- a/jscomp/super_errors/super_location.ml
+++ b/jscomp/super_errors/super_location.ml
@@ -9,9 +9,84 @@ open Ctype
 open Format
 open Printtyp
 
+open Location
+
+let file_lines filePath =
+  (* open_in_bin works on windows, as opposed to open_in, afaik? *)
+  let chan = open_in_bin filePath in
+  let lines = ref [] in
+  try
+    while true do
+      lines := (input_line chan) :: !lines
+     done;
+     (* leave this here to make things type. The loop will definitly raise *)
+     [||]
+  with
+  | End_of_file -> begin
+      close_in chan; 
+      List.rev (!lines) |> Array.of_list
+    end
+
+let setup_colors () =
+  Misc.Color.setup !Clflags.color
+
+let print_filename ppf file =
+  Format.fprintf ppf "%s" (Location.show_filename file)
+
+let print_loc ppf loc =
+  setup_colors ();
+  let (file, _, _) = Location.get_pos_info loc.loc_start in
+  if file = "//toplevel//" then begin
+    if highlight_locations ppf [loc] then () else
+      fprintf ppf "Characters %i-%i"
+              loc.loc_start.pos_cnum loc.loc_end.pos_cnum
+  end else begin
+    fprintf ppf "@{<filename>%a@}" print_filename file;
+  end
+;;
+
+let print intro ppf loc =
+  setup_colors ();
+  (* TODO: handle locations such as _none_ and "" *)
+  if loc.loc_start.pos_fname = "//toplevel//"
+  && highlight_locations ppf [loc] then ()
+  else
+    fprintf ppf "@[@{<intro>%s@}@]@," intro;   
+    fprintf ppf "@[%a@]@,@," print_loc loc;
+    let (file, start_line, start_char) = Location.get_pos_info loc.loc_start in
+    let (_, end_line, end_char) = Location.get_pos_info loc.loc_end in
+    (* things to special-case: startchar & endchar2 both -1  *)
+    if start_char == -1 || end_char == -1 then
+      (* happens sometimes. Syntax error for example *)
+      fprintf ppf "This is likely a syntax error. The more relevant message should be just above!@ If it's not, please file an issue here:@ github.com/facebook/reason/issues@,"
+    else begin
+      try 
+        let lines = file_lines file in
+        fprintf ppf "%a"
+          (Super_misc.print_file
+          ~lines
+          ~range:(
+            (start_line, start_char + 1), (* make everything 1-index based. See justifications in Super_mic.print_file *)
+            (end_line, end_char)
+          ))
+          ()
+      with
+      (* this shouldn't happen, but gracefully fall back to the default reporter just in case *)
+      | Sys_error _ -> Location.print ppf loc
+    end
+;;
+
 (* taken from https://github.com/ocaml/ocaml/blob/4.02/parsing/location.ml#L337 *)
-(* we override the default reporter with this one. Everything is the same as of the 4.02, except the part commented below *)
+(* This is the error report entry point. We'll replace the default reporter with this one. *)
 let rec super_error_reporter ppf ({Location.loc; msg; sub; if_highlight} as err) =
+  Super_misc.colorize_tagged_string ppf (function
+  | "intro" -> [Bold; FG Red]
+  | "filename" -> [FG Cyan]
+  | "affected_line_number" -> [Bold; FG Red]
+  | "affected_line_content" -> [FG Red]
+  | "separator" -> [Dim]
+  | _ -> []
+  );
   let highlighted =
     if if_highlight <> "" then
       let rec collect_locs locs {Location.loc; sub; if_highlight; _} =
@@ -25,21 +100,31 @@ let rec super_error_reporter ppf ({Location.loc; msg; sub; if_highlight} as err)
   if highlighted then
     Format.pp_print_string ppf if_highlight
   else begin
-    Format.fprintf ppf "%a%a %s" Location.print loc Location.print_error_prefix () (msg ^ "\n");
-    (* this `super_error_reporter` part is the part that's different from default_error_reporter. In the future, we might customize the formatting a bit more too. *)
-    List.iter (Format.fprintf ppf "@\n@[<2>%a@]" super_error_reporter) sub
+    (* open a vertical box. Everything in our message is indented 2 spaces *)
+    Format.fprintf ppf "@[<v 2>@,%a@,%s@,@]" (print "We've found a bug for you!") loc msg;
+    List.iter (Format.fprintf ppf "@,@[%a@]" super_error_reporter) sub;
+    (* no need to flush here; location's report_exception (which uses this ultimately) flushes *)
   end
 
-let warning_prefix = "Warning"
-
 (* extracted from https://github.com/ocaml/ocaml/blob/4.02/parsing/location.ml#L280 *)
-(* this is the same code except we use Super_warnings.print instead of Warnings.print  *)
-(* we'll replace the default printer with this one *)
+(* This is the warning report entry point. We'll replace the default printer with this one *)
 let super_warning_printer loc ppf w =
   if Warnings.is_active w then begin
+    Super_misc.colorize_tagged_string ppf (function
+    | "intro" -> [Bold; FG Yellow]
+    | "filename" -> [FG Cyan]
+    | "affected_line_number" -> [Bold; FG Yellow]
+    | "affected_line_content" -> [FG Yellow]
+    | "separator" -> [Dim]
+    | _ -> []
+    );
     Misc.Color.setup !Clflags.color;
-    Location.print ppf loc;
-    Format.fprintf ppf "@{<warning>%s@} %a@." warning_prefix Super_warnings.print w
+    (* open a vertical box. Everything in our message is indented 2 spaces *)
+    Format.fprintf ppf "@[<v 2>@,%a@,%a@,@]" 
+      (print ("Warning number " ^ (Super_warnings.number w |> string_of_int))) 
+      loc 
+      Super_warnings.print 
+      w
   end
 ;;
 

--- a/jscomp/super_errors/super_misc.ml
+++ b/jscomp/super_errors/super_misc.ml
@@ -30,7 +30,7 @@ let leading_space_count str =
   being handled programmatically (or humanly for that matter. If you're an
   ocaml contributor reading this: who the heck reads the character count
   starting from the first erroring character?) *)
-(* range coordinates all 1-indexed, like for editors. Otherwise this code's
+(* Range coordinates all 1-indexed, like for editors. Otherwise this code
   would have way too many off-by-one errors *)
 let print_file ~range:((start_line, start_char), (end_line, end_char)) ~lines ppf () =
   (* show 2 lines before & after the erroring lines *)

--- a/jscomp/super_errors/super_misc.ml
+++ b/jscomp/super_errors/super_misc.ml
@@ -1,0 +1,130 @@
+(* This file has nothing to do with misc.ml in ocaml's source. Just thought it'd be an appropriate parallel to call it so *)
+
+let fprintf = Format.fprintf
+
+let string_slice ~start str =
+  let last = String.length str in
+  if last <= start then "" else String.sub str start (last - start)
+
+let sp = Printf.sprintf
+
+let number_of_digits n =
+  let digits = ref 1 in
+  let nn = ref n in
+  while ((!nn) / 10) > 0 do (nn := ((!nn) / 10); digits := ((!digits) + 1))
+    done;
+  !digits
+
+let pad ?(ch=' ') content n =
+  (String.make (n - (String.length content)) ch) ^ content
+
+let leading_space_count str =
+  let rec _leading_space_count str str_length current_index =
+    if current_index == str_length then current_index
+    else if (str.[current_index]) <> ' ' then current_index 
+    else _leading_space_count str str_length (current_index + 1)
+  in
+  _leading_space_count str (String.length str) 0
+
+(* ocaml's reported line/col numbering is horrible and super error-prone when
+  being handled programmatically (or humanly for that matter. If you're an
+  ocaml contributor reading this: who the heck reads the character count
+  starting from the first erroring character?) *)
+(* range coordinates all 1-indexed, like for editors. Otherwise this code's
+  would have way too many off-by-one errors *)
+let print_file ~range:((start_line, start_char), (end_line, end_char)) ~lines ppf () =
+  (* show 2 lines before & after the erroring lines *)
+  let first_shown_line = max 1 (start_line - 2) in
+  let last_shown_line = min (Array.length lines) (end_line + 2) in
+  let max_line_number_number_of_digits = number_of_digits last_shown_line in
+  (* sometimes the code's very indented, and we'd end up displaying quite a
+    few columsn of leading whitespace; left-trim these. The general spirit is
+    to center the erroring spot. In this case, almost literally *)
+  (* to achieve this, go through the shown lines and check the minimum number of leading whitespaces *)
+  let columns_to_cut = ref None in
+  for i = first_shown_line to last_shown_line do
+    let current_line = lines.(i - 1) in
+    (* disregard lines that are empty or are nothing but whitespace *)
+    if String.length (String.trim current_line) == 0 then ()
+    else
+      let current_line_leading_space_count = leading_space_count current_line in
+      match !columns_to_cut with
+      | None ->
+        columns_to_cut := Some current_line_leading_space_count
+      | Some n when n > current_line_leading_space_count ->
+        columns_to_cut := Some current_line_leading_space_count
+      | Some n -> ()
+  done;
+  let columns_to_cut = match !columns_to_cut with
+  | None -> 0
+  | Some n -> n
+  in
+  (* btw, these are unicode chars. They're not of length 1. Careful; we need to
+    explicitly tell Format to treat them as length 1 below *)
+  let separator = if columns_to_cut = 0 then "│" else "┆" in
+
+  fprintf ppf "@[<v 0>";
+  (* inclusive *)
+  for i = first_shown_line to last_shown_line do
+    let current_line = lines.(i - 1) in
+    let current_line_cut = current_line |> string_slice ~start:columns_to_cut in
+    let padded_line_number = pad (string_of_int i) max_line_number_number_of_digits in
+
+    fprintf ppf "@[<h 0>";
+
+    fprintf ppf "@[<h 0>";
+
+    (* this is where you insrt the vertical separator. Mark them as legnth 1 as explained above *)
+    if i < start_line || i > end_line then begin
+      (* normal, non-highlighted line *)
+      fprintf ppf "%s@{<separator> @<1>%s @}" padded_line_number separator
+    end else begin
+      (* highlighted row *)
+      fprintf ppf "@{<affected_line_number>%s@}@{<separator> @<1>%s @}" padded_line_number separator
+    end;
+
+    fprintf ppf "@]"; (* h *)
+
+    fprintf ppf "@[<hov 0>";
+
+    let current_line_strictly_between_start_and_end_line = i > start_line && i < end_line in
+
+    if current_line_strictly_between_start_and_end_line then fprintf ppf "@{<affected_line_content>";
+
+    let current_line_cut_length = String.length current_line_cut in
+    (* inclusive. To be consistent with using 1-indexed indices and count and i, j will be 1-indexed too *)
+    for j = 1 to current_line_cut_length do begin
+      let current_char = current_line_cut.[j - 1] in
+      if current_line_strictly_between_start_and_end_line then
+        fprintf ppf "%c@," current_char
+      else if i = start_line then begin
+        if j == (start_char - columns_to_cut) then fprintf ppf "@{<affected_line_content>";
+        fprintf ppf "%c@," current_char;
+        if j == (end_char - columns_to_cut) then fprintf ppf "@}"
+      end else if i = end_line then begin
+        if j == 1 then fprintf ppf "@{<affected_line_content>";
+        fprintf ppf "%c@," current_char;
+        if j == (end_char - columns_to_cut) then fprintf ppf "@}"
+      end else
+        (* normal, non-highlighted line *)
+        fprintf ppf "%c@," current_char
+    end
+    done;
+
+    if current_line_strictly_between_start_and_end_line then fprintf ppf "@}";
+
+    fprintf ppf "@]"; (* hov *)
+
+    fprintf ppf "@]@," (* h *)
+
+  done;
+  fprintf ppf "@]" (* v *)
+
+(* This allows you to, just like css, define which tag gets colored in which
+  way. See usage in e.g. Super_location.super_error_reporter *)
+let colorize_tagged_string ppf f =
+  Format.pp_set_formatter_tag_functions ppf
+    ({ (Format.pp_get_formatter_tag_functions ppf () ) with
+      mark_open_tag = Ext_color.ansi_of_tag ~style_of_tag:f;
+      mark_close_tag = (fun _ -> Ext_color.reset_lit);
+    })

--- a/jscomp/super_errors/super_misc.mli
+++ b/jscomp/super_errors/super_misc.mli
@@ -1,6 +1,5 @@
 (** Range coordinates all 1-indexed, like for editors. Otherwise this code
   would have way too many off-by-one errors *)
-val print_file: range:(int * int) * (int * int) -> lines:string array -> Format.formatter -> unit -> unit
+val print_file: is_warning:bool -> range:(int * int) * (int * int) -> lines:string array -> Format.formatter -> unit -> unit
 
-(** This will be called in super_main. This is how you override the default error and warning printers *)
-val colorize_tagged_string: Format.formatter -> (string -> Ext_color.style list) -> unit
+val setup_colors: Format.formatter -> unit

--- a/jscomp/super_errors/super_misc.mli
+++ b/jscomp/super_errors/super_misc.mli
@@ -1,0 +1,6 @@
+(** Range coordinates all 1-indexed, like for editors. Otherwise this code
+  would have way too many off-by-one errors *)
+val print_file: range:(int * int) * (int * int) -> lines:string array -> Format.formatter -> unit -> unit
+
+(** This will be called in super_main. This is how you override the default error and warning printers *)
+val colorize_tagged_string: Format.formatter -> (string -> Ext_color.style list) -> unit

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -48,9 +48,9 @@ let report_error env ppf = function
       (* modified *)
       report_unification_error ppf env trace
         (function ppf ->
-           fprintf ppf "@{<Expr_type_clash.this>This is:@}")
+           fprintf ppf "@{<error>This is:@}")
         (function ppf ->
-           fprintf ppf "@{<Expr_type_clash.wanted>but somewhere wanted:@}")
+           fprintf ppf "@{<info>but somewhere wanted:@}")
   | Apply_non_function typ ->
       (* modified *)
       reset_and_mark_loops typ;
@@ -233,11 +233,7 @@ let report_error env ppf = function
 
 (* https://github.com/ocaml/ocaml/blob/4.02/typing/typecore.ml#L3979 *)
 let report_error env ppf err =
-  Super_misc.colorize_tagged_string ppf (function
-  | "Expr_type_clash.this" -> [Bold; FG Red]
-  | "Expr_type_clash.wanted" -> [Bold; FG Yellow]
-  | _ -> []
-  );
+  Super_misc.setup_colors ppf;
   wrap_printing_env env (fun () -> report_error env ppf err)
 
 (* This will be called in super_main. This is how you'd override the default error printer from the compiler & register new error_of_exn handlers *)

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -45,11 +45,12 @@ let report_error env ppf = function
       fprintf ppf "Variable %s must occur on both sides of this | pattern"
         (Ident.name id)
   | Expr_type_clash trace ->
+      (* modified *)
       report_unification_error ppf env trace
         (function ppf ->
-           fprintf ppf "this beeeeeautiful expression has type")
+           fprintf ppf "@{<Expr_type_clash.this>This is:@}")
         (function ppf ->
-           fprintf ppf "but an expression was expected of type")
+           fprintf ppf "@{<Expr_type_clash.wanted>but somewhere wanted:@}")
   | Apply_non_function typ ->
       (* modified *)
       reset_and_mark_loops typ;
@@ -232,6 +233,11 @@ let report_error env ppf = function
 
 (* https://github.com/ocaml/ocaml/blob/4.02/typing/typecore.ml#L3979 *)
 let report_error env ppf err =
+  Super_misc.colorize_tagged_string ppf (function
+  | "Expr_type_clash.this" -> [Bold; FG Red]
+  | "Expr_type_clash.wanted" -> [Bold; FG Yellow]
+  | _ -> []
+  );
   wrap_printing_env env (fun () -> report_error env ppf err)
 
 (* This will be called in super_main. This is how you'd override the default error printer from the compiler & register new error_of_exn handlers *)

--- a/jscomp/super_errors/super_warnings.ml
+++ b/jscomp/super_errors/super_warnings.ml
@@ -1,5 +1,6 @@
+let fprintf = Format.fprintf
 (* this is lifted https://github.com/ocaml/ocaml/blob/4.02/utils/warnings.ml *)
-(* modified branches are commented *)
+(* actual modified message branches are commented *)
 let message = Warnings.(function
   | Comment_start -> "this is the start of a comment."
   | Comment_not_end -> "this is not the end of a comment."
@@ -215,8 +216,7 @@ let number = Warnings.(function
   it (not sure what it's for, actually) *)
 let print ppf w =
   let msg = message w in
-  let num = number w in
-  Format.fprintf ppf "%d: %s" num msg;
+  Format.fprintf ppf "%s" msg;
   Format.pp_print_flush ppf ()
   (*if (!current).error.(num) then incr nerrors*)
 ;;


### PR DESCRIPTION
This makes it so that turning on `-bs-better-error` shows errors inline, a big request from the community.

It gracefully degrades to the normal reporting.
<img width="649" alt="screenshot 2017-08-05 13 57 48" src="https://user-images.githubusercontent.com/1909539/28998678-1ffaaaec-79e6-11e7-8e67-ca53b310c4ca.png">
<img width="435" alt="screenshot 2017-08-05 13 57 57" src="https://user-images.githubusercontent.com/1909539/28998679-21cb9520-79e6-11e7-909d-85d3c439b553.png">
