### PR TITLE
namespace part3 (WIP)

### DIFF
--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -448,9 +448,10 @@ core/lam_compile_const.cmx : core/lam_compile_util.cmx core/lam.cmx \
     syntax/ast_arg.cmx core/lam_compile_const.cmi
 core/lam_inner.cmx : core/lam.cmx core/lam_inner.cmi
 core/lam_util.cmx : core/lam_stats.cmx core/lam_print.cmx \
-    core/lam_id_kind.cmx core/lam_analysis.cmx core/lam.cmx ext/ident_set.cmx \
-    ext/ident_map.cmx ext/ident_hashtbl.cmx ext/ext_list.cmx \
-    ext/ext_array.cmx core/lam_util.cmi
+    core/lam_id_kind.cmx core/lam_analysis.cmx core/lam.cmx \
+    common/js_config.cmx ext/ident_set.cmx ext/ident_map.cmx \
+    ext/ident_hashtbl.cmx common/ext_log.cmx ext/ext_list.cmx \
+    ext/ext_filename.cmx ext/ext_array.cmx core/lam_util.cmi
 core/lam_eta_conversion.cmx : ext/literals.cmx core/lam.cmx ext/ext_list.cmx \
     ext/ext_ident.cmx core/lam_eta_conversion.cmi
 core/lam_group.cmx : core/lam_print.cmx core/lam.cmx core/lam_group.cmi
@@ -513,7 +514,9 @@ core/js_dump.cmx : ext/literals.cmx core/lam_module_ident.cmx \
     core/js_exp_make.cmx common/js_config.cmx core/js_closure.cmx core/j.cmx \
     ext/ident_set.cmx ext/ext_string.cmx ext/ext_pp_scope.cmx ext/ext_pp.cmx \
     ext/ext_list.cmx ext/ext_ident.cmx common/bs_version.cmx core/js_dump.cmi
-core/js_pass_debug.cmx : core/j.cmx core/js_pass_debug.cmi
+core/js_pass_debug.cmx : core/js_dump.cmx common/js_config.cmx core/j.cmx \
+    ext/ext_pervasives.cmx common/ext_log.cmx ext/ext_filename.cmx \
+    core/js_pass_debug.cmi
 core/js_of_lam_option.cmx : core/js_exp_make.cmx common/js_config.cmx \
     core/js_analyzer.cmx core/j.cmx core/js_of_lam_option.cmi
 core/js_output.cmx : core/lam_compile_defs.cmx core/lam_analysis.cmx \
@@ -579,7 +582,8 @@ core/lam_pass_eliminate_ref.cmx : core/lam.cmx ext/ident_set.cmx \
 core/lam_pass_lets_dce.cmx : core/lam_util.cmx \
     core/lam_pass_eliminate_ref.cmx core/lam_pass_count.cmx \
     core/lam_beta_reduce.cmx core/lam_analysis.cmx core/lam.cmx \
-    ext/ident_hashtbl.cmx ext/ext_list.cmx core/lam_pass_lets_dce.cmi
+    ext/ident_hashtbl.cmx common/ext_log.cmx ext/ext_list.cmx \
+    core/lam_pass_lets_dce.cmi
 core/lam_pass_remove_alias.cmx : core/lam_util.cmx core/lam_stats.cmx \
     core/lam_inline_util.cmx core/lam_compile_env.cmx core/lam_closure.cmx \
     core/lam_beta_reduce.cmx core/lam_analysis.cmx core/lam.cmx \
@@ -602,8 +606,9 @@ core/lam_compile_group.cmx : core/lam_util.cmx core/lam_stats_export.cmx \
     core/js_pass_flatten.cmx core/js_pass_debug.cmx core/js_output.cmx \
     core/js_fold_basic.cmx core/js_exp_make.cmx core/js_dump.cmx \
     common/js_config.cmx core/js_cmj_format.cmx core/j.cmx ext/ident_set.cmx \
-    ext/ext_string.cmx ext/ext_pervasives.cmx ext/ext_list.cmx \
-    ext/ext_ident.cmx ext/ext_filename.cmx core/lam_compile_group.cmi
+    ext/ext_string.cmx ext/ext_pervasives.cmx common/ext_log.cmx \
+    ext/ext_list.cmx ext/ext_ident.cmx ext/ext_filename.cmx \
+    core/lam_compile_group.cmi
 core/js_implementation.cmx : core/ocaml_parse.cmx ext/literals.cmx \
     core/lam_compile_group.cmx core/lam_compile_env.cmx common/js_config.cmx \
     ext/ext_pervasives.cmx common/ext_log.cmx syntax/bs_ast_invariant.cmx \
@@ -786,16 +791,16 @@ bsb/bsb_ninja_file_groups.cmx : ext/string_set.cmx ext/string_map.cmx \
     bsb/bsb_build_cache.cmx bsb/bsb_ninja_file_groups.cmi
 bsb/bsb_ninja_gen.cmx : ext/string_map.cmx ext/literals.cmx \
     ext/ext_string.cmx ext/ext_list.cmx ext/ext_filename.cmx bsb/bsb_rule.cmx \
-    bsb/bsb_parse_sources.cmx bsb/bsb_ninja_util.cmx \
+    bsb/bsb_pkg_map_gen.cmx bsb/bsb_parse_sources.cmx bsb/bsb_ninja_util.cmx \
     bsb/bsb_ninja_global_vars.cmx bsb/bsb_ninja_file_groups.cmx \
     bsb/bsb_dir_index.cmx bsb/bsb_config_types.cmx bsb/bsb_config.cmx \
     bsb/bsb_build_util.cmx bsb/bsb_build_schemas.cmx bsb/bsb_build_cache.cmx \
     bsb/bsb_ninja_gen.cmi
 bsb/bsb_ninja_global_vars.cmx :
 bsb/bsb_ninja_regen.cmx : ext/literals.cmx ext/ext_filename.cmx \
-    bsb/bsb_pkg_map_gen.cmx bsb/bsb_ninja_gen.cmx bsb/bsb_merlin_gen.cmx \
-    bsb/bsb_config_parse.cmx bsb/bsb_config.cmx bsb/bsb_clean.cmx \
-    bsb/bsb_build_util.cmx bsb/bsb_bsdeps.cmx bsb/bsb_ninja_regen.cmi
+    bsb/bsb_ninja_gen.cmx bsb/bsb_merlin_gen.cmx bsb/bsb_config_parse.cmx \
+    bsb/bsb_config.cmx bsb/bsb_clean.cmx bsb/bsb_build_util.cmx \
+    bsb/bsb_bsdeps.cmx bsb/bsb_ninja_regen.cmi
 bsb/bsb_ninja_util.cmx : ext/ext_string.cmx bsb/bsb_rule.cmx \
     bsb/bsb_ninja_util.cmi
 bsb/bsb_os_dependent.cmx :
@@ -815,8 +820,8 @@ bsb/bsb_pkg_cmi_create.cmx :
 bsb/bsb_pkg_create.cmx : bsb/bsb_ninja_global_vars.cmx \
     bsb/bsb_pkg_create.cmi
 bsb/bsb_pkg_map_gen.cmx : ext/string_map.cmx common/ml_binary.cmx \
-    ext/ext_filename.cmx bsb/bsb_pkg_create.cmx bsb/bsb_parse_sources.cmx \
-    bsb/bsb_config.cmx bsb/bsb_pkg_map_gen.cmi
+    ext/literals.cmx ext/ext_filename.cmx bsb/bsb_pkg_create.cmx \
+    bsb/bsb_parse_sources.cmx bsb/bsb_pkg_map_gen.cmi
 bsb/bsb_query.cmx : ext/string_map.cmx ext/ext_json_noloc.cmx \
     ext/ext_array.cmx bsb/bsb_parse_sources.cmx bsb/bsb_ninja_regen.cmx \
     bsb/bsb_config_types.cmx bsb/bsb_query.cmi

--- a/jscomp/bin/bsb_helper.ml
+++ b/jscomp/bin/bsb_helper.ml
@@ -2750,6 +2750,7 @@ let refmt_flags = "refmt_flags"
 let postbuild = "postbuild"
 
 let namespace = "namespace" 
+let open_package = "open_package"
 
 let package_sep = "-"
 end
@@ -2857,6 +2858,7 @@ let output_file oc source namespace =
   match namespace with 
   | None -> ()
   | Some x ->
+
     output_string oc 
       Bsb_ninja_global_vars.package_sep ; 
     output_string oc x 
@@ -2877,6 +2879,13 @@ let oc_impl set input_file lhs_suffix rhs_suffix
   output_file oc input_file namespace ; 
   output_string oc lhs_suffix; 
   output_string oc dep_lit ; 
+  (* (match namespace with 
+   | None -> ()
+   | Some x ->
+     output_string oc Ext_string.single_space;
+     output_string oc x;
+     output_string oc rhs_suffix;
+  ); *)
   for i = 0 to Array.length set - 1 do
     let k = Array.unsafe_get set i in 
     match String_map.find_opt k data.(0) with
@@ -2884,11 +2893,11 @@ let oc_impl set input_file lhs_suffix rhs_suffix
       -> 
       output_string oc Ext_string.single_space ;  
       output_file oc source namespace;
-      output_string oc rhs_suffix 
+      output_string oc rhs_suffix  
     | Some {mli = Mli_source (source,_)  } -> 
       output_string oc Ext_string.single_space ;  
       output_file oc source namespace;
-      output_string oc Literals.suffix_cmi 
+      output_string oc Literals.suffix_cmi  
     | Some {mli= Mli_empty; ml = Ml_empty} -> assert false
     | None  -> 
       if Bsb_dir_index.is_lib_dir index  then () 
@@ -2898,11 +2907,11 @@ let oc_impl set input_file lhs_suffix rhs_suffix
             -> 
             output_string oc Ext_string.single_space ;  
             output_file oc source namespace;
-            output_string oc rhs_suffix
+            output_string oc rhs_suffix 
           | Some {mli = Mli_source (source,_) } -> 
             output_string oc Ext_string.single_space ;  
             output_file oc source namespace;
-            output_string oc Literals.suffix_cmi 
+            output_string oc Literals.suffix_cmi  
           | Some {mli = Mli_empty; ml = Ml_empty} -> assert false
           | None -> ()
         end
@@ -2923,6 +2932,13 @@ let oc_intf
   output_file oc input_file namespace ; 
   output_string oc Literals.suffix_cmi ; 
   output_string oc dep_lit;
+  (* (match namespace with 
+   | None -> ()
+   | Some x ->
+     output_string oc Ext_string.single_space;
+     output_string oc x;
+     output_string oc Literals.suffix_cmi;
+  ); *)
   for i = 0 to Array.length set - 1 do               
     let k = Array.unsafe_get set i in 
     match String_map.find_opt k data.(0) with 

--- a/jscomp/bsb/bsb_ninja_file_groups.mli
+++ b/jscomp/bsb/bsb_ninja_file_groups.mli
@@ -23,18 +23,18 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
- type info = {
-  all_config_deps : string list  ;
+type info =  string list  
 
-}
 
 val zero : info
 
 
-val handle_file_groups : out_channel ->
+val handle_file_groups :
+  out_channel ->
   package_specs:Bsb_package_specs.t ->  
   js_post_build_cmd:string option -> 
   files_to_install:String_hash_set.t ->  
-  custom_rules:Bsb_rule.t String_map.t -> 
+  custom_rules:Bsb_rule.t String_map.t ->
   Bsb_parse_sources.file_group list ->
+  string option -> 
   info -> info

--- a/jscomp/bsb/bsb_ninja_gen.mli
+++ b/jscomp/bsb/bsb_ninja_gen.mli
@@ -25,7 +25,8 @@
 (** 
   generate ninja file based on [cwd] and [bsc_dir]
 *)
-val output_ninja :
-  cwd:string ->
+val 
+  output_ninja_and_namespace_map :
+  cwd:string ->  
   bsc_dir:string ->  
   Bsb_config_types.t -> unit 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -48,5 +48,6 @@ let refmt_flags = "refmt_flags"
 let postbuild = "postbuild"
 
 let namespace = "namespace" 
+let open_package = "open_package"
 
 let package_sep = "-"

--- a/jscomp/bsb/bsb_ninja_regen.ml
+++ b/jscomp/bsb/bsb_ninja_regen.ml
@@ -68,16 +68,9 @@ let regenerate_ninja
           cwd in 
       begin 
         Bsb_merlin_gen.merlin_file_gen ~cwd
-          (bsc_dir // bsppx_exe) config;
-        (match config.namespace with 
-        | None -> ()
-        | Some namespace -> 
-          (* generate a map file
-            TODO: adapt ninja rules
-          *)
-          Bsb_pkg_map_gen.output ~cwd namespace config.bs_file_groups
-        );
-        Bsb_ninja_gen.output_ninja ~cwd ~bsc_dir config ; 
+          (bsc_dir // bsppx_exe) config;       
+        Bsb_ninja_gen.output_ninja_and_namespace_map 
+          ~cwd ~bsc_dir config ; 
         Literals.bsconfig_json :: config.globbed_dirs
         |> List.map
           (fun x ->

--- a/jscomp/bsb/bsb_parse_sources.ml
+++ b/jscomp/bsb/bsb_parse_sources.ml
@@ -61,6 +61,17 @@ type t =
     globbed_dirs : string list ; 
   }
 
+exception No_lib_dir_found
+
+let rec find_first_lib_dir 
+  (file_groups : file_group list ) =
+  match file_groups with 
+  | [] -> raise No_lib_dir_found
+  | {dir ; dir_index } :: rest -> 
+    if Bsb_dir_index.is_lib_dir dir_index then dir 
+    else find_first_lib_dir rest 
+  
+
 let (//) = Ext_filename.combine
 
 let (|?)  m (key, cb) =

--- a/jscomp/bsb/bsb_parse_sources.mli
+++ b/jscomp/bsb/bsb_parse_sources.mli
@@ -67,7 +67,9 @@ type cxt = {
   cut_generators : bool
 }
 
-
+val find_first_lib_dir 
+  : file_group list -> string
+  
 (** entry is to the 
     [sources] in the schema
 

--- a/jscomp/bsb/bsb_pkg_create.ml
+++ b/jscomp/bsb/bsb_pkg_create.ml
@@ -38,12 +38,14 @@ let loc = Location.none
 let make_structure_item pkg_name cunit : Parsetree.structure_item =
   Str.module_ 
     (Mb.mk {txt = cunit; loc }
-       (Mod.ident {txt = Lident (pkg_name ^ package_sep ^ cunit) ; loc}))
+       (Mod.ident 
+        {txt = Lident (cunit ^ package_sep ^ pkg_name) ; loc}))
 
 let make_signature_item pkg_name cunit : Parsetree.signature_item = 
   Sig.module_
     (Md.mk {txt = cunit; loc}
-       (Mty.alias {txt = Lident (pkg_name ^ package_sep ^ cunit); loc})
+       (Mty.alias 
+        {txt = Lident (  cunit ^  package_sep ^ pkg_name); loc})
     )        
 
 let make_structure pkg_name cunits : Parsetree.structure =     

--- a/jscomp/bsb/bsb_pkg_map_gen.ml
+++ b/jscomp/bsb/bsb_pkg_map_gen.ml
@@ -25,13 +25,15 @@
 let (//) = Ext_filename.combine
 
 
-let output ~cwd namespace 
+
+
+
+
+let output ~dir namespace 
     (file_groups : Bsb_parse_sources.file_group list)
   = 
-  (* FIXME : *)
-  let fname = namespace ^ ".ml" in 
-  let oc = open_out_bin 
-      (cwd // Bsb_config.lib_bs// fname ) in 
+  let fname = namespace ^ Literals.suffix_ml in 
+  let oc = open_out_bin (dir// fname ) in 
   let modules =     
     List.fold_left 
     (fun acc (x : Bsb_parse_sources.file_group) ->

--- a/jscomp/bsb/bsb_pkg_map_gen.mli
+++ b/jscomp/bsb/bsb_pkg_map_gen.mli
@@ -23,8 +23,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
- val output : 
-  cwd:string ->
+val output : 
+  dir:string ->
   string -> 
   Bsb_parse_sources.file_group list ->
   unit 

--- a/jscomp/bsb/bsb_rule.ml
+++ b/jscomp/bsb/bsb_rule.ml
@@ -146,7 +146,7 @@ let copy_resources =
 let build_cmj_js =
   define
     ~command:"${bsc} ${bs_package_flags} -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include  \
-              ${bs_package_includes} ${bsc_lib_includes} ${bsc_extra_includes} ${bsc_flags} -o ${in} -c  ${in} $postbuild"
+              ${bs_package_includes} ${bsc_lib_includes} ${bsc_extra_includes} ${open_package} ${bsc_flags} -o ${out} -c  ${in} $postbuild"
 
     ~depfile:"${in}.d"
     "build_cmj_only"
@@ -154,16 +154,20 @@ let build_cmj_js =
 let build_cmj_cmi_js =
   define
     ~command:"${bsc} ${bs_package_flags} -bs-assume-no-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include \
-              ${bs_package_includes} ${bsc_lib_includes} ${bsc_extra_includes} ${bsc_flags} -o ${in} -c  ${in} $postbuild"
+              ${bs_package_includes} ${bsc_lib_includes} ${bsc_extra_includes} ${open_package} ${bsc_flags} -o ${out} -c  ${in} $postbuild"
     ~depfile:"${in}.d"
     "build_cmj_cmi" (* the compiler should never consult [.cmi] when [.mli] does not exist *)
 let build_cmi =
   define
     ~command:"${bsc} ${bs_package_flags} -bs-no-builtin-ppx-mli -bs-no-implicit-include \
-              ${bs_package_includes} ${bsc_lib_includes} ${bsc_extra_includes} ${bsc_flags} -o ${out} -c  ${in}"
+              ${bs_package_includes} ${bsc_lib_includes} ${bsc_extra_includes} ${open_package} ${bsc_flags} -o ${out} -c  ${in}"
     ~depfile:"${in}.d"
     "build_cmi" (* the compiler should always consult [.cmi], current the vanilla ocaml compiler only consult [.cmi] when [.mli] found*)
 
+let build_package = 
+  define
+    ~command:"${bsc} -w -49 -no-alias-deps -c ${in}"
+    "build_package"
 
 (* a snapshot of rule_names environment*)
 let built_in_rule_names = !rule_names 
@@ -183,6 +187,8 @@ let reset (custom_rules : string String_map.t) =
     build_cmj_js.used <- false;
     build_cmj_cmi_js.used <- false ;
     build_cmi.used <- false ;
+    build_package.used <- false;
+    
     String_map.mapi (fun name command -> 
         define ~command name
       ) custom_rules

--- a/jscomp/bsb/bsb_rule.mli
+++ b/jscomp/bsb/bsb_rule.mli
@@ -37,7 +37,7 @@ val copy_resources : t
 val build_cmj_js : t
 val build_cmj_cmi_js : t 
 val build_cmi : t
-
+val build_package : t 
 
 (** rules are generally composed of built-in rules and customized rules, there are two design choices:
     1. respect custom rules with the same name, then we need adjust our built-in 


### PR DESCRIPTION
- We create binary ast for package map, the major benefit is  not for perf  but to express some invariants
- build namespace should be in parallel with build ast so that such time 
          is almost free (in config stage), 
          since it is compiled in the config stage so it is not 
          needed to be specified as dependency later
- we should check that no `pkg-name.ml` exists either
- Which directory we  should put our `pkg-name.ml`
- We need figure out a proper place to be -I ed
- ninja has a special treatment for depfile 
            {[
            expected depfile to mention, got ..
            ]}
- make sure merlin can handle it (-open in .merlin)
- make sure install correct (install public modules + namespace map)
- generated Js code for global bindings look reasonable
```ocaml
X.length
```
```
var X$Pkg = require('pkg/lib/js/x-pkg.js')
X$Pkg.length
```