### PR TITLE
[Super errors] Revert the colors hack

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -345,7 +345,7 @@ BSB_SRCS= bsb_config\
 	oCamlRes\
 	bsb_templates\
 	bsb_init
-SUPER_ERRORS_SRCS=super_misc super_warnings super_typecore super_typetexp super_location super_main
+SUPER_ERRORS_SRCS=super_misc super_warnings super_location super_typecore super_typetexp super_main
 REASON_OUTCOME_PRINTER_SRCS=tweaked_reason_oprint reason_outcome_printer_main
 
 BSB_CMXS=$(addprefix bsb/, $(addsuffix .cmx, $(BSB_SRCS)))

--- a/jscomp/super_errors/README.md
+++ b/jscomp/super_errors/README.md
@@ -1,4 +1,4 @@
-Hello! This is the subdirectory for the new, newcomer-friendly OCaml/Reason warning & error report system. Most of the logic are lifted from the compiler (https://github.com/ocaml/ocaml/tree/4.02). The convention here is to have a `super_foo` for each corresponding compiler's file `foo`. So, for example, `warnings.ml` becomes `super_warnings.ml`. The exception is `super_main`, the entry point.
+Hello! This is the subdirectory for the new, newcomer-friendly OCaml/Reason warning & error report system. Most of the logic are lifted from the compiler (https://github.com/BuckleScript/ocaml/tree/master). The convention here is to have a `super_foo` for each corresponding compiler's file `foo`. So, for example, `warnings.ml` becomes `super_warnings.ml`. The exception is `super_main`, the entry point.
 
 Feel free to submit new ones or tweak existing messages in these files! They also have more precise comments in them that tells you how they work.
 

--- a/jscomp/super_errors/super_location.ml
+++ b/jscomp/super_errors/super_location.ml
@@ -81,7 +81,7 @@ let print ~is_warning intro ppf loc =
     end
 ;;
 
-(* taken from https://github.com/ocaml/ocaml/blob/4.02/parsing/location.ml#L337 *)
+(* taken from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/parsing/location.ml#L380 *)
 (* This is the error report entry point. We'll replace the default reporter with this one. *)
 let rec super_error_reporter ppf ({Location.loc; msg; sub; if_highlight} as err) =
   let highlighted =
@@ -97,19 +97,17 @@ let rec super_error_reporter ppf ({Location.loc; msg; sub; if_highlight} as err)
   if highlighted then
     Format.pp_print_string ppf if_highlight
   else begin
-    Super_misc.setup_colors ppf;
     (* open a vertical box. Everything in our message is indented 2 spaces *)
     Format.fprintf ppf "@[<v 2>@,%a@,%s@,@]" (print ~is_warning:false "We've found a bug for you!") loc msg;
     List.iter (Format.fprintf ppf "@,@[%a@]" super_error_reporter) sub;
     (* no need to flush here; location's report_exception (which uses this ultimately) flushes *)
   end
 
-(* extracted from https://github.com/ocaml/ocaml/blob/4.02/parsing/location.ml#L280 *)
+(* extracted from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/parsing/location.ml#L299 *)
 (* This is the warning report entry point. We'll replace the default printer with this one *)
 let super_warning_printer loc ppf w =
   if Warnings.is_active w then begin
-    Super_misc.setup_colors ppf;
-    Misc.Color.setup !Clflags.color;
+    setup_colors ();
     (* open a vertical box. Everything in our message is indented 2 spaces *)
     Format.fprintf ppf "@[<v 2>@,%a@,%a@,@]" 
       (print ~is_warning:true ("Warning number " ^ (Super_warnings.number w |> string_of_int))) 

--- a/jscomp/super_errors/super_misc.ml
+++ b/jscomp/super_errors/super_misc.ml
@@ -129,10 +129,3 @@ ppf
 
   done;
   fprintf ppf "@]" (* v *)
-
-let setup_colors ppf =
-  Format.pp_set_formatter_tag_functions ppf
-    ({ (Format.pp_get_formatter_tag_functions ppf () ) with
-      mark_open_tag = Ext_color.ansi_of_tag;
-      mark_close_tag = (fun _ -> Ext_color.reset_lit);
-    })

--- a/jscomp/super_errors/super_misc.mli
+++ b/jscomp/super_errors/super_misc.mli
@@ -1,5 +1,3 @@
 (** Range coordinates all 1-indexed, like for editors. Otherwise this code
   would have way too many off-by-one errors *)
 val print_file: is_warning:bool -> range:(int * int) * (int * int) -> lines:string array -> Format.formatter -> unit -> unit
-
-val setup_colors: Format.formatter -> unit

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -9,7 +9,7 @@ open Ctype
 open Format
 open Printtyp
 
-(* taken from https://github.com/ocaml/ocaml/blob/4.02/typing/typecore.ml#L3769 *)
+(* taken from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/typing/typecore.ml#L3769 *)
 (* modified branches are commented *)
 let report_error env ppf = function
   | Typecore.Polymorphic_label lid ->
@@ -231,9 +231,7 @@ let report_error env ppf = function
       fprintf ppf
         "@[Exception patterns must be at the top level of a match case.@]"
 
-(* https://github.com/ocaml/ocaml/blob/4.02/typing/typecore.ml#L3979 *)
 let report_error env ppf err =
-  Super_misc.setup_colors ppf;
   wrap_printing_env env (fun () -> report_error env ppf err)
 
 (* This will be called in super_main. This is how you'd override the default error printer from the compiler & register new error_of_exn handlers *)

--- a/jscomp/super_errors/super_typetexp.ml
+++ b/jscomp/super_errors/super_typetexp.ml
@@ -54,7 +54,7 @@ let spellcheck ppf fold env lid =
 let spellcheck ppf fold =
   spellcheck ppf (fun f -> fold (fun s _ _ x -> f s x))
 
-(* taken from https://github.com/ocaml/ocaml/blob/4.02/typing/typetexp.ml#L911 *)
+(* taken from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/typing/typetexp.ml#L918 *)
 (* modified branches are commented *)
 let report_error env ppf = function
   | Typetexp.Unbound_type_variable name ->

--- a/jscomp/super_errors/super_warnings.ml
+++ b/jscomp/super_errors/super_warnings.ml
@@ -1,10 +1,10 @@
 let fprintf = Format.fprintf
-(* this is lifted https://github.com/ocaml/ocaml/blob/4.02/utils/warnings.ml *)
+(* taken from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/utils/warnings.ml#L251 *)
 (* actual modified message branches are commented *)
 let message = Warnings.(function
   | Comment_start -> "this is the start of a comment."
   | Comment_not_end -> "this is not the end of a comment."
-  | Deprecated s -> "deprecated: " ^ s
+  | Deprecated s -> s ^ " is deprecated. "
   | Fragile_match "" ->
       "this pattern-matching is fragile."
   | Fragile_match s ->
@@ -210,7 +210,7 @@ let number = Warnings.(function
   | Bad_docstring _ -> 50
 );;
 
-(* helper extracted from https://github.com/ocaml/ocaml/blob/4.02/utils/warnings.ml#L396 *)
+(* taken from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/utils/warnings.ml#L396 *)
 (* the only difference is the 2 first `let`s, where we use our own `message`
   and `number` functions, and the last line commented out because we don't use
   it (not sure what it's for, actually) *)


### PR DESCRIPTION
Depends on #1919

Now that we're using a compiler patch for coloring, we can kill the old custom color logic I needed Took the occasion to clean up some comment and a deprecation warning