### PR TITLE
[Super errors] display type unification more clearly

### DIFF
--- a/jscomp/super_errors/super_location.ml
+++ b/jscomp/super_errors/super_location.ml
@@ -117,6 +117,21 @@ let super_warning_printer loc ppf w =
   end
 ;;
 
+(* taken from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/parsing/location.ml#L354 *) 
+let print_phanton_error_prefix ppf =
+  (* modified from the original. We use only 2 indentations for error report
+    (see super_error_reporter above) *)
+  Format.pp_print_as ppf 2 ""
+
+let errorf ?(loc = none) ?(sub = []) ?(if_highlight = "") fmt =
+  Location.pp_ksprintf
+    ~before:print_phanton_error_prefix
+    (fun msg -> {loc; msg; sub; if_highlight})
+    fmt
+
+let error_of_printer loc print x =
+  errorf ~loc "%a@?" print x
+
 (* This will be called in super_main. This is how you override the default error and warning printers *)
 let setup () =
   Location.error_reporter := super_error_reporter;

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -48,9 +48,9 @@ let report_error env ppf = function
       (* modified *)
       report_unification_error ppf env trace
         (function ppf ->
-           fprintf ppf "@{<error>This is:@}")
+           fprintf ppf "This is:")
         (function ppf ->
-           fprintf ppf "@{<info>but somewhere wanted:@}")
+           fprintf ppf "But somewhere wanted:")
   | Apply_non_function typ ->
       (* modified *)
       reset_and_mark_loops typ;
@@ -239,7 +239,7 @@ let setup () =
   Location.register_error_of_exn
     (function
       | Typecore.Error (loc, env, err) ->
-        Some (Location.error_of_printer loc (report_error env) err)
+        Some (Super_location.error_of_printer loc (report_error env) err)
       | Typecore.Error_forward err ->
         Some err
       | _ ->

--- a/jscomp/super_errors/super_typetexp.ml
+++ b/jscomp/super_errors/super_typetexp.ml
@@ -159,7 +159,7 @@ let setup () =
   Location.register_error_of_exn
     (function
       | Typetexp.Error (loc, env, err) ->
-        Some (Location.error_of_printer loc (report_error env) err)
+        Some (Super_location.error_of_printer loc (report_error env) err)
       (* typetexp doesn't expose Error_forward  *)
       (* | Error_forward err ->
         Some err *)


### PR DESCRIPTION
Final part of #1919

Before:

![screenshot 2017-08-22 01 20 50](https://user-images.githubusercontent.com/1909539/29590939-2b99e58e-8751-11e7-9ae3-cf54a4ad9a03.png)

After:

![screenshot 2017-08-22 01 28 25](https://user-images.githubusercontent.com/1909539/29590943-2fe18322-8751-11e7-91ee-73c456f42d39.png)
