### PR TITLE
Broken links in JS Modules documentation

### DIFF
--- a/site/docsource/js-lib.adoc
+++ b/site/docsource/js-lib.adoc
@@ -77,47 +77,47 @@ for coercing to and from `bool`: `Js.to_bool` and `Js.Boolean.to_js_boolean`.
 
 _These APIs might change, but is considered mostly complete_
 
-* link:../api/Js.Null.html[Js.Null]
-* link:../api/Js.Undefined.html[Js.Undefined]
-* link:../api/Js.Null_undefined.html[Js.Null_undefined]
+* link:./api/Js.Null.html[Js.Null]
+* link:./api/Js.Undefined.html[Js.Undefined]
+* link:./api/Js.Null_undefined.html[Js.Null_undefined]
 
-* link:../api/Js.Array.html[Js.Array]
-* link:../api/Js.Date.html[Js.Date]
-* link:../api/Js.Math.html[Js.Math]
-* link:../api/Js.Re.html[Js.Re]
-* link:../api/Js.String.html[Js.String]
-* link:../api/Js.Typed_array.html[Js.Typed_array]
+* link:./api/Js.Array.html[Js.Array]
+* link:./api/Js.Date.html[Js.Date]
+* link:./api/Js.Math.html[Js.Math]
+* link:./api/Js.Re.html[Js.Re]
+* link:./api/Js.String.html[Js.String]
+* link:./api/Js.Typed_array.html[Js.Typed_array]
 
 === Experimental/incomplete submodules
 
 _Expect these APIs to change drastically, **use only if you accept breakage.**_
 
-* link:../api/Js.Boolean.html[Js.Boolean]
-* link:../api/Js.Dict.html[Js.Dict]
-* link:../api/Js.Obj.html[Js.Obj]
+* link:./api/Js.Boolean.html[Js.Boolean]
+* link:./api/Js.Dict.html[Js.Dict]
+* link:./api/Js.Obj.html[Js.Obj]
 
 === Very experimental/internal submodules
 
 *_Do not use these APIs unless absolutely necessary, they're mostly internal_*
 
-* link:../api/Js_float.html[Js_float]
-* link:../api/Js_int.html[Js_int]
-* link:../api/Js_int64.html[Js_int64]
-* link:../api/Js_json.html[Js.Json]
-* link:../api/Js_nativeint.html[Js_nativeint]
-* link:../api/Js_primitive.html[Js_primitive]
-* link:../api/Js_types.html[Js.Types]
-* link:../api/Js_unsafe.html[Js_unsafe]
+* link:./api/Js_float.html[Js_float]
+* link:./api/Js_int.html[Js_int]
+* link:./api/Js_int64.html[Js_int64]
+* link:./api/Js_json.html[Js.Json]
+* link:./api/Js_nativeint.html[Js_nativeint]
+* link:./api/Js_primitive.html[Js_primitive]
+* link:./api/Js_types.html[Js.Types]
+* link:./api/Js_unsafe.html[Js_unsafe]
 
 == Node module
 
-link:../api/Node.html[Node]
+link:./api/Node.html[Node]
 
 === Submodules
 
-* link:../api/Node_buffer.html[Node.Buffer]
-* link:../api/Node_child_process.html[Node.Child_process]
-* link:../api/Node_fs.html[Node.Fs]
-* link:../api/Node_module.html[Node.Module]
-* link:../api/Node_path.html[Node.Path]
-* link:../api/Node_process.html[Node.Process]
+* link:./api/Node_buffer.html[Node.Buffer]
+* link:./api/Node_child_process.html[Node.Child_process]
+* link:./api/Node_fs.html[Node.Fs]
+* link:./api/Node_module.html[Node.Module]
+* link:./api/Node_path.html[Node.Path]
+* link:./api/Node_process.html[Node.Process]


### PR DESCRIPTION
See the following sections for examples:
- https://bucklescript.github.io/bucklescript/Manual.html#_stable_ish_submodules
- https://bucklescript.github.io/bucklescript/Manual.html#_experimental_incomplete_submodules
- https://bucklescript.github.io/bucklescript/Manual.html#_very_experimental_internal_submodules
- https://bucklescript.github.io/bucklescript/Manual.html#_node_module

These links are located within `site/docsource/js-lib.adoc`, which I've updated to be relative to the current folder.

Have tested locally by running `site/docsource/build.sh` and browsing `docs/Manual.html`.