### PR TITLE
Add line numbers and char indexes to super errors output

### DIFF
--- a/jscomp/super_errors/super_location.ml
+++ b/jscomp/super_errors/super_location.ml
@@ -56,14 +56,14 @@ let print ~is_warning intro ppf loc =
     else begin
       fprintf ppf "@[@{<error>%s@}@]@," intro
     end;
-    fprintf ppf "@[%a@]@," print_loc loc;
     let (file, start_line, start_char) = Location.get_pos_info loc.loc_start in
     let (_, end_line, end_char) = Location.get_pos_info loc.loc_end in
     (* things to special-case: startchar & endchar2 both -1  *)
     if start_char == -1 || end_char == -1 then
       (* happens sometimes. Syntax error for example. Just show the file and do nothing for now *)
-      ()
+      fprintf ppf "@[%a@]@," print_loc loc
     else begin
+      fprintf ppf "@[%a@], from l%d-c%d to l%d-c%d@," print_loc loc start_line start_char end_line end_char;
       try
         let lines = file_lines file in
         (* we're putting a line break here rather than above, because this


### PR DESCRIPTION
Fixes #2015 (not directly, but the need to add an option to not strip color chars in ninja wouldn't be required anymore).

To read error data from `ocaml-language-server`, this PR just adds the line numbers and index positions in an explicit format for the server to pick them up more easily. This removes the need to parse ANSI color chars.

Below the output with this addition, just some more information is added after the file name:

```
  We've found a bug for you!
  /Users/javi/sandbox/reason-hello/src/demo.re, from l10-c16 to l10-c24
  
   8 │   };
   9 │ 
  10 │ Js.log(greeting "John");
  11 │ 
  12 │ let score = 10;
  
  This is:
    string
  But somewhere wanted:
    schoolPerson
```

@bobzhang @chenglou heads up: this is the first time I write OCaml so there must be between 3 and 30 things wrong :)