### PR TITLE
[Super errors] display line and column

### DIFF
--- a/jscomp/super_errors/super_location.ml
+++ b/jscomp/super_errors/super_location.ml
@@ -33,16 +33,23 @@ let setup_colors () =
 let print_filename ppf file =
   Format.fprintf ppf "%s" (Location.show_filename file)
 
-let print_loc ppf loc =
+let print_loc ~normalizedRange ppf loc =
   setup_colors ();
   let (file, _, _) = Location.get_pos_info loc.loc_start in
   if file = "//toplevel//" then begin
     if highlight_locations ppf [loc] then () else
       fprintf ppf "Characters %i-%i"
               loc.loc_start.pos_cnum loc.loc_end.pos_cnum
-  end else begin
-    fprintf ppf "@{<filename>%a@}" print_filename file;
-  end
+  end else 
+    let dim_loc ppf = function
+    | None -> ()
+    | Some ((start_line, start_line_start_char), (end_line, end_line_end_char)) ->
+      if start_line = end_line then 
+        fprintf ppf " @{<dim>%i:%i-%i@}" start_line start_line_start_char end_line_end_char
+      else
+        fprintf ppf " @{<dim>%i:%i-%i:%i@}" start_line start_line_start_char end_line end_line_end_char
+    in
+    fprintf ppf "@{<filename>%a@}%a" print_filename file dim_loc normalizedRange
 ;;
 
 let print ~is_warning intro ppf loc =
@@ -56,30 +63,30 @@ let print ~is_warning intro ppf loc =
     else begin
       fprintf ppf "@[@{<error>%s@}@]@," intro
     end;
-    fprintf ppf "@[%a@]@," print_loc loc;
+
     let (file, start_line, start_char) = Location.get_pos_info loc.loc_start in
     let (_, end_line, end_char) = Location.get_pos_info loc.loc_end in
-    (* things to special-case: startchar & endchar2 both -1  *)
-    if start_char == -1 || end_char == -1 then
-      (* happens sometimes. Syntax error for example. Just show the file and do nothing for now *)
-      ()
-    else begin
+    (* line is 1-indexed, column is 0-indexed. We convert all of them to 1-indexed to avoid confusion *)
+    (* start_char is inclusive *)
+    (* end_char is exclusive, so +1-1=0 *)
+    let normalizedRange = 
+      if start_char == -1 || end_char == -1 then
+        (* happens sometimes. Syntax error for example *)
+        None
+      else 
+        Some ((start_line, start_char + 1), (end_line, end_char))
+    in
+    fprintf ppf "@[%a@]@," (print_loc ~normalizedRange) loc;
+    match normalizedRange with
+    | None -> ()
+    | Some range -> begin
       try
         let lines = file_lines file in
-        (* we're putting a line break here rather than above, because this
+        (* we're putting the line break `@,` here rather than above, because this
            branch might not be reached (aka no inline file content display) so 
            we don't wanna end up with two line breaks in the the consequent *)
         fprintf ppf "@,%a"
-          (Super_misc.print_file
-          ~is_warning
-          ~lines
-          ~range:(
-            (* line is 1-indexed, column is 0-indexed. We convert all of them to 1-indexed to avoid confusion *)
-            (* start_char is inclusive *)
-            (start_line, start_char + 1),
-            (* start_char is exclusive *)
-            (end_line, end_char + 1)
-          ))
+          (Super_misc.print_file ~is_warning ~lines ~range)
           ()
       with
       (* this shouldn't happen, but gracefully fall back to the default reporter just in case *)

--- a/jscomp/super_errors/super_location.ml
+++ b/jscomp/super_errors/super_location.ml
@@ -70,8 +70,7 @@ let print ~is_warning intro ppf loc =
     let (file, start_line, start_char) = Location.get_pos_info loc.loc_start in
     let (_, end_line, end_char) = Location.get_pos_info loc.loc_end in
     (* line is 1-indexed, column is 0-indexed. We convert all of them to 1-indexed to avoid confusion *)
-    (* start_char is inclusive *)
-    (* end_char is exclusive, so +1-1=0 *)
+    (* start_char is inclusive, end_char is exclusive *)
     let normalizedRange = 
       if start_char == -1 || end_char == -1 then
         (* happens sometimes. Syntax error for example *)
@@ -84,6 +83,7 @@ let print ~is_warning intro ppf loc =
         let same_char = start_char + 1 in
         Some ((start_line, same_char), (end_line, same_char))
       else
+        (* again: end_char is exclusive, so +1-1=0 *)
         Some ((start_line, start_char + 1), (end_line, end_char))
     in
     fprintf ppf "@[%a@]@," (print_loc ~normalizedRange) loc;

--- a/jscomp/super_errors/super_misc.ml
+++ b/jscomp/super_errors/super_misc.ml
@@ -130,10 +130,6 @@ ppf
           ~end_highlight_line:(j = offset_current_line_length)
           current_char 
       | Only_error_line ->
-        (* in some errors, starting char and ending char can be the same. But
-           since ending char was supposed to be exclusive and had a -1, here it 
-           might end up smaller than the starting char *)
-        let offset_end_line_end_char = max offset_end_line_end_char offset_start_line_start_char in
         print_char_maybe_highlight 
           ~begin_highlight_line:(j = offset_start_line_start_char) 
           ~end_highlight_line:(j = offset_end_line_end_char)

--- a/jscomp/super_errors/super_misc.ml
+++ b/jscomp/super_errors/super_misc.ml
@@ -41,6 +41,7 @@ type current_printed_line_status =
   would have way too many off-by-one errors *)
 let print_file 
 ~is_warning 
+(* start_line_start_char inclusive, end_line_end_char exclusive *)
 ~range:((start_line, start_line_start_char), (end_line, end_line_end_char)) 
 ~lines
 ppf 
@@ -118,7 +119,7 @@ ppf
     let offset_current_line_length = String.length offset_current_line in
     let offset_start_line_start_char = start_line_start_char - columns_to_cut in
     (* end_line_end_char is exclusive *)
-    let offset_end_line_end_char = end_line_end_char - 1 - columns_to_cut in
+    let offset_end_line_end_char = end_line_end_char - columns_to_cut in
     (* inclusive. To be consistent with using 1-indexed indices and count and i, j will be 1-indexed too *)
     for j = 1 to offset_current_line_length do
       let current_char = offset_current_line.[j - 1] in


### PR DESCRIPTION
And they're correctly normalized!

Formats:

```
path/to/file.re
path/to/file.re 10:20
path/to/file.re 10:20-30
path/to/file.re 10:20-15:5
```

Replaces #2023