### PR TITLE
catch the error of the buildocaml script and print it for more information

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -90,7 +90,14 @@ function non_windows_npm_release() {
         child_process.execSync('node ../scripts/config_compiler.js', working_config)
     } catch (e) {
         console.log('Build a local version of OCaml compiler, it may take a couple of minutes')
-        child_process.execSync(path.join(__dirname, 'buildocaml.sh')) // TODO: sh -c ? this will be wrong if we have white space in the path
+        try {
+            child_process.execSync(path.join(__dirname, 'buildocaml.sh')) // TODO: sh -c ? this will be wrong if we have white space in the path
+        } catch (e) {
+            console.log(e.stdout.toString());
+            console.log(e.stderr.toString());
+            console.log('Building a local version of the OCaml compiler failed, check the outut above for more information. A possible problem is that you don\'t have a compiler installed');
+            throw e;
+        }
         console.log('configure again with local ocaml installed')
         child_process.execSync('node ../scripts/config_compiler.js', working_config)
         console.log("config finished")


### PR DESCRIPTION
This is a possible solution for #2086.

I only catch this one command, but maybe the other commands can fail as well, but I don't know what possible reasons are for failure of these other commands.