### PR TITLE
dump mli/rei from cmi , fix Js.Internal leaking in error message

### DIFF
--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -11795,7 +11795,7 @@ let make_common_shadows
   in 
   if is_re then 
     { key = Bsb_ninja_global_vars.bsc_flags; 
-      op = AppendList ["-bs-re-error"; "-bs-super-errors"]
+      op = AppendList ["-bs-re-out"; "-bs-super-errors"]
     } :: shadows
   else shadows
 

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -115482,9 +115482,9 @@ let buckle_script_flags : (string * Arg.spec * string) list =
    " Better error message combined with other tools "
   )
   :: 
-  ("-bs-re-error",
+  ("-bs-re-out",
     Arg.Unit Reason_outcome_printer_main.setup,
-   " Print compiler errors in Reason syntax"
+   " Print compiler output in Reason syntax"
   )
   :: 
   ("-bs-no-implicit-include", Arg.Set Clflags.no_implicit_current_dir

--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -91,7 +91,7 @@ let make_common_shadows
   in 
   if is_re then 
     { key = Bsb_ninja_global_vars.bsc_flags; 
-      op = AppendList ["-bs-re-error"; "-bs-super-errors"]
+      op = AppendList ["-bs-re-out"; "-bs-super-errors"]
     } :: shadows
   else shadows
 

--- a/jscomp/core/js_main.ml
+++ b/jscomp/core/js_main.ml
@@ -102,9 +102,9 @@ let buckle_script_flags : (string * Arg.spec * string) list =
    " Better error message combined with other tools "
   )
   :: 
-  ("-bs-re-error",
+  ("-bs-re-out",
     Arg.Unit Reason_outcome_printer_main.setup,
-   " Print compiler errors in Reason syntax"
+   " Print compiler output in Reason syntax"
   )
   :: 
   ("-bs-no-implicit-include", Arg.Set Clflags.no_implicit_current_dir

--- a/jscomp/core/js_main.ml
+++ b/jscomp/core/js_main.ml
@@ -29,6 +29,12 @@ let process_file ppf name =
     -> Js_implementation.implementation_mlast ppf name opref
   | Mlmap, opref 
     -> Js_implementation.implementation_map ppf name opref
+  | Cmi, _ 
+    ->
+      let {Cmi_format.cmi_sign } =  Cmi_format.read_cmi name in 
+      Printtyp.signature Format.std_formatter cmi_sign ; 
+      Format.pp_print_newline Format.std_formatter ()
+      
 
 let usage = "Usage: bsc <options> <files>\nOptions are:"
 
@@ -84,7 +90,7 @@ let define_variable s =
   | _ -> raise (Arg.Bad ("illegal definition: " ^ s))
 
   
-let buckle_script_flags =
+let buckle_script_flags : (string * Arg.spec * string) list =
   ("-bs-super-errors",
     Arg.Unit 
       (* needs to be set here instead of, say, setting a

--- a/jscomp/core/ocaml_parse.ml
+++ b/jscomp/core/ocaml_parse.ml
@@ -52,6 +52,7 @@ type valid_input =
   | Mlast    
   | Mliast 
   | Mlmap
+  | Cmi
   
 let check_suffix  name  = 
   if Filename.check_suffix name ".ml"
@@ -70,5 +71,7 @@ let check_suffix  name  =
     Mliast, Compenv.output_prefix name 
   else if Filename.check_suffix name ".mlmap"  then 
     Mlmap, Compenv.output_prefix name 
+  else if Filename.check_suffix name ".cmi" then 
+    Cmi, Compenv.output_prefix name
   else 
     raise(Arg.Bad("don't know what to do with " ^ name))

--- a/jscomp/core/ocaml_parse.mli
+++ b/jscomp/core/ocaml_parse.mli
@@ -37,5 +37,5 @@ type valid_input =
   | Mlast    
   | Mliast 
   | Mlmap
-  
+  | Cmi
 val check_suffix :  string -> valid_input * string

--- a/jscomp/reason_outcome_printer/tweaked_reason_oprint.ml
+++ b/jscomp/reason_outcome_printer/tweaked_reason_oprint.ml
@@ -251,6 +251,71 @@ and print_simple_out_type ppf =
     Otyp_class (ng, id, tyl) ->
       fprintf ppf "@[%s#%a%a@]" (if ng then "_" else "")
         print_ident id print_typargs tyl
+#if undefined BS_NO_COMPILER_PATCH then         
+  | Otyp_constr ( (Oide_dot ((Oide_dot (Oide_ident "Js", "Internal")),
+                             ("fn" | "meth" as name )) as id) ,
+                 ([Otyp_variant(_,Ovar_fields [ variant, _, tys], _,_); result] as tyl))
+    ->
+      (* Otyp_arrow*)
+      let make tys result =
+        if tys = [] then
+          Otyp_arrow ("", Otyp_constr (Oide_ident "unit", []),result)
+        else
+            match tys with
+          | [ Otyp_tuple tys as single] -> 
+              if variant = "Arity_1" then
+                Otyp_arrow ("", single, result)
+              else 
+                List.fold_right (fun x acc  -> Otyp_arrow("",x,acc) ) tys result
+          | [single] ->
+              Otyp_arrow ("", single, result)
+          | _ -> 
+              raise_notrace Not_found
+      in
+      begin match (make tys result) with
+      | exception _ ->
+          begin 
+            pp_open_box ppf 0;
+            print_typargs ppf tyl;
+            print_ident ppf id;
+            pp_close_box ppf ()
+          end
+      | res ->
+          begin match name  with
+          | "fn" -> 
+              fprintf ppf "@[<0>(%a@ [@bs])@]" print_out_type_1 res
+          | "meth" ->
+              fprintf ppf "@[<0>(%a@ [@bs.meth])@]" print_out_type_1 res
+          | _ -> assert false 
+          end
+      end
+  | Otyp_constr ((Oide_dot (Oide_dot (Oide_ident "Js", "Internal"), "meth_callback" ) as id) ,
+                 ([Otyp_variant(_,Ovar_fields [ variant, _, tys], _,_); result] as tyl))
+    ->
+      let make tys result =
+          match tys with
+          | [ Otyp_tuple tys as single ] -> 
+              if variant = "Arity_1" then Otyp_arrow ("", single, result)
+              else 
+                List.fold_right (fun x acc  -> Otyp_arrow("",x,acc) ) tys result
+          | [single] ->
+              Otyp_arrow ("", single, result)
+          | _ -> 
+              raise_notrace Not_found
+      in
+      begin match (make tys result) with
+      | exception _ ->
+          begin 
+            pp_open_box ppf 0;
+            print_typargs ppf tyl;
+            print_ident ppf id;
+            pp_close_box ppf ()
+          end
+      | res ->
+          fprintf ppf "@[<0>(%a@ [@bs.this])@]" print_out_type_1 res
+
+      end
+#end         
   | Otyp_constr (id, tyl) ->
       pp_open_box ppf 0;
       print_ident ppf id;
@@ -497,30 +562,30 @@ and print_out_sig_item ppf =
           | Orec_first -> "type"
           | Orec_next  -> "and")
         ppf td
-#if defined BS_NO_COMPILER_PATCH then
-  | Osig_value {oval_name; oval_type; oval_prims; oval_attributes} ->
-#else
-  | Osig_value(oval_name, oval_type, oval_prims) ->
-#end
-    let kwd = if oval_prims = [] then "let" else "external" in
+  | Osig_value(name, ty, prims) ->
+    let kwd = if prims = [] then "let" else "external" in
     let pr_prims ppf =
       function
         [] -> ()
       | s :: sl ->
           fprintf ppf "@ = \"%s\"" s;
-          List.iter (fun s -> fprintf ppf "@ \"%s\"" s) sl
+          List.iter (fun s -> 
+(* TODO: in general, we should print bs attributes, some attributes like
+  bs.splice does need it *)
+#if undefined BS_NO_COMPILER_PATCH then
+    let len = String.length s in
+    if len >= 3 && s.[0] = 'B' && s.[1] = 'S' && s.[2] = ':' then
+      fprintf ppf "@ \"BS-EXTERNAL\"" 
+    else
+      fprintf ppf "@ \"%s\"" s
+#else    
+      fprintf ppf "@ \"%s\"" s
+#end               
+    ) sl
     in
-#if defined BS_NO_COMPILER_PATCH then
-    fprintf ppf "@[<2>%s %a :@ %a%a%a@]" kwd value_ident oval_name
-        !out_type oval_type pr_prims oval_prims
-        (fun ppf -> List.iter (fun a -> fprintf ppf "@ [@@@@%s]" a.oattr_name))
-        oval_attributes
-  | Osig_ellipsis ->
-    fprintf ppf "..."
-#else
-    fprintf ppf "@[<2>%s %a :@ %a%a@]" kwd value_ident oval_name
-        !out_type oval_type pr_prims oval_prims
-#end
+    fprintf ppf "@[<2>%s %a :@ %a%a@]" kwd value_ident name !out_type 
+      ty pr_prims prims
+
 
 and print_out_type_decl kwd ppf td =
   let print_constraints ppf =


### PR DESCRIPTION
```
jscomp/bin/bsc.exe  jscomp/others/js_list.cmi
```

```
type 'a t = 'a list
val length : 'a t -> int
val cons : 'a -> 'a t -> 'a t
val isEmpty : 'a t -> bool
val hd : 'a t -> 'a option
val tl : 'a t -> 'a t option
val nth : 'a t -> int -> 'a option
val revAppend : 'a t -> 'a t -> 'a t
val rev : 'a t -> 'a t
val mapRev : ('a -> 'b [@bs]) -> 'a t -> 'b t
val map : ('a -> 'b [@bs]) -> 'a t -> 'b t
val iter : ('a -> unit [@bs]) -> 'a t -> unit
val iteri : (int -> 'a -> unit [@bs]) -> 'a t -> unit
val foldLeft : ('a -> 'b -> 'a [@bs]) -> 'a -> 'b list -> 'a
val foldRight : ('a -> 'b -> 'b [@bs]) -> 'a list -> 'b -> 'b
val flatten : 'a t t -> 'a t
val filter : ('a -> bool [@bs]) -> 'a t -> 'a t
val filterMap : ('a -> 'b option [@bs]) -> 'a t -> 'b t
val countBy : ('a -> bool [@bs]) -> 'a list -> int
val init : int -> (int -> 'a [@bs]) -> 'a t
val equal : ('a -> 'a -> bool [@bs]) -> 'a list -> 'a list -> bool

```

```
jscomp/bin/bsc.exe -bs-re-out jscomp/others/js_list.cmi 
```
```re
jscomp$bin/bsc.exe -bs-re-out others/js_list.cmi
type t 'a = list 'a;
let length : t 'a => int;
let cons : 'a => t 'a => t 'a;
let isEmpty : t 'a => bool;
let hd : t 'a => option 'a;
let tl : t 'a => option (t 'a);
let nth : t 'a => int => option 'a;
let revAppend : t 'a => t 'a => t 'a;
let rev : t 'a => t 'a;
let mapRev : ('a => 'b [@bs]) => t 'a => t 'b;
let map : ('a => 'b [@bs]) => t 'a => t 'b;
let iter : ('a => unit [@bs]) => t 'a => unit;
let iteri : (int => 'a => unit [@bs]) => t 'a => unit;
let foldLeft : ('a => 'b => 'a [@bs]) => 'a => list 'b => 'a;
let foldRight : ('a => 'b => 'b [@bs]) => list 'a => 'b => 'b;
let flatten : t (t 'a) => t 'a;
let filter : ('a => bool [@bs]) => t 'a => t 'a;
let filterMap : ('a => option 'b [@bs]) => t 'a => t 'b;
let countBy : ('a => bool [@bs]) => list 'a => int;
let init : int => (int => 'a [@bs]) => t 'a;
let equal : ('a => 'a => bool [@bs]) => list 'a => list 'a => bool;
```