### PR TITLE
Editing for doc comments and some help text

### DIFF
--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -14237,7 +14237,7 @@ let bsb_main_flags : (string * Arg.spec * string) list=
     "-make-world", Arg.Unit set_make_world,
     " Build all dependencies and itself ";
     "-init", Arg.String (fun path -> generate_theme_with_path := Some path),
-    " Init sample project to get started. Note (`bsb -init sample` will create a sample project while `bsb -init .` will resuse current directory)";
+    " Init sample project to get started. Note (`bsb -init sample` will create a sample project while `bsb -init .` will reuse current directory)";
     "-theme", Arg.String set_theme,
     " The theme for project initialization, default is basic(https://github.com/bucklescript/bucklescript/tree/master/jscomp/bsb/templates)";
     "-query", Arg.String (fun s -> Bsb_query.query ~cwd ~bsc_dir s ),

--- a/jscomp/bsb/bsb_bsdeps.mli
+++ b/jscomp/bsb/bsb_bsdeps.mli
@@ -27,7 +27,7 @@
   be regenerated. Everytime [bsb] run [regenerate_ninja], 
   bsb will try to [check] if it is needed, 
   if needed, we will regenerate ninja file and store the 
-  meta data again
+  metadata again
 *)
 
 

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -72,7 +72,7 @@ let bsb_main_flags : (string * Arg.spec * string) list=
     "-make-world", Arg.Unit set_make_world,
     " Build all dependencies and itself ";
     "-init", Arg.String (fun path -> generate_theme_with_path := Some path),
-    " Init sample project to get started. Note (`bsb -init sample` will create a sample project while `bsb -init .` will resuse current directory)";
+    " Init sample project to get started. Note (`bsb -init sample` will create a sample project while `bsb -init .` will reuse current directory)";
     "-theme", Arg.String set_theme,
     " The theme for project initialization, default is basic(https://github.com/bucklescript/bucklescript/tree/master/jscomp/bsb/templates)";
     "-query", Arg.String (fun s -> Bsb_query.query ~cwd ~bsc_dir s ),

--- a/jscomp/common/js_config.mli
+++ b/jscomp/common/js_config.mli
@@ -46,7 +46,7 @@ val no_version_header : bool ref
 (* val set_package_name : string -> unit  
 val get_package_name : unit -> string option *)
 
-(** corss module inline option *)
+(** cross module inline option *)
 val cross_module_inline : bool ref
 val set_cross_module_inline : bool -> unit
 val get_cross_module_inline : unit -> bool
@@ -60,7 +60,7 @@ val set_diagnose : bool -> unit
 (** generate tds option *)
 val default_gen_tds : bool ref
 
-(** options for builtion ppx *)
+(** options for builtin ppx *)
 val no_builtin_ppx_ml : bool ref 
 val no_builtin_ppx_mli : bool ref 
 val no_warn_ffi_type : bool ref 
@@ -70,8 +70,8 @@ val no_error_unused_bs_attribute : bool ref
 val check_div_by_zero : bool ref 
 val get_check_div_by_zero : unit -> bool 
 
-(* It will imply [-noassert] be set too, note from the implmentation point of view, 
-   in the lambda layer, it is impossible to tell whehther it is [assert (3 <> 2)] or 
+(* It will imply [-noassert] be set too, note from the implementation point of view,
+   in the lambda layer, it is impossible to tell whether it is [assert (3 <> 2)] or
    [if (3<>2) then assert false]
  *)
 val no_any_assert : bool ref 
@@ -100,4 +100,4 @@ val syntax_only  : bool ref
 val binary_ast : bool ref
 
 
-val bs_suffix : bool ref 
+val bs_suffix : bool ref

--- a/jscomp/others/bs.ml
+++ b/jscomp/others/bs.ml
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-(** place holder for BuckleScript datastructures *)
+(** Placeholder for BuckleScript data structures *)
 
 (**/*)
 module Dyn = Bs_dyn

--- a/jscomp/others/js_dict.mli
+++ b/jscomp/others/js_dict.mli
@@ -27,7 +27,7 @@ type 'a t
 (** Dictionary type (ie an '\{ \}' JS object). However it is restricted 
     to hold a single type; therefore values must have the same type. 
     
-    This Dictionary type is mostly use with the [Js_json.t] type. *)
+    This Dictionary type is mostly used with the [Js_json.t] type. *)
 
 type key = string
 (** Key type *)
@@ -57,7 +57,7 @@ external keys : 'a t -> string array = "Object.keys" [@@bs.val]
 (** [keys dict] returns all the keys in the dictionary [dict]*)
 
 external empty : unit -> 'a t = "" [@@bs.obj]
-(** [empty ()] returns en empty dictionary *)
+(** [empty ()] returns an empty dictionary *)
 
 (** Experimental internal funciton *)
 val unsafeDeleteKey : string t -> string -> unit [@bs]
@@ -71,11 +71,11 @@ val values : 'a t -> 'a array
 (** [entries dict] returns the values in [dict] (ES2017) *)
 
 val fromList : (key * 'a) list -> 'a t
-(** [fromList entries] creates a new dictionary using with containing each
+(** [fromList entries] creates a new dictionary containing each
 [(key, value)] pair in [entries] *)
 
 val fromArray : (key * 'a) array -> 'a t
-(** [fromArray entries] creates a new dictionary using with containing each
+(** [fromArray entries] creates a new dictionary containing each
 [(key, value)] pair in [entries] *)
 
 val map : ('a -> 'b [@bs]) -> 'a t -> 'b t

--- a/jscomp/others/js_promise.ml
+++ b/jscomp/others/js_promise.ml
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-(** Specialized bindings to Promise, note for simplicity,  
+(** Specialized bindings to Promise. Note: For simplicity,
     this binding does not track the error type, it treat it as an opaque type
     {[
 

--- a/jscomp/others/node.ml
+++ b/jscomp/others/node.ml
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-(** place holder for node bindings *)
+(** Placeholder for Node bindings *)
 
 module Path = Node_path
 
@@ -74,7 +74,7 @@ type _ string_buffer_kind =
   | Buffer :  buffer string_buffer_kind
 
 
-(** We except a good inliner will eliminate such boxing in the future *)
+(** We expect a good inliner will eliminate such boxing in the future *)
 let test (type t) (x : string_buffer) : (t string_buffer_kind * t)= 
   if Js.typeof x = "string" then 
     (Obj.magic String : t string_buffer_kind),  (Obj.magic x : t)

--- a/jscomp/runtime/js.mli
+++ b/jscomp/runtime/js.mli
@@ -25,7 +25,7 @@
 
 (* DESIGN:  
     - It does not have any code, all its code will be inlined so that
-       there will be never
+       there will never be
        {[ require('js')]}
     - Its interface should be minimal
 *)
@@ -142,12 +142,12 @@ external unsafe_ge : 'a -> 'a -> bool = "#unsafe_ge"
 (** {12 nested modules}*)
 
 module Null = Js_null
-(** Provide utilities arond ['a null] *)
+(** Provide utilities around ['a null] *)
 
 module Undefined = Js_undefined
 (** Provide utilities around {!undefined} *)
 module Nullable = Js_null_undefined
-(** Provide utilities arond {!null_undefined} *)
+(** Provide utilities around {!null_undefined} *)
 module Null_undefined = Js_null_undefined
 
 module Exn = Js_exn
@@ -158,7 +158,7 @@ module Array = Js_array
 module String = Js_string
 (** Provide bindings to JS string *)
 module Boolean = Js_boolean
-(** Provide utilties for {!boolean} *)
+(** Provide utilities for {!boolean} *)
 
 module Re = Js_re
 (** Provide bindings to Js regex expression *)
@@ -188,7 +188,7 @@ module Typed_array = Js_typed_array
 (** Provide bindings for JS typed array *)
 
 module Types = Js_types
-(** Provide utilities for maninpulatig JS types  *)
+(** Provide utilities for manipulating JS types  *)
 module Float = Js_float
 (** Provide utilities for JS float *)
 module Int = Js_int
@@ -198,9 +198,9 @@ module Option = Js_option
 (** Provide utilities for option *)
 
 module Result = Js_result
-(** definie the interface for result *)
+(** Define the interface for result *)
 
 module List = Js_list 
-(** Provide utilties for list *)
+(** Provide utilities for list *)
 
 module Vector = Js_vector 


### PR DESCRIPTION
This fixes some misspellings and grammar issues noticed while browsing the documentation and looking at the help text for the `bsb` executable.