### PR TITLE
Allow loading compiled modules via JS API

### DIFF
--- a/jscomp/core/js_cmj_datasets.mli
+++ b/jscomp/core/js_cmj_datasets.mli
@@ -1,1 +1,1 @@
-val data_sets : Js_cmj_format.t Lazy.t String_map.t
+val data_sets : Js_cmj_format.t Lazy.t String_map.t ref

--- a/jscomp/core/js_cmj_load.ml
+++ b/jscomp/core/js_cmj_load.ml
@@ -36,7 +36,7 @@ let find_cmj file : string * Js_cmj_format.t =
 #if BS_COMPILER_IN_BROWSER then  
         "BROWSER", (   
         let target = String.uncapitalize (Filename.basename file) in
-        match String_map.find_exn  target Js_cmj_datasets.data_sets with 
+        match String_map.find_exn  target !Js_cmj_datasets.data_sets with
         | v
           -> 
           begin match Lazy.force v with

--- a/jscomp/jscmj_main.ml
+++ b/jscomp/jscmj_main.ml
@@ -73,8 +73,9 @@ let from_cmj (files : string list) (output_file : string) =
       in
       Ext_pp.string f "(* -*-mode:fundamental-*- *)"  ;
       Ext_pp.newline f ;
-      Ext_pp.string f "let data_sets = String_map.of_list "    ;
-      Ext_pp.bracket_vgroup f 1 (fun _ -> List.iter aux files))
+      Ext_pp.string f "let data_sets = let map = String_map.of_list "    ;
+      Ext_pp.bracket_vgroup f 1 (fun _ -> List.iter aux files);
+      Ext_pp.string f " in ref map")
 
 
 (** the cache should be readable and also update *)


### PR DESCRIPTION
Add `load_module` to `ocaml` object:

    ocaml.load_module cmi_path cmi_content cmj_name cmj_content

where `cmi_path` is the `.cmi` path in the (JSOO) pseudo file-system, `cmi_content` is the binary serialization of the `.cmi` file, `cmj_name` is the `.cmj` filename, and `cmj_content` is the binary serialization of the `.cmj` file. File contents should be serialized like [this](https://github.com/ocsigen/js_of_ocaml/blob/master/compiler/lib/js_output.ml#L279).

Example:

    ocaml.load_module("/cmis/reactDOMRe.cmi", "Caml1999I017\x84\x95..., "reactDOMRe.cmj", "BUCKLE20170907\x84\x95...);

Signed-off-by: Alessandro Strada <alessandro.strada@gmail.com>
