### PR TITLE
Update links to reason-react children docs

### DIFF
--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -60,7 +60,7 @@ let report_error env ppf = function
       else if Super_reason_react.is_array_wanted_reactElement trace then
         fprintf ppf "@[<v>\
           @[@{<info>Are you passing an array as a ReasonReact DOM (lower-case) component's children?@}@ If not, disregard this.@ \
-          If so, please use `ReasonReact.createDomElement`:@ https://reasonml.github.io/reason-react/index.html#reason-react-working-with-children@]@,@,\
+          If so, please use `ReasonReact.createDomElement`:@ https://reasonml.github.io/reason-react/docs/en/children.html@]@,@,\
           @[@{<info>Here's the original error message@}@]@,\
         @]";
       super_report_unification_error ppf env trace


### PR DESCRIPTION
Hi, thanks for the work all of you have put into this project 🙂

I saw that the error messages pointed to the wrong documentation url for reason-react children and tracked them here. I don't know if this solves it as I have little knowledge of how all of this fits together, but hope it helps.