### PR TITLE
Reason templates should use new syntax.

### DIFF
--- a/jscomp/bsb/templates/basic-reason/bsconfig.json
+++ b/jscomp/bsb/templates/basic-reason/bsconfig.json
@@ -10,6 +10,7 @@
     "module": "commonjs",
     "in-source": true
   },
+  "refmt": 3,
   "suffix": ".bs.js",
   "bs-dependencies": [
       // add your dependencies here. You'd usually install them normally through `npm install my-dependency`. If my-dependency has a bsconfig.json too, then everything will work seamlessly.

--- a/jscomp/bsb/templates/basic-reason/src/demo.re
+++ b/jscomp/bsb/templates/basic-reason/src/demo.re
@@ -1,1 +1,1 @@
-Js.log "Hello, BuckleScript and Reason!";
+Js.log("Hello, BuckleScript and Reason!");

--- a/jscomp/bsb/templates/react/bsconfig.json
+++ b/jscomp/bsb/templates/react/bsconfig.json
@@ -12,6 +12,7 @@
     "module": "commonjs",
     "in-source": true
   }],
+  "refmt": 3,
   "suffix": ".bs.js",
   "namespace": true,
   "bs-dependencies": [

--- a/jscomp/bsb/templates/react/src/index.re
+++ b/jscomp/bsb/templates/react/src/index.re
@@ -1,1 +1,1 @@
-ReactDOMRe.renderToElementWithId <Page message="Hello!" /> "index";
+ReactDOMRe.renderToElementWithId(<Page message="Hello!" />, "index");

--- a/jscomp/bsb/templates/react/src/page.re
+++ b/jscomp/bsb/templates/react/src/page.re
@@ -1,10 +1,10 @@
 /* This is the basic component. */
-let component = ReasonReact.statelessComponent "Page";
+let component = ReasonReact.statelessComponent("Page");
 
 /* Your familiar handleClick from ReactJS. This mandatorily takes the payload,
    then the `self` record, which contains state (none here), `handle`, `reduce`
    and other utilities */
-let handleClick _event _self => Js.log "clicked!";
+let handleClick = (_event, _self) => Js.log("clicked!");
 
 /* `make` is the function that mandatorily takes `children` (if you want to use
    `JSX). `message` is a named argument, which simulates ReactJS props. Usage:
@@ -13,9 +13,9 @@ let handleClick _event _self => Js.log "clicked!";
 
    Which desugars to
 
-   `ReasonReact.element (Page.make message::"hello" [||])` */
-let make ::message _children => {
+   `ReasonReact.element(Page.make(~message="hello", [||]))` */
+let make = (~message, _children) => {
   ...component,
-  render: fun self =>
-    <div onClick=(self.handle handleClick)> (ReasonReact.stringToElement message) </div>
+  render: (self) =>
+    <div onClick=(self.handle(handleClick))> (ReasonReact.stringToElement(message)) </div>
 };


### PR DESCRIPTION
Projects generated with `bsb -init my-first-app -theme basic-reason` aren't generating compilable code right now.  This fixes it for `basic-reason` and `react`.

There will probably be failing tests since I was unable to get the project to actually build or run unit tests in my Linux VM.  I will address them if a CI can report the specific failures on this PR.