### PR TITLE
Make watcher mode in linux accept ninja progress animation

### DIFF
--- a/bin/bsb
+++ b/bin/bsb
@@ -213,7 +213,7 @@ if (watch_mode) {
             watch_build(files)
         }
     }
-    var sub_config = { stdio: ['ignore', 'inherit', 'pipe'] }
+    var sub_config = { stdio: ['inherit', 'inherit', 'pipe'] }
 
 
     /**


### PR DESCRIPTION
That thing where instead of outputting a build command and its results onto hundreds of lines, ninja overrides the existing line in the terminal. Not sure why this still worked on mac without problem.