### PR TITLE
Use js_of_ocaml 3.0 to compile BuckleScript

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -540,11 +540,14 @@ SNAPSHOT_DEPS=$(SNAPSHOT_SRCS:.ml=.d)
 ../lib/bspp.ml:./bin/bspack.exe
 	  $< -D BS_MIN_LEX_DEPS=true -U BS_DEBUG -bs-MD -module-alias Config=Config_whole_compiler   -I $(OCAML_SRC_UTILS) -I $(OCAML_SRC_PARSING)?parser  -I ../lib -I common -I ext -I syntax -I depends -I bspp -I core -bs-main Bspp_main -o $@
 
+../lib/bspp.exe:../lib/bspp.mli ../lib/bspp.ml
+	make -C ../lib bspp.exe
+
 ../lib/reactjs_jsx_ppx_v2.ml:./bin/reactjs_jsx_ppx_v2.bspp.ml ../lib/bspp.exe
-	./bin/bspp.exe $^ > $@
+	../lib/bspp.exe $^ > $@
 
 bin/jsoo_reactjs_jsx_ppx_v2.ml:./bin/reactjs_jsx_ppx_v2.bspp.ml ../lib/bspp.exe
-	BS_COMPILER_IN_BROWSER=true ./bin/bspp.exe $^ > $@
+	BS_COMPILER_IN_BROWSER=true ../lib/bspp.exe $^ > $@
 
 bin/js_compiler.ml:./bin/bspack.exe
 	 ./bin/bspack.exe -D BS_COMPILER_IN_BROWSER=true -U BS_DEBUG -bs-MD  -prelude-str 'module Config = Config_whole_compiler' -bs-exclude-I config -o $@ -bs-main Jsoo_main -I $(OCAML_SRC_UTILS) -I $(OCAML_SRC_PARSING) -I $(OCAML_SRC_TYPING) -I $(OCAML_SRC_BYTECOMP) -I $(OCAML_SRC_DRIVER) -I stubs -I ext -I syntax -I depends -I common -I core

--- a/jscomp/README.md
+++ b/jscomp/README.md
@@ -136,7 +136,7 @@ however, it should also compile readable output code.
 ```
 opam switch 4.02.3
 eval `opam config env`
-opam install js_of_ocaml.2.8.4
+opam install js_of_ocaml
 which js_of_ocaml # symlink this into your $PATH, maybe /usr/local/bin or something
 ```
 

--- a/jscomp/core/jsoo_main.ml
+++ b/jscomp/core/jsoo_main.ml
@@ -136,13 +136,13 @@ module Js = struct
   type js_string
   external string : string -> js_string t = "caml_js_from_string"
   external to_string : js_string t -> string = "caml_js_to_string"
-  external fs_register : js_string t -> js_string t -> unit = "caml_fs_register"
+  external create_file : js_string t -> js_string t -> unit = "caml_create_file"
   external to_bytestring : js_string t -> string = "caml_js_to_byte_string"
 end
 
 
 let load_module cmi_path cmi_content cmj_name cmj_content =
-  Js.fs_register cmi_path cmi_content;
+  Js.create_file cmi_path cmi_content;
   Js_cmj_datasets.data_sets :=
     String_map.add
       cmj_name (lazy (Js_cmj_format.from_string cmj_content))
@@ -160,7 +160,7 @@ let dir_directory d =
 
 
 let () = 
-  dir_directory "/cmis"
+  dir_directory "/static/cmis"
 
 
 

--- a/jscomp/repl.js
+++ b/jscomp/repl.js
@@ -48,7 +48,7 @@ function prepare() {
 
     e(`rm -rf  ${playground}/pre_load.js`)
     e(`cp ./pre_load.js ${playground}`)
-    e(`cp ../lib/es6/*.js ${playground}/stdlib`)
+    e(`cp ../lib/amdjs/*.js ${playground}/stdlib`)
 
     // Build JSX v2 PPX with jsoo
     try {
@@ -73,7 +73,7 @@ prepare()
 
 console.log(`playground : ${playground}`)
 
-var includes = [`stdlib`, `runtime`, `others`, `ext`].map(x => path.join(__dirname, x)).map(x => `-I ${x}`).join(` `)
+var includes = [`stdlib`, `runtime`, `others`].map(x => path.join(__dirname, x)).map(x => `-I ${x}`).join(` `)
 
 var cmi_files =
     [

--- a/jscomp/repl.js
+++ b/jscomp/repl.js
@@ -44,11 +44,11 @@ function prepare() {
     e(`./bin/jsgen.exe --`)
     e(`./bin/jscmj.exe`)
 
-    e(`ocamlc.opt -w -30-40 -no-check-prims -I bin -I outcome_printer ext.cma outcome_printer.cma bin/config_whole_compiler.mli bin/config_whole_compiler.ml bin/js_compiler.mli bin/js_compiler.ml -o jsc.byte`)
+    e(`ocamlc.opt -w -30-40 -no-check-prims -I bin -I ../lib -I outcome_printer ext.cma outcome_printer.cma ../lib/config_whole_compiler.mli ../lib/config_whole_compiler.ml bin/js_compiler.mli bin/js_compiler.ml -o jsc.byte`)
 
     e(`rm -rf  ${playground}/pre_load.js`)
     e(`cp ./pre_load.js ${playground}`)
-    e(`cp ../lib/amdjs/*.js ${playground}/stdlib`)
+    e(`cp ../lib/es6/*.js ${playground}/stdlib`)
 
     // Build JSX v2 PPX with jsoo
     try {
@@ -73,7 +73,7 @@ prepare()
 
 console.log(`playground : ${playground}`)
 
-var includes = [`stdlib`, `runtime`, `others`].map(x => path.join(__dirname, x)).map(x => `-I ${x}`).join(` `)
+var includes = [`stdlib`, `runtime`, `others`, `ext`].map(x => path.join(__dirname, x)).map(x => `-I ${x}`).join(` `)
 
 var cmi_files =
     [
@@ -86,8 +86,8 @@ var cmi_files =
         `arrayLabels`, `bytesLabels`, `complex`, `gc`, `genlex`, `listLabels`,
         `moreLabels`, `queue`, `scanf`, `sort`,`stack`, `stdLabels`, `stream`,
         `stringLabels`
-    ].map(x => `${x}.cmi:/cmis/${x}.cmi`).map(x => `--file ${x}`).join(` `)
-e(`js_of_ocaml  --toplevel +weak.js   ./polyfill.js jsc.byte ${includes} ${cmi_files} -o ${playground}/exports.js`)
+    ].map(x => `${x}.cmi:/static/cmis/${x}.cmi`).map(x => `--file ${x}`).join(` `)
+e(`js_of_ocaml --toplevel +weak.js ./polyfill.js jsc.byte ${includes} ${cmi_files} -o ${playground}/exports.js`)
 
 
 


### PR DESCRIPTION
* Fix Makefile
* Update jsoo_main to use js_of_ocaml 3.0 new api

Signed-off-by: Alessandro Strada <alessandro.strada@gmail.com>