### PR TITLE
scripts/install.js: Fix typo in missing compiler error message

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -105,7 +105,7 @@ function tryToProvideOCamlCompiler() {
         } catch (e) {
             console.log(e.stdout.toString());
             console.log(e.stderr.toString());
-            console.log('Building a local version of the OCaml compiler failed, check the outut above for more information. A possible problem is that you don\'t have a compiler installed');
+            console.log('Building a local version of the OCaml compiler failed, check the output above for more information. A possible problem is that you don\'t have a compiler installed.');
             throw e;
         }
         console.log('configure again with local ocaml installed')


### PR DESCRIPTION
Tiny contribution to fix a typo in an error message.

Introduced in https://github.com/BuckleScript/bucklescript/pull/2089.