### PR TITLE
[Super errors] Fix terminal output colors & update docs

### DIFF
--- a/jscomp/build_tests/super_errors/index.js
+++ b/jscomp/build_tests/super_errors/index.js
@@ -19,7 +19,7 @@ const processFile = ([name, fullPath], colors, rebuild) => {
     return new Promise((res, rej) => {
       // we need this so we can reference Js_unsafe & other bucklescript goodies
       const runtime = path.join(__dirname, '../../runtime')
-      const prefix = `bsc.exe -bs-re-out -I ${runtime} -pp 'refmt3.exe --print binary' -w +10-40+6+7+27+32..39+44+45`
+      const prefix = `lib/bsc.exe -bs-re-out -I ${runtime} -pp 'lib/refmt3.exe --print binary' -w +10-40+6+7+27+32..39+44+45`
       child_process.exec(`${prefix} -color ${colors ? 'always' : 'never'} -bs-super-errors -impl ${dest}`, (err, stdout, stderr) => {
         const superErr = trimTmpNames(trimTrailingWhitespace(stderr).trimRight())
         child_process.exec(`${prefix} -color never -impl ${dest}`, (err, stdout, stderr) => {

--- a/jscomp/super_errors/README.md
+++ b/jscomp/super_errors/README.md
@@ -25,27 +25,47 @@ make world.opt
 make install
 
 # Build BuckleScript itself
-cd ../../jscomp
-make world
+cd ../../
+make
+make install
 
 # install this local bs globally
-cd ..
 npm -g install .
 ```
 
+#### Testing on a dummy project
+
+Now, for testing super_errors on a dummy project. Go somewhere else and do this:
+
+```
+bsb -init foo -theme basic-reason
+cd foo
+npm run build
+```
+
+And whenever you modify a file in super_errors, run this inside `jscomp/`:
+
+```
+make ../lib/bsc.exe && ./install-bsc.sh
+```
+
+This will substitute the global `bsc.exe` you just installed with the newly built one. Then run `npm build again` in the dummy project and see the changes! The iteration cycle for testing these should be around 2 seconds =).
+
 ##### Troubleshooting
 
-Did you do "eval `opam config env`" In your CLI/bashrc/zshrc?
+Did any of the above step not work?
 
-If you've contributed to this part, but pulled in new changes and are now having problems building, it might mean that your artifacts are stale after that pull. In this case, do `git clean -xdf` at the root of the project. **Careful**, this will kill clean all your unsaved changes! Afterward, redo the above build process (skip the `opam` part. That part's likely not changed).
+- Make sure you did "eval `opam config env`" In your CLI/bashrc/zshrc
 
-**If these fail too**, make sure you do have the correct `ocamlopt` in your environment: `which ocamlcopt` should show an `opam` path, not `reason-cli` path. If you see the latter, this means it overrode the global `ocamlopt` BuckleScript needed. In this case, either temporarily uninstall reason-cli or make sure your opam PATH overrides the reason-cli PATH (and not the other way around) in your bashrc/zshrc.
+- **If the vendored ocaml changed between when you last iterated on the repo and now**, you probably skipped the `opam switch reinstall 4.02.3+buckle-master` part. You'll have to do `git clean -xdf` and then restart with the build instructions. Careful, as `git clean` removes your uncommitted changes.
 
-#### Tests
+- **If these fail too**, make sure you do have the correct `ocamlopt` in your environment: `which ocamlcopt` should show an `opam` path, not `reason-cli` path. If you see the latter, this means it overrode the global `ocamlopt` BuckleScript needed. In this case, either temporarily uninstall reason-cli or make sure your opam PATH overrides the reason-cli PATH (and not the other way around) in your bashrc/zshrc.
+
+#### General Tests
 
 Note: currently you can't test things with external libraries (e.g. ReasonReact).
 
-The fixture tests are located in `../build_tests/super_errors/` and look like:
+The fixture tests are located in `jscomp/build_tests/super_errors/` and look like:
 ```
 {some code}
 /*
@@ -64,27 +84,9 @@ etc
 
 Files in `formattingTests` get printed with `-colors always` so we can test formatting. The other ones are printed with `-colors never` so that it's readable.
 
-To add a new test case, add your code to the end of a file, and run `./build_tests/super_errors/rebuild.sh`. The output will be appended.
+To add a new test case, add your code to the end of a file, and run `jscomp/build_tests/super_errors/rebuild.sh`. The output will be appended.
 
 To recompile `bsc`, you can, from the `jscomp` directory, run `make bin/bsc.exe`. If this doesn't work, you likely have a problem with the ocaml installation -- go back to `Build` and make sure you followed everything to the letter.
-
-#### Testing on a dummy project
-
-Now, for testing super_errors on a dummy project. Go somewhere else and do this:
-
-```
-bsb -init foo -theme basic-reason
-cd foo
-npm run build
-```
-
-And whenever you modify a file in super_errors, run this inside `jscomp/`:
-
-```
-make bin/bsc.exe && ./install-bsc.sh
-```
-
-This will substitute the global `bsc.exe` you just installed with the newly built one. Then run `npm build again` in the dummy project and see the changes! The iteration cycle for testing these should be around 2 seconds =).
 
 ##### Special Iteration Workflow
 

--- a/jscomp/super_errors/super_location.ml
+++ b/jscomp/super_errors/super_location.ml
@@ -38,6 +38,7 @@ let print_filename ppf file =
   | real_file -> Format.fprintf ppf "%s" (Location.show_filename real_file)
 
 let print_loc ~normalizedRange ppf loc =
+  setup_colors ();
   let (file, _, _) = Location.get_pos_info loc.loc_start in
   if file = "//toplevel//" then begin
     if highlight_locations ppf [loc] then () else
@@ -59,6 +60,7 @@ let print_loc ~normalizedRange ppf loc =
 ;;
 
 let print ~is_warning intro ppf loc =
+  setup_colors ();
   if loc.loc_start.pos_fname = "//toplevel//"
   && highlight_locations ppf [loc] then ()
   else
@@ -135,6 +137,7 @@ let rec super_error_reporter ppf ({Location.loc; msg; sub; if_highlight} as err)
 (* This is the warning report entry point. We'll replace the default printer with this one *)
 let super_warning_printer loc ppf w =
   if Warnings.is_active w then begin
+    setup_colors ();
     (* open a vertical box. Everything in our message is indented 2 spaces *)
     Format.fprintf ppf "@[<v 2>@,%a@,%a@,@]"
       (print ~is_warning:true ("Warning number " ^ (Warnings.number w |> string_of_int)))

--- a/jscomp/super_errors/super_main.ml
+++ b/jscomp/super_errors/super_main.ml
@@ -1,6 +1,5 @@
 (* the entry point. This is used by js_main.ml *)
 let setup () =
-  Super_location.setup_colors();
   Super_location.setup ();
   Super_typetexp.setup ();
   Super_typemod.setup ();

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -37,7 +37,7 @@ let print_simple_conversion ppf (actual, expected) =
     let converter = List.assoc (actual, expected) simple_conversions in
     Format.pp_print_newline ppf ();
     Format.pp_print_newline ppf ();
-    fprintf ppf "You can convert a @{<info>%s@} to a @{<info>%s@} with @{<info>%s@}.@;" actual expected converter
+    fprintf ppf "You can convert a @{<info>%s@} to a @{<info>%s@} with @{<info>%s@}." actual expected converter
   ) with | Not_found -> ()
 
 let print_simple_message ppf = function
@@ -131,9 +131,9 @@ let report_error env ppf = function
         | None ->
           super_report_unification_error ppf env trace
             (function ppf ->
-                fprintf ppf "This value has type:")
+                fprintf ppf "This has type:")
             (function ppf ->
-                fprintf ppf "But was expected to be:");
+                fprintf ppf "But somewhere wanted:");
           show_extra_help ppf env trace
       end
   | Apply_non_function typ ->

--- a/jscomp/super_errors/super_typetexp.ml
+++ b/jscomp/super_errors/super_typetexp.ml
@@ -126,13 +126,13 @@ let report_error env ppf = function
   | Repeated_method_label s ->
       fprintf ppf "@[This is the second method `%s' of this object type.@ %s@]"
         s "Multiple occurences are not allowed."
-  | Unbound_value lid -> 
+  | Unbound_value lid ->
       (* modified *)
       begin
         match lid with
         | Ldot (outer, inner) ->
           fprintf ppf "The value %s can't be found in %a"
-            inner 
+            inner
             Printtyp.longident outer;
         | other_ident -> fprintf ppf "The value %a can't be found" Printtyp.longident other_ident
       end;


### PR DESCRIPTION
This reverts the color logic part of e114d2c786b7c22626a6a1f28732b6c529d1df91.

I've forgotten why the colors logic were changed.

The related tests (which aren't triggered yet still) aren't fixed yet;
will do it in a separate diff.