### PR TITLE
now really close when stdin stops

### DIFF
--- a/lib/bsb
+++ b/lib/bsb
@@ -95,7 +95,9 @@ if (watch_mode) {
             process.on('SIGTERM', onExit)
             process.on('SIGHUP', onExit)
             process.on('uncaughtException', onExit)
-            process.stdin.on('close', onExit)
+            // close when stdin stops
+            process.stdin.on('end', onExit)
+            process.stdin.resume()
 
             return true
         } catch (exn) {


### PR DESCRIPTION
This really fixes #2226. It seems my first fix didn't really work (I've must have missed something with my first tests because I thought it did...)

Researched a bit more and tested better and this fix works (does the same as webpack-dev-server: https://github.com/webpack/webpack-dev-server/blob/0a8f8965fba4a46a862497f6e7d1ad9377040a15/bin/webpack-dev-server.js#L262). 
@jackalcooper maybe you can test this as well, because you have the same issue. If you just replace my fixed file into a project where you have the problem in the folder `node_modules/.bin` then it should work.