### PR TITLE
Turn partial application warning into error for bsb react template

### DIFF
--- a/jscomp/bsb/templates/react/bsconfig.json
+++ b/jscomp/bsb/templates/react/bsconfig.json
@@ -17,5 +17,8 @@
   "bs-dependencies": [
     "reason-react"
   ],
-  "refmt": 3
+  "refmt": 3,
+  "warnings": {
+    "error": "+5"
+  }
 }


### PR DESCRIPTION
Not sure if we should turn it on by default everywhere. At least in
ReasonReact this is frequent enough to warrant this.