### PR TITLE
Better errors for when there's a compiler version mismatch

### DIFF
--- a/jscomp/syntax/external_ffi_types.ml
+++ b/jscomp/syntax/external_ffi_types.ml
@@ -254,5 +254,5 @@ let from_string s : t =
     else 
       Ext_pervasives.failwithf 
         ~loc:__LOC__
-        "compiler version mismatch, please do a clean build"
+        "Compiler version mismatch. The project might have been built with one version of BuckleScript, and then with another. Please wipe the artifacts and do a clean build."
   else Ffi_normal    


### PR DESCRIPTION
Though I'm not sure how to trigger this warning anymore. Would be good
to have a repro