### PR TITLE
[ocaml] Fix ocaml tests.

### DIFF
--- a/vendor/ocaml/testsuite/tests/typing-gadts/pr5332.ml.reference
+++ b/vendor/ocaml/testsuite/tests/typing-gadts/pr5332.ml.reference
@@ -15,5 +15,5 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a value that is not matched:
 (Tbool, Tvar _)
 val f : ('env, 'a) typ -> ('env, 'a) typ -> int = <fun>
-#   Exception: Match_failure ("//toplevel//", 9, 1).
+#   Exception: Match_failure ("toplevel", 9, 1).
 # 

--- a/vendor/ocaml/testsuite/tests/typing-gadts/pr5989.ml.reference
+++ b/vendor/ocaml/testsuite/tests/typing-gadts/pr5989.ml.reference
@@ -8,7 +8,7 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a value that is not matched:
 Eq
 val f : (M.s, [ `A | `B ]) t -> string = <fun>
-#   Exception: Match_failure ("//toplevel//", 14, 39).
+#   Exception: Match_failure ("toplevel", 14, 39).
 #                     module N :
   sig
     type s = private < a : int; .. >

--- a/vendor/ocaml/testsuite/tests/typing-gadts/pr5997.ml.reference
+++ b/vendor/ocaml/testsuite/tests/typing-gadts/pr5997.ml.reference
@@ -8,7 +8,7 @@
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a value that is not matched:
 Eq
-Exception: Match_failure ("//toplevel//", 13, 0).
+Exception: Match_failure ("toplevel", 13, 0).
 #   module U : sig type t = { x : int; } end
 #               module M : sig type t = { x : int; } val comp : (U.t, t) comp end
 #   Characters 1-34:
@@ -17,5 +17,5 @@ Exception: Match_failure ("//toplevel//", 13, 0).
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a value that is not matched:
 Eq
-Exception: Match_failure ("//toplevel//", 22, 0).
+Exception: Match_failure ("toplevel", 22, 0).
 # 

--- a/vendor/ocaml/testsuite/tests/typing-gadts/pr6241.ml.principal.reference
+++ b/vendor/ocaml/testsuite/tests/typing-gadts/pr6241.ml.principal.reference
@@ -11,5 +11,5 @@ module M :
     sig val f : ((module A.T), (module B.T)) t -> string end
 #   module A : sig module type T = sig  end end
 #   module N : sig val f : ((module A.T), (module A.T)) t -> string end
-#   Exception: Match_failure ("//toplevel//", 7, 52).
+#   Exception: Match_failure ("toplevel", 7, 52).
 # 

--- a/vendor/ocaml/testsuite/tests/typing-gadts/pr6241.ml.reference
+++ b/vendor/ocaml/testsuite/tests/typing-gadts/pr6241.ml.reference
@@ -11,5 +11,5 @@ module M :
     sig val f : ((module A.T), (module B.T)) t -> string end
 #   module A : sig module type T = sig  end end
 #   module N : sig val f : ((module A.T), (module A.T)) t -> string end
-#   Exception: Match_failure ("//toplevel//", 7, 52).
+#   Exception: Match_failure ("toplevel", 7, 52).
 # 


### PR DESCRIPTION
Fix ocaml tests.
The output for match failure in the toplevel changed after https://github.com/BuckleScript/bucklescript/commit/32d4d50a4e8cfa824d9e5b315fc5a163ea047a48.