### PR TITLE
Use "close" instead of "end" so we don't need `.resume`

### DIFF
--- a/lib/bsb
+++ b/lib/bsb
@@ -96,8 +96,7 @@ if (watch_mode) {
             process.on('SIGHUP', onExit)
             process.on('uncaughtException', onExit)
             // close when stdin stops
-            process.stdin.on('end', onExit)
-            process.stdin.resume()
+            process.stdin.on('close', onExit)
 
             return true
         } catch (exn) {


### PR DESCRIPTION
Related to https://github.com/BuckleScript/bucklescript/issues/2425