### PR TITLE
Fix trailing space on react-jsx

### DIFF
--- a/jscomp/bsb/templates/react/bsconfig.json
+++ b/jscomp/bsb/templates/react/bsconfig.json
@@ -4,7 +4,9 @@
   an issue! */
 {
   "name": "react-template",
-  "reason": {"react-jsx" : 2},
+  "reason": {
+    "react-jsx": 2
+  },
   "sources": [
     "src"
   ],


### PR DESCRIPTION
This pull-request changes is just a small style change on `bsconfig.json` for the React theme. Every attribute was using `:·` and the `react-jsx` attribute had an extra space before, being `·:·`.