### PR TITLE
Add publicPath to webpack config

### DIFF
--- a/jscomp/bsb/templates/react/webpack.config.js
+++ b/jscomp/bsb/templates/react/webpack.config.js
@@ -1,9 +1,11 @@
 const path = require('path');
+const outputDir = path.join(__dirname, "build/");
 
 module.exports = {
   entry: './src/Index.bs.js',
   output: {
-    path: path.join(__dirname, "build"),
+    path: outputDir,
+    publicPath: outputDir,
     filename: 'Index.js',
   },
 };


### PR DESCRIPTION
Currently if you import a file that uses code splitting with [Dynamic Imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports) (e.g. `import("./path/to/file")`):

**dynamicImports.js**
```js
module.exports = import("./file1");
```
**Index.re**
```reason
[@bs.module] external dynamicComponents : Js.Promise.t(ReasonReact.reactClass) : "./dynamicImports"
```
 it will look for it in the `src` directory (`src/0.index.js`) which causes it to fail when loading the chunk. Adding `publicPath` to the webpack config will let it resolve the file properly to `build/0.index.js`.
