### PR TITLE
Prevent config.js throwing error on FreeBSD

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -10,6 +10,8 @@ var sys_extension;
 switch (os.type()) {
     case 'Darwin':
         sys_extension = ".darwin"; break;
+    case 'FreeBSD':
+        sys_extension = ".freebsd"; break;
     case 'Linux':
         sys_extension = ".linux64"; break;
     case 'Windows_NT':


### PR DESCRIPTION
As pointed out in #2340 the else clause in `config.js` prevents building on FreeBSD. With the changes in this PR the build proceeds (even though there are no prebuilt components) and successfully completes.