### PR TITLE
[SuperErrors] Check arity mismatch for uncurried [@bs] application.

### DIFF
--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -70,12 +70,14 @@ let rec collect_missing_arguments rettype targettype = match rettype with
 let check_bs_arity_mismatch ppf trace =
   let arity t = match t.desc with
     | Tvariant { row_fields = [(label,_)] } ->
-        let len = String.length label in
-        if len > 6 &&
-          String.sub label 0 6 = "Arity_"
+        let label_len = String.length label in
+        let arity_str = "Arity_" in
+        let arity_len = String.length arity_str in
+        if arity_len < label_len &&
+          String.sub label 0 arity_len = arity_str
         then
           try
-            Some (int_of_string (String.sub label 6 (len-6)))
+            Some (int_of_string (String.sub label arity_len (label_len-arity_len)))
           with _ -> None
         else None
     | _ ->


### PR DESCRIPTION
The following repro:
```
/lib/bsc.exe -bs-super-errors -bs-eval 'let add = ((fun x  -> fun y  -> x + y)[@bs ]) let x = ((add 3)[@bs ])'
```
Now gives:
```
Found uncurried application [@bs] with arity 2, where arity 1 was expected.
This has type:
  (int -> int -> int [@bs]) (defined as (int -> int -> int [@bs]))
But somewhere wanted:
  ('a -> 'b [@bs]) (defined as ('a -> 'b [@bs]))
These two variant types have no intersection
```