### PR TITLE
fix build instructions

### DIFF
--- a/jscomp/README.md
+++ b/jscomp/README.md
@@ -27,7 +27,7 @@ install an OCaml compiler from scratch, and retry again
 opam update
 opam switch 4.02.3+buckle-master
 opam switch reinstall 4.02.3+buckle-master # do this if you get errors even from a clean compilation
-opam install camlp4
+opam install camlp4 cppo
 eval `opam config env`
 ```
 
@@ -41,7 +41,7 @@ make install
 
 #### build all of Bucklescript
 ```sh
-cd ../../jscomp
+cd ../../
 make world
 ```
 
@@ -147,7 +147,7 @@ opam switch 4.02.3+buckle-master
 eval `opam config env`
 opam install camlp4 ocp-ocamlres
 (cd vendor/ocaml && make world)
-(cd jscomp && node repl.js)
+(cd jscomp && BS_RELEASE_BUILD=true BS_PLAYGROUND=../../bucklescript-playground node repl.js)
 ```
 
 # Sub directories


### PR DESCRIPTION
I still don't understand what `(cd vendor/ocaml && make world)` is about. I've already run `make.world.opt` and `make install` from going through the "Setup" section. And why is this and the `node repl.js`, the command that actually does most of the work, in parentheses? The only thing that comes to mind is that it means they're optional, but that makes absolutely zero sense.

I also think the move to js_of_ocaml 3.0 broke webpack compatibility. There's now a bunch of "Critical dependency: the request of a dependency is an expression" warnings from webpack, and it fails in the browser with the error `Error: Cannot find module "."`. Still trying to figure this one out.

cc @astrada 

Edit: Forgot to mention, `BS_RELEASE_BUILD=true` is required to generate amdjs modules. Should maybe explain that in the instructions too.