### PR TITLE
[Belt] Tweak internal representation output

### DIFF
--- a/jscomp/others/belt_MapDict.ml
+++ b/jscomp/others/belt_MapDict.ml
@@ -232,7 +232,7 @@ let rec mergeU s1 s2 f ~cmp =
         f k None (Some v) [@bs]
       )
   | Some s1n , Some s2n -> 
-    if N.h s1n  >= N.h s2n  then
+    if N.height s1n  >= N.height s2n  then
       let l1, v1, d1, r1 = N.(left s1n, key s1n, value s1n, right s1n) in 
       let d2 = ref None in 
       let (l2, r2) = splitAuxPivot ~cmp s2n v1 d2 in

--- a/jscomp/others/belt_MutableSet.ml
+++ b/jscomp/others/belt_MutableSet.ml
@@ -46,7 +46,7 @@ type ('k, 'id) t = ('k, 'id) S.t
 
 
 let rec remove0 nt x ~cmp = 
-  let k = N.key nt in 
+  let k = N.value nt in 
   let c = cmp x k [@bs] in 
   if c = 0 then 
     let l,r = N.(left nt, right nt) in       
@@ -103,7 +103,7 @@ let removeMany d xs =
 
 
 let rec removeCheck0  nt x removed ~cmp= 
-  let k = N.key nt in 
+  let k = N.value nt in 
   let c = (Belt_Id.getCmpInternal cmp) x k [@bs] in 
   if c = 0 then 
     let () = removed := true in  
@@ -151,7 +151,7 @@ let rec addCheck0  t x added ~cmp  =
     added := true;
     N.singleton x 
   | Some nt -> 
-    let k = N.key nt in 
+    let k = N.value nt in 
     let c = cmp x k [@bs] in  
     if c = 0 then t 
     else

--- a/jscomp/others/belt_MutableSetInt.ml
+++ b/jscomp/others/belt_MutableSetInt.ml
@@ -46,7 +46,7 @@ type t = {
 
 
 let rec remove0 nt (x : value)= 
-  let k = N.key nt in 
+  let k = N.value nt in 
   if x = k then 
     let l,r = N.(left nt, right nt) in       
     match N.(toOpt l, toOpt r) with 
@@ -99,7 +99,7 @@ let removeMany  (d : t) xs =
     dataSet d  (removeMany0 nt xs 0 len) 
     
 let rec removeCheck0  nt (x : value) removed = 
-  let k = N.key nt in 
+  let k = N.value nt in 
   if x = k then 
     let () = removed := true in  
     let l,r = N.(left nt, right nt) in       
@@ -145,7 +145,7 @@ let rec addCheck0  t (x : value) added  =
     added := true;
     N.singleton x 
   | Some nt -> 
-    let k = N.key nt in 
+    let k = N.value nt in 
     if x = k then t 
     else
       let l, r = N.(left nt, right nt) in 

--- a/jscomp/others/belt_MutableSetString.ml
+++ b/jscomp/others/belt_MutableSetString.ml
@@ -46,7 +46,7 @@ type t = {
 
 
 let rec remove0 nt (x : value)= 
-  let k = N.key nt in 
+  let k = N.value nt in 
   if x = k then 
     let l,r = N.(left nt, right nt) in       
     match N.(toOpt l, toOpt r) with 
@@ -99,7 +99,7 @@ let removeMany  (d : t) xs =
     dataSet d  (removeMany0 nt xs 0 len) 
     
 let rec removeCheck0  nt (x : value) removed = 
-  let k = N.key nt in 
+  let k = N.value nt in 
   if x = k then 
     let () = removed := true in  
     let l,r = N.(left nt, right nt) in       
@@ -145,7 +145,7 @@ let rec addCheck0  t (x : value) added  =
     added := true;
     N.singleton x 
   | Some nt -> 
-    let k = N.key nt in 
+    let k = N.value nt in 
     if x = k then t 
     else
       let l, r = N.(left nt, right nt) in 

--- a/jscomp/others/belt_SetDict.ml
+++ b/jscomp/others/belt_SetDict.ml
@@ -38,7 +38,7 @@ let rec add  (t : _ t) x  ~cmp : _ t =
   match N.toOpt t with 
   | None -> N.singleton x 
   | Some nt ->
-    let k = N.key nt in 
+    let k = N.value nt in 
     let c = (Belt_Id.getCmpInternal cmp) x k [@bs] in
     if c = 0 then t
     else
@@ -56,14 +56,14 @@ let rec remove (t : _ t) x  ~cmp : _ t =
   match N.toOpt t with 
     None -> t
   | Some n  ->
-    let l,v,r = N.(left n , key n, right n) in 
+    let l,v,r = N.(left n , value n, right n) in 
     let c = (Belt_Id.getCmpInternal cmp) x v [@bs] in
     if c = 0 then 
       match N.toOpt l, N.toOpt r with 
       | (None, _) -> r 
       | (_, None) -> l 
       | (_, Some rn) -> 
-        let v = ref (N.key rn) in 
+        let v = ref (N.value rn) in 
         let r = N.removeMinAuxWithRef rn v in 
         N.bal l !v r 
     else
@@ -95,7 +95,7 @@ let removeMany h arr ~cmp =
   !v 
 
 let rec splitAuxNoPivot ~cmp (n : _ N.node) x : _ *  _ =   
-  let l,v,r = N.(left n , key n, right n) in  
+  let l,v,r = N.(left n , value n, right n) in  
   let c = (Belt_Id.getCmpInternal cmp) x v [@bs] in
   if c = 0 then l,r
   else 
@@ -115,7 +115,7 @@ let rec splitAuxNoPivot ~cmp (n : _ N.node) x : _ *  _ =
       N.joinShared l v lr, rr
 
 let rec splitAuxPivot ~cmp (n : _ N.node) x pres : _ *  _ =   
-  let l,v,r = N.(left n , key n, right n) in  
+  let l,v,r = N.(left n , value n, right n) in  
   let c = (Belt_Id.getCmpInternal cmp) x v [@bs] in
   if c = 0 then 
     begin
@@ -155,18 +155,18 @@ let rec union (s1 : _ t) (s2 : _ t) ~cmp : _ t =
     (None, _) -> s2
   | (_, None) -> s1
   | Some n1, Some n2 ->
-    let h1, h2 = N.(h n1 , h n2) in                 
+    let h1, h2 = N.(height n1 , height n2) in                 
     if h1 >= h2 then
-      if h2 = 1 then add ~cmp s1 (N.key n2)  
+      if h2 = 1 then add ~cmp s1 (N.value n2)  
       else begin
-        let l1, v1, r1 = N.(left n1, key n1, right n1) in      
+        let l1, v1, r1 = N.(left n1, value n1, right n1) in      
         let l2, r2 = splitAuxNoPivot ~cmp n2 v1 in
         N.joinShared (union ~cmp l1 l2) v1 (union ~cmp r1 r2)
       end
     else
-    if h1 = 1 then add s2 ~cmp (N.key n1) 
+    if h1 = 1 then add s2 ~cmp (N.value n1) 
     else begin
-      let l2, v2, r2 = N.(left n2 , key n2, right n2) in 
+      let l2, v2, r2 = N.(left n2 , value n2, right n2) in 
       let l1, r1 = splitAuxNoPivot ~cmp n1 v2  in
       N.joinShared (union ~cmp l1 l2) v2 (union ~cmp r1 r2)
     end
@@ -176,7 +176,7 @@ let rec intersect  (s1 : _ t) (s2 : _ t) ~cmp =
   | None, _ 
   | _, None -> N.empty
   | Some n1, Some n2  ->
-    let l1,v1,r1 = N.(left n1, key n1, right n1) in  
+    let l1,v1,r1 = N.(left n1, value n1, right n1) in  
     let pres = ref false in 
     let l2,r2 = splitAuxPivot ~cmp n2 v1 pres in 
     let ll = intersect ~cmp l1 l2 in 
@@ -189,7 +189,7 @@ let rec diff s1 s2 ~cmp  =
     (None, _) 
   | (_, None) -> s1
   | Some n1, Some n2  ->
-    let l1,v1,r1 = N.(left n1, key n1, right n1) in
+    let l1,v1,r1 = N.(left n1, value n1, right n1) in
     let pres = ref false in 
     let l2, r2 = splitAuxPivot ~cmp n2 v1 pres in 
     let ll = diff ~cmp l1 l2 in 

--- a/jscomp/others/belt_SetInt.ml
+++ b/jscomp/others/belt_SetInt.ml
@@ -38,7 +38,7 @@ let rec add  (t : t) (x : value) : t =
   match N.toOpt t with 
     None -> N.singleton x 
   | Some nt  ->
-    let v = N.key nt in  
+    let v = N.value nt in  
     if x = v then t else
       let l, r = N.(left nt , right nt) in 
       if x < v then 
@@ -64,13 +64,13 @@ let rec remove (t : t) (x : value) : t =
   match N.toOpt t with 
   | None -> t
   | Some n  ->
-    let l,v,r = N.(left n, key n, right n) in 
+    let l,v,r = N.(left n, value n, right n) in 
     if x = v then 
       match N.toOpt l, N.toOpt r with 
       | None, _ -> r 
       | _, None -> l 
       | _, Some rn -> 
-        let v = ref (N.key rn) in 
+        let v = ref (N.value rn) in 
         let r = N.removeMinAuxWithRef rn v in 
         N.bal l !v r
     else
@@ -102,7 +102,7 @@ let subset = I.subset
 let has = I.has
 
 let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =   
-  let l,v,r = N.(left n , key n, right n) in  
+  let l,v,r = N.(left n , value n, right n) in  
   if x = v then l,  r
   else if x < v then
     match N.toOpt l with 
@@ -121,9 +121,9 @@ let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =
 
 
 let rec splitAuxPivot (n : _ N.node) (x : value) pres : t  * t =   
-  let l,v,r = N.(left n , key n, right n) in  
+  let l,v,r = N.(left n , value n, right n) in  
   if x = v then begin 
-    pres := true;  
+    pres := true;
     (l, r)
   end
   else if x < v then
@@ -156,16 +156,16 @@ let rec union (s1 : t) (s2 : t) =
     (None, _) -> s2
   | (_, None) -> s1
   | Some n1, Some n2 (* (Node(l1, v1, r1, h1), Node(l2, v2, r2, h2)) *) ->    
-    let h1, h2 = N.(h n1 , h n2) in             
+    let h1, h2 = N.(height n1 , height n2) in             
     if h1 >= h2 then
-      if h2 = 1 then add  s1 (N.key n2) else begin
-        let l1, v1, r1 = N.(left n1, key n1, right n1) in      
+      if h2 = 1 then add  s1 (N.value n2) else begin
+        let l1, v1, r1 = N.(left n1, value n1, right n1) in      
         let (l2,  r2) = splitAuxNoPivot n2 v1 in
         N.joinShared (union l1 l2) v1 (union r1 r2)
       end
     else
-    if h1 = 1 then add  s2 (N.key n1) else begin
-      let l2, v2, r2 = N.(left n2 , key n2, right n2) in 
+    if h1 = 1 then add  s2 (N.value n1) else begin
+      let l2, v2, r2 = N.(left n2 , value n2, right n2) in 
       let (l1, r1) = splitAuxNoPivot n1 v2 in
       N.joinShared (union l1 l2) v2 (union r1 r2)
     end
@@ -175,7 +175,7 @@ let  rec intersect (s1 : t) (s2 : t) =
     (None, _) 
   | (_, None) -> N.empty
   | Some n1, Some n2 (* (Node(l1, v1, r1, _), t2) *) ->
-    let l1,v1,r1 = N.(left n1, key n1, right n1) in  
+    let l1,v1,r1 = N.(left n1, value n1, right n1) in  
     let pres = ref false in 
     let l2,r2 =  splitAuxPivot n2 v1 pres in 
     let ll = intersect l1 l2 in 
@@ -188,7 +188,7 @@ let rec diff (s1 : t) (s2 : t) =
   | (None, _) 
   | (_, None) -> s1
   | Some n1, Some n2 (* (Node(l1, v1, r1, _), t2) *) ->
-    let l1,v1,r1 = N.(left n1, key n1, right n1) in
+    let l1,v1,r1 = N.(left n1, value n1, right n1) in
     let pres = ref false in 
     let l2, r2 = splitAuxPivot  n2 v1 pres in 
     let ll = diff  l1 l2 in 

--- a/jscomp/others/belt_SetString.ml
+++ b/jscomp/others/belt_SetString.ml
@@ -38,7 +38,7 @@ let rec add  (t : t) (x : value) : t =
   match N.toOpt t with 
     None -> N.singleton x 
   | Some nt  ->
-    let v = N.key nt in  
+    let v = N.value nt in  
     if x = v then t else
       let l, r = N.(left nt , right nt) in 
       if x < v then 
@@ -64,13 +64,13 @@ let rec remove (t : t) (x : value) : t =
   match N.toOpt t with 
   | None -> t
   | Some n  ->
-    let l,v,r = N.(left n, key n, right n) in 
+    let l,v,r = N.(left n, value n, right n) in 
     if x = v then 
       match N.toOpt l, N.toOpt r with 
       | None, _ -> r 
       | _, None -> l 
       | _, Some rn -> 
-        let v = ref (N.key rn) in 
+        let v = ref (N.value rn) in 
         let r = N.removeMinAuxWithRef rn v in 
         N.bal l !v r
     else
@@ -102,7 +102,7 @@ let subset = I.subset
 let has = I.has
 
 let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =   
-  let l,v,r = N.(left n , key n, right n) in  
+  let l,v,r = N.(left n , value n, right n) in  
   if x = v then l,  r
   else if x < v then
     match N.toOpt l with 
@@ -121,9 +121,9 @@ let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =
 
 
 let rec splitAuxPivot (n : _ N.node) (x : value) pres : t  * t =   
-  let l,v,r = N.(left n , key n, right n) in  
+  let l,v,r = N.(left n , value n, right n) in  
   if x = v then begin 
-    pres := true;  
+    pres := true;
     (l, r)
   end
   else if x < v then
@@ -156,16 +156,16 @@ let rec union (s1 : t) (s2 : t) =
     (None, _) -> s2
   | (_, None) -> s1
   | Some n1, Some n2 (* (Node(l1, v1, r1, h1), Node(l2, v2, r2, h2)) *) ->    
-    let h1, h2 = N.(h n1 , h n2) in             
+    let h1, h2 = N.(height n1 , height n2) in             
     if h1 >= h2 then
-      if h2 = 1 then add  s1 (N.key n2) else begin
-        let l1, v1, r1 = N.(left n1, key n1, right n1) in      
+      if h2 = 1 then add  s1 (N.value n2) else begin
+        let l1, v1, r1 = N.(left n1, value n1, right n1) in      
         let (l2,  r2) = splitAuxNoPivot n2 v1 in
         N.joinShared (union l1 l2) v1 (union r1 r2)
       end
     else
-    if h1 = 1 then add  s2 (N.key n1) else begin
-      let l2, v2, r2 = N.(left n2 , key n2, right n2) in 
+    if h1 = 1 then add  s2 (N.value n1) else begin
+      let l2, v2, r2 = N.(left n2 , value n2, right n2) in 
       let (l1, r1) = splitAuxNoPivot n1 v2 in
       N.joinShared (union l1 l2) v2 (union r1 r2)
     end
@@ -175,7 +175,7 @@ let  rec intersect (s1 : t) (s2 : t) =
     (None, _) 
   | (_, None) -> N.empty
   | Some n1, Some n2 (* (Node(l1, v1, r1, _), t2) *) ->
-    let l1,v1,r1 = N.(left n1, key n1, right n1) in  
+    let l1,v1,r1 = N.(left n1, value n1, right n1) in  
     let pres = ref false in 
     let l2,r2 =  splitAuxPivot n2 v1 pres in 
     let ll = intersect l1 l2 in 
@@ -188,7 +188,7 @@ let rec diff (s1 : t) (s2 : t) =
   | (None, _) 
   | (_, None) -> s1
   | Some n1, Some n2 (* (Node(l1, v1, r1, _), t2) *) ->
-    let l1,v1,r1 = N.(left n1, key n1, right n1) in
+    let l1,v1,r1 = N.(left n1, value n1, right n1) in
     let pres = ref false in 
     let l2, r2 = splitAuxPivot  n2 v1 pres in 
     let ll = diff  l1 l2 in 

--- a/jscomp/others/belt_internalAVLset.mli
+++ b/jscomp/others/belt_internalAVLset.mli
@@ -31,10 +31,10 @@
 *)
 type 'value t = 'value node Js.null
 and 'value node  = private {
+  value : 'value; 
+  height : int;
   mutable left : 'value t;
-   key : 'value ; 
   mutable right : 'value t;
-  h : int
 } [@@bs.deriving abstract]
 
 type ('a, 'b) cmp = ('a, 'b) Belt_Id.cmp

--- a/jscomp/others/belt_internalAVLtree.mli
+++ b/jscomp/others/belt_internalAVLtree.mli
@@ -27,11 +27,11 @@
 type ('key, 'a) t = ('key, 'a) node Js.null
 
 and ('k,  'v) node  = private {
-  mutable left : ('k,'v) t;
   mutable key : 'k; 
   mutable value : 'v; 
-  mutable right : ('k,'v) t;
-  h : int 
+  height : int; 
+  mutable left : ('k,'v) t;
+  mutable right : ('k,'v) t
 } [@@bs.deriving abstract]
 
 

--- a/jscomp/others/belt_internalMapInt.ml
+++ b/jscomp/others/belt_internalMapInt.ml
@@ -112,7 +112,7 @@ let rec mergeU s1 s2 f =
   match N.(toOpt s1, toOpt s2) with
     (None, None) -> N.empty
   | Some n (* (Node (l1, v1, d1, r1, h1), _)*), _ 
-    when N.(h n >= (match N.toOpt s2 with None -> 0 | Some n -> N.h n)) ->
+    when N.(height n >= (match N.toOpt s2 with None -> 0 | Some n -> N.height n)) ->
     let (l1,v1,d1,r1) = N.(left n, key n, value n, right n ) in 
     let (l2, d2, r2) = split v1 s2 in
     N.concatOrJoin (mergeU l1 l2 f) v1 (f v1 (Some d1) d2 [@bs]) (mergeU r1 r2 f)

--- a/jscomp/others/belt_internalMapString.ml
+++ b/jscomp/others/belt_internalMapString.ml
@@ -112,7 +112,7 @@ let rec mergeU s1 s2 f =
   match N.(toOpt s1, toOpt s2) with
     (None, None) -> N.empty
   | Some n (* (Node (l1, v1, d1, r1, h1), _)*), _ 
-    when N.(h n >= (match N.toOpt s2 with None -> 0 | Some n -> N.h n)) ->
+    when N.(height n >= (match N.toOpt s2 with None -> 0 | Some n -> N.height n)) ->
     let (l1,v1,d1,r1) = N.(left n, key n, value n, right n ) in 
     let (l2, d2, r2) = split v1 s2 in
     N.concatOrJoin (mergeU l1 l2 f) v1 (f v1 (Some d1) d2 [@bs]) (mergeU r1 r2 f)

--- a/jscomp/others/belt_internalSetInt.ml
+++ b/jscomp/others/belt_internalSetInt.ml
@@ -14,14 +14,14 @@ let rec has (t : t) (x : value)  =
   match N.toOpt t with 
   | None -> false
   | Some n  ->                
-    let v = N.key n in 
+    let v = N.value n in 
     x = v || has (if x < v then N.left n else N.right n) x
 
 
 let rec compareAux e1 e2  =
     match e1,e2 with 
     | h1::t1, h2::t2 ->
-        let (k1 : value) ,k2 = N.key h1, N.key h2 in 
+        let (k1 : value) ,k2 = N.value h1, N.value h2 in 
         if k1 = k2 then  
           compareAux 
             (N.stackAllLeft (N.right h1) t1 ) 
@@ -52,8 +52,8 @@ let rec subset (s1 : t) (s2 : t) =
   | _, None ->
     false
   | Some t1, Some t2 (* Node (l1, v1, r1, _), (Node (l2, v2, r2, _) as t2) *) ->
-    let l1,v1,r1 = N.(left t1, key t1, right t1) in  
-    let l2,v2,r2 = N.(left t2, key t2, right t2) in 
+    let l1,v1,r1 = N.(left t1, value t1, right t1) in  
+    let l2,v2,r2 = N.(left t2, value t2, right t2) in 
     if v1 = v2 then
       subset l1 l2 && subset r1 r2
     else if v1 < v2 then
@@ -66,7 +66,7 @@ let rec get (n :t) (x : value) =
   match N.toOpt n with 
   | None -> None
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then Some v
     else get (if x < v then N.left t else N.right t) x
 
@@ -76,7 +76,7 @@ let rec getUndefined (n :t) (x : value)   =
   match N.toOpt n with 
   | None -> Js.undefined
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then Js.Undefined.return v
     else getUndefined  (if x < v then N.left t else N.right t) x
 
@@ -84,7 +84,7 @@ let rec getExn  (n :t) (x : value) =
   match N.toOpt n with 
   | None -> [%assert "getExn"]
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then  v
     else getExn (if x < v then N.left t else N.right t) x
 
@@ -93,7 +93,7 @@ let rec addMutate  t  (x : value)=
   match N.toOpt t with 
   | None -> N.singleton x
   | Some nt -> 
-    let k = N.key nt in 
+    let k = N.value nt in 
     if x = k then t 
     else
       let l, r = N.(left nt, right nt) in 

--- a/jscomp/others/belt_internalSetString.ml
+++ b/jscomp/others/belt_internalSetString.ml
@@ -14,14 +14,14 @@ let rec has (t : t) (x : value)  =
   match N.toOpt t with 
   | None -> false
   | Some n  ->                
-    let v = N.key n in 
+    let v = N.value n in 
     x = v || has (if x < v then N.left n else N.right n) x
 
 
 let rec compareAux e1 e2  =
     match e1,e2 with 
     | h1::t1, h2::t2 ->
-        let (k1 : value) ,k2 = N.key h1, N.key h2 in 
+        let (k1 : value) ,k2 = N.value h1, N.value h2 in 
         if k1 = k2 then  
           compareAux 
             (N.stackAllLeft (N.right h1) t1 ) 
@@ -52,8 +52,8 @@ let rec subset (s1 : t) (s2 : t) =
   | _, None ->
     false
   | Some t1, Some t2 (* Node (l1, v1, r1, _), (Node (l2, v2, r2, _) as t2) *) ->
-    let l1,v1,r1 = N.(left t1, key t1, right t1) in  
-    let l2,v2,r2 = N.(left t2, key t2, right t2) in 
+    let l1,v1,r1 = N.(left t1, value t1, right t1) in  
+    let l2,v2,r2 = N.(left t2, value t2, right t2) in 
     if v1 = v2 then
       subset l1 l2 && subset r1 r2
     else if v1 < v2 then
@@ -66,7 +66,7 @@ let rec get (n :t) (x : value) =
   match N.toOpt n with 
   | None -> None
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then Some v
     else get (if x < v then N.left t else N.right t) x
 
@@ -76,7 +76,7 @@ let rec getUndefined (n :t) (x : value)   =
   match N.toOpt n with 
   | None -> Js.undefined
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then Js.Undefined.return v
     else getUndefined  (if x < v then N.left t else N.right t) x
 
@@ -84,7 +84,7 @@ let rec getExn  (n :t) (x : value) =
   match N.toOpt n with 
   | None -> [%assert "getExn"]
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then  v
     else getExn (if x < v then N.left t else N.right t) x
 
@@ -93,7 +93,7 @@ let rec addMutate  t  (x : value)=
   match N.toOpt t with 
   | None -> N.singleton x
   | Some nt -> 
-    let k = N.key nt in 
+    let k = N.value nt in 
     if x = k then t 
     else
       let l, r = N.(left nt, right nt) in 

--- a/jscomp/others/internal_map.cppo.ml
+++ b/jscomp/others/internal_map.cppo.ml
@@ -116,7 +116,7 @@ let rec mergeU s1 s2 f =
   match N.(toOpt s1, toOpt s2) with
     (None, None) -> N.empty
   | Some n (* (Node (l1, v1, d1, r1, h1), _)*), _ 
-    when N.(h n >= (match N.toOpt s2 with None -> 0 | Some n -> N.h n)) ->
+    when N.(height n >= (match N.toOpt s2 with None -> 0 | Some n -> N.height n)) ->
     let (l1,v1,d1,r1) = N.(left n, key n, value n, right n ) in 
     let (l2, d2, r2) = split v1 s2 in
     N.concatOrJoin (mergeU l1 l2 f) v1 (f v1 (Some d1) d2 [@bs]) (mergeU r1 r2 f)

--- a/jscomp/others/internal_set.cppo.ml
+++ b/jscomp/others/internal_set.cppo.ml
@@ -19,14 +19,14 @@ let rec has (t : t) (x : value)  =
   match N.toOpt t with 
   | None -> false
   | Some n  ->                
-    let v = N.key n in 
+    let v = N.value n in 
     x = v || has (if x < v then N.left n else N.right n) x
 
 
 let rec compareAux e1 e2  =
     match e1,e2 with 
     | h1::t1, h2::t2 ->
-        let (k1 : value) ,k2 = N.key h1, N.key h2 in 
+        let (k1 : value) ,k2 = N.value h1, N.value h2 in 
         if k1 = k2 then  
           compareAux 
             (N.stackAllLeft (N.right h1) t1 ) 
@@ -57,8 +57,8 @@ let rec subset (s1 : t) (s2 : t) =
   | _, None ->
     false
   | Some t1, Some t2 (* Node (l1, v1, r1, _), (Node (l2, v2, r2, _) as t2) *) ->
-    let l1,v1,r1 = N.(left t1, key t1, right t1) in  
-    let l2,v2,r2 = N.(left t2, key t2, right t2) in 
+    let l1,v1,r1 = N.(left t1, value t1, right t1) in  
+    let l2,v2,r2 = N.(left t2, value t2, right t2) in 
     if v1 = v2 then
       subset l1 l2 && subset r1 r2
     else if v1 < v2 then
@@ -71,7 +71,7 @@ let rec get (n :t) (x : value) =
   match N.toOpt n with 
   | None -> None
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then Some v
     else get (if x < v then N.left t else N.right t) x
 
@@ -81,7 +81,7 @@ let rec getUndefined (n :t) (x : value)   =
   match N.toOpt n with 
   | None -> Js.undefined
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then Js.Undefined.return v
     else getUndefined  (if x < v then N.left t else N.right t) x
 
@@ -89,7 +89,7 @@ let rec getExn  (n :t) (x : value) =
   match N.toOpt n with 
   | None -> [%assert "getExn"]
   | Some t  ->    
-    let v = N.key t in     
+    let v = N.value t in     
     if x = v then  v
     else getExn (if x < v then N.left t else N.right t) x
 
@@ -98,7 +98,7 @@ let rec addMutate  t  (x : value)=
   match N.toOpt t with 
   | None -> N.singleton x
   | Some nt -> 
-    let k = N.key nt in 
+    let k = N.value nt in 
     if x = k then t 
     else
       let l, r = N.(left nt, right nt) in 

--- a/jscomp/others/set.cppo.ml
+++ b/jscomp/others/set.cppo.ml
@@ -42,7 +42,7 @@ let rec add  (t : t) (x : value) : t =
   match N.toOpt t with 
     None -> N.singleton x 
   | Some nt  ->
-    let v = N.key nt in  
+    let v = N.value nt in  
     if x = v then t else
       let l, r = N.(left nt , right nt) in 
       if x < v then 
@@ -68,13 +68,13 @@ let rec remove (t : t) (x : value) : t =
   match N.toOpt t with 
   | None -> t
   | Some n  ->
-    let l,v,r = N.(left n, key n, right n) in 
+    let l,v,r = N.(left n, value n, right n) in 
     if x = v then 
       match N.toOpt l, N.toOpt r with 
       | None, _ -> r 
       | _, None -> l 
       | _, Some rn -> 
-        let v = ref (N.key rn) in 
+        let v = ref (N.value rn) in 
         let r = N.removeMinAuxWithRef rn v in 
         N.bal l !v r
     else
@@ -106,7 +106,7 @@ let subset = I.subset
 let has = I.has
 
 let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =   
-  let l,v,r = N.(left n , key n, right n) in  
+  let l,v,r = N.(left n , value n, right n) in  
   if x = v then l,  r
   else if x < v then
     match N.toOpt l with 
@@ -125,9 +125,9 @@ let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =
 
 
 let rec splitAuxPivot (n : _ N.node) (x : value) pres : t  * t =   
-  let l,v,r = N.(left n , key n, right n) in  
+  let l,v,r = N.(left n , value n, right n) in  
   if x = v then begin 
-    pres := true;  
+    pres := true;
     (l, r)
   end
   else if x < v then
@@ -160,16 +160,16 @@ let rec union (s1 : t) (s2 : t) =
     (None, _) -> s2
   | (_, None) -> s1
   | Some n1, Some n2 (* (Node(l1, v1, r1, h1), Node(l2, v2, r2, h2)) *) ->    
-    let h1, h2 = N.(h n1 , h n2) in             
+    let h1, h2 = N.(height n1 , height n2) in             
     if h1 >= h2 then
-      if h2 = 1 then add  s1 (N.key n2) else begin
-        let l1, v1, r1 = N.(left n1, key n1, right n1) in      
+      if h2 = 1 then add  s1 (N.value n2) else begin
+        let l1, v1, r1 = N.(left n1, value n1, right n1) in      
         let (l2,  r2) = splitAuxNoPivot n2 v1 in
         N.joinShared (union l1 l2) v1 (union r1 r2)
       end
     else
-    if h1 = 1 then add  s2 (N.key n1) else begin
-      let l2, v2, r2 = N.(left n2 , key n2, right n2) in 
+    if h1 = 1 then add  s2 (N.value n1) else begin
+      let l2, v2, r2 = N.(left n2 , value n2, right n2) in 
       let (l1, r1) = splitAuxNoPivot n1 v2 in
       N.joinShared (union l1 l2) v2 (union r1 r2)
     end
@@ -179,7 +179,7 @@ let  rec intersect (s1 : t) (s2 : t) =
     (None, _) 
   | (_, None) -> N.empty
   | Some n1, Some n2 (* (Node(l1, v1, r1, _), t2) *) ->
-    let l1,v1,r1 = N.(left n1, key n1, right n1) in  
+    let l1,v1,r1 = N.(left n1, value n1, right n1) in  
     let pres = ref false in 
     let l2,r2 =  splitAuxPivot n2 v1 pres in 
     let ll = intersect l1 l2 in 
@@ -192,7 +192,7 @@ let rec diff (s1 : t) (s2 : t) =
   | (None, _) 
   | (_, None) -> s1
   | Some n1, Some n2 (* (Node(l1, v1, r1, _), t2) *) ->
-    let l1,v1,r1 = N.(left n1, key n1, right n1) in
+    let l1,v1,r1 = N.(left n1, value n1, right n1) in
     let pres = ref false in 
     let l2, r2 = splitAuxPivot  n2 v1 pres in 
     let ll = diff  l1 l2 in 

--- a/jscomp/others/setm.cppo.ml
+++ b/jscomp/others/setm.cppo.ml
@@ -50,7 +50,7 @@ type t = {
 
 
 let rec remove0 nt (x : value)= 
-  let k = N.key nt in 
+  let k = N.value nt in 
   if x = k then 
     let l,r = N.(left nt, right nt) in       
     match N.(toOpt l, toOpt r) with 
@@ -103,7 +103,7 @@ let removeMany  (d : t) xs =
     dataSet d  (removeMany0 nt xs 0 len) 
     
 let rec removeCheck0  nt (x : value) removed = 
-  let k = N.key nt in 
+  let k = N.value nt in 
   if x = k then 
     let () = removed := true in  
     let l,r = N.(left nt, right nt) in       
@@ -149,7 +149,7 @@ let rec addCheck0  t (x : value) added  =
     added := true;
     N.singleton x 
   | Some nt -> 
-    let k = N.key nt in 
+    let k = N.value nt in 
     if x = k then t 
     else
       let l, r = N.(left nt, right nt) in 

--- a/lib/js/belt_MapDict.js
+++ b/lib/js/belt_MapDict.js
@@ -7,9 +7,7 @@ function set(t, newK, newD, cmp) {
   if (t !== null) {
     var k = t.key;
     var c = cmp(newK, k);
-    if (c === 0) {
-      return Belt_internalAVLtree.updateValue(t, newD);
-    } else {
+    if (c) {
       var l = t.left;
       var r = t.right;
       var v = t.value;
@@ -18,6 +16,8 @@ function set(t, newK, newD, cmp) {
       } else {
         return Belt_internalAVLtree.bal(l, k, v, set(r, newK, newD, cmp));
       }
+    } else {
+      return Belt_internalAVLtree.updateValue(t, newD);
     }
   } else {
     return Belt_internalAVLtree.singleton(newK, newD);
@@ -28,43 +28,43 @@ function updateU(t, newK, f, cmp) {
   if (t !== null) {
     var k = t.key;
     var c = cmp(newK, k);
-    if (c === 0) {
+    if (c) {
+      var l = t.left;
+      var r = t.right;
+      var v = t.value;
+      if (c < 0) {
+        var ll = updateU(l, newK, f, cmp);
+        if (l === ll) {
+          return t;
+        } else {
+          return Belt_internalAVLtree.bal(ll, k, v, r);
+        }
+      } else {
+        var rr = updateU(r, newK, f, cmp);
+        if (r === rr) {
+          return t;
+        } else {
+          return Belt_internalAVLtree.bal(l, k, v, rr);
+        }
+      }
+    } else {
       var match = f(/* Some */[t.value]);
       if (match) {
         return Belt_internalAVLtree.updateValue(t, match[0]);
       } else {
-        var l = t.left;
-        var r = t.right;
-        if (l !== null) {
-          if (r !== null) {
-            var kr = [r.key];
-            var vr = [r.value];
-            var r$1 = Belt_internalAVLtree.removeMinAuxWithRef(r, kr, vr);
-            return Belt_internalAVLtree.bal(l, kr[0], vr[0], r$1);
+        var l$1 = t.left;
+        var r$1 = t.right;
+        if (l$1 !== null) {
+          if (r$1 !== null) {
+            var kr = [r$1.key];
+            var vr = [r$1.value];
+            var r$2 = Belt_internalAVLtree.removeMinAuxWithRef(r$1, kr, vr);
+            return Belt_internalAVLtree.bal(l$1, kr[0], vr[0], r$2);
           } else {
-            return l;
+            return l$1;
           }
         } else {
-          return r;
-        }
-      }
-    } else {
-      var l$1 = t.left;
-      var r$2 = t.right;
-      var v = t.value;
-      if (c < 0) {
-        var ll = updateU(l$1, newK, f, cmp);
-        if (l$1 === ll) {
-          return t;
-        } else {
-          return Belt_internalAVLtree.bal(ll, k, v, r$2);
-        }
-      } else {
-        var rr = updateU(r$2, newK, f, cmp);
-        if (r$2 === rr) {
-          return t;
-        } else {
-          return Belt_internalAVLtree.bal(l$1, k, v, rr);
+          return r$1;
         }
       }
     }
@@ -87,39 +87,39 @@ function removeAux0(n, x, cmp) {
   var v = n.key;
   var r = n.right;
   var c = cmp(x, v);
-  if (c === 0) {
-    if (l !== null) {
-      if (r !== null) {
-        var kr = [r.key];
-        var vr = [r.value];
-        var r$1 = Belt_internalAVLtree.removeMinAuxWithRef(r, kr, vr);
-        return Belt_internalAVLtree.bal(l, kr[0], vr[0], r$1);
+  if (c) {
+    if (c < 0) {
+      if (l !== null) {
+        var ll = removeAux0(l, x, cmp);
+        if (ll === l) {
+          return n;
+        } else {
+          return Belt_internalAVLtree.bal(ll, v, n.value, r);
+        }
       } else {
-        return l;
+        return n;
       }
-    } else {
-      return r;
-    }
-  } else if (c < 0) {
-    if (l !== null) {
-      var ll = removeAux0(l, x, cmp);
-      if (ll === l) {
+    } else if (r !== null) {
+      var rr = removeAux0(r, x, cmp);
+      if (rr === r) {
         return n;
       } else {
-        return Belt_internalAVLtree.bal(ll, v, n.value, r);
+        return Belt_internalAVLtree.bal(l, v, n.value, rr);
       }
     } else {
       return n;
     }
-  } else if (r !== null) {
-    var rr = removeAux0(r, x, cmp);
-    if (rr === r) {
-      return n;
+  } else if (l !== null) {
+    if (r !== null) {
+      var kr = [r.key];
+      var vr = [r.value];
+      var r$1 = Belt_internalAVLtree.removeMinAuxWithRef(r, kr, vr);
+      return Belt_internalAVLtree.bal(l, kr[0], vr[0], r$1);
     } else {
-      return Belt_internalAVLtree.bal(l, v, n.value, rr);
+      return l;
     }
   } else {
-    return n;
+    return r;
   }
 }
 
@@ -147,35 +147,37 @@ function splitAuxPivot(n, x, pres, cmp) {
   var d = n.value;
   var r = n.right;
   var c = cmp(x, v);
-  if (c === 0) {
+  if (c) {
+    if (c < 0) {
+      if (l !== null) {
+        var match = splitAuxPivot(l, x, pres, cmp);
+        return /* tuple */[
+                match[0],
+                Belt_internalAVLtree.join(match[1], v, d, r)
+              ];
+      } else {
+        return /* tuple */[
+                Belt_internalAVLtree.empty,
+                n
+              ];
+      }
+    } else if (r !== null) {
+      var match$1 = splitAuxPivot(r, x, pres, cmp);
+      return /* tuple */[
+              Belt_internalAVLtree.join(l, v, d, match$1[0]),
+              match$1[1]
+            ];
+    } else {
+      return /* tuple */[
+              n,
+              Belt_internalAVLtree.empty
+            ];
+    }
+  } else {
     pres[0] = /* Some */[d];
     return /* tuple */[
             l,
             r
-          ];
-  } else if (c < 0) {
-    if (l !== null) {
-      var match = splitAuxPivot(l, x, pres, cmp);
-      return /* tuple */[
-              match[0],
-              Belt_internalAVLtree.join(match[1], v, d, r)
-            ];
-    } else {
-      return /* tuple */[
-              Belt_internalAVLtree.empty,
-              n
-            ];
-    }
-  } else if (r !== null) {
-    var match$1 = splitAuxPivot(r, x, pres, cmp);
-    return /* tuple */[
-            Belt_internalAVLtree.join(l, v, d, match$1[0]),
-            match$1[1]
-          ];
-  } else {
-    return /* tuple */[
-            n,
-            Belt_internalAVLtree.empty
           ];
   }
 }
@@ -202,7 +204,7 @@ function split(n, x, cmp) {
 function mergeU(s1, s2, f, cmp) {
   if (s1 !== null) {
     if (s2 !== null) {
-      if (s1.h >= s2.h) {
+      if (s1.height >= s2.height) {
         var l1 = s1.left;
         var v1 = s1.key;
         var d1 = s1.value;

--- a/lib/js/belt_MutableMap.js
+++ b/lib/js/belt_MutableMap.js
@@ -6,7 +6,25 @@ var Belt_internalAVLtree = require("./belt_internalAVLtree.js");
 function removeMutateAux(nt, x, cmp) {
   var k = nt.key;
   var c = cmp(x, k);
-  if (c === 0) {
+  if (c) {
+    if (c < 0) {
+      var match = nt.left;
+      if (match !== null) {
+        nt.left = removeMutateAux(match, x, cmp);
+        return Belt_internalAVLtree.balMutate(nt);
+      } else {
+        return nt;
+      }
+    } else {
+      var match$1 = nt.right;
+      if (match$1 !== null) {
+        nt.right = removeMutateAux(match$1, x, cmp);
+        return Belt_internalAVLtree.balMutate(nt);
+      } else {
+        return nt;
+      }
+    }
+  } else {
     var l = nt.left;
     var r = nt.right;
     if (l !== null) {
@@ -20,22 +38,6 @@ function removeMutateAux(nt, x, cmp) {
       return r;
     } else {
       return l;
-    }
-  } else if (c < 0) {
-    var match = nt.left;
-    if (match !== null) {
-      nt.left = removeMutateAux(match, x, cmp);
-      return Belt_internalAVLtree.balMutate(nt);
-    } else {
-      return nt;
-    }
-  } else {
-    var match$1 = nt.right;
-    if (match$1 !== null) {
-      nt.right = removeMutateAux(match$1, x, cmp);
-      return Belt_internalAVLtree.balMutate(nt);
-    } else {
-      return nt;
     }
   }
 }
@@ -96,37 +98,37 @@ function updateDone(t, x, f, cmp) {
   if (t !== null) {
     var k = t.key;
     var c = cmp(x, k);
-    if (c === 0) {
+    if (c) {
+      var l = t.left;
+      var r = t.right;
+      if (c < 0) {
+        var ll = updateDone(l, x, f, cmp);
+        t.left = ll;
+      } else {
+        t.right = updateDone(r, x, f, cmp);
+      }
+      return Belt_internalAVLtree.balMutate(t);
+    } else {
       var match = f(/* Some */[t.value]);
       if (match) {
         t.value = match[0];
         return t;
       } else {
-        var l = t.left;
-        var r = t.right;
-        if (l !== null) {
-          if (r !== null) {
-            t.right = Belt_internalAVLtree.removeMinAuxWithRootMutate(t, r);
+        var l$1 = t.left;
+        var r$1 = t.right;
+        if (l$1 !== null) {
+          if (r$1 !== null) {
+            t.right = Belt_internalAVLtree.removeMinAuxWithRootMutate(t, r$1);
             return Belt_internalAVLtree.balMutate(t);
           } else {
-            return l;
+            return l$1;
           }
-        } else if (r !== null) {
-          return r;
+        } else if (r$1 !== null) {
+          return r$1;
         } else {
-          return l;
+          return l$1;
         }
       }
-    } else {
-      var l$1 = t.left;
-      var r$1 = t.right;
-      if (c < 0) {
-        var ll = updateDone(l$1, x, f, cmp);
-        t.left = ll;
-      } else {
-        t.right = updateDone(r$1, x, f, cmp);
-      }
-      return Belt_internalAVLtree.balMutate(t);
     }
   } else {
     var match$1 = f(/* None */0);

--- a/lib/js/belt_MutableSet.js
+++ b/lib/js/belt_MutableSet.js
@@ -5,9 +5,27 @@ var Belt_SortArray = require("./belt_SortArray.js");
 var Belt_internalAVLset = require("./belt_internalAVLset.js");
 
 function remove0(nt, x, cmp) {
-  var k = nt.key;
+  var k = nt.value;
   var c = cmp(x, k);
-  if (c === 0) {
+  if (c) {
+    if (c < 0) {
+      var match = nt.left;
+      if (match !== null) {
+        nt.left = remove0(match, x, cmp);
+        return Belt_internalAVLset.balMutate(nt);
+      } else {
+        return nt;
+      }
+    } else {
+      var match$1 = nt.right;
+      if (match$1 !== null) {
+        nt.right = remove0(match$1, x, cmp);
+        return Belt_internalAVLset.balMutate(nt);
+      } else {
+        return nt;
+      }
+    }
+  } else {
     var l = nt.left;
     var r = nt.right;
     if (l !== null) {
@@ -19,22 +37,6 @@ function remove0(nt, x, cmp) {
       }
     } else {
       return r;
-    }
-  } else if (c < 0) {
-    var match = nt.left;
-    if (match !== null) {
-      nt.left = remove0(match, x, cmp);
-      return Belt_internalAVLset.balMutate(nt);
-    } else {
-      return nt;
-    }
-  } else {
-    var match$1 = nt.right;
-    if (match$1 !== null) {
-      nt.right = remove0(match$1, x, cmp);
-      return Belt_internalAVLset.balMutate(nt);
-    } else {
-      return nt;
     }
   }
 }
@@ -87,9 +89,27 @@ function removeMany(d, xs) {
 }
 
 function removeCheck0(nt, x, removed, cmp) {
-  var k = nt.key;
+  var k = nt.value;
   var c = cmp(x, k);
-  if (c === 0) {
+  if (c) {
+    if (c < 0) {
+      var match = nt.left;
+      if (match !== null) {
+        nt.left = removeCheck0(match, x, removed, cmp);
+        return Belt_internalAVLset.balMutate(nt);
+      } else {
+        return nt;
+      }
+    } else {
+      var match$1 = nt.right;
+      if (match$1 !== null) {
+        nt.right = removeCheck0(match$1, x, removed, cmp);
+        return Belt_internalAVLset.balMutate(nt);
+      } else {
+        return nt;
+      }
+    }
+  } else {
     removed[0] = /* true */1;
     var l = nt.left;
     var r = nt.right;
@@ -102,22 +122,6 @@ function removeCheck0(nt, x, removed, cmp) {
       }
     } else {
       return r;
-    }
-  } else if (c < 0) {
-    var match = nt.left;
-    if (match !== null) {
-      nt.left = removeCheck0(match, x, removed, cmp);
-      return Belt_internalAVLset.balMutate(nt);
-    } else {
-      return nt;
-    }
-  } else {
-    var match$1 = nt.right;
-    if (match$1 !== null) {
-      nt.right = removeCheck0(match$1, x, removed, cmp);
-      return Belt_internalAVLset.balMutate(nt);
-    } else {
-      return nt;
     }
   }
 }
@@ -138,11 +142,9 @@ function removeCheck(d, v) {
 
 function addCheck0(t, x, added, cmp) {
   if (t !== null) {
-    var k = t.key;
+    var k = t.value;
     var c = cmp(x, k);
-    if (c === 0) {
-      return t;
-    } else {
+    if (c) {
       var l = t.left;
       var r = t.right;
       if (c < 0) {
@@ -152,6 +154,8 @@ function addCheck0(t, x, added, cmp) {
         t.right = addCheck0(r, x, added, cmp);
       }
       return Belt_internalAVLset.balMutate(t);
+    } else {
+      return t;
     }
   } else {
     added[0] = /* true */1;

--- a/lib/js/belt_MutableSetInt.js
+++ b/lib/js/belt_MutableSetInt.js
@@ -6,7 +6,7 @@ var Belt_internalAVLset = require("./belt_internalAVLset.js");
 var Belt_internalSetInt = require("./belt_internalSetInt.js");
 
 function remove0(nt, x) {
-  var k = nt.key;
+  var k = nt.value;
   if (x === k) {
     var l = nt.left;
     var r = nt.right;
@@ -87,7 +87,7 @@ function removeMany(d, xs) {
 }
 
 function removeCheck0(nt, x, removed) {
-  var k = nt.key;
+  var k = nt.value;
   if (x === k) {
     removed[0] = /* true */1;
     var l = nt.left;
@@ -137,7 +137,7 @@ function removeCheck(d, v) {
 
 function addCheck0(t, x, added) {
   if (t !== null) {
-    var k = t.key;
+    var k = t.value;
     if (x === k) {
       return t;
     } else {

--- a/lib/js/belt_MutableSetString.js
+++ b/lib/js/belt_MutableSetString.js
@@ -6,7 +6,7 @@ var Belt_SortArrayString = require("./belt_SortArrayString.js");
 var Belt_internalSetString = require("./belt_internalSetString.js");
 
 function remove0(nt, x) {
-  var k = nt.key;
+  var k = nt.value;
   if (x === k) {
     var l = nt.left;
     var r = nt.right;
@@ -87,7 +87,7 @@ function removeMany(d, xs) {
 }
 
 function removeCheck0(nt, x, removed) {
-  var k = nt.key;
+  var k = nt.value;
   if (x === k) {
     removed[0] = /* true */1;
     var l = nt.left;
@@ -137,7 +137,7 @@ function removeCheck(d, v) {
 
 function addCheck0(t, x, added) {
   if (t !== null) {
-    var k = t.key;
+    var k = t.value;
     if (x === k) {
       return t;
     } else {

--- a/lib/js/belt_SetDict.js
+++ b/lib/js/belt_SetDict.js
@@ -4,11 +4,9 @@ var Belt_internalAVLset = require("./belt_internalAVLset.js");
 
 function add(t, x, cmp) {
   if (t !== null) {
-    var k = t.key;
+    var k = t.value;
     var c = cmp(x, k);
-    if (c === 0) {
-      return t;
-    } else {
+    if (c) {
       var l = t.left;
       var r = t.right;
       if (c < 0) {
@@ -26,6 +24,8 @@ function add(t, x, cmp) {
           return Belt_internalAVLset.bal(l, k, rr);
         }
       }
+    } else {
+      return t;
     }
   } else {
     return Belt_internalAVLset.singleton(x);
@@ -35,35 +35,35 @@ function add(t, x, cmp) {
 function remove(t, x, cmp) {
   if (t !== null) {
     var l = t.left;
-    var v = t.key;
+    var v = t.value;
     var r = t.right;
     var c = cmp(x, v);
-    if (c === 0) {
-      if (l !== null) {
-        if (r !== null) {
-          var v$1 = [r.key];
-          var r$1 = Belt_internalAVLset.removeMinAuxWithRef(r, v$1);
-          return Belt_internalAVLset.bal(l, v$1[0], r$1);
+    if (c) {
+      if (c < 0) {
+        var ll = remove(l, x, cmp);
+        if (ll === l) {
+          return t;
         } else {
-          return l;
+          return Belt_internalAVLset.bal(ll, v, r);
         }
       } else {
-        return r;
+        var rr = remove(r, x, cmp);
+        if (rr === r) {
+          return t;
+        } else {
+          return Belt_internalAVLset.bal(l, v, rr);
+        }
       }
-    } else if (c < 0) {
-      var ll = remove(l, x, cmp);
-      if (ll === l) {
-        return t;
+    } else if (l !== null) {
+      if (r !== null) {
+        var v$1 = [r.value];
+        var r$1 = Belt_internalAVLset.removeMinAuxWithRef(r, v$1);
+        return Belt_internalAVLset.bal(l, v$1[0], r$1);
       } else {
-        return Belt_internalAVLset.bal(ll, v, r);
+        return l;
       }
     } else {
-      var rr = remove(r, x, cmp);
-      if (rr === r) {
-        return t;
-      } else {
-        return Belt_internalAVLset.bal(l, v, rr);
-      }
+      return r;
     }
   } else {
     return t;
@@ -92,75 +92,79 @@ function removeMany(h, arr, cmp) {
 
 function splitAuxNoPivot(cmp, n, x) {
   var l = n.left;
-  var v = n.key;
+  var v = n.value;
   var r = n.right;
   var c = cmp(x, v);
-  if (c === 0) {
-    return /* tuple */[
-            l,
-            r
-          ];
-  } else if (c < 0) {
-    if (l !== null) {
-      var match = splitAuxNoPivot(cmp, l, x);
+  if (c) {
+    if (c < 0) {
+      if (l !== null) {
+        var match = splitAuxNoPivot(cmp, l, x);
+        return /* tuple */[
+                match[0],
+                Belt_internalAVLset.joinShared(match[1], v, r)
+              ];
+      } else {
+        return /* tuple */[
+                Belt_internalAVLset.empty,
+                n
+              ];
+      }
+    } else if (r !== null) {
+      var match$1 = splitAuxNoPivot(cmp, r, x);
       return /* tuple */[
-              match[0],
-              Belt_internalAVLset.joinShared(match[1], v, r)
+              Belt_internalAVLset.joinShared(l, v, match$1[0]),
+              match$1[1]
             ];
     } else {
       return /* tuple */[
-              Belt_internalAVLset.empty,
-              n
+              n,
+              Belt_internalAVLset.empty
             ];
     }
-  } else if (r !== null) {
-    var match$1 = splitAuxNoPivot(cmp, r, x);
-    return /* tuple */[
-            Belt_internalAVLset.joinShared(l, v, match$1[0]),
-            match$1[1]
-          ];
   } else {
     return /* tuple */[
-            n,
-            Belt_internalAVLset.empty
+            l,
+            r
           ];
   }
 }
 
 function splitAuxPivot(cmp, n, x, pres) {
   var l = n.left;
-  var v = n.key;
+  var v = n.value;
   var r = n.right;
   var c = cmp(x, v);
-  if (c === 0) {
+  if (c) {
+    if (c < 0) {
+      if (l !== null) {
+        var match = splitAuxPivot(cmp, l, x, pres);
+        return /* tuple */[
+                match[0],
+                Belt_internalAVLset.joinShared(match[1], v, r)
+              ];
+      } else {
+        return /* tuple */[
+                Belt_internalAVLset.empty,
+                n
+              ];
+      }
+    } else if (r !== null) {
+      var match$1 = splitAuxPivot(cmp, r, x, pres);
+      return /* tuple */[
+              Belt_internalAVLset.joinShared(l, v, match$1[0]),
+              match$1[1]
+            ];
+    } else {
+      return /* tuple */[
+              n,
+              Belt_internalAVLset.empty
+            ];
+    }
+  } else {
     pres[0] = /* true */1;
     return /* tuple */[
             l,
             r
-          ];
-  } else if (c < 0) {
-    if (l !== null) {
-      var match = splitAuxPivot(cmp, l, x, pres);
-      return /* tuple */[
-              match[0],
-              Belt_internalAVLset.joinShared(match[1], v, r)
-            ];
-    } else {
-      return /* tuple */[
-              Belt_internalAVLset.empty,
-              n
-            ];
-    }
-  } else if (r !== null) {
-    var match$1 = splitAuxPivot(cmp, r, x, pres);
-    return /* tuple */[
-            Belt_internalAVLset.joinShared(l, v, match$1[0]),
-            match$1[1]
-          ];
-  } else {
-    return /* tuple */[
-            n,
-            Belt_internalAVLset.empty
           ];
   }
 }
@@ -187,23 +191,23 @@ function split(t, x, cmp) {
 function union(s1, s2, cmp) {
   if (s1 !== null) {
     if (s2 !== null) {
-      var h1 = s1.h;
-      var h2 = s2.h;
+      var h1 = s1.height;
+      var h2 = s2.height;
       if (h1 >= h2) {
         if (h2 === 1) {
-          return add(s1, s2.key, cmp);
+          return add(s1, s2.value, cmp);
         } else {
           var l1 = s1.left;
-          var v1 = s1.key;
+          var v1 = s1.value;
           var r1 = s1.right;
           var match = splitAuxNoPivot(cmp, s2, v1);
           return Belt_internalAVLset.joinShared(union(l1, match[0], cmp), v1, union(r1, match[1], cmp));
         }
       } else if (h1 === 1) {
-        return add(s2, s1.key, cmp);
+        return add(s2, s1.value, cmp);
       } else {
         var l2 = s2.left;
-        var v2 = s2.key;
+        var v2 = s2.value;
         var r2 = s2.right;
         var match$1 = splitAuxNoPivot(cmp, s1, v2);
         return Belt_internalAVLset.joinShared(union(match$1[0], l2, cmp), v2, union(match$1[1], r2, cmp));
@@ -220,7 +224,7 @@ function intersect(s1, s2, cmp) {
   if (s1 !== null) {
     if (s2 !== null) {
       var l1 = s1.left;
-      var v1 = s1.key;
+      var v1 = s1.value;
       var r1 = s1.right;
       var pres = [/* false */0];
       var match = splitAuxPivot(cmp, s2, v1, pres);
@@ -243,7 +247,7 @@ function diff(s1, s2, cmp) {
   if (s1 !== null) {
     if (s2 !== null) {
       var l1 = s1.left;
-      var v1 = s1.key;
+      var v1 = s1.value;
       var r1 = s1.right;
       var pres = [/* false */0];
       var match = splitAuxPivot(cmp, s2, v1, pres);

--- a/lib/js/belt_SetInt.js
+++ b/lib/js/belt_SetInt.js
@@ -5,7 +5,7 @@ var Belt_internalSetInt = require("./belt_internalSetInt.js");
 
 function add(t, x) {
   if (t !== null) {
-    var v = t.key;
+    var v = t.value;
     if (x === v) {
       return t;
     } else {
@@ -45,12 +45,12 @@ function mergeMany(h, arr) {
 function remove(t, x) {
   if (t !== null) {
     var l = t.left;
-    var v = t.key;
+    var v = t.value;
     var r = t.right;
     if (x === v) {
       if (l !== null) {
         if (r !== null) {
-          var v$1 = [r.key];
+          var v$1 = [r.value];
           var r$1 = Belt_internalAVLset.removeMinAuxWithRef(r, v$1);
           return Belt_internalAVLset.bal(l, v$1[0], r$1);
         } else {
@@ -91,7 +91,7 @@ function removeMany(h, arr) {
 
 function splitAuxNoPivot(n, x) {
   var l = n.left;
-  var v = n.key;
+  var v = n.value;
   var r = n.right;
   if (x === v) {
     return /* tuple */[
@@ -127,7 +127,7 @@ function splitAuxNoPivot(n, x) {
 
 function splitAuxPivot(n, x, pres) {
   var l = n.left;
-  var v = n.key;
+  var v = n.value;
   var r = n.right;
   if (x === v) {
     pres[0] = /* true */1;
@@ -184,23 +184,23 @@ function split(t, x) {
 function union(s1, s2) {
   if (s1 !== null) {
     if (s2 !== null) {
-      var h1 = s1.h;
-      var h2 = s2.h;
+      var h1 = s1.height;
+      var h2 = s2.height;
       if (h1 >= h2) {
         if (h2 === 1) {
-          return add(s1, s2.key);
+          return add(s1, s2.value);
         } else {
           var l1 = s1.left;
-          var v1 = s1.key;
+          var v1 = s1.value;
           var r1 = s1.right;
           var match = splitAuxNoPivot(s2, v1);
           return Belt_internalAVLset.joinShared(union(l1, match[0]), v1, union(r1, match[1]));
         }
       } else if (h1 === 1) {
-        return add(s2, s1.key);
+        return add(s2, s1.value);
       } else {
         var l2 = s2.left;
-        var v2 = s2.key;
+        var v2 = s2.value;
         var r2 = s2.right;
         var match$1 = splitAuxNoPivot(s1, v2);
         return Belt_internalAVLset.joinShared(union(match$1[0], l2), v2, union(match$1[1], r2));
@@ -217,7 +217,7 @@ function intersect(s1, s2) {
   if (s1 !== null) {
     if (s2 !== null) {
       var l1 = s1.left;
-      var v1 = s1.key;
+      var v1 = s1.value;
       var r1 = s1.right;
       var pres = [/* false */0];
       var match = splitAuxPivot(s2, v1, pres);
@@ -240,7 +240,7 @@ function diff(s1, s2) {
   if (s1 !== null) {
     if (s2 !== null) {
       var l1 = s1.left;
-      var v1 = s1.key;
+      var v1 = s1.value;
       var r1 = s1.right;
       var pres = [/* false */0];
       var match = splitAuxPivot(s2, v1, pres);

--- a/lib/js/belt_SetString.js
+++ b/lib/js/belt_SetString.js
@@ -5,7 +5,7 @@ var Belt_internalSetString = require("./belt_internalSetString.js");
 
 function add(t, x) {
   if (t !== null) {
-    var v = t.key;
+    var v = t.value;
     if (x === v) {
       return t;
     } else {
@@ -45,12 +45,12 @@ function mergeMany(h, arr) {
 function remove(t, x) {
   if (t !== null) {
     var l = t.left;
-    var v = t.key;
+    var v = t.value;
     var r = t.right;
     if (x === v) {
       if (l !== null) {
         if (r !== null) {
-          var v$1 = [r.key];
+          var v$1 = [r.value];
           var r$1 = Belt_internalAVLset.removeMinAuxWithRef(r, v$1);
           return Belt_internalAVLset.bal(l, v$1[0], r$1);
         } else {
@@ -91,7 +91,7 @@ function removeMany(h, arr) {
 
 function splitAuxNoPivot(n, x) {
   var l = n.left;
-  var v = n.key;
+  var v = n.value;
   var r = n.right;
   if (x === v) {
     return /* tuple */[
@@ -127,7 +127,7 @@ function splitAuxNoPivot(n, x) {
 
 function splitAuxPivot(n, x, pres) {
   var l = n.left;
-  var v = n.key;
+  var v = n.value;
   var r = n.right;
   if (x === v) {
     pres[0] = /* true */1;
@@ -184,23 +184,23 @@ function split(t, x) {
 function union(s1, s2) {
   if (s1 !== null) {
     if (s2 !== null) {
-      var h1 = s1.h;
-      var h2 = s2.h;
+      var h1 = s1.height;
+      var h2 = s2.height;
       if (h1 >= h2) {
         if (h2 === 1) {
-          return add(s1, s2.key);
+          return add(s1, s2.value);
         } else {
           var l1 = s1.left;
-          var v1 = s1.key;
+          var v1 = s1.value;
           var r1 = s1.right;
           var match = splitAuxNoPivot(s2, v1);
           return Belt_internalAVLset.joinShared(union(l1, match[0]), v1, union(r1, match[1]));
         }
       } else if (h1 === 1) {
-        return add(s2, s1.key);
+        return add(s2, s1.value);
       } else {
         var l2 = s2.left;
-        var v2 = s2.key;
+        var v2 = s2.value;
         var r2 = s2.right;
         var match$1 = splitAuxNoPivot(s1, v2);
         return Belt_internalAVLset.joinShared(union(match$1[0], l2), v2, union(match$1[1], r2));
@@ -217,7 +217,7 @@ function intersect(s1, s2) {
   if (s1 !== null) {
     if (s2 !== null) {
       var l1 = s1.left;
-      var v1 = s1.key;
+      var v1 = s1.value;
       var r1 = s1.right;
       var pres = [/* false */0];
       var match = splitAuxPivot(s2, v1, pres);
@@ -240,7 +240,7 @@ function diff(s1, s2) {
   if (s1 !== null) {
     if (s2 !== null) {
       var l1 = s1.left;
-      var v1 = s1.key;
+      var v1 = s1.value;
       var r1 = s1.right;
       var pres = [/* false */0];
       var match = splitAuxPivot(s2, v1, pres);

--- a/lib/js/belt_internalAVLset.js
+++ b/lib/js/belt_internalAVLset.js
@@ -3,9 +3,9 @@
 var Curry = require("./curry.js");
 var Belt_SortArray = require("./belt_SortArray.js");
 
-function height(n) {
+function treeHeight(n) {
   if (n !== null) {
-    return n.h;
+    return n.height;
   } else {
     return 0;
   }
@@ -16,10 +16,10 @@ function copy(n) {
     var l = n.left;
     var r = n.right;
     return {
+            value: n.value,
+            height: n.height,
             left: copy(l),
-            key: n.key,
-            right: copy(r),
-            h: n.h
+            right: copy(r)
           };
   } else {
     return n;
@@ -27,29 +27,29 @@ function copy(n) {
 }
 
 function create(l, v, r) {
-  var hl = l !== null ? l.h : 0;
-  var hr = r !== null ? r.h : 0;
+  var hl = l !== null ? l.height : 0;
+  var hr = r !== null ? r.height : 0;
   return {
+          value: v,
+          height: hl >= hr ? hl + 1 | 0 : hr + 1 | 0,
           left: l,
-          key: v,
-          right: r,
-          h: hl >= hr ? hl + 1 | 0 : hr + 1 | 0
+          right: r
         };
 }
 
 function singleton(x) {
   return {
+          value: x,
+          height: 1,
           left: null,
-          key: x,
-          right: null,
-          h: 1
+          right: null
         };
 }
 
 function heightGe(l, r) {
   if (r !== null) {
     if (l !== null) {
-      return +(l.h >= r.h);
+      return +(l.height >= r.height);
     } else {
       return /* false */0;
     }
@@ -59,38 +59,38 @@ function heightGe(l, r) {
 }
 
 function bal(l, v, r) {
-  var hl = l !== null ? l.h : 0;
-  var hr = r !== null ? r.h : 0;
+  var hl = l !== null ? l.height : 0;
+  var hr = r !== null ? r.height : 0;
   if (hl > (hr + 2 | 0)) {
     var ll = l.left;
-    var lv = l.key;
+    var lv = l.value;
     var lr = l.right;
     if (heightGe(ll, lr)) {
       return create(ll, lv, create(lr, v, r));
     } else {
       var lrl = lr.left;
-      var lrv = lr.key;
+      var lrv = lr.value;
       var lrr = lr.right;
       return create(create(ll, lv, lrl), lrv, create(lrr, v, r));
     }
   } else if (hr > (hl + 2 | 0)) {
     var rl = r.left;
-    var rv = r.key;
+    var rv = r.value;
     var rr = r.right;
     if (heightGe(rr, rl)) {
       return create(create(l, v, rl), rv, rr);
     } else {
       var rll = rl.left;
-      var rlv = rl.key;
+      var rlv = rl.value;
       var rlr = rl.right;
       return create(create(l, v, rll), rlv, create(rlr, rv, rr));
     }
   } else {
     return {
+            value: v,
+            height: hl >= hr ? hl + 1 | 0 : hr + 1 | 0,
             left: l,
-            key: v,
-            right: r,
-            h: hl >= hr ? hl + 1 | 0 : hr + 1 | 0
+            right: r
           };
   }
 }
@@ -104,7 +104,7 @@ function min0Aux(_n) {
       continue ;
       
     } else {
-      return n.key;
+      return n.value;
     }
   };
 }
@@ -134,7 +134,7 @@ function max0Aux(_n) {
       continue ;
       
     } else {
-      return n.key;
+      return n.value;
     }
   };
 }
@@ -158,7 +158,7 @@ function maxUndefined(n) {
 function removeMinAuxWithRef(n, v) {
   var ln = n.left;
   var rn = n.right;
-  var kn = n.key;
+  var kn = n.value;
   if (ln !== null) {
     return bal(removeMinAuxWithRef(ln, v), kn, rn);
   } else {
@@ -198,7 +198,7 @@ function forEachU(_n, f) {
     var n = _n;
     if (n !== null) {
       forEachU(n.left, f);
-      f(n.key);
+      f(n.value);
       _n = n.right;
       continue ;
       
@@ -218,7 +218,7 @@ function reduceU(_s, _accu, f) {
     var s = _s;
     if (s !== null) {
       var l = s.left;
-      var k = s.key;
+      var k = s.value;
       var r = s.right;
       _accu = f(reduceU(l, accu, f), k);
       _s = r;
@@ -238,7 +238,7 @@ function everyU(_n, p) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      if (p(n.key)) {
+      if (p(n.value)) {
         if (everyU(n.left, p)) {
           _n = n.right;
           continue ;
@@ -263,7 +263,7 @@ function someU(_n, p) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      if (p(n.key)) {
+      if (p(n.value)) {
         return /* true */1;
       } else if (someU(n.left, p)) {
         return /* true */1;
@@ -284,7 +284,7 @@ function some(n, p) {
 
 function addMinElement(n, v) {
   if (n !== null) {
-    return bal(addMinElement(n.left, v), n.key, n.right);
+    return bal(addMinElement(n.left, v), n.value, n.right);
   } else {
     return singleton(v);
   }
@@ -292,7 +292,7 @@ function addMinElement(n, v) {
 
 function addMaxElement(n, v) {
   if (n !== null) {
-    return bal(n.left, n.key, addMaxElement(n.right, v));
+    return bal(n.left, n.value, addMaxElement(n.right, v));
   } else {
     return singleton(v);
   }
@@ -301,12 +301,12 @@ function addMaxElement(n, v) {
 function joinShared(ln, v, rn) {
   if (ln !== null) {
     if (rn !== null) {
-      var lh = ln.h;
-      var rh = rn.h;
+      var lh = ln.height;
+      var rh = rn.height;
       if (lh > (rh + 2 | 0)) {
-        return bal(ln.left, ln.key, joinShared(ln.right, v, rn));
+        return bal(ln.left, ln.value, joinShared(ln.right, v, rn));
       } else if (rh > (lh + 2 | 0)) {
-        return bal(joinShared(ln, v, rn.left), rn.key, rn.right);
+        return bal(joinShared(ln, v, rn.left), rn.value, rn.right);
       } else {
         return create(ln, v, rn);
       }
@@ -321,7 +321,7 @@ function joinShared(ln, v, rn) {
 function concatShared(t1, t2) {
   if (t1 !== null) {
     if (t2 !== null) {
-      var v = [t2.key];
+      var v = [t2.value];
       var t2r = removeMinAuxWithRef(t2, v);
       return joinShared(t1, v[0], t2r);
     } else {
@@ -334,23 +334,23 @@ function concatShared(t1, t2) {
 
 function partitionSharedU(n, p) {
   if (n !== null) {
-    var key = n.key;
+    var value = n.value;
     var match = partitionSharedU(n.left, p);
     var lf = match[1];
     var lt = match[0];
-    var pv = p(key);
+    var pv = p(value);
     var match$1 = partitionSharedU(n.right, p);
     var rf = match$1[1];
     var rt = match$1[0];
     if (pv) {
       return /* tuple */[
-              joinShared(lt, key, rt),
+              joinShared(lt, value, rt),
               concatShared(lf, rf)
             ];
     } else {
       return /* tuple */[
               concatShared(lt, rt),
-              joinShared(lf, key, rf)
+              joinShared(lf, value, rf)
             ];
     }
   } else {
@@ -388,7 +388,7 @@ function toListAux(_accu, _n) {
     if (n !== null) {
       _n = n.left;
       _accu = /* :: */[
-        n.key,
+        n.value,
         toListAux(accu, n.right)
       ];
       continue ;
@@ -409,7 +409,7 @@ function checkInvariantInternal(_v) {
     if (v !== null) {
       var l = v.left;
       var r = v.right;
-      var diff = height(l) - height(r) | 0;
+      var diff = treeHeight(l) - treeHeight(r) | 0;
       if (!(diff <= 2 && diff >= -2)) {
         throw new Error("File \"belt_internalAVLset.ml\", line 301, characters 6-12");
       }
@@ -428,7 +428,7 @@ function fillArray(_n, _i, arr) {
     var i = _i;
     var n = _n;
     var l = n.left;
-    var v = n.key;
+    var v = n.value;
     var r = n.right;
     var next = l !== null ? fillArray(l, i, arr) : i;
     arr[next] = v;
@@ -448,7 +448,7 @@ function fillArrayWithPartition(_n, cursor, arr, p) {
   while(true) {
     var n = _n;
     var l = n.left;
-    var v = n.key;
+    var v = n.value;
     var r = n.right;
     if (l !== null) {
       fillArrayWithPartition(l, cursor, arr, p);
@@ -477,7 +477,7 @@ function fillArrayWithFilter(_n, _i, arr, p) {
     var i = _i;
     var n = _n;
     var l = n.left;
-    var v = n.key;
+    var v = n.value;
     var r = n.right;
     var next = l !== null ? fillArrayWithFilter(l, i, arr, p) : i;
     var rnext = p(v) ? (arr[next] = v, next + 1 | 0) : next;
@@ -520,20 +520,20 @@ function ofSortedArrayRevAux(arr, off, len) {
           var x0 = arr[off];
           var x1 = arr[off - 1 | 0];
           return {
+                  value: x1,
+                  height: 2,
                   left: singleton(x0),
-                  key: x1,
-                  right: null,
-                  h: 2
+                  right: null
                 };
       case 3 : 
           var x0$1 = arr[off];
           var x1$1 = arr[off - 1 | 0];
           var x2 = arr[off - 2 | 0];
           return {
+                  value: x1$1,
+                  height: 2,
                   left: singleton(x0$1),
-                  key: x1$1,
-                  right: singleton(x2),
-                  h: 2
+                  right: singleton(x2)
                 };
       
     }
@@ -557,20 +557,20 @@ function ofSortedArrayAux(arr, off, len) {
           var x0 = arr[off];
           var x1 = arr[off + 1 | 0];
           return {
+                  value: x1,
+                  height: 2,
                   left: singleton(x0),
-                  key: x1,
-                  right: null,
-                  h: 2
+                  right: null
                 };
       case 3 : 
           var x0$1 = arr[off];
           var x1$1 = arr[off + 1 | 0];
           var x2 = arr[off + 2 | 0];
           return {
+                  value: x1$1,
+                  height: 2,
                   left: singleton(x0$1),
-                  key: x1$1,
-                  right: singleton(x2),
-                  h: 2
+                  right: singleton(x2)
                 };
       
     }
@@ -584,7 +584,7 @@ function ofSortedArrayUnsafe(arr) {
 function keepSharedU(n, p) {
   if (n !== null) {
     var l = n.left;
-    var v = n.key;
+    var v = n.value;
     var r = n.right;
     var newL = keepSharedU(l, p);
     var pv = p(v);
@@ -653,14 +653,14 @@ function has(_t, x, cmp) {
   while(true) {
     var t = _t;
     if (t !== null) {
-      var v = t.key;
+      var v = t.value;
       var c = cmp(x, v);
-      if (c === 0) {
-        return /* true */1;
-      } else {
+      if (c) {
         _t = c < 0 ? t.left : t.right;
         continue ;
         
+      } else {
+        return /* true */1;
       }
     } else {
       return /* false */0;
@@ -682,14 +682,14 @@ function cmp(s1, s2, cmp$1) {
         if (e2) {
           var h2 = e2[0];
           var h1 = e1[0];
-          var c = cmp$2(h1.key, h2.key);
-          if (c === 0) {
+          var c = cmp$2(h1.value, h2.value);
+          if (c) {
+            return c;
+          } else {
             _e2 = stackAllLeft(h2.right, e2[1]);
             _e1 = stackAllLeft(h1.right, e1[1]);
             continue ;
             
-          } else {
-            return c;
           }
         } else {
           return 0;
@@ -716,31 +716,31 @@ function subset(_s1, _s2, cmp) {
     if (s1 !== null) {
       if (s2 !== null) {
         var l1 = s1.left;
-        var v1 = s1.key;
+        var v1 = s1.value;
         var r1 = s1.right;
         var l2 = s2.left;
-        var v2 = s2.key;
+        var v2 = s2.value;
         var r2 = s2.right;
         var c = cmp(v1, v2);
-        if (c === 0) {
-          if (subset(l1, l2, cmp)) {
-            _s2 = r2;
-            _s1 = r1;
+        if (c) {
+          if (c < 0) {
+            if (subset(create(l1, v1, null), l2, cmp)) {
+              _s1 = r1;
+              continue ;
+              
+            } else {
+              return /* false */0;
+            }
+          } else if (subset(create(null, v1, r1), r2, cmp)) {
+            _s1 = l1;
             continue ;
             
           } else {
             return /* false */0;
           }
-        } else if (c < 0) {
-          if (subset(create(l1, v1, null), l2, cmp)) {
-            _s1 = r1;
-            continue ;
-            
-          } else {
-            return /* false */0;
-          }
-        } else if (subset(create(null, v1, r1), r2, cmp)) {
-          _s1 = l1;
+        } else if (subset(l1, l2, cmp)) {
+          _s2 = r2;
+          _s1 = r1;
           continue ;
           
         } else {
@@ -759,14 +759,14 @@ function get(_n, x, cmp) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       var c = cmp(x, v);
-      if (c === 0) {
-        return /* Some */[v];
-      } else {
+      if (c) {
         _n = c < 0 ? n.left : n.right;
         continue ;
         
+      } else {
+        return /* Some */[v];
       }
     } else {
       return /* None */0;
@@ -778,14 +778,14 @@ function getUndefined(_n, x, cmp) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       var c = cmp(x, v);
-      if (c === 0) {
-        return v;
-      } else {
+      if (c) {
         _n = c < 0 ? n.left : n.right;
         continue ;
         
+      } else {
+        return v;
       }
     } else {
       return undefined;
@@ -797,14 +797,14 @@ function getExn(_n, x, cmp) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       var c = cmp(x, v);
-      if (c === 0) {
-        return v;
-      } else {
+      if (c) {
         _n = c < 0 ? n.left : n.right;
         continue ;
         
+      } else {
+        return v;
       }
     } else {
       throw new Error("getExn0");
@@ -816,14 +816,14 @@ function rotateWithLeftChild(k2) {
   var k1 = k2.left;
   k2.left = k1.right;
   k1.right = k2;
-  var hlk2 = height(k2.left);
-  var hrk2 = height(k2.right);
-  k2.h = (
+  var hlk2 = treeHeight(k2.left);
+  var hrk2 = treeHeight(k2.right);
+  k2.height = (
     hlk2 > hrk2 ? hlk2 : hrk2
   ) + 1 | 0;
-  var hlk1 = height(k1.left);
-  var hk2 = k2.h;
-  k1.h = (
+  var hlk1 = treeHeight(k1.left);
+  var hk2 = k2.height;
+  k1.height = (
     hlk1 > hk2 ? hlk1 : hk2
   ) + 1 | 0;
   return k1;
@@ -833,14 +833,14 @@ function rotateWithRightChild(k1) {
   var k2 = k1.right;
   k1.right = k2.left;
   k2.left = k1;
-  var hlk1 = height(k1.left);
-  var hrk1 = height(k1.right);
-  k1.h = (
+  var hlk1 = treeHeight(k1.left);
+  var hrk1 = treeHeight(k1.right);
+  k1.height = (
     hlk1 > hrk1 ? hlk1 : hrk1
   ) + 1 | 0;
-  var hrk2 = height(k2.right);
-  var hk1 = k1.h;
-  k2.h = (
+  var hrk2 = treeHeight(k2.right);
+  var hk1 = k1.height;
+  k2.height = (
     hrk2 > hk1 ? hrk2 : hk1
   ) + 1 | 0;
   return k2;
@@ -859,9 +859,9 @@ function doubleWithRightChild(k2) {
 }
 
 function heightUpdateMutate(t) {
-  var hlt = height(t.left);
-  var hrt = height(t.right);
-  t.h = (
+  var hlt = treeHeight(t.left);
+  var hrt = treeHeight(t.right);
+  t.height = (
     hlt > hrt ? hlt : hrt
   ) + 1 | 0;
   return t;
@@ -870,8 +870,8 @@ function heightUpdateMutate(t) {
 function balMutate(nt) {
   var l = nt.left;
   var r = nt.right;
-  var hl = height(l);
-  var hr = height(r);
+  var hl = treeHeight(l);
+  var hr = treeHeight(r);
   if (hl > (2 + hr | 0)) {
     var ll = l.left;
     var lr = l.right;
@@ -889,7 +889,7 @@ function balMutate(nt) {
       return heightUpdateMutate(doubleWithRightChild(nt));
     }
   } else {
-    nt.h = (
+    nt.height = (
       hl > hr ? hl : hr
     ) + 1 | 0;
     return nt;
@@ -898,11 +898,9 @@ function balMutate(nt) {
 
 function addMutate(cmp, t, x) {
   if (t !== null) {
-    var k = t.key;
+    var k = t.value;
     var c = cmp(x, k);
-    if (c === 0) {
-      return t;
-    } else {
+    if (c) {
       var l = t.left;
       var r = t.right;
       if (c < 0) {
@@ -912,6 +910,8 @@ function addMutate(cmp, t, x) {
         t.right = addMutate(cmp, r, x);
       }
       return balMutate(t);
+    } else {
+      return t;
     }
   } else {
     return singleton(x);
@@ -920,9 +920,7 @@ function addMutate(cmp, t, x) {
 
 function ofArray(xs, cmp) {
   var len = xs.length;
-  if (len === 0) {
-    return null;
-  } else {
+  if (len) {
     var next = Belt_SortArray.strictlySortedLengthU(xs, (function (x, y) {
             return +(cmp(x, y) < 0);
           }));
@@ -937,6 +935,8 @@ function ofArray(xs, cmp) {
       result = addMutate(cmp, result, xs[i]);
     }
     return result;
+  } else {
+    return null;
   }
 }
 
@@ -947,7 +947,7 @@ function removeMinAuxWithRootMutate(nt, n) {
     n.left = removeMinAuxWithRootMutate(nt, ln);
     return balMutate(n);
   } else {
-    nt.key = n.key;
+    nt.value = n.value;
     return rn;
   }
 }

--- a/lib/js/belt_internalAVLtree.js
+++ b/lib/js/belt_internalAVLtree.js
@@ -3,9 +3,9 @@
 var Curry = require("./curry.js");
 var Belt_SortArray = require("./belt_SortArray.js");
 
-function height(n) {
+function treeHeight(n) {
   if (n !== null) {
-    return n.h;
+    return n.height;
   } else {
     return 0;
   }
@@ -16,11 +16,11 @@ function copy(n) {
     var l = n.left;
     var r = n.right;
     return {
-            left: copy(l),
             key: n.key,
             value: n.value,
-            right: copy(r),
-            h: n.h
+            height: n.height,
+            left: copy(l),
+            right: copy(r)
           };
   } else {
     return n;
@@ -28,31 +28,31 @@ function copy(n) {
 }
 
 function create(l, x, d, r) {
-  var hl = height(l);
-  var hr = height(r);
+  var hl = treeHeight(l);
+  var hr = treeHeight(r);
   return {
-          left: l,
           key: x,
           value: d,
-          right: r,
-          h: hl >= hr ? hl + 1 | 0 : hr + 1 | 0
+          height: hl >= hr ? hl + 1 | 0 : hr + 1 | 0,
+          left: l,
+          right: r
         };
 }
 
 function singleton(x, d) {
   return {
-          left: null,
           key: x,
           value: d,
-          right: null,
-          h: 1
+          height: 1,
+          left: null,
+          right: null
         };
 }
 
 function heightGe(l, r) {
   if (r !== null) {
     if (l !== null) {
-      return +(l.h >= r.h);
+      return +(l.height >= r.height);
     } else {
       return /* false */0;
     }
@@ -66,24 +66,24 @@ function updateValue(n, newValue) {
     return n;
   } else {
     return {
-            left: n.left,
             key: n.key,
             value: newValue,
-            right: n.right,
-            h: n.h
+            height: n.height,
+            left: n.left,
+            right: n.right
           };
   }
 }
 
 function bal(l, x, d, r) {
-  var hl = l !== null ? l.h : 0;
-  var hr = r !== null ? r.h : 0;
+  var hl = l !== null ? l.height : 0;
+  var hr = r !== null ? r.height : 0;
   if (hl > (hr + 2 | 0)) {
     var ll = l.left;
     var lv = l.key;
     var ld = l.value;
     var lr = l.right;
-    if (height(ll) >= height(lr)) {
+    if (treeHeight(ll) >= treeHeight(lr)) {
       return create(ll, lv, ld, create(lr, x, d, r));
     } else {
       var lrl = lr.left;
@@ -97,7 +97,7 @@ function bal(l, x, d, r) {
     var rv = r.key;
     var rd = r.value;
     var rr = r.right;
-    if (height(rr) >= height(rl)) {
+    if (treeHeight(rr) >= treeHeight(rl)) {
       return create(create(l, x, d, rl), rv, rd, rr);
     } else {
       var rll = rl.left;
@@ -108,11 +108,11 @@ function bal(l, x, d, r) {
     }
   } else {
     return {
-            left: l,
             key: x,
             value: d,
-            right: r,
-            h: hl >= hr ? hl + 1 | 0 : hr + 1 | 0
+            height: hl >= hr ? hl + 1 | 0 : hr + 1 | 0,
+            left: l,
+            right: r
           };
   }
 }
@@ -308,11 +308,11 @@ function mapU(n, f) {
     var newD = f(n.value);
     var newRight = mapU(n.right, f);
     return {
-            left: newLeft,
             key: n.key,
             value: newD,
-            right: newRight,
-            h: n.h
+            height: n.height,
+            left: newLeft,
+            right: newRight
           };
   } else {
     return null;
@@ -330,11 +330,11 @@ function mapWithKeyU(n, f) {
     var newD = f(key, n.value);
     var newRight = mapWithKeyU(n.right, f);
     return {
-            left: newLeft,
             key: key,
             value: newD,
-            right: newRight,
-            h: n.h
+            height: n.height,
+            left: newLeft,
+            right: newRight
           };
   } else {
     return null;
@@ -439,12 +439,12 @@ function join(ln, v, d, rn) {
       var lv = ln.key;
       var ld = ln.value;
       var lr = ln.right;
-      var lh = ln.h;
+      var lh = ln.height;
       var rl = rn.left;
       var rv = rn.key;
       var rd = rn.value;
       var rr = rn.right;
-      var rh = rn.h;
+      var rh = rn.height;
       if (lh > (rh + 2 | 0)) {
         return bal(ll, lv, ld, join(lr, v, d, rn));
       } else if (rh > (lh + 2 | 0)) {
@@ -606,7 +606,7 @@ function checkInvariantInternal(_v) {
     if (v !== null) {
       var l = v.left;
       var r = v.right;
-      var diff = height(l) - height(r) | 0;
+      var diff = treeHeight(l) - treeHeight(r) | 0;
       if (!(diff <= 2 && diff >= -2)) {
         throw new Error("File \"belt_internalAVLtree.ml\", line 368, characters 6-12");
       }
@@ -738,11 +738,11 @@ function ofSortedArrayRevAux(arr, off, len) {
           var match$2 = match_001;
           var match$3 = match_000;
           return {
-                  left: singleton(match$3[0], match$3[1]),
                   key: match$2[0],
                   value: match$2[1],
-                  right: null,
-                  h: 2
+                  height: 2,
+                  left: singleton(match$3[0], match$3[1]),
+                  right: null
                 };
       case 3 : 
           var match_000$1 = arr[off];
@@ -752,11 +752,11 @@ function ofSortedArrayRevAux(arr, off, len) {
           var match$5 = match_001$1;
           var match$6 = match_000$1;
           return {
-                  left: singleton(match$6[0], match$6[1]),
                   key: match$5[0],
                   value: match$5[1],
-                  right: singleton(match$4[0], match$4[1]),
-                  h: 2
+                  height: 2,
+                  left: singleton(match$6[0], match$6[1]),
+                  right: singleton(match$4[0], match$4[1])
                 };
       
     }
@@ -783,11 +783,11 @@ function ofSortedArrayAux(arr, off, len) {
           var match$2 = match_001;
           var match$3 = match_000;
           return {
-                  left: singleton(match$3[0], match$3[1]),
                   key: match$2[0],
                   value: match$2[1],
-                  right: null,
-                  h: 2
+                  height: 2,
+                  left: singleton(match$3[0], match$3[1]),
+                  right: null
                 };
       case 3 : 
           var match_000$1 = arr[off];
@@ -797,11 +797,11 @@ function ofSortedArrayAux(arr, off, len) {
           var match$5 = match_001$1;
           var match$6 = match_000$1;
           return {
-                  left: singleton(match$6[0], match$6[1]),
                   key: match$5[0],
                   value: match$5[1],
-                  right: singleton(match$4[0], match$4[1]),
-                  h: 2
+                  height: 2,
+                  left: singleton(match$6[0], match$6[1]),
+                  right: singleton(match$4[0], match$4[1])
                 };
       
     }
@@ -828,18 +828,18 @@ function cmpU(s1, s2, kcmp, vcmp) {
           var h2 = e2[0];
           var h1 = e1[0];
           var c = kcmp$1(h1.key, h2.key);
-          if (c === 0) {
+          if (c) {
+            return c;
+          } else {
             var cx = vcmp$1(h1.value, h2.value);
-            if (cx === 0) {
+            if (cx) {
+              return cx;
+            } else {
               _e2 = stackAllLeft(h2.right, e2[1]);
               _e1 = stackAllLeft(h1.right, e1[1]);
               continue ;
               
-            } else {
-              return cx;
             }
-          } else {
-            return c;
           }
         } else {
           return 0;
@@ -904,12 +904,12 @@ function get(_n, x, cmp) {
     if (n !== null) {
       var v = n.key;
       var c = cmp(x, v);
-      if (c === 0) {
-        return /* Some */[n.value];
-      } else {
+      if (c) {
         _n = c < 0 ? n.left : n.right;
         continue ;
         
+      } else {
+        return /* Some */[n.value];
       }
     } else {
       return /* None */0;
@@ -923,12 +923,12 @@ function getUndefined(_n, x, cmp) {
     if (n !== null) {
       var v = n.key;
       var c = cmp(x, v);
-      if (c === 0) {
-        return n.value;
-      } else {
+      if (c) {
         _n = c < 0 ? n.left : n.right;
         continue ;
         
+      } else {
+        return n.value;
       }
     } else {
       return undefined;
@@ -942,12 +942,12 @@ function getExn(_n, x, cmp) {
     if (n !== null) {
       var v = n.key;
       var c = cmp(x, v);
-      if (c === 0) {
-        return n.value;
-      } else {
+      if (c) {
         _n = c < 0 ? n.left : n.right;
         continue ;
         
+      } else {
+        return n.value;
       }
     } else {
       throw new Error("getExn0");
@@ -961,12 +961,12 @@ function getWithDefault(_n, x, def, cmp) {
     if (n !== null) {
       var v = n.key;
       var c = cmp(x, v);
-      if (c === 0) {
-        return n.value;
-      } else {
+      if (c) {
         _n = c < 0 ? n.left : n.right;
         continue ;
         
+      } else {
+        return n.value;
       }
     } else {
       return def;
@@ -980,12 +980,12 @@ function has(_n, x, cmp) {
     if (n !== null) {
       var v = n.key;
       var c = cmp(x, v);
-      if (c === 0) {
-        return /* true */1;
-      } else {
+      if (c) {
         _n = c < 0 ? n.left : n.right;
         continue ;
         
+      } else {
+        return /* true */1;
       }
     } else {
       return /* false */0;
@@ -997,14 +997,14 @@ function rotateWithLeftChild(k2) {
   var k1 = k2.left;
   k2.left = k1.right;
   k1.right = k2;
-  var hlk2 = height(k2.left);
-  var hrk2 = height(k2.right);
-  k2.h = (
+  var hlk2 = treeHeight(k2.left);
+  var hrk2 = treeHeight(k2.right);
+  k2.height = (
     hlk2 > hrk2 ? hlk2 : hrk2
   ) + 1 | 0;
-  var hlk1 = height(k1.left);
-  var hk2 = k2.h;
-  k1.h = (
+  var hlk1 = treeHeight(k1.left);
+  var hk2 = k2.height;
+  k1.height = (
     hlk1 > hk2 ? hlk1 : hk2
   ) + 1 | 0;
   return k1;
@@ -1014,14 +1014,14 @@ function rotateWithRightChild(k1) {
   var k2 = k1.right;
   k1.right = k2.left;
   k2.left = k1;
-  var hlk1 = height(k1.left);
-  var hrk1 = height(k1.right);
-  k1.h = (
+  var hlk1 = treeHeight(k1.left);
+  var hrk1 = treeHeight(k1.right);
+  k1.height = (
     hlk1 > hrk1 ? hlk1 : hrk1
   ) + 1 | 0;
-  var hrk2 = height(k2.right);
-  var hk1 = k1.h;
-  k2.h = (
+  var hrk2 = treeHeight(k2.right);
+  var hk1 = k1.height;
+  k2.height = (
     hrk2 > hk1 ? hrk2 : hk1
   ) + 1 | 0;
   return k2;
@@ -1040,9 +1040,9 @@ function doubleWithRightChild(k2) {
 }
 
 function heightUpdateMutate(t) {
-  var hlt = height(t.left);
-  var hrt = height(t.right);
-  t.h = (
+  var hlt = treeHeight(t.left);
+  var hrt = treeHeight(t.right);
+  t.height = (
     hlt > hrt ? hlt : hrt
   ) + 1 | 0;
   return t;
@@ -1051,8 +1051,8 @@ function heightUpdateMutate(t) {
 function balMutate(nt) {
   var l = nt.left;
   var r = nt.right;
-  var hl = height(l);
-  var hr = height(r);
+  var hl = treeHeight(l);
+  var hr = treeHeight(r);
   if (hl > (2 + hr | 0)) {
     var ll = l.left;
     var lr = l.right;
@@ -1070,7 +1070,7 @@ function balMutate(nt) {
       return heightUpdateMutate(doubleWithRightChild(nt));
     }
   } else {
-    nt.h = (
+    nt.height = (
       hl > hr ? hl : hr
     ) + 1 | 0;
     return nt;
@@ -1081,10 +1081,7 @@ function updateMutate(t, x, data, cmp) {
   if (t !== null) {
     var k = t.key;
     var c = cmp(x, k);
-    if (c === 0) {
-      t.value = data;
-      return t;
-    } else {
+    if (c) {
       var l = t.left;
       var r = t.right;
       if (c < 0) {
@@ -1094,6 +1091,9 @@ function updateMutate(t, x, data, cmp) {
         t.right = updateMutate(r, x, data, cmp);
       }
       return balMutate(t);
+    } else {
+      t.value = data;
+      return t;
     }
   } else {
     return singleton(x, data);
@@ -1102,9 +1102,7 @@ function updateMutate(t, x, data, cmp) {
 
 function ofArray(xs, cmp) {
   var len = xs.length;
-  if (len === 0) {
-    return null;
-  } else {
+  if (len) {
     var next = Belt_SortArray.strictlySortedLengthU(xs, (function (param, param$1) {
             return +(cmp(param[0], param$1[0]) < 0);
           }));
@@ -1120,6 +1118,8 @@ function ofArray(xs, cmp) {
       result = updateMutate(result, match[0], match[1], cmp);
     }
     return result;
+  } else {
+    return null;
   }
 }
 

--- a/lib/js/belt_internalMapInt.js
+++ b/lib/js/belt_internalMapInt.js
@@ -198,8 +198,8 @@ function split(x, n) {
 function mergeU(s1, s2, f) {
   var exit = 0;
   if (s1 !== null) {
-    if (s1.h >= (
-        s2 !== null ? s2.h : 0
+    if (s1.height >= (
+        s2 !== null ? s2.height : 0
       )) {
       var l1 = s1.left;
       var v1 = s1.key;
@@ -243,18 +243,18 @@ function compareAux(_e1, _e2, vcmp) {
         var h2 = e2[0];
         var h1 = e1[0];
         var c = Caml_primitive.caml_int_compare(h1.key, h2.key);
-        if (c === 0) {
+        if (c) {
+          return c;
+        } else {
           var cx = vcmp(h1.value, h2.value);
-          if (cx === 0) {
+          if (cx) {
+            return cx;
+          } else {
             _e2 = Belt_internalAVLtree.stackAllLeft(h2.right, e2[1]);
             _e1 = Belt_internalAVLtree.stackAllLeft(h1.right, e1[1]);
             continue ;
             
-          } else {
-            return cx;
           }
-        } else {
-          return c;
         }
       } else {
         return 0;
@@ -345,9 +345,7 @@ function addMutate(t, x, data) {
 
 function ofArray(xs) {
   var len = xs.length;
-  if (len === 0) {
-    return Belt_internalAVLtree.empty;
-  } else {
+  if (len) {
     var next = Belt_SortArray.strictlySortedLengthU(xs, (function (param, param$1) {
             return +(param[0] < param$1[0]);
           }));
@@ -363,6 +361,8 @@ function ofArray(xs) {
       result = addMutate(result, match[0], match[1]);
     }
     return result;
+  } else {
+    return Belt_internalAVLtree.empty;
   }
 }
 

--- a/lib/js/belt_internalMapString.js
+++ b/lib/js/belt_internalMapString.js
@@ -198,8 +198,8 @@ function split(x, n) {
 function mergeU(s1, s2, f) {
   var exit = 0;
   if (s1 !== null) {
-    if (s1.h >= (
-        s2 !== null ? s2.h : 0
+    if (s1.height >= (
+        s2 !== null ? s2.height : 0
       )) {
       var l1 = s1.left;
       var v1 = s1.key;
@@ -243,18 +243,18 @@ function compareAux(_e1, _e2, vcmp) {
         var h2 = e2[0];
         var h1 = e1[0];
         var c = Caml_primitive.caml_string_compare(h1.key, h2.key);
-        if (c === 0) {
+        if (c) {
+          return c;
+        } else {
           var cx = vcmp(h1.value, h2.value);
-          if (cx === 0) {
+          if (cx) {
+            return cx;
+          } else {
             _e2 = Belt_internalAVLtree.stackAllLeft(h2.right, e2[1]);
             _e1 = Belt_internalAVLtree.stackAllLeft(h1.right, e1[1]);
             continue ;
             
-          } else {
-            return cx;
           }
-        } else {
-          return c;
         }
       } else {
         return 0;
@@ -345,9 +345,7 @@ function addMutate(t, x, data) {
 
 function ofArray(xs) {
   var len = xs.length;
-  if (len === 0) {
-    return Belt_internalAVLtree.empty;
-  } else {
+  if (len) {
     var next = Belt_SortArray.strictlySortedLengthU(xs, (function (param, param$1) {
             return +(param[0] < param$1[0]);
           }));
@@ -363,6 +361,8 @@ function ofArray(xs) {
       result = addMutate(result, match[0], match[1]);
     }
     return result;
+  } else {
+    return Belt_internalAVLtree.empty;
   }
 }
 

--- a/lib/js/belt_internalSetInt.js
+++ b/lib/js/belt_internalSetInt.js
@@ -7,7 +7,7 @@ function has(_t, x) {
   while(true) {
     var t = _t;
     if (t !== null) {
-      var v = t.key;
+      var v = t.value;
       if (x === v) {
         return /* true */1;
       } else {
@@ -29,8 +29,8 @@ function compareAux(_e1, _e2) {
       if (e2) {
         var h2 = e2[0];
         var h1 = e1[0];
-        var k1 = h1.key;
-        var k2 = h2.key;
+        var k1 = h1.value;
+        var k2 = h2.value;
         if (k1 === k2) {
           _e2 = Belt_internalAVLset.stackAllLeft(h2.right, e2[1]);
           _e1 = Belt_internalAVLset.stackAllLeft(h1.right, e1[1]);
@@ -73,10 +73,10 @@ function subset(_s1, _s2) {
     if (s1 !== null) {
       if (s2 !== null) {
         var l1 = s1.left;
-        var v1 = s1.key;
+        var v1 = s1.value;
         var r1 = s1.right;
         var l2 = s2.left;
-        var v2 = s2.key;
+        var v2 = s2.value;
         var r2 = s2.right;
         if (v1 === v2) {
           if (subset(l1, l2)) {
@@ -115,7 +115,7 @@ function get(_n, x) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       if (x === v) {
         return /* Some */[v];
       } else {
@@ -133,7 +133,7 @@ function getUndefined(_n, x) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       if (x === v) {
         return v;
       } else {
@@ -151,7 +151,7 @@ function getExn(_n, x) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       if (x === v) {
         return v;
       } else {
@@ -167,7 +167,7 @@ function getExn(_n, x) {
 
 function addMutate(t, x) {
   if (t !== null) {
-    var k = t.key;
+    var k = t.value;
     if (x === k) {
       return t;
     } else {
@@ -187,9 +187,7 @@ function addMutate(t, x) {
 
 function ofArray(xs) {
   var len = xs.length;
-  if (len === 0) {
-    return Belt_internalAVLset.empty;
-  } else {
+  if (len) {
     var next = Belt_SortArrayInt.strictlySortedLength(xs);
     var result;
     if (next >= 0) {
@@ -202,6 +200,8 @@ function ofArray(xs) {
       result = addMutate(result, xs[i]);
     }
     return result;
+  } else {
+    return Belt_internalAVLset.empty;
   }
 }
 

--- a/lib/js/belt_internalSetString.js
+++ b/lib/js/belt_internalSetString.js
@@ -7,7 +7,7 @@ function has(_t, x) {
   while(true) {
     var t = _t;
     if (t !== null) {
-      var v = t.key;
+      var v = t.value;
       if (x === v) {
         return /* true */1;
       } else {
@@ -29,8 +29,8 @@ function compareAux(_e1, _e2) {
       if (e2) {
         var h2 = e2[0];
         var h1 = e1[0];
-        var k1 = h1.key;
-        var k2 = h2.key;
+        var k1 = h1.value;
+        var k2 = h2.value;
         if (k1 === k2) {
           _e2 = Belt_internalAVLset.stackAllLeft(h2.right, e2[1]);
           _e1 = Belt_internalAVLset.stackAllLeft(h1.right, e1[1]);
@@ -73,10 +73,10 @@ function subset(_s1, _s2) {
     if (s1 !== null) {
       if (s2 !== null) {
         var l1 = s1.left;
-        var v1 = s1.key;
+        var v1 = s1.value;
         var r1 = s1.right;
         var l2 = s2.left;
-        var v2 = s2.key;
+        var v2 = s2.value;
         var r2 = s2.right;
         if (v1 === v2) {
           if (subset(l1, l2)) {
@@ -115,7 +115,7 @@ function get(_n, x) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       if (x === v) {
         return /* Some */[v];
       } else {
@@ -133,7 +133,7 @@ function getUndefined(_n, x) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       if (x === v) {
         return v;
       } else {
@@ -151,7 +151,7 @@ function getExn(_n, x) {
   while(true) {
     var n = _n;
     if (n !== null) {
-      var v = n.key;
+      var v = n.value;
       if (x === v) {
         return v;
       } else {
@@ -167,7 +167,7 @@ function getExn(_n, x) {
 
 function addMutate(t, x) {
   if (t !== null) {
-    var k = t.key;
+    var k = t.value;
     if (x === k) {
       return t;
     } else {
@@ -187,9 +187,7 @@ function addMutate(t, x) {
 
 function ofArray(xs) {
   var len = xs.length;
-  if (len === 0) {
-    return Belt_internalAVLset.empty;
-  } else {
+  if (len) {
     var next = Belt_SortArrayString.strictlySortedLength(xs);
     var result;
     if (next >= 0) {
@@ -202,6 +200,8 @@ function ofArray(xs) {
       result = addMutate(result, xs[i]);
     }
     return result;
+  } else {
+    return Belt_internalAVLset.empty;
   }
 }
 


### PR DESCRIPTION
Addresses a first wave of beta feedback.

This puts the most important stuff in prominent position. Before:

```js
{ left: { left: null, key: 1, right: null, h: 1 },
  key: 2,
  right:
   { left: null,
     key: 3,
     right: { left: null, key: 5, right: null, h: 1 },
     h: 2 },
  h: 3 }
```

After:

```js
{ value: 2,
  height: 3,
  left: { value: 1, height: 1, left: null, right: null },
  right:
   { value: 3,
     height: 2,
     left: null,
     right: { value: 5, height: 1, left: null, right: null } } }
```

Friendlier in browser consoles too. Explicitly name "h" to "height" for extra education.
