### PR TITLE
Change set terminology of elt to value

### DIFF
--- a/jscomp/others/belt_HashSet.ml
+++ b/jscomp/others/belt_HashSet.ml
@@ -160,7 +160,7 @@ let has h key =
 
 
 
-let make (type elt) (type identity)  ~hintSize ~(id: (elt, identity) id)=
+let make (type value) (type identity)  ~hintSize ~(id: (value, identity) id)=
   let module M = (val id) in 
   C.make ~hintSize ~hash:M.hash ~eq:M.eq
 

--- a/jscomp/others/belt_MutableSet.ml
+++ b/jscomp/others/belt_MutableSet.ml
@@ -35,10 +35,10 @@ type ('k, 'id) id = ('k, 'id) Belt_Id.comparable
 type ('key, 'id ) cmp = ('key, 'id) Belt_Id.cmp
 
 module S = struct
-  type ('elt,'id) t =
+  type ('value,'id) t =
     {
-      cmp: ('elt, 'id) cmp;
-      mutable data: 'elt N.t
+      cmp: ('value, 'id) cmp;
+      mutable data: 'value N.t
     } [@@bs.deriving abstract]
 end
 
@@ -189,7 +189,7 @@ let mergeMany d xs =
   S.dataSet d (addArrayMutate (S.data d) xs ~cmp:(S.cmp d))
 
 
-let make (type elt) (type identity) ~(id : (elt, identity) id) =
+let make (type value) (type identity) ~(id : (value, identity) id) =
   let module M = (val id) in 
   S.t ~cmp:M.cmp ~data:N.empty
     
@@ -220,7 +220,7 @@ let toList d =
 let toArray d = 
   N.toArray (S.data d)
 
-let ofSortedArrayUnsafe (type elt) (type identity) xs ~(id : (elt,identity) id) : _ t =
+let ofSortedArrayUnsafe (type value) (type identity) xs ~(id : (value,identity) id) : _ t =
   let module M = (val id) in 
   S.t ~data:(N.ofSortedArrayUnsafe xs) ~cmp:M.cmp
     
@@ -228,7 +228,7 @@ let checkInvariantInternal d =
   N.checkInvariantInternal (S.data d)
     
     
-let ofArray (type elt) (type identity)  data ~(id : (elt,identity) id) =
+let ofArray (type value) (type identity)  data ~(id : (value,identity) id) =
   let module M = (val id) in
   let cmp = M.cmp in 
   S.t ~cmp ~data:(N.ofArray ~cmp data)

--- a/jscomp/others/belt_MutableSet.mli
+++ b/jscomp/others/belt_MutableSet.mli
@@ -87,88 +87,88 @@ type ('k,'id) t
 
 type ('k, 'id) id = ('k, 'id) Belt_Id.comparable
 
-val make: id:('elt, 'id) id -> ('elt, 'id) t
+val make: id:('value, 'id) id -> ('value, 'id) t
 
 val ofArray: 'k array -> id:('k, 'id) id ->   ('k, 'id) t
-val ofSortedArrayUnsafe: 'elt array -> id:('elt, 'id) id ->  ('elt,'id) t
+val ofSortedArrayUnsafe: 'value array -> id:('value, 'id) id ->  ('value,'id) t
 val copy: ('k, 'id) t -> ('k, 'id) t     
 val isEmpty: _ t -> bool
-val has:  ('elt, _) t -> 'elt ->  bool
+val has:  ('value, _) t -> 'value ->  bool
 
-val add: ('elt, 'id) t -> 'elt -> unit 
+val add: ('value, 'id) t -> 'value -> unit 
 
 val addCheck:
-  ('elt, 'id) t -> 'elt -> bool 
+  ('value, 'id) t -> 'value -> bool 
 
 val mergeMany:
-  ('elt, 'id) t -> 'elt array -> unit 
+  ('value, 'id) t -> 'value array -> unit 
 
-val remove: ('elt, 'id) t -> 'elt -> unit 
+val remove: ('value, 'id) t -> 'value -> unit 
 
-val removeCheck: ('elt, 'id) t -> 'elt -> bool
+val removeCheck: ('value, 'id) t -> 'value -> bool
    (* [b = removeCheck s e] [b] is true means one element removed *)      
 
 val removeMany:
-  ('elt, 'id) t -> 'elt array -> unit 
+  ('value, 'id) t -> 'value array -> unit 
 
-val union: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t
-val intersect: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t 
-val diff: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t 
-val subset: ('elt, 'id) t -> ('elt, 'id) t -> bool     
+val union: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
+val intersect: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t 
+val diff: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t 
+val subset: ('value, 'id) t -> ('value, 'id) t -> bool     
 
 val cmp:  
-  ('elt, 'id) t -> ('elt, 'id) t -> int
+  ('value, 'id) t -> ('value, 'id) t -> int
 val eq:  
-  ('elt, 'id) t -> ('elt, 'id) t -> bool
+  ('value, 'id) t -> ('value, 'id) t -> bool
 
-val forEachU: ('elt, 'id) t -> ('elt -> unit [@bs]) ->  unit
-val forEach: ('elt, 'id) t -> ('elt -> unit) ->  unit
+val forEachU: ('value, 'id) t -> ('value -> unit [@bs]) ->  unit
+val forEach: ('value, 'id) t -> ('value -> unit) ->  unit
 (** [forEach m f] applies [f] in turn to all elements of [m].
     In increasing order *)
   
-val reduceU: ('elt, 'id) t -> 'a -> ('a -> 'elt -> 'a [@bs]) -> 'a
-val reduce: ('elt, 'id) t -> 'a -> ('a -> 'elt -> 'a) -> 'a  
+val reduceU: ('value, 'id) t -> 'a -> ('a -> 'value -> 'a [@bs]) -> 'a
+val reduce: ('value, 'id) t -> 'a -> ('a -> 'value -> 'a) -> 'a  
 (** In increasing order. *)
   
-val everyU: ('elt, 'id) t -> ('elt -> bool [@bs]) -> bool
-val every: ('elt, 'id) t -> ('elt -> bool) -> bool  
+val everyU: ('value, 'id) t -> ('value -> bool [@bs]) -> bool
+val every: ('value, 'id) t -> ('value -> bool) -> bool  
 (** [every s p] checks if all elements of the set
     satisfy the predicate [p]. Order unspecified *)
 
-val someU: ('elt, 'id) t ->  ('elt -> bool [@bs]) -> bool
-val some: ('elt, 'id) t ->  ('elt -> bool) -> bool  
+val someU: ('value, 'id) t ->  ('value -> bool [@bs]) -> bool
+val some: ('value, 'id) t ->  ('value -> bool) -> bool  
 (** [some p s] checks if at least one element of
     the set satisfies the predicate [p]. *)
 
-val keepU: ('elt, 'id) t -> ('elt -> bool [@bs]) -> ('elt, 'id) t
-val keep: ('elt, 'id) t -> ('elt -> bool) -> ('elt, 'id) t    
+val keepU: ('value, 'id) t -> ('value -> bool [@bs]) -> ('value, 'id) t
+val keep: ('value, 'id) t -> ('value -> bool) -> ('value, 'id) t    
 (** [keep s p] returns the set of all elements in [s]
     that satisfy predicate [p]. *)    
 
-val partitionU: ('elt, 'id) t -> ('elt -> bool [@bs]) -> ('elt, 'id) t * ('elt, 'id) t
-val partition: ('elt, 'id) t -> ('elt -> bool) -> ('elt, 'id) t * ('elt, 'id) t                                                           
+val partitionU: ('value, 'id) t -> ('value -> bool [@bs]) -> ('value, 'id) t * ('value, 'id) t
+val partition: ('value, 'id) t -> ('value -> bool) -> ('value, 'id) t * ('value, 'id) t                                                           
 (** [partition p s] returns a pair of sets [(s1, s2)], where
     [s1] is the set of all the elements of [s] that satisfy the
     predicate [p], and [s2] is the set of all the elements of
     [s] that do not satisfy [p]. *)
 
 
-val size:  ('elt, 'id) t -> int    
-val toList: ('elt, 'id) t -> 'elt list
+val size:  ('value, 'id) t -> int    
+val toList: ('value, 'id) t -> 'value list
 (** In increasing order*)
-val toArray: ('elt, 'id) t -> 'elt array
+val toArray: ('value, 'id) t -> 'value array
 
-val minimum: ('elt, 'id) t -> 'elt option
-val minUndefined: ('elt, 'id) t -> 'elt Js.undefined
-val maximum: ('elt, 'id) t -> 'elt option
-val maxUndefined: ('elt, 'id) t -> 'elt Js.undefined
+val minimum: ('value, 'id) t -> 'value option
+val minUndefined: ('value, 'id) t -> 'value Js.undefined
+val maximum: ('value, 'id) t -> 'value option
+val maxUndefined: ('value, 'id) t -> 'value Js.undefined
 
-val get: ('elt, 'id) t -> 'elt -> 'elt option 
-val getUndefined: ('elt, 'id) t -> 'elt -> 'elt Js.undefined
-val getExn: ('elt, 'id) t -> 'elt -> 'elt 
+val get: ('value, 'id) t -> 'value -> 'value option 
+val getUndefined: ('value, 'id) t -> 'value -> 'value Js.undefined
+val getExn: ('value, 'id) t -> 'value -> 'value 
 
 
-val split: ('elt, 'id) t -> 'elt ->  (('elt, 'id) t * ('elt, 'id) t) * bool
+val split: ('value, 'id) t -> 'value ->  (('value, 'id) t * ('value, 'id) t) * bool
 (** [split s x] returns a triple [((l, r), present)], where
       [l] is the set of elements of [s] that are
       strictly less than [x];
@@ -187,8 +187,8 @@ val checkInvariantInternal: _ t -> unit
 (*
   [add0] was not exposed for various reasons:
   1. such api is dangerious
-  [ cmp: ('elt,'id) Belt_Cmp.cmp -> 
-    ('elt, 'id) t0 -> 'elt ->  
-    ('elt, 'id) t0]
+  [ cmp: ('value,'id) Belt_Cmp.cmp -> 
+    ('value, 'id) t0 -> 'value ->  
+    ('value, 'id) t0]
   2. It is not really significantly more *)
 

--- a/jscomp/others/belt_MutableSetInt.ml
+++ b/jscomp/others/belt_MutableSetInt.ml
@@ -35,7 +35,7 @@ module S = Belt_SortArrayInt
 module N = Belt_internalAVLset
 module A = Belt_Array 
 
-type elt = I.elt
+type value = I.value
 (** The type of the set elements. *)
              
 
@@ -45,7 +45,7 @@ type t = {
 (** The type of sets. *)
 
 
-let rec remove0 nt (x : elt)= 
+let rec remove0 nt (x : value)= 
   let k = N.key nt in 
   if x = k then 
     let l,r = N.(left nt, right nt) in       
@@ -98,7 +98,7 @@ let removeMany  (d : t) xs =
     let len = A.length xs in 
     dataSet d  (removeMany0 nt xs 0 len) 
     
-let rec removeCheck0  nt (x : elt) removed = 
+let rec removeCheck0  nt (x : value) removed = 
   let k = N.key nt in 
   if x = k then 
     let () = removed := true in  
@@ -139,7 +139,7 @@ let removeCheck  (d :  t) v =
     !removed
 
     
-let rec addCheck0  t (x : elt) added  =   
+let rec addCheck0  t (x : value) added  =   
   match N.toOpt t with 
   | None -> 
     added := true;

--- a/jscomp/others/belt_MutableSetInt.mli
+++ b/jscomp/others/belt_MutableSetInt.mli
@@ -33,7 +33,7 @@
 
 
 # 37
-type elt = int
+type value = int
 # 41
 (** The type of the set elements. *)
 
@@ -43,18 +43,18 @@ type t
   
 val make: unit -> t
 
-val ofArray: elt array -> t
-val ofSortedArrayUnsafe: elt array -> t
+val ofArray: value array -> t
+val ofSortedArrayUnsafe: value array -> t
 val copy: t -> t 
 val isEmpty: t -> bool
-val has: t -> elt -> bool
+val has: t -> value -> bool
 
-val add: t -> elt -> unit
-val addCheck: t -> elt -> bool 
-val mergeMany: t -> elt array -> unit
-val remove: t -> elt -> unit
-val removeCheck: t -> elt -> bool 
-val removeMany: t -> elt array -> unit
+val add: t -> value -> unit
+val addCheck: t -> value -> bool 
+val mergeMany: t -> value array -> unit
+val remove: t -> value -> unit
+val removeCheck: t -> value -> bool 
+val removeMany: t -> value array -> unit
   
 val union: t -> t -> t
 val intersect: t -> t -> t
@@ -65,51 +65,51 @@ val cmp: t -> t -> int
 val eq: t -> t -> bool
 
 
-val forEachU: t -> (elt -> unit [@bs]) ->  unit
-val forEach: t -> (elt -> unit ) ->  unit
+val forEachU: t -> (value -> unit [@bs]) ->  unit
+val forEach: t -> (value -> unit ) ->  unit
 (** In increasing order*)
 
-val reduceU: t -> 'a -> ('a -> elt -> 'a [@bs]) -> 'a
-val reduce: t -> 'a -> ('a -> elt -> 'a ) -> 'a  
+val reduceU: t -> 'a -> ('a -> value -> 'a [@bs]) -> 'a
+val reduce: t -> 'a -> ('a -> value -> 'a ) -> 'a  
 (** Iterate in increasing order. *)
 
-val everyU: t -> (elt -> bool [@bs]) -> bool
-val every: t -> (elt -> bool) ->  bool  
+val everyU: t -> (value -> bool [@bs]) -> bool
+val every: t -> (value -> bool) ->  bool  
 (** [every p s] checks if all elements of the set
     satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (elt -> bool [@bs]) -> bool
-val some: t -> (elt -> bool) ->  bool  
+val someU: t -> (value -> bool [@bs]) -> bool
+val some: t -> (value -> bool) ->  bool  
 (** [some p s] checks if at least one element of
     the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (elt -> bool [@bs]) ->  t
-val keep: t -> (elt -> bool) ->  t  
+val keepU: t -> (value -> bool [@bs]) ->  t
+val keep: t -> (value -> bool) ->  t  
 (** [keep s p] returns a fresh copy of the set of all elements in [s]
     that satisfy predicate [p]. *)
 
-val partitionU: t -> (elt -> bool [@bs]) ->  t * t
-val partition: t -> (elt -> bool) ->  t * t 
+val partitionU: t -> (value -> bool [@bs]) ->  t * t
+val partition: t -> (value -> bool) ->  t * t 
 (** [partition s p] returns a fresh copy pair of sets [(s1, s2)], where
     [s1] is the set of all the elements of [s] that satisfy the
     predicate [p], and [s2] is the set of all the elements of
     [s] that do not satisfy [p]. *)
 
 val size: t -> int
-val toList: t -> elt list
+val toList: t -> value list
  (** In increasing order with respect *)
-val toArray: t -> elt array
+val toArray: t -> value array
 
 
-val minimum: t -> elt option
-val minUndefined: t -> elt Js.undefined
-val maximum: t -> elt option
-val maxUndefined: t -> elt Js.undefined
+val minimum: t -> value option
+val minUndefined: t -> value Js.undefined
+val maximum: t -> value option
+val maxUndefined: t -> value Js.undefined
 
-val get:  t -> elt -> elt option
-val getUndefined:  t -> elt -> elt Js.undefined
-val getExn: t -> elt -> elt
-val split:  t -> elt  -> (t * t) * bool 
+val get:  t -> value -> value option
+val getUndefined:  t -> value -> value Js.undefined
+val getExn: t -> value -> value
+val split:  t -> value  -> (t * t) * bool 
 (**
     [split s key] return a fresh copy of each
 *)

--- a/jscomp/others/belt_MutableSetString.ml
+++ b/jscomp/others/belt_MutableSetString.ml
@@ -35,7 +35,7 @@ module S = Belt_SortArrayString
 module N = Belt_internalAVLset
 module A = Belt_Array 
 
-type elt = I.elt
+type value = I.value
 (** The type of the set elements. *)
              
 
@@ -45,7 +45,7 @@ type t = {
 (** The type of sets. *)
 
 
-let rec remove0 nt (x : elt)= 
+let rec remove0 nt (x : value)= 
   let k = N.key nt in 
   if x = k then 
     let l,r = N.(left nt, right nt) in       
@@ -98,7 +98,7 @@ let removeMany  (d : t) xs =
     let len = A.length xs in 
     dataSet d  (removeMany0 nt xs 0 len) 
     
-let rec removeCheck0  nt (x : elt) removed = 
+let rec removeCheck0  nt (x : value) removed = 
   let k = N.key nt in 
   if x = k then 
     let () = removed := true in  
@@ -139,7 +139,7 @@ let removeCheck  (d :  t) v =
     !removed
 
     
-let rec addCheck0  t (x : elt) added  =   
+let rec addCheck0  t (x : value) added  =   
   match N.toOpt t with 
   | None -> 
     added := true;

--- a/jscomp/others/belt_MutableSetString.mli
+++ b/jscomp/others/belt_MutableSetString.mli
@@ -33,7 +33,7 @@
 
 
 # 35
-type elt = string
+type value = string
 # 41
 (** The type of the set elements. *)
 
@@ -43,18 +43,18 @@ type t
   
 val make: unit -> t
 
-val ofArray: elt array -> t
-val ofSortedArrayUnsafe: elt array -> t
+val ofArray: value array -> t
+val ofSortedArrayUnsafe: value array -> t
 val copy: t -> t 
 val isEmpty: t -> bool
-val has: t -> elt -> bool
+val has: t -> value -> bool
 
-val add: t -> elt -> unit
-val addCheck: t -> elt -> bool 
-val mergeMany: t -> elt array -> unit
-val remove: t -> elt -> unit
-val removeCheck: t -> elt -> bool 
-val removeMany: t -> elt array -> unit
+val add: t -> value -> unit
+val addCheck: t -> value -> bool 
+val mergeMany: t -> value array -> unit
+val remove: t -> value -> unit
+val removeCheck: t -> value -> bool 
+val removeMany: t -> value array -> unit
   
 val union: t -> t -> t
 val intersect: t -> t -> t
@@ -65,51 +65,51 @@ val cmp: t -> t -> int
 val eq: t -> t -> bool
 
 
-val forEachU: t -> (elt -> unit [@bs]) ->  unit
-val forEach: t -> (elt -> unit ) ->  unit
+val forEachU: t -> (value -> unit [@bs]) ->  unit
+val forEach: t -> (value -> unit ) ->  unit
 (** In increasing order*)
 
-val reduceU: t -> 'a -> ('a -> elt -> 'a [@bs]) -> 'a
-val reduce: t -> 'a -> ('a -> elt -> 'a ) -> 'a  
+val reduceU: t -> 'a -> ('a -> value -> 'a [@bs]) -> 'a
+val reduce: t -> 'a -> ('a -> value -> 'a ) -> 'a  
 (** Iterate in increasing order. *)
 
-val everyU: t -> (elt -> bool [@bs]) -> bool
-val every: t -> (elt -> bool) ->  bool  
+val everyU: t -> (value -> bool [@bs]) -> bool
+val every: t -> (value -> bool) ->  bool  
 (** [every p s] checks if all elements of the set
     satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (elt -> bool [@bs]) -> bool
-val some: t -> (elt -> bool) ->  bool  
+val someU: t -> (value -> bool [@bs]) -> bool
+val some: t -> (value -> bool) ->  bool  
 (** [some p s] checks if at least one element of
     the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (elt -> bool [@bs]) ->  t
-val keep: t -> (elt -> bool) ->  t  
+val keepU: t -> (value -> bool [@bs]) ->  t
+val keep: t -> (value -> bool) ->  t  
 (** [keep s p] returns a fresh copy of the set of all elements in [s]
     that satisfy predicate [p]. *)
 
-val partitionU: t -> (elt -> bool [@bs]) ->  t * t
-val partition: t -> (elt -> bool) ->  t * t 
+val partitionU: t -> (value -> bool [@bs]) ->  t * t
+val partition: t -> (value -> bool) ->  t * t 
 (** [partition s p] returns a fresh copy pair of sets [(s1, s2)], where
     [s1] is the set of all the elements of [s] that satisfy the
     predicate [p], and [s2] is the set of all the elements of
     [s] that do not satisfy [p]. *)
 
 val size: t -> int
-val toList: t -> elt list
+val toList: t -> value list
  (** In increasing order with respect *)
-val toArray: t -> elt array
+val toArray: t -> value array
 
 
-val minimum: t -> elt option
-val minUndefined: t -> elt Js.undefined
-val maximum: t -> elt option
-val maxUndefined: t -> elt Js.undefined
+val minimum: t -> value option
+val minUndefined: t -> value Js.undefined
+val maximum: t -> value option
+val maxUndefined: t -> value Js.undefined
 
-val get:  t -> elt -> elt option
-val getUndefined:  t -> elt -> elt Js.undefined
-val getExn: t -> elt -> elt
-val split:  t -> elt  -> (t * t) * bool 
+val get:  t -> value -> value option
+val getUndefined:  t -> value -> value Js.undefined
+val getExn: t -> value -> value
+val split:  t -> value  -> (t * t) * bool 
 (**
     [split s key] return a fresh copy of each
 *)

--- a/jscomp/others/belt_Set.ml
+++ b/jscomp/others/belt_Set.ml
@@ -41,7 +41,7 @@ end
 
 type ('k, 'id) t = ('k, 'id) S.t
     
-let ofArray (type elt) (type identity) data ~(id : (elt,identity) id)  = 
+let ofArray (type value) (type identity) data ~(id : (value,identity) id)  = 
   let module M = (val id ) in
   let cmp = M.cmp in 
   S.t ~cmp ~data:(Dict.ofArray ~cmp data)
@@ -88,7 +88,7 @@ let split m e =
   let (l,  r), b = Dict.split ~cmp (S.data m) e in 
   (S.t ~cmp ~data:l, S.t ~cmp ~data:r), b
   
-let make (type elt) (type identity) ~(id : (elt, identity) id) =
+let make (type value) (type identity) ~(id : (value, identity) id) =
   let module M = (val id) in 
   S.t ~cmp:M.cmp  ~data:Dict.empty
 
@@ -145,7 +145,7 @@ let getExn m e =
 let has m e = 
   Dict.has ~cmp:(S.cmp m) (S.data m) e
 
-let ofSortedArrayUnsafe (type elt) (type identity) xs ~(id : (elt,identity) id ) =
+let ofSortedArrayUnsafe (type value) (type identity) xs ~(id : (value,identity) id ) =
   let module M = (val id) in 
   S.t ~cmp:M.cmp ~data:(Dict.ofSortedArrayUnsafe xs)
 
@@ -154,15 +154,15 @@ let ofSortedArrayUnsafe (type elt) (type identity) xs ~(id : (elt,identity) id )
 
 let getData = S.data
 
-let getId (type elt) (type identity) (m : (elt,identity) t) : (elt, identity) id =
+let getId (type value) (type identity) (m : (value,identity) t) : (value, identity) id =
   let module T = struct
     type nonrec identity = identity
-    type nonrec t = elt
+    type nonrec t = value
     let cmp =  S.cmp m
   end in
   (module T)
   
-let packIdData (type elt) (type identity) ~(id : (elt, identity) id) ~data  =
+let packIdData (type value) (type identity) ~(id : (value, identity) id) ~data  =
   let module M = (val id) in 
   S.t ~cmp:M.cmp ~data
 

--- a/jscomp/others/belt_Set.mli
+++ b/jscomp/others/belt_Set.mli
@@ -104,7 +104,7 @@ type ('key, 'id) id = ('key, 'id) Belt_Id.comparable
 (** The identity needed for making a set from scratch
 *)
 
-val make: id:('elt, 'id) id -> ('elt, 'id) t
+val make: id:('value, 'id) id -> ('value, 'id) t
 (** [make ~id]
    
      @example {[
@@ -128,7 +128,7 @@ val ofArray:  'k array -> id:('k, 'id) id ->  ('k, 'id) t
 *)
 
 
-val ofSortedArrayUnsafe: 'elt array -> id:('elt, 'id) id -> ('elt,'id) t
+val ofSortedArrayUnsafe: 'value array -> id:('value, 'id) id -> ('value,'id) t
 (** [ofSortedArrayUnsafe xs ~id]
 
     The same as {!ofArray} except it is after assuming the input array [x] is already sorted
@@ -148,7 +148,7 @@ val isEmpty: _ t -> bool
      isEmpty (ofArray [|1|] ~id:(module IntCmp)) = true;;  
    ]}
 *)
-val has: ('elt, 'id) t -> 'elt ->  bool
+val has: ('value, 'id) t -> 'value ->  bool
 (**
    @example {[
      module IntCmp =
@@ -162,7 +162,7 @@ val has: ('elt, 'id) t -> 'elt ->  bool
 *)
 
 val add:   
-  ('elt, 'id) t -> 'elt -> ('elt, 'id) t
+  ('value, 'id) t -> 'value -> ('value, 'id) t
 (** [add s x] If [x] was already in [s], [s] is returned unchanged.
 
     @example {[
@@ -182,7 +182,7 @@ val add:
     ]}
 *)
     
-val mergeMany: ('elt, 'id) t -> 'elt array -> ('elt, 'id) t 
+val mergeMany: ('value, 'id) t -> 'value array -> ('value, 'id) t 
 (** [mergeMany s xs]
 
     Adding each of [xs] to [s], note unlike {!add},
@@ -190,7 +190,7 @@ val mergeMany: ('elt, 'id) t -> 'elt array -> ('elt, 'id) t
     exist [s]
    
 *)
-val remove: ('elt, 'id) t -> 'elt -> ('elt, 'id) t
+val remove: ('value, 'id) t -> 'value -> ('value, 'id) t
 (** [remove m x] If [x] was not in [m], [m] is returned reference unchanged.
 
     @example {[
@@ -210,7 +210,7 @@ val remove: ('elt, 'id) t -> 'elt -> ('elt, 'id) t
 *)
 
 val removeMany:
-  ('elt, 'id) t -> 'elt array -> ('elt, 'id) t
+  ('value, 'id) t -> 'value array -> ('value, 'id) t
 (** [removeMany s xs]
 
     Removing each of [xs] to [s], note unlike {!remove},
@@ -218,7 +218,7 @@ val removeMany:
     exists [s]
 *)    
 
-val union: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t
+val union: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 (**
    [union s0 s1]
 
@@ -233,7 +233,7 @@ val union: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t
    ]}
 *)
 
-val intersect: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t
+val intersect: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 (** [intersect s0 s1]
    @example {[
      module IntCmp =
@@ -246,7 +246,7 @@ val intersect: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t
    ]}
 
 *)    
-val diff: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t
+val diff: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 (** [diff s0 s1]
     @example {[
       module IntCmp =
@@ -260,7 +260,7 @@ val diff: ('elt, 'id) t -> ('elt, 'id) t -> ('elt, 'id) t
     ]}
 *)
 
-val subset: ('elt, 'id) t -> ('elt, 'id) t -> bool     
+val subset: ('value, 'id) t -> ('value, 'id) t -> bool     
 (** [subset s0 s1]
 
     @example {[
@@ -277,21 +277,21 @@ val subset: ('elt, 'id) t -> ('elt, 'id) t -> bool
     ]}
 *)
   
-val cmp: ('elt, 'id) t -> ('elt, 'id) t -> int
+val cmp: ('value, 'id) t -> ('value, 'id) t -> int
 (** Total ordering between sets. Can be used as the ordering function
     for doing sets of sets.
     It compare [size] first and then iterate over
     each element following the order of elements
 *)
   
-val eq: ('elt, 'id) t -> ('elt, 'id) t -> bool
+val eq: ('value, 'id) t -> ('value, 'id) t -> bool
 (** [eq s0 s1]
 
     @return true if [toArray s0 = toArray s1] 
 *)
   
-val forEachU: ('elt, 'id) t -> ('elt -> unit [@bs]) ->  unit
-val forEach: ('elt, 'id) t -> ('elt -> unit ) ->  unit  
+val forEachU: ('value, 'id) t -> ('value -> unit [@bs]) ->  unit
+val forEach: ('value, 'id) t -> ('value -> unit ) ->  unit  
 (** [forEach s f] applies [f] in turn to all elements of [s].
     In increasing order
 
@@ -307,8 +307,8 @@ val forEach: ('elt, 'id) t -> ('elt -> unit ) ->  unit
     ]}
 *)
 
-val reduceU: ('elt, 'id) t -> 'a  -> ('a -> 'elt -> 'a [@bs]) ->  'a
-val reduce: ('elt, 'id) t -> 'a  -> ('a -> 'elt -> 'a ) ->  'a  
+val reduceU: ('value, 'id) t -> 'a  -> ('a -> 'value -> 'a [@bs]) ->  'a
+val reduce: ('value, 'id) t -> 'a  -> ('a -> 'value -> 'a ) ->  'a  
 (** In increasing order.
 
     @example {[
@@ -321,30 +321,30 @@ val reduce: ('elt, 'id) t -> 'a  -> ('a -> 'elt -> 'a ) ->  'a
     ]}
 *)
 
-val everyU: ('elt, 'id) t -> ('elt -> bool [@bs]) -> bool
-val every: ('elt, 'id) t -> ('elt -> bool ) -> bool  
+val everyU: ('value, 'id) t -> ('value -> bool [@bs]) -> bool
+val every: ('value, 'id) t -> ('value -> bool ) -> bool  
 (** [every p s] checks if all elements of the set
     satisfy the predicate [p]. Order unspecified.
 *)
 
-val someU: ('elt, 'id) t ->  ('elt -> bool [@bs]) -> bool
-val some: ('elt, 'id) t ->  ('elt -> bool ) -> bool  
+val someU: ('value, 'id) t ->  ('value -> bool [@bs]) -> bool
+val some: ('value, 'id) t ->  ('value -> bool ) -> bool  
 (** [some p s] checks if at least one element of
     the set satisfies the predicate [p]. *)
 
-val keepU: ('elt, 'id) t ->  ('elt -> bool [@bs]) -> ('elt, 'id) t
-val keep: ('elt, 'id) t ->  ('elt -> bool ) -> ('elt, 'id) t    
+val keepU: ('value, 'id) t ->  ('value -> bool [@bs]) -> ('value, 'id) t
+val keep: ('value, 'id) t ->  ('value -> bool ) -> ('value, 'id) t    
 (** [keep m p] returns the set of all elements in [s]
     that satisfy predicate [p]. *)
     
-val partitionU: ('elt, 'id) t -> ('elt -> bool [@bs]) ->  ('elt, 'id) t * ('elt, 'id) t
-val partition: ('elt, 'id) t -> ('elt -> bool) ->  ('elt, 'id) t * ('elt, 'id) t
+val partitionU: ('value, 'id) t -> ('value -> bool [@bs]) ->  ('value, 'id) t * ('value, 'id) t
+val partition: ('value, 'id) t -> ('value -> bool) ->  ('value, 'id) t * ('value, 'id) t
 (** [partition m p] returns a pair of sets [(s1, s2)], where
     [s1] is the set of all the elements of [s] that satisfy the
     predicate [p], and [s2] is the set of all the elements of
     [s] that do not satisfy [p]. *)
 
-val size:  ('elt, 'id) t -> int
+val size:  ('value, 'id) t -> int
 (** [size s]
 
     @example {[
@@ -357,7 +357,7 @@ val size:  ('elt, 'id) t -> int
     ]}
 *)
   
-val toArray: ('elt, 'id) t -> 'elt array
+val toArray: ('value, 'id) t -> 'value array
 (** [toArray s0]
    @example {[
       module IntCmp =
@@ -368,36 +368,36 @@ val toArray: ('elt, 'id) t -> 'elt array
       toArray s0 = [|2;3;5;6|];;
     ]}*)
     
-val toList: ('elt, 'id) t -> 'elt list
+val toList: ('value, 'id) t -> 'value list
 (** In increasing order
 
     {b See} {!toArray}
 *)
 
-val minimum: ('elt, 'id) t -> 'elt option
+val minimum: ('value, 'id) t -> 'value option
 (** [minimum s0]
 
     @return the minimum element of the collection, [None] if it is empty
 *)    
 
-val minUndefined: ('elt, 'id) t -> 'elt Js.undefined
+val minUndefined: ('value, 'id) t -> 'value Js.undefined
 (** [minUndefined s0]
 
    @return the minimum element of the collection, [undefined] if it is empty
 *)    
 
-val maximum: ('elt, 'id) t -> 'elt option
+val maximum: ('value, 'id) t -> 'value option
 (** [maximum s0]
 
     @return the maximum element of the collection, [None] if it is empty
 *)    
-val maxUndefined: ('elt, 'id) t -> 'elt Js.undefined
+val maxUndefined: ('value, 'id) t -> 'value Js.undefined
 (** [maxUndefined s0]
 
     @return the maximum element of the collection, [undefined] if it is empty
 *)    
 
-val get: ('elt, 'id) t -> 'elt -> 'elt option
+val get: ('value, 'id) t -> 'value -> 'value option
 (** [get s0 k]
 
     @return the reference of the value [k'] which is equivalent to [k]
@@ -405,17 +405,17 @@ val get: ('elt, 'id) t -> 'elt -> 'elt option
     if it does not exist
 *)
 
-val getUndefined: ('elt, 'id) t -> 'elt -> 'elt Js.undefined
+val getUndefined: ('value, 'id) t -> 'value -> 'value Js.undefined
 (** {b See} {!get}
     *)    
 
-val getExn: ('elt, 'id) t -> 'elt -> 'elt
+val getExn: ('value, 'id) t -> 'value -> 'value
 (** {b See} {!get}
 
     {b raise} if not exist
 *)  
 
-val split: ('elt, 'id) t -> 'elt -> (('elt, 'id) t  * ('elt, 'id) t) * bool
+val split: ('value, 'id) t -> 'value -> (('value, 'id) t  * ('value, 'id) t) * bool
 (** [split set ele]
 
     @return  a tuple [((smaller, larger), present)],

--- a/jscomp/others/belt_SetDict.mli
+++ b/jscomp/others/belt_SetDict.mli
@@ -26,14 +26,14 @@ type ('key, 'id) t
 
 type ('key, 'id) cmp = ('key, 'id) Belt_Id.cmp
     
-val empty: ('elt, 'id) t
+val empty: ('value, 'id) t
 
 val ofArray:
   'k array ->
   cmp:('k, 'id) cmp ->
   ('k, 'id) t
 
-val ofSortedArrayUnsafe: 'elt array ->  ('elt,'id) t
+val ofSortedArrayUnsafe: 'value array ->  ('value,'id) t
     
 val isEmpty: _ t -> bool
 val has:
@@ -49,104 +49,104 @@ val add:
 (** [add s x] If [x] was already in [s], [s] is returned unchanged. *)
     
 val mergeMany:
-  ('elt, 'id) t -> 'elt array ->
-  cmp:('elt, 'id) cmp ->
-  ('elt, 'id) t 
+  ('value, 'id) t -> 'value array ->
+  cmp:('value, 'id) cmp ->
+  ('value, 'id) t 
 
 val remove:
-  ('elt, 'id) t ->
-  'elt ->
-  cmp:('elt, 'id) cmp ->
-  ('elt, 'id) t
+  ('value, 'id) t ->
+  'value ->
+  cmp:('value, 'id) cmp ->
+  ('value, 'id) t
 (** [remove m x] If [x] was not in [m], [m] is returned reference unchanged. *)
 
 val removeMany:
-  ('elt, 'id) t -> 'elt array ->
-  cmp:('elt, 'id) cmp ->
-  ('elt, 'id) t 
+  ('value, 'id) t -> 'value array ->
+  cmp:('value, 'id) cmp ->
+  ('value, 'id) t 
 
 
 val union:
-  ('elt, 'id) t -> ('elt, 'id) t ->
-  cmp:('elt, 'id) cmp ->
-  ('elt, 'id) t
+  ('value, 'id) t -> ('value, 'id) t ->
+  cmp:('value, 'id) cmp ->
+  ('value, 'id) t
 val intersect:
-  ('elt, 'id) t -> ('elt, 'id) t ->
-    cmp:('elt, 'id) cmp ->
-  ('elt, 'id) t
+  ('value, 'id) t -> ('value, 'id) t ->
+    cmp:('value, 'id) cmp ->
+  ('value, 'id) t
     
-val diff: ('elt, 'id) t -> ('elt, 'id) t ->
-  cmp:('elt, 'id) cmp ->
-  ('elt, 'id) t
-val subset: ('elt, 'id) t -> ('elt, 'id) t ->
-  cmp:('elt, 'id) cmp ->
+val diff: ('value, 'id) t -> ('value, 'id) t ->
+  cmp:('value, 'id) cmp ->
+  ('value, 'id) t
+val subset: ('value, 'id) t -> ('value, 'id) t ->
+  cmp:('value, 'id) cmp ->
   bool     
 
-val cmp: ('elt, 'id) t -> ('elt, 'id) t ->
-  cmp:('elt, 'id) cmp ->
+val cmp: ('value, 'id) t -> ('value, 'id) t ->
+  cmp:('value, 'id) cmp ->
   int
 (** Total ordering between sets. Can be used as the ordering function
     for doing sets of sets. *)
-val eq: ('elt, 'id) t -> ('elt, 'id) t ->
-  cmp:('elt, 'id) cmp ->
+val eq: ('value, 'id) t -> ('value, 'id) t ->
+  cmp:('value, 'id) cmp ->
   bool
 
-val forEachU: ('elt, 'id) t -> ('elt -> unit [@bs]) ->  unit
-val forEach: ('elt, 'id) t -> ('elt -> unit ) ->  unit  
+val forEachU: ('value, 'id) t -> ('value -> unit [@bs]) ->  unit
+val forEach: ('value, 'id) t -> ('value -> unit ) ->  unit  
 (** [forEach s f] applies [f] in turn to all elements of [s].
     In increasing order *)
   
-val reduceU: ('elt, 'id) t -> 'a  -> ('a -> 'elt -> 'a [@bs]) ->  'a
-val reduce: ('elt, 'id) t -> 'a  -> ('a -> 'elt -> 'a) ->  'a  
+val reduceU: ('value, 'id) t -> 'a  -> ('a -> 'value -> 'a [@bs]) ->  'a
+val reduce: ('value, 'id) t -> 'a  -> ('a -> 'value -> 'a) ->  'a  
 (** In increasing order. *)
 
-val everyU: ('elt, 'id) t -> ('elt -> bool [@bs]) -> bool
-val every: ('elt, 'id) t -> ('elt -> bool) -> bool  
+val everyU: ('value, 'id) t -> ('value -> bool [@bs]) -> bool
+val every: ('value, 'id) t -> ('value -> bool) -> bool  
 (** [every p s] checks if all elements of the set
     satisfy the predicate [p]. Order unspecified *)
 
-val someU: ('elt, 'id) t ->  ('elt -> bool [@bs]) -> bool
-val some: ('elt, 'id) t ->  ('elt -> bool) -> bool  
+val someU: ('value, 'id) t ->  ('value -> bool [@bs]) -> bool
+val some: ('value, 'id) t ->  ('value -> bool) -> bool  
 (** [some p s] checks if at least one element of
     the set satisfies the predicate [p]. *)
 
-val keepU: ('elt, 'id) t ->  ('elt -> bool [@bs]) -> ('elt, 'id) t
-val keep: ('elt, 'id) t ->  ('elt -> bool) -> ('elt, 'id) t
+val keepU: ('value, 'id) t ->  ('value -> bool [@bs]) -> ('value, 'id) t
+val keep: ('value, 'id) t ->  ('value -> bool) -> ('value, 'id) t
 (** [keep m p] returns the set of all elements in [s]
     that satisfy predicate [p]. *)    
 
-val partitionU: ('elt, 'id) t -> ('elt -> bool [@bs]) ->  ('elt, 'id) t * ('elt, 'id) t
-val partition: ('elt, 'id) t -> ('elt -> bool ) ->  ('elt, 'id) t * ('elt, 'id) t                                                            
+val partitionU: ('value, 'id) t -> ('value -> bool [@bs]) ->  ('value, 'id) t * ('value, 'id) t
+val partition: ('value, 'id) t -> ('value -> bool ) ->  ('value, 'id) t * ('value, 'id) t                                                            
 (** [partition m p] returns a pair of sets [(s1, s2)], where
     [s1] is the set of all the elements of [s] that satisfy the
     predicate [p], and [s2] is the set of all the elements of
     [s] that do not satisfy [p]. *)
 
-val size:  ('elt, 'id) t -> int
-val toList: ('elt, 'id) t -> 'elt list
+val size:  ('value, 'id) t -> int
+val toList: ('value, 'id) t -> 'value list
 (** In increasing order*)
-val toArray: ('elt, 'id) t -> 'elt array
+val toArray: ('value, 'id) t -> 'value array
 
-val minimum: ('elt, 'id) t -> 'elt option
-val minUndefined: ('elt, 'id) t -> 'elt Js.undefined
-val maximum: ('elt, 'id) t -> 'elt option
-val maxUndefined: ('elt, 'id) t -> 'elt Js.undefined
+val minimum: ('value, 'id) t -> 'value option
+val minUndefined: ('value, 'id) t -> 'value Js.undefined
+val maximum: ('value, 'id) t -> 'value option
+val maxUndefined: ('value, 'id) t -> 'value Js.undefined
 
 
 
-val get: ('elt, 'id) t -> 'elt ->
-  cmp:('elt, 'id) cmp ->
-  'elt option 
-val getUndefined: ('elt, 'id) t -> 'elt ->
-  cmp:('elt, 'id) cmp ->
-  'elt Js.undefined
-val getExn: ('elt, 'id) t -> 'elt ->
-  cmp:('elt, 'id) cmp ->
-  'elt 
+val get: ('value, 'id) t -> 'value ->
+  cmp:('value, 'id) cmp ->
+  'value option 
+val getUndefined: ('value, 'id) t -> 'value ->
+  cmp:('value, 'id) cmp ->
+  'value Js.undefined
+val getExn: ('value, 'id) t -> 'value ->
+  cmp:('value, 'id) cmp ->
+  'value 
 
-val split: ('elt, 'id) t -> 'elt ->
-  cmp:('elt, 'id) cmp ->
-  (('elt, 'id) t  * ('elt, 'id) t) * bool
+val split: ('value, 'id) t -> 'value ->
+  cmp:('value, 'id) cmp ->
+  (('value, 'id) t  * ('value, 'id) t) * bool
                                     
 val checkInvariantInternal: _ t -> unit
 (**

--- a/jscomp/others/belt_SetInt.ml
+++ b/jscomp/others/belt_SetInt.ml
@@ -4,7 +4,7 @@ module I = Belt_internalSetInt
 module N = Belt_internalAVLset
 module A = Belt_Array
 
-type elt = I.elt
+type value = I.value
 type t = I.t 
 
 
@@ -34,7 +34,7 @@ let toArray = N.toArray
 let ofSortedArrayUnsafe = N.ofSortedArrayUnsafe
 let checkInvariantInternal = N.checkInvariantInternal
 
-let rec add  (t : t) (x : elt) : t =
+let rec add  (t : t) (x : value) : t =
   match N.toOpt t with 
     None -> N.singleton x 
   | Some nt  ->
@@ -60,7 +60,7 @@ let mergeMany h arr =
   !v 
 
 
-let rec remove (t : t) (x : elt) : t = 
+let rec remove (t : t) (x : value) : t = 
   match N.toOpt t with 
   | None -> t
   | Some n  ->
@@ -101,7 +101,7 @@ let getExn = I.getExn
 let subset = I.subset 
 let has = I.has
 
-let rec splitAuxNoPivot (n : _ N.node) (x : elt) : t * t =   
+let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =   
   let l,v,r = N.(left n , key n, right n) in  
   if x = v then l,  r
   else if x < v then
@@ -120,7 +120,7 @@ let rec splitAuxNoPivot (n : _ N.node) (x : elt) : t * t =
       N.joinShared l v lr,  rr
 
 
-let rec splitAuxPivot (n : _ N.node) (x : elt) pres : t  * t =   
+let rec splitAuxPivot (n : _ N.node) (x : value) pres : t  * t =   
   let l,v,r = N.(left n , key n, right n) in  
   if x = v then begin 
     pres := true;  
@@ -142,7 +142,7 @@ let rec splitAuxPivot (n : _ N.node) (x : elt) pres : t  * t =
       N.joinShared l v lr,  rr
 
 
-let split  (t : t) (x : elt) =
+let split  (t : t) (x : value) =
   match N.toOpt t with 
     None ->
     (N.empty,  N.empty), false

--- a/jscomp/others/belt_SetInt.mli
+++ b/jscomp/others/belt_SetInt.mli
@@ -31,7 +31,7 @@
 *)
 
 # 35
-type elt = int
+type value = int
 # 39
 (** The type of the set elements. *)
 
@@ -42,17 +42,17 @@ type t
 val empty: t
 
 
-val ofArray: elt array -> t
-val ofSortedArrayUnsafe: elt array -> t     
+val ofArray: value array -> t
+val ofSortedArrayUnsafe: value array -> t     
 val isEmpty: t -> bool
-val has: t -> elt -> bool
+val has: t -> value -> bool
   
-val add:  t -> elt -> t
+val add:  t -> value -> t
 (** If [x] was already in [s], [s] is returned unchanged. *)
-val mergeMany: t -> elt array -> t 
-val remove:  t -> elt -> t
+val mergeMany: t -> value array -> t 
+val remove:  t -> value -> t
 (**  If [x] was not in [s], [s] is returned unchanged. *)
-val removeMany: t -> elt array -> t
+val removeMany: t -> value array -> t
   
 val union: t -> t -> t
 val intersect: t -> t -> t
@@ -70,53 +70,53 @@ val eq: t -> t -> bool
    equal, that is, contain equal elements. *)
 
 
-val forEachU: t -> (elt -> unit [@bs]) ->  unit
-val forEach: t -> (elt -> unit ) ->  unit  
+val forEachU: t -> (value -> unit [@bs]) ->  unit
+val forEach: t -> (value -> unit ) ->  unit  
 (** In increasing order*)
 
-val reduceU: t -> 'a -> ('a -> elt ->  'a [@bs]) ->  'a
-val reduce: t -> 'a -> ('a -> elt ->  'a ) ->  'a  
+val reduceU: t -> 'a -> ('a -> value ->  'a [@bs]) ->  'a
+val reduce: t -> 'a -> ('a -> value ->  'a ) ->  'a  
 (** Iterate in increasing order. *)
 
-val everyU: t -> (elt -> bool [@bs]) ->  bool
-val every: t -> (elt -> bool ) ->  bool  
+val everyU: t -> (value -> bool [@bs]) ->  bool
+val every: t -> (value -> bool ) ->  bool  
 (** [every p s] checks if all elements of the set
    satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (elt -> bool [@bs]) ->  bool
-val some: t -> (elt -> bool ) ->  bool  
+val someU: t -> (value -> bool [@bs]) ->  bool
+val some: t -> (value -> bool ) ->  bool  
 (** [some p s] checks if at least one element of
    the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (elt -> bool [@bs]) ->  t
-val keep: t -> (elt -> bool ) ->  t  
+val keepU: t -> (value -> bool [@bs]) ->  t
+val keep: t -> (value -> bool ) ->  t  
 (** [keep p s] returns the set of all elements in [s]
    that satisfy predicate [p]. *)
 
-val partitionU: t -> (elt -> bool [@bs]) ->  t * t
-val partition: t -> (elt -> bool ) ->  t * t
+val partitionU: t -> (value -> bool [@bs]) ->  t * t
+val partition: t -> (value -> bool ) ->  t * t
 (** [partition p s] returns a pair of sets [(s1, s2)], where
    [s1] is the set of all the elements of [s] that satisfy the
    predicate [p], and [s2] is the set of all the elements of
    [s] that do not satisfy [p]. *)
 
 val size: t -> int
-val toList: t -> elt list
+val toList: t -> value list
 (** In increasing order with respect *)
-val toArray: t -> elt array
+val toArray: t -> value array
 
 
-val minimum: t -> elt option
-val minUndefined: t -> elt Js.undefined
-val maximum: t -> elt option
-val maxUndefined: t -> elt Js.undefined
+val minimum: t -> value option
+val minUndefined: t -> value Js.undefined
+val maximum: t -> value option
+val maxUndefined: t -> value Js.undefined
 
 
 
-val get:  t -> elt -> elt option
-val getUndefined:  t -> elt -> elt Js.undefined
-val getExn: t -> elt -> elt    
-val split:  t -> elt -> (t * t) * bool  
+val get:  t -> value -> value option
+val getUndefined:  t -> value -> value Js.undefined
+val getExn: t -> value -> value    
+val split:  t -> value -> (t * t) * bool  
 (** [split x s] returns a triple [(l, present, r)], where
       [l] is the set of elements of [s] that are
       strictly less than [x];

--- a/jscomp/others/belt_SetString.ml
+++ b/jscomp/others/belt_SetString.ml
@@ -4,7 +4,7 @@ module I = Belt_internalSetString
 module N = Belt_internalAVLset
 module A = Belt_Array
 
-type elt = I.elt
+type value = I.value
 type t = I.t 
 
 
@@ -34,7 +34,7 @@ let toArray = N.toArray
 let ofSortedArrayUnsafe = N.ofSortedArrayUnsafe
 let checkInvariantInternal = N.checkInvariantInternal
 
-let rec add  (t : t) (x : elt) : t =
+let rec add  (t : t) (x : value) : t =
   match N.toOpt t with 
     None -> N.singleton x 
   | Some nt  ->
@@ -60,7 +60,7 @@ let mergeMany h arr =
   !v 
 
 
-let rec remove (t : t) (x : elt) : t = 
+let rec remove (t : t) (x : value) : t = 
   match N.toOpt t with 
   | None -> t
   | Some n  ->
@@ -101,7 +101,7 @@ let getExn = I.getExn
 let subset = I.subset 
 let has = I.has
 
-let rec splitAuxNoPivot (n : _ N.node) (x : elt) : t * t =   
+let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =   
   let l,v,r = N.(left n , key n, right n) in  
   if x = v then l,  r
   else if x < v then
@@ -120,7 +120,7 @@ let rec splitAuxNoPivot (n : _ N.node) (x : elt) : t * t =
       N.joinShared l v lr,  rr
 
 
-let rec splitAuxPivot (n : _ N.node) (x : elt) pres : t  * t =   
+let rec splitAuxPivot (n : _ N.node) (x : value) pres : t  * t =   
   let l,v,r = N.(left n , key n, right n) in  
   if x = v then begin 
     pres := true;  
@@ -142,7 +142,7 @@ let rec splitAuxPivot (n : _ N.node) (x : elt) pres : t  * t =
       N.joinShared l v lr,  rr
 
 
-let split  (t : t) (x : elt) =
+let split  (t : t) (x : value) =
   match N.toOpt t with 
     None ->
     (N.empty,  N.empty), false

--- a/jscomp/others/belt_SetString.mli
+++ b/jscomp/others/belt_SetString.mli
@@ -31,7 +31,7 @@
 *)
 
 # 33
-type elt = string
+type value = string
 # 39
 (** The type of the set elements. *)
 
@@ -42,17 +42,17 @@ type t
 val empty: t
 
 
-val ofArray: elt array -> t
-val ofSortedArrayUnsafe: elt array -> t     
+val ofArray: value array -> t
+val ofSortedArrayUnsafe: value array -> t     
 val isEmpty: t -> bool
-val has: t -> elt -> bool
+val has: t -> value -> bool
   
-val add:  t -> elt -> t
+val add:  t -> value -> t
 (** If [x] was already in [s], [s] is returned unchanged. *)
-val mergeMany: t -> elt array -> t 
-val remove:  t -> elt -> t
+val mergeMany: t -> value array -> t 
+val remove:  t -> value -> t
 (**  If [x] was not in [s], [s] is returned unchanged. *)
-val removeMany: t -> elt array -> t
+val removeMany: t -> value array -> t
   
 val union: t -> t -> t
 val intersect: t -> t -> t
@@ -70,53 +70,53 @@ val eq: t -> t -> bool
    equal, that is, contain equal elements. *)
 
 
-val forEachU: t -> (elt -> unit [@bs]) ->  unit
-val forEach: t -> (elt -> unit ) ->  unit  
+val forEachU: t -> (value -> unit [@bs]) ->  unit
+val forEach: t -> (value -> unit ) ->  unit  
 (** In increasing order*)
 
-val reduceU: t -> 'a -> ('a -> elt ->  'a [@bs]) ->  'a
-val reduce: t -> 'a -> ('a -> elt ->  'a ) ->  'a  
+val reduceU: t -> 'a -> ('a -> value ->  'a [@bs]) ->  'a
+val reduce: t -> 'a -> ('a -> value ->  'a ) ->  'a  
 (** Iterate in increasing order. *)
 
-val everyU: t -> (elt -> bool [@bs]) ->  bool
-val every: t -> (elt -> bool ) ->  bool  
+val everyU: t -> (value -> bool [@bs]) ->  bool
+val every: t -> (value -> bool ) ->  bool  
 (** [every p s] checks if all elements of the set
    satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (elt -> bool [@bs]) ->  bool
-val some: t -> (elt -> bool ) ->  bool  
+val someU: t -> (value -> bool [@bs]) ->  bool
+val some: t -> (value -> bool ) ->  bool  
 (** [some p s] checks if at least one element of
    the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (elt -> bool [@bs]) ->  t
-val keep: t -> (elt -> bool ) ->  t  
+val keepU: t -> (value -> bool [@bs]) ->  t
+val keep: t -> (value -> bool ) ->  t  
 (** [keep p s] returns the set of all elements in [s]
    that satisfy predicate [p]. *)
 
-val partitionU: t -> (elt -> bool [@bs]) ->  t * t
-val partition: t -> (elt -> bool ) ->  t * t
+val partitionU: t -> (value -> bool [@bs]) ->  t * t
+val partition: t -> (value -> bool ) ->  t * t
 (** [partition p s] returns a pair of sets [(s1, s2)], where
    [s1] is the set of all the elements of [s] that satisfy the
    predicate [p], and [s2] is the set of all the elements of
    [s] that do not satisfy [p]. *)
 
 val size: t -> int
-val toList: t -> elt list
+val toList: t -> value list
 (** In increasing order with respect *)
-val toArray: t -> elt array
+val toArray: t -> value array
 
 
-val minimum: t -> elt option
-val minUndefined: t -> elt Js.undefined
-val maximum: t -> elt option
-val maxUndefined: t -> elt Js.undefined
+val minimum: t -> value option
+val minUndefined: t -> value Js.undefined
+val maximum: t -> value option
+val maxUndefined: t -> value Js.undefined
 
 
 
-val get:  t -> elt -> elt option
-val getUndefined:  t -> elt -> elt Js.undefined
-val getExn: t -> elt -> elt    
-val split:  t -> elt -> (t * t) * bool  
+val get:  t -> value -> value option
+val getUndefined:  t -> value -> value Js.undefined
+val getExn: t -> value -> value    
+val split:  t -> value -> (t * t) * bool  
 (** [split x s] returns a triple [(l, present, r)], where
       [l] is the set of elements of [s] that are
       strictly less than [x];

--- a/jscomp/others/belt_internalAVLset.ml
+++ b/jscomp/others/belt_internalAVLset.ml
@@ -24,13 +24,13 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
-type 'elt node  = {
-  mutable left : 'elt t;
-  mutable key : 'elt ; 
-  mutable right : 'elt t;
+type 'value node  = {
+  mutable left : 'value t;
+  mutable key : 'value ; 
+  mutable right : 'value t;
   mutable h : int 
 }
-and 'elt t =  'elt node Js.null
+and 'value t =  'value node Js.null
 [@@bs.deriving abstract]
 
 module A = Belt_Array

--- a/jscomp/others/belt_internalAVLset.mli
+++ b/jscomp/others/belt_internalAVLset.mli
@@ -29,11 +29,11 @@
   Such methods could be shared between 
   [generic set/specalized set] whether mutable or immutable depends on use cases
 *)
-type 'elt t = 'elt node Js.null
-and 'elt node  = private {
-  mutable left : 'elt t;
-   key : 'elt ; 
-  mutable right : 'elt t;
+type 'value t = 'value node Js.null
+and 'value node  = private {
+  mutable left : 'value t;
+   key : 'value ; 
+  mutable right : 'value t;
   h : int
 } [@@bs.deriving abstract]
 

--- a/jscomp/others/belt_internalSetInt.ml
+++ b/jscomp/others/belt_internalSetInt.ml
@@ -1,5 +1,5 @@
 # 5 "internal_set.cppo.ml"
-type elt = int
+type value = int
 module S = Belt_SortArrayInt
 
 
@@ -8,9 +8,9 @@ module N = Belt_internalAVLset
 module A = Belt_Array 
 
 
-type t = elt N.t
+type t = value N.t
 
-let rec has (t : t) (x : elt)  =
+let rec has (t : t) (x : value)  =
   match N.toOpt t with 
   | None -> false
   | Some n  ->                
@@ -21,7 +21,7 @@ let rec has (t : t) (x : elt)  =
 let rec compareAux e1 e2  =
     match e1,e2 with 
     | h1::t1, h2::t2 ->
-        let (k1 : elt) ,k2 = N.key h1, N.key h2 in 
+        let (k1 : value) ,k2 = N.key h1, N.key h2 in 
         if k1 = k2 then  
           compareAux 
             (N.stackAllLeft (N.right h1) t1 ) 
@@ -62,7 +62,7 @@ let rec subset (s1 : t) (s2 : t) =
       subset N.(create empty v1 r1 ) r2 && subset l1 s2
 
 
-let rec get (n :t) (x : elt) = 
+let rec get (n :t) (x : value) = 
   match N.toOpt n with 
   | None -> None
   | Some t  ->    
@@ -72,7 +72,7 @@ let rec get (n :t) (x : elt) =
 
 
 
-let rec getUndefined (n :t) (x : elt)   = 
+let rec getUndefined (n :t) (x : value)   = 
   match N.toOpt n with 
   | None -> Js.undefined
   | Some t  ->    
@@ -80,7 +80,7 @@ let rec getUndefined (n :t) (x : elt)   =
     if x = v then Js.Undefined.return v
     else getUndefined  (if x < v then N.left t else N.right t) x
 
-let rec getExn  (n :t) (x : elt) = 
+let rec getExn  (n :t) (x : value) = 
   match N.toOpt n with 
   | None -> [%assert "getExn"]
   | Some t  ->    
@@ -89,7 +89,7 @@ let rec getExn  (n :t) (x : elt) =
     else getExn (if x < v then N.left t else N.right t) x
 
 (****************************************************************************)
-let rec addMutate  t  (x : elt)=   
+let rec addMutate  t  (x : value)=   
   match N.toOpt t with 
   | None -> N.singleton x
   | Some nt -> 
@@ -106,7 +106,7 @@ let rec addMutate  t  (x : elt)=
 
 
 
-let ofArray (xs : elt array) =   
+let ofArray (xs : value array) =   
   let len = A.length xs in 
   if len = 0 then N.empty
   else

--- a/jscomp/others/belt_internalSetString.ml
+++ b/jscomp/others/belt_internalSetString.ml
@@ -1,5 +1,5 @@
 # 2 "internal_set.cppo.ml"
-type elt = string
+type value = string
 module S = Belt_SortArrayString
 
 
@@ -8,9 +8,9 @@ module N = Belt_internalAVLset
 module A = Belt_Array 
 
 
-type t = elt N.t
+type t = value N.t
 
-let rec has (t : t) (x : elt)  =
+let rec has (t : t) (x : value)  =
   match N.toOpt t with 
   | None -> false
   | Some n  ->                
@@ -21,7 +21,7 @@ let rec has (t : t) (x : elt)  =
 let rec compareAux e1 e2  =
     match e1,e2 with 
     | h1::t1, h2::t2 ->
-        let (k1 : elt) ,k2 = N.key h1, N.key h2 in 
+        let (k1 : value) ,k2 = N.key h1, N.key h2 in 
         if k1 = k2 then  
           compareAux 
             (N.stackAllLeft (N.right h1) t1 ) 
@@ -62,7 +62,7 @@ let rec subset (s1 : t) (s2 : t) =
       subset N.(create empty v1 r1 ) r2 && subset l1 s2
 
 
-let rec get (n :t) (x : elt) = 
+let rec get (n :t) (x : value) = 
   match N.toOpt n with 
   | None -> None
   | Some t  ->    
@@ -72,7 +72,7 @@ let rec get (n :t) (x : elt) =
 
 
 
-let rec getUndefined (n :t) (x : elt)   = 
+let rec getUndefined (n :t) (x : value)   = 
   match N.toOpt n with 
   | None -> Js.undefined
   | Some t  ->    
@@ -80,7 +80,7 @@ let rec getUndefined (n :t) (x : elt)   =
     if x = v then Js.Undefined.return v
     else getUndefined  (if x < v then N.left t else N.right t) x
 
-let rec getExn  (n :t) (x : elt) = 
+let rec getExn  (n :t) (x : value) = 
   match N.toOpt n with 
   | None -> [%assert "getExn"]
   | Some t  ->    
@@ -89,7 +89,7 @@ let rec getExn  (n :t) (x : elt) =
     else getExn (if x < v then N.left t else N.right t) x
 
 (****************************************************************************)
-let rec addMutate  t  (x : elt)=   
+let rec addMutate  t  (x : value)=   
   match N.toOpt t with 
   | None -> N.singleton x
   | Some nt -> 
@@ -106,7 +106,7 @@ let rec addMutate  t  (x : elt)=
 
 
 
-let ofArray (xs : elt array) =   
+let ofArray (xs : value array) =   
   let len = A.length xs in 
   if len = 0 then N.empty
   else

--- a/jscomp/others/internal_set.cppo.ml
+++ b/jscomp/others/internal_set.cppo.ml
@@ -1,8 +1,8 @@
 #ifdef TYPE_STRING
-type elt = string
+type value = string
 module S = Belt_SortArrayString
 #elif defined TYPE_INT  
-type elt = int
+type value = int
 module S = Belt_SortArrayInt
 #else
   [%error "unknown type"]  
@@ -13,9 +13,9 @@ module N = Belt_internalAVLset
 module A = Belt_Array 
 
 
-type t = elt N.t
+type t = value N.t
 
-let rec has (t : t) (x : elt)  =
+let rec has (t : t) (x : value)  =
   match N.toOpt t with 
   | None -> false
   | Some n  ->                
@@ -26,7 +26,7 @@ let rec has (t : t) (x : elt)  =
 let rec compareAux e1 e2  =
     match e1,e2 with 
     | h1::t1, h2::t2 ->
-        let (k1 : elt) ,k2 = N.key h1, N.key h2 in 
+        let (k1 : value) ,k2 = N.key h1, N.key h2 in 
         if k1 = k2 then  
           compareAux 
             (N.stackAllLeft (N.right h1) t1 ) 
@@ -67,7 +67,7 @@ let rec subset (s1 : t) (s2 : t) =
       subset N.(create empty v1 r1 ) r2 && subset l1 s2
 
 
-let rec get (n :t) (x : elt) = 
+let rec get (n :t) (x : value) = 
   match N.toOpt n with 
   | None -> None
   | Some t  ->    
@@ -77,7 +77,7 @@ let rec get (n :t) (x : elt) =
 
 
 
-let rec getUndefined (n :t) (x : elt)   = 
+let rec getUndefined (n :t) (x : value)   = 
   match N.toOpt n with 
   | None -> Js.undefined
   | Some t  ->    
@@ -85,7 +85,7 @@ let rec getUndefined (n :t) (x : elt)   =
     if x = v then Js.Undefined.return v
     else getUndefined  (if x < v then N.left t else N.right t) x
 
-let rec getExn  (n :t) (x : elt) = 
+let rec getExn  (n :t) (x : value) = 
   match N.toOpt n with 
   | None -> [%assert "getExn"]
   | Some t  ->    
@@ -94,7 +94,7 @@ let rec getExn  (n :t) (x : elt) =
     else getExn (if x < v then N.left t else N.right t) x
 
 (****************************************************************************)
-let rec addMutate  t  (x : elt)=   
+let rec addMutate  t  (x : value)=   
   match N.toOpt t with 
   | None -> N.singleton x
   | Some nt -> 
@@ -111,7 +111,7 @@ let rec addMutate  t  (x : elt)=
 
 
 
-let ofArray (xs : elt array) =   
+let ofArray (xs : value array) =   
   let len = A.length xs in 
   if len = 0 then N.empty
   else

--- a/jscomp/others/set.cppo.ml
+++ b/jscomp/others/set.cppo.ml
@@ -8,7 +8,7 @@ module I = Belt_internalSetString
 module N = Belt_internalAVLset
 module A = Belt_Array
 
-type elt = I.elt
+type value = I.value
 type t = I.t 
 
 
@@ -38,7 +38,7 @@ let toArray = N.toArray
 let ofSortedArrayUnsafe = N.ofSortedArrayUnsafe
 let checkInvariantInternal = N.checkInvariantInternal
 
-let rec add  (t : t) (x : elt) : t =
+let rec add  (t : t) (x : value) : t =
   match N.toOpt t with 
     None -> N.singleton x 
   | Some nt  ->
@@ -64,7 +64,7 @@ let mergeMany h arr =
   !v 
 
 
-let rec remove (t : t) (x : elt) : t = 
+let rec remove (t : t) (x : value) : t = 
   match N.toOpt t with 
   | None -> t
   | Some n  ->
@@ -105,7 +105,7 @@ let getExn = I.getExn
 let subset = I.subset 
 let has = I.has
 
-let rec splitAuxNoPivot (n : _ N.node) (x : elt) : t * t =   
+let rec splitAuxNoPivot (n : _ N.node) (x : value) : t * t =   
   let l,v,r = N.(left n , key n, right n) in  
   if x = v then l,  r
   else if x < v then
@@ -124,7 +124,7 @@ let rec splitAuxNoPivot (n : _ N.node) (x : elt) : t * t =
       N.joinShared l v lr,  rr
 
 
-let rec splitAuxPivot (n : _ N.node) (x : elt) pres : t  * t =   
+let rec splitAuxPivot (n : _ N.node) (x : value) pres : t  * t =   
   let l,v,r = N.(left n , key n, right n) in  
   if x = v then begin 
     pres := true;  
@@ -146,7 +146,7 @@ let rec splitAuxPivot (n : _ N.node) (x : elt) pres : t  * t =
       N.joinShared l v lr,  rr
 
 
-let split  (t : t) (x : elt) =
+let split  (t : t) (x : value) =
   match N.toOpt t with 
     None ->
     (N.empty,  N.empty), false

--- a/jscomp/others/set.cppo.mli
+++ b/jscomp/others/set.cppo.mli
@@ -30,9 +30,9 @@
 *)
 
 #ifdef TYPE_STRING
-type elt = string
+type value = string
 #elif defined TYPE_INT
-type elt = int
+type value = int
 #else 
 [%error "unknown type"]
 #endif  
@@ -45,17 +45,17 @@ type t
 val empty: t
 
 
-val ofArray: elt array -> t
-val ofSortedArrayUnsafe: elt array -> t     
+val ofArray: value array -> t
+val ofSortedArrayUnsafe: value array -> t     
 val isEmpty: t -> bool
-val has: t -> elt -> bool
+val has: t -> value -> bool
   
-val add:  t -> elt -> t
+val add:  t -> value -> t
 (** If [x] was already in [s], [s] is returned unchanged. *)
-val mergeMany: t -> elt array -> t 
-val remove:  t -> elt -> t
+val mergeMany: t -> value array -> t 
+val remove:  t -> value -> t
 (**  If [x] was not in [s], [s] is returned unchanged. *)
-val removeMany: t -> elt array -> t
+val removeMany: t -> value array -> t
   
 val union: t -> t -> t
 val intersect: t -> t -> t
@@ -73,53 +73,53 @@ val eq: t -> t -> bool
    equal, that is, contain equal elements. *)
 
 
-val forEachU: t -> (elt -> unit [@bs]) ->  unit
-val forEach: t -> (elt -> unit ) ->  unit  
+val forEachU: t -> (value -> unit [@bs]) ->  unit
+val forEach: t -> (value -> unit ) ->  unit  
 (** In increasing order*)
 
-val reduceU: t -> 'a -> ('a -> elt ->  'a [@bs]) ->  'a
-val reduce: t -> 'a -> ('a -> elt ->  'a ) ->  'a  
+val reduceU: t -> 'a -> ('a -> value ->  'a [@bs]) ->  'a
+val reduce: t -> 'a -> ('a -> value ->  'a ) ->  'a  
 (** Iterate in increasing order. *)
 
-val everyU: t -> (elt -> bool [@bs]) ->  bool
-val every: t -> (elt -> bool ) ->  bool  
+val everyU: t -> (value -> bool [@bs]) ->  bool
+val every: t -> (value -> bool ) ->  bool  
 (** [every p s] checks if all elements of the set
    satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (elt -> bool [@bs]) ->  bool
-val some: t -> (elt -> bool ) ->  bool  
+val someU: t -> (value -> bool [@bs]) ->  bool
+val some: t -> (value -> bool ) ->  bool  
 (** [some p s] checks if at least one element of
    the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (elt -> bool [@bs]) ->  t
-val keep: t -> (elt -> bool ) ->  t  
+val keepU: t -> (value -> bool [@bs]) ->  t
+val keep: t -> (value -> bool ) ->  t  
 (** [keep p s] returns the set of all elements in [s]
    that satisfy predicate [p]. *)
 
-val partitionU: t -> (elt -> bool [@bs]) ->  t * t
-val partition: t -> (elt -> bool ) ->  t * t
+val partitionU: t -> (value -> bool [@bs]) ->  t * t
+val partition: t -> (value -> bool ) ->  t * t
 (** [partition p s] returns a pair of sets [(s1, s2)], where
    [s1] is the set of all the elements of [s] that satisfy the
    predicate [p], and [s2] is the set of all the elements of
    [s] that do not satisfy [p]. *)
 
 val size: t -> int
-val toList: t -> elt list
+val toList: t -> value list
 (** In increasing order with respect *)
-val toArray: t -> elt array
+val toArray: t -> value array
 
 
-val minimum: t -> elt option
-val minUndefined: t -> elt Js.undefined
-val maximum: t -> elt option
-val maxUndefined: t -> elt Js.undefined
+val minimum: t -> value option
+val minUndefined: t -> value Js.undefined
+val maximum: t -> value option
+val maxUndefined: t -> value Js.undefined
 
 
 
-val get:  t -> elt -> elt option
-val getUndefined:  t -> elt -> elt Js.undefined
-val getExn: t -> elt -> elt    
-val split:  t -> elt -> (t * t) * bool  
+val get:  t -> value -> value option
+val getUndefined:  t -> value -> value Js.undefined
+val getExn: t -> value -> value    
+val split:  t -> value -> (t * t) * bool  
 (** [split x s] returns a triple [(l, present, r)], where
       [l] is the set of elements of [s] that are
       strictly less than [x];

--- a/jscomp/others/setm.cppo.ml
+++ b/jscomp/others/setm.cppo.ml
@@ -39,7 +39,7 @@ module S = Belt_SortArrayString
 module N = Belt_internalAVLset
 module A = Belt_Array 
 
-type elt = I.elt
+type value = I.value
 (** The type of the set elements. *)
              
 
@@ -49,7 +49,7 @@ type t = {
 (** The type of sets. *)
 
 
-let rec remove0 nt (x : elt)= 
+let rec remove0 nt (x : value)= 
   let k = N.key nt in 
   if x = k then 
     let l,r = N.(left nt, right nt) in       
@@ -102,7 +102,7 @@ let removeMany  (d : t) xs =
     let len = A.length xs in 
     dataSet d  (removeMany0 nt xs 0 len) 
     
-let rec removeCheck0  nt (x : elt) removed = 
+let rec removeCheck0  nt (x : value) removed = 
   let k = N.key nt in 
   if x = k then 
     let () = removed := true in  
@@ -143,7 +143,7 @@ let removeCheck  (d :  t) v =
     !removed
 
     
-let rec addCheck0  t (x : elt) added  =   
+let rec addCheck0  t (x : value) added  =   
   match N.toOpt t with 
   | None -> 
     added := true;

--- a/jscomp/others/setm.cppo.mli
+++ b/jscomp/others/setm.cppo.mli
@@ -32,9 +32,9 @@
 
 
 #ifdef TYPE_STRING
-type elt = string
+type value = string
 #elif defined TYPE_INT
-type elt = int
+type value = int
 #else
   [%error "unknown type"]
 #endif  
@@ -46,18 +46,18 @@ type t
   
 val make: unit -> t
 
-val ofArray: elt array -> t
-val ofSortedArrayUnsafe: elt array -> t
+val ofArray: value array -> t
+val ofSortedArrayUnsafe: value array -> t
 val copy: t -> t 
 val isEmpty: t -> bool
-val has: t -> elt -> bool
+val has: t -> value -> bool
 
-val add: t -> elt -> unit
-val addCheck: t -> elt -> bool 
-val mergeMany: t -> elt array -> unit
-val remove: t -> elt -> unit
-val removeCheck: t -> elt -> bool 
-val removeMany: t -> elt array -> unit
+val add: t -> value -> unit
+val addCheck: t -> value -> bool 
+val mergeMany: t -> value array -> unit
+val remove: t -> value -> unit
+val removeCheck: t -> value -> bool 
+val removeMany: t -> value array -> unit
   
 val union: t -> t -> t
 val intersect: t -> t -> t
@@ -68,51 +68,51 @@ val cmp: t -> t -> int
 val eq: t -> t -> bool
 
 
-val forEachU: t -> (elt -> unit [@bs]) ->  unit
-val forEach: t -> (elt -> unit ) ->  unit
+val forEachU: t -> (value -> unit [@bs]) ->  unit
+val forEach: t -> (value -> unit ) ->  unit
 (** In increasing order*)
 
-val reduceU: t -> 'a -> ('a -> elt -> 'a [@bs]) -> 'a
-val reduce: t -> 'a -> ('a -> elt -> 'a ) -> 'a  
+val reduceU: t -> 'a -> ('a -> value -> 'a [@bs]) -> 'a
+val reduce: t -> 'a -> ('a -> value -> 'a ) -> 'a  
 (** Iterate in increasing order. *)
 
-val everyU: t -> (elt -> bool [@bs]) -> bool
-val every: t -> (elt -> bool) ->  bool  
+val everyU: t -> (value -> bool [@bs]) -> bool
+val every: t -> (value -> bool) ->  bool  
 (** [every p s] checks if all elements of the set
     satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (elt -> bool [@bs]) -> bool
-val some: t -> (elt -> bool) ->  bool  
+val someU: t -> (value -> bool [@bs]) -> bool
+val some: t -> (value -> bool) ->  bool  
 (** [some p s] checks if at least one element of
     the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (elt -> bool [@bs]) ->  t
-val keep: t -> (elt -> bool) ->  t  
+val keepU: t -> (value -> bool [@bs]) ->  t
+val keep: t -> (value -> bool) ->  t  
 (** [keep s p] returns a fresh copy of the set of all elements in [s]
     that satisfy predicate [p]. *)
 
-val partitionU: t -> (elt -> bool [@bs]) ->  t * t
-val partition: t -> (elt -> bool) ->  t * t 
+val partitionU: t -> (value -> bool [@bs]) ->  t * t
+val partition: t -> (value -> bool) ->  t * t 
 (** [partition s p] returns a fresh copy pair of sets [(s1, s2)], where
     [s1] is the set of all the elements of [s] that satisfy the
     predicate [p], and [s2] is the set of all the elements of
     [s] that do not satisfy [p]. *)
 
 val size: t -> int
-val toList: t -> elt list
+val toList: t -> value list
  (** In increasing order with respect *)
-val toArray: t -> elt array
+val toArray: t -> value array
 
 
-val minimum: t -> elt option
-val minUndefined: t -> elt Js.undefined
-val maximum: t -> elt option
-val maxUndefined: t -> elt Js.undefined
+val minimum: t -> value option
+val minUndefined: t -> value Js.undefined
+val maximum: t -> value option
+val maxUndefined: t -> value Js.undefined
 
-val get:  t -> elt -> elt option
-val getUndefined:  t -> elt -> elt Js.undefined
-val getExn: t -> elt -> elt
-val split:  t -> elt  -> (t * t) * bool 
+val get:  t -> value -> value option
+val getUndefined:  t -> value -> value Js.undefined
+val getExn: t -> value -> value
+val split:  t -> value  -> (t * t) * bool 
 (**
     [split s key] return a fresh copy of each
 *)


### PR DESCRIPTION
Second diff of #2536, pulled out.

> For set, understandably it's the "key" that's hashed and compared, but everyone I've talked to think of a set item in terms of "value" instead.