### PR TITLE
[Belt] Make comparable label-less

### DIFF
--- a/jscomp/others/belt_Id.ml
+++ b/jscomp/others/belt_Id.ml
@@ -55,7 +55,7 @@ end
 
 let comparableU
   (type key) 
-  ~cmp   
+  cmp   
   =
   let module N = MakeComparable(struct
       type t = key
@@ -64,8 +64,8 @@ let comparableU
   (module N : Comparable with type t = key)
 
 
-let comparable ~cmp =
-  comparableU ~cmp:(fun[@bs] a b -> cmp a b)
+let comparable cmp =
+  comparableU (fun[@bs] a b -> cmp a b)
     
 module type Hashable = sig 
   type identity 

--- a/jscomp/others/belt_Id.mli
+++ b/jscomp/others/belt_Id.mli
@@ -76,11 +76,11 @@ type ('key, 'id) comparable =
 *)
 
 val comparableU:
-  cmp:('a -> 'a -> int [@bs]) ->
+  ('a -> 'a -> int [@bs]) ->
   (module Comparable with type t = 'a)
 
 val comparable:
-  cmp:('a -> 'a -> int) -> 
+  ('a -> 'a -> int) -> 
   (module Comparable with type t = 'a)
   
 module type Hashable = sig 


### PR DESCRIPTION
It's a single arg, so reduces the burden of using that pattern a little.

I'll update the docs after this