### PR TITLE
fix #2303

### DIFF
--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -459,7 +459,7 @@ core/js_map.cmx : core/j.cmx
 core/js_fold.cmx : core/j.cmx
 core/js_fold_basic.cmx : core/lam_module_ident.cmx \
     core/js_runtime_modules.cmx core/js_fold.cmx core/j.cmx ext/ident_set.cmx \
-    ext/ext_ident.cmx core/js_fold_basic.cmi
+    core/js_fold_basic.cmi
 core/js_pass_scope.cmx : core/js_fun_env.cmx core/js_fold.cmx \
     core/js_closure.cmx ext/ident_set.cmx common/ext_log.cmx ext/ext_list.cmx \
     core/js_pass_scope.cmi
@@ -565,9 +565,9 @@ core/js_dump_import_export.cmx : core/js_dump_string.cmx \
 core/js_dump.cmx : core/js_stmt_make.cmx core/js_runtime_modules.cmx \
     core/js_op_util.cmx core/js_op.cmx core/js_number.cmx core/js_fun_env.cmx \
     core/js_exp_make.cmx core/js_dump_string.cmx core/js_dump_property.cmx \
-    core/js_dump_lit.cmx core/js_dump_import_export.cmx core/js_closure.cmx \
-    core/j.cmx ext/ident_set.cmx ext/ext_pp_scope.cmx ext/ext_pp.cmx \
-    ext/ext_list.cmx ext/ext_ident.cmx core/js_dump.cmi
+    core/js_dump_lit.cmx core/js_closure.cmx core/j.cmx ext/ident_set.cmx \
+    ext/ext_pp_scope.cmx ext/ext_pp.cmx ext/ext_list.cmx ext/ext_ident.cmx \
+    core/js_dump.cmi
 core/js_name_of_module_id.cmx : core/lam_compile_env.cmx \
     core/js_packages_state.cmx core/js_packages_info.cmx \
     core/js_name_of_module_id.cmi

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -1472,14 +1472,14 @@ and block cxt f b =
 
 
 
-let program f cxt   ( x : J.program ) = 
+(* let program f cxt   ( x : J.program ) = 
   let () = P.force_newline f in
   let cxt =  statement_list true cxt f x.block  in
   let () = P.force_newline f in
-  Js_dump_import_export.exports cxt f x.exports
+  Js_dump_import_export.exports cxt f x.exports *)
 
-let dump_program (x : J.program) oc = 
-  ignore (program (P.from_channel oc)  Ext_pp_scope.empty  x )
+(* let dump_program (x : J.program) oc = 
+  ignore (program (P.from_channel oc)  Ext_pp_scope.empty  x ) *)
 
 let string_of_block  block  
   = 

--- a/jscomp/core/js_dump.mli
+++ b/jscomp/core/js_dump.mli
@@ -22,9 +22,9 @@
 
 
 
-(** Print JS IR to vanilla Javascript code *)
-
-
+(** Print JS IR to vanilla Javascript code 
+    Called by module {!Js_dump_program}
+*)
 val statement_list : 
   bool ->
   Ext_pp_scope.t -> 

--- a/jscomp/core/js_dump_program.mli
+++ b/jscomp/core/js_dump_program.mli
@@ -23,16 +23,22 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
-
+(** only used for debugging purpose *)
 val dump_program : J.program -> out_channel -> unit
 
 
 val pp_deps_program :
   output_prefix:string ->
-  Js_packages_info.module_system -> J.deps_program -> Ext_pp.t -> unit
+  Js_packages_info.module_system ->
+  J.deps_program -> 
+  Ext_pp.t -> 
+  unit
 
 
 val dump_deps_program :
   output_prefix:string ->
-  Js_packages_info.module_system  -> J.deps_program -> out_channel -> unit
+  Js_packages_info.module_system  -> 
+  J.deps_program -> 
+  out_channel -> 
+  unit
   

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -101,11 +101,10 @@ let flat_call ?comment e0 es : t =
   {expression_desc = FlatCall (e0,es); comment }
 
 let runtime_var_dot ?comment (x : string)  (e1 : string) : J.expression = 
-  {expression_desc = 
-     Var (Qualified(Ext_ident.create_js x,Runtime, Some e1)); comment }
+  { expression_desc = 
+     Var (Qualified(Ident.create_persistent x,Runtime, Some e1));
+    comment }
 
-(* let runtime_var_vid  x  e1 : J.vident = 
-  Qualified(Ext_ident.create_js x,Runtime, Some e1) *)
 
 let ml_var_dot ?comment ( id  : Ident.t) e : J.expression =     
   {expression_desc = Var (Qualified(id, Ml, Some e)); comment }

--- a/jscomp/core/js_fold_basic.ml
+++ b/jscomp/core/js_fold_basic.ml
@@ -71,7 +71,8 @@ class count_hard_dependencies =
         (* see [Js_exp_make.runtime_var_dot] *)
         -> 
         add_lam_module_ident hard_dependencies 
-          (Lam_module_ident.of_runtime (Ext_ident.create_js Js_runtime_modules.curry));
+          (Lam_module_ident.of_runtime 
+            (Ident.create_persistent Js_runtime_modules.curry));
         super#expression x             
       | {expression_desc = Caml_block(_,_, tag, tag_info); _}
         -> 
@@ -84,7 +85,8 @@ class count_hard_dependencies =
           | _, _
             -> 
             add_lam_module_ident hard_dependencies 
-              (Lam_module_ident.of_runtime (Ext_ident.create_js Js_runtime_modules.block));
+              (Lam_module_ident.of_runtime               
+                (Ident.create_persistent Js_runtime_modules.block));
         end;
         super#expression x 
       | _ -> super#expression x

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -85,6 +85,7 @@ big_enum.cmj :
 big_polyvar_test.cmj :
 bigarray_test.cmj : ../stdlib/int32.cmj ../stdlib/complex.cmj \
     ../stdlib/bigarray.cmj
+block_alias_test.cmj :
 boolean_test.cmj : test_bool_equal.cmj mt.cmj
 bs_MapInt_test.cmj : ../runtime/js.cmj ../others/belt.cmj
 bs_abstract_test.cmj : ../runtime/js.cmj bs_abstract_test.cmi

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -85,7 +85,7 @@ big_enum.cmj :
 big_polyvar_test.cmj :
 bigarray_test.cmj : ../stdlib/int32.cmj ../stdlib/complex.cmj \
     ../stdlib/bigarray.cmj
-block_alias_test.cmj :
+block_alias_test.cmj : mt.cmj ../stdlib/list.cmj
 boolean_test.cmj : test_bool_equal.cmj mt.cmj
 bs_MapInt_test.cmj : ../runtime/js.cmj ../others/belt.cmj
 bs_abstract_test.cmj : ../runtime/js.cmj bs_abstract_test.cmi

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -240,6 +240,7 @@ OTHERS := test_literals a test_ari test_export2 test_internalOO test_obj_simple_
 	imm_map_bench\
 	gpr_2487\
 	gpr_2503_test\
+	block_alias_test\
 # bs_uncurry_test
 # needs Lam to get rid of Uncurry arity first
 # simple_derive_test

--- a/jscomp/test/block_alias_test.js
+++ b/jscomp/test/block_alias_test.js
@@ -1,27 +1,77 @@
 'use strict';
 
+var Mt = require("./mt.js");
+var List = require("../../lib/js/list.js");
 var Block = require("../../lib/js/block.js");
+var Caml_obj = require("../../lib/js/caml_obj.js");
 
-var Block = /* module */[];
+var suites = [/* [] */0];
+
+var test_id = [0];
+
+function eq(loc, x, y) {
+  return Mt.eq_suites(test_id, suites, loc, x, y);
+}
+
+function b(loc, x) {
+  return Mt.bool_suites(test_id, suites, loc, x);
+}
 
 var Block$1 = /* module */[];
-
-var N_001 = /* v1 : A */Block.__(1, [
-    0,
-    1
-  ]);
-
-var N = /* module */[
-  /* Block */Block$1,
-  N_001
-];
 
 var v0 = /* A */Block.__(1, [
     0,
     1
   ]);
 
-exports.Block = Block;
+var Block$2 = /* module */[];
+
+var v1 = /* A */Block.__(1, [
+    0,
+    1
+  ]);
+
+var N = /* module */[
+  /* Block */Block$2,
+  /* v1 */v1
+];
+
+var Caml_obj$1 = /* module */[];
+
+var List$1 = /* module */[];
+
+var V = /* module */[/* List */List$1];
+
+var f = Caml_obj.caml_equal;
+
+eq("File \"block_alias_test.ml\", line 32, characters 6-13", List.length(/* :: */[
+          1,
+          /* :: */[
+            2,
+            /* [] */0
+          ]
+        ]), 2);
+
+b("File \"block_alias_test.ml\", line 33, characters 5-12", Caml_obj.caml_equal(v0, /* A */Block.__(1, [
+            0,
+            1
+          ])));
+
+eq("File \"block_alias_test.ml\", line 34, characters 6-13", v0, v1);
+
+Mt.from_pair_suites("block_alias_test.ml", suites[0]);
+
+var h = List.length;
+
+exports.suites = suites;
+exports.test_id = test_id;
+exports.eq = eq;
+exports.b = b;
+exports.Block = Block$1;
 exports.v0 = v0;
 exports.N = N;
-/* No side effect */
+exports.Caml_obj = Caml_obj$1;
+exports.V = V;
+exports.f = f;
+exports.h = h;
+/*  Not a pure module */

--- a/jscomp/test/block_alias_test.js
+++ b/jscomp/test/block_alias_test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var Block = require("../../lib/js/block.js");
+
+var Block = /* module */[];
+
+var Block$1 = /* module */[];
+
+var N_001 = /* v1 : A */Block.__(1, [
+    0,
+    1
+  ]);
+
+var N = /* module */[
+  /* Block */Block$1,
+  N_001
+];
+
+var v0 = /* A */Block.__(1, [
+    0,
+    1
+  ]);
+
+exports.Block = Block;
+exports.v0 = v0;
+exports.N = N;
+/* No side effect */

--- a/jscomp/test/block_alias_test.ml
+++ b/jscomp/test/block_alias_test.ml
@@ -1,4 +1,8 @@
 
+let suites =  ref []
+let test_id = ref 0 
+let eq loc x y = Mt.eq_suites ~test_id ~suites loc x y
+let b loc x = Mt.bool_suites ~test_id ~suites loc x
 
 module Block = struct 
 end 
@@ -13,3 +17,20 @@ module N = struct
   module Block = struct end
   let v1 = A (0,1) 
 end 
+
+module Caml_obj = struct 
+end 
+
+module V = struct 
+  module List = struct 
+  end 
+end 
+let f a b = a = b
+
+let h = List.length 
+
+;; eq __LOC__ (h [1;2]) 2 
+;; b __LOC__ (f v0 (A(0,1))) 
+;; eq __LOC__ v0 N.v1
+
+;; Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/block_alias_test.ml
+++ b/jscomp/test/block_alias_test.ml
@@ -1,0 +1,15 @@
+
+
+module Block = struct 
+end 
+type t = 
+  | A0 of int
+  | A of int * int 
+
+let v0 = A (0,1)
+
+
+module N = struct 
+  module Block = struct end
+  let v1 = A (0,1) 
+end 


### PR DESCRIPTION
Note this is a more serious issue than #2303 described, previously, when user create a local module which happens to be a runtime module, it would cause issues. This PR fix such issues.

TODO:  error out when user create toplevel modules 
              whose name happens to be runtime modules (in bsb) 

Note in our runtime support: suppose `Caml_obj` is called directly and instrumented by the compiler, it should be fine. On user land, user could not call `Caml_obj` directly, the only way to create `Caml_obj` is to define a global module and call it which should be disallowed.