### PR TITLE
Fix typo in `Js.Undefined.to_opt` deprecation message.

### DIFF
--- a/jscomp/runtime/js_undefined.mli
+++ b/jscomp/runtime/js_undefined.mli
@@ -97,4 +97,4 @@ val from_opt : 'a option -> 'a t
 *)
 external toOption : 'a t -> 'a option = "#undefined_to_opt"
 external to_opt : 'a t -> 'a option = "#undefined_to_opt"
-[@@deprecated "use toOpt instead"]  
+[@@deprecated "use toOption instead"]


### PR DESCRIPTION
Just a tiny contribution.