### PR TITLE
[Belt] Put comparable ~cmp label back

### DIFF
--- a/jscomp/others/belt_Id.ml
+++ b/jscomp/others/belt_Id.ml
@@ -1,6 +1,6 @@
 
 (* Copyright (C) 2017 Authors of BuckleScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -18,7 +18,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -27,7 +27,7 @@
 type ('a, 'id) hash = ('a -> int [@bs])
 type ('a, 'id) eq = ('a -> 'a -> bool [@bs])
 type ('a, 'id) cmp = ('a -> 'a -> int [@bs])
-                     
+
 external getHashInternal : ('a,'id) hash -> ('a -> int [@bs]) = "%identity"
 external getEqInternal : ('a, 'id) eq -> ('a -> 'a -> bool [@bs]) = "%identity"
 external getCmpInternal : ('a,'id) cmp -> ('a -> 'a -> int [@bs]) = "%identity"
@@ -61,39 +61,39 @@ struct
   type identity
   type t = M.t
   (* see https://github.com/BuckleScript/bucklescript/pull/2589/files/5ef875b7665ee08cfdc59af368fc52bac1fe9130#r173330825 *)
-  let cmp = 
+  let cmp =
     let cmp = M.cmp in fun[@bs] a b -> cmp a b
 end
 
 let comparableU
-  (type key) 
-  cmp   
+  (type key)
+  ~cmp
   =
   let module N = MakeComparableU(struct
       type t = key
       let cmp = cmp
-    end) in 
+    end) in
   (module N : Comparable with type t = key)
 
 let comparable
-  (type key) 
-  cmp   
+  (type key)
+  ~cmp
   =
   let module N = MakeComparable(struct
       type t = key
       let cmp = cmp
-    end) in 
+    end) in
   (module N : Comparable with type t = key)
 
-module type Hashable = sig 
-  type identity 
-  type t 
+module type Hashable = sig
+  type identity
+  type t
   val hash: (t,identity) hash
   val eq:  (t,identity) eq
 end
 
 type ('key, 'id) hashable = (module Hashable with type t = 'key and type identity = 'id)
-                            
+
 module MakeHashableU (M : sig
    type t
    val hash : t -> int [@bs]
@@ -114,24 +114,24 @@ module MakeHashable (M : sig
 struct
   type identity
   type t = M.t
-  let hash = 
+  let hash =
     let hash = M.hash in fun[@bs] a -> hash a
-  let eq = 
+  let eq =
     let eq = M.eq in fun[@bs] a b -> eq a b
 end
 
-let hashableU (type key) ~hash ~eq = 
-  let module N = MakeHashableU(struct 
-    type t = key 
-    let hash = hash 
-    let eq = eq 
-  end) in 
-  (module N : Hashable with type t = key) 
+let hashableU (type key) ~hash ~eq =
+  let module N = MakeHashableU(struct
+    type t = key
+    let hash = hash
+    let eq = eq
+  end) in
+  (module N : Hashable with type t = key)
 
-let hashable (type key) ~hash ~eq = 
-  let module N = MakeHashable(struct 
-    type t = key 
-    let hash = hash 
-    let eq = eq 
-  end) in 
-  (module N : Hashable with type t = key) 
+let hashable (type key) ~hash ~eq =
+  let module N = MakeHashable(struct
+    type t = key
+    let hash = hash
+    let eq = eq
+  end) in
+  (module N : Hashable with type t = key)

--- a/jscomp/others/belt_Id.mli
+++ b/jscomp/others/belt_Id.mli
@@ -1,6 +1,6 @@
 
 (* Copyright (C) 2017 Authors of BuckleScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -18,18 +18,18 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
 (** {!Belt.Id}
-    
-    Provide utiliites to create identified comparators or hashes for 
-    data structures used below. 
-    
-    It create a unique identifer per module of functions so that different data structures with slightly different 
+
+    Provide utiliites to create identified comparators or hashes for
+    data structures used below.
+
+    It create a unique identifer per module of functions so that different data structures with slightly different
     comparison functions won't mix.
 *)
 
@@ -38,21 +38,21 @@
 type ('a, 'id) hash
 (** [('a, 'id) hash]
 
-    Its runtime represenation is a [hash] function, but signed with a 
+    Its runtime represenation is a [hash] function, but signed with a
     type parameter, so that different hash functions type mismatch
-*) 
+*)
 
 type ('a, 'id) eq
 (** [('a, 'id) eq]
- 
-    Its runtime represenation is an [eq] function, but signed with a 
+
+    Its runtime represenation is an [eq] function, but signed with a
     type parameter, so that different hash functions type mismatch
-*) 
+*)
 
 type ('a, 'id) cmp
 (** [('a,'id) cmp]
-  
-    Its runtime representation is a [cmp] function, but signed with a 
+
+    Its runtime representation is a [cmp] function, but signed with a
     type parameter, so that different hash functions type mismatch
 *)
 module type Comparable = sig
@@ -66,39 +66,39 @@ type ('key, 'id) comparable =
 (** [('key, 'id) cmparable] is a module of functions, here it only includes [cmp].
 
     Unlike normal functions, when created, it comes with a unique identity (guaranteed
-    by the type system). 
-    
-    It can be created using function {!comparableU} or{!comparable}. 
-   
-    The idea of a unique identity when created is that it makes sure two sets would type 
+    by the type system).
+
+    It can be created using function {!comparableU} or{!comparable}.
+
+    The idea of a unique identity when created is that it makes sure two sets would type
     mismatch if they use different comparison function
 *)
 
-module MakeComparableU : 
-  functor (M : sig 
-    type t 
-    val cmp : t -> t -> int [@bs] 
-  end) -> 
+module MakeComparableU :
+  functor (M : sig
+    type t
+    val cmp : t -> t -> int [@bs]
+  end) ->
   Comparable with type t = M.t
 
-module MakeComparable : 
-  functor (M : sig 
-    type t 
-    val cmp : t -> t -> int 
+module MakeComparable :
+  functor (M : sig
+    type t
+    val cmp : t -> t -> int
   end) ->
   Comparable with type t = M.t
 
 val comparableU:
-  ('a -> 'a -> int [@bs]) ->
+  cmp:('a -> 'a -> int [@bs]) ->
   (module Comparable with type t = 'a)
 [@@ocaml.deprecated "Use the MakeComparableU functor API instead"]
 
 val comparable:
-  ('a -> 'a -> int) -> 
+  cmp:('a -> 'a -> int) ->
   (module Comparable with type t = 'a)
 [@@ocaml.deprecated "Use the MakeComparable functor API instead"]
-  
-module type Hashable = sig 
+
+module type Hashable = sig
   type identity
   type t
   val hash : (t, identity) hash
@@ -108,27 +108,27 @@ end
 type ('key, 'id) hashable =
   (module Hashable with type t = 'key and type identity = 'id)
 (** [('key, 'id) hashable] is a module of functions, here it only includes [hash], [eq].
-    
+
     Unlike normal functions, when created, it comes with a unique identity (guaranteed
-    by the type system). 
-    
+    by the type system).
+
     It can be created using function {!hashableU} or {!hashable}.
 
-    The idea of a unique identity when created is that it makes sure two hash sets would type 
+    The idea of a unique identity when created is that it makes sure two hash sets would type
     mismatch if they use different comparison function
 *)
 
-module MakeHashableU : 
-  functor (M : sig 
-    type t 
+module MakeHashableU :
+  functor (M : sig
+    type t
      val hash : t -> int [@bs]
      val eq : t -> t -> bool [@bs]
   end) ->
   Hashable with type t = M.t
 
-module MakeHashable : 
-  functor (M : sig 
-    type t 
+module MakeHashable :
+  functor (M : sig
+    type t
      val hash : t -> int
      val eq : t -> t -> bool
   end) ->

--- a/jscomp/test/bs_hashtbl_string_test.ml
+++ b/jscomp/test/bs_hashtbl_string_test.ml
@@ -3,8 +3,8 @@ type seed = int
 external caml_hash_mix_string : seed -> string -> seed  = "caml_hash_mix_string"
 external final_mix : seed -> seed = "caml_hash_final_mix"
 
-let hash_string  s = 
-  final_mix (caml_hash_mix_string 0 s) 
+let hash_string  s =
+  final_mix (caml_hash_mix_string 0 s)
 
 let hashString : string -> int  = [%raw{|function (str) {
                                               var hash = 5381,
@@ -13,183 +13,183 @@ let hashString : string -> int  = [%raw{|function (str) {
                                               while(i !== 0) {
                                               hash = (hash * 33) ^ str.charCodeAt(--i);
                                               }
-                                              return hash  
+                                              return hash
                                               }
                                             |}]
 
-module String = 
-  (val Belt.Id.hashable 
+module String =
+  (val Belt.Id.hashable
       ~eq:(fun (x:string) y -> x = y )
       ~hash:Hashtbl.hash)
 
-module String1 = 
+module String1 =
   (val Belt.Id.hashable
       ~eq:(fun (x:string) y -> x = y )
       ~hash:hashString)
-module String2 = 
+module String2 =
   (val Belt.Id.hashable
       ~eq:(fun (x:string) y -> x = y )
       ~hash:(fun  (x:string) -> hash_string x))
 
-module Int = 
+module Int =
   (val Belt.Id.hashable
       ~eq:(fun (x:int) y -> x = y )
       ~hash:Hashtbl.hash)
 module N = Belt.HashMap
-let empty = 
+let empty =
   N.make ~id:(module Int) ~hintSize:500_000
 
-let bench() = 
-  let count  = 1_000_000 in   
+let bench() =
+  let count  = 1_000_000 in
   (* let add = N.setDone in  *)
   let mem = N.has in
-  for i  = 0 to  count do      
+  for i  = 0 to  count do
     N.set empty i i
   done ;
-  for i = 0 to count do 
+  for i = 0 to count do
     assert (mem empty i)
   done ;
   N.logStats empty
 
 
-let count  = 1_000_000 
+let count  = 1_000_000
 let initial_size = 1_000_000
 (* module B = Belt.Bag  *)
 (*
     (empty : _ Belt.HashMap.t)
-    #.add (string_of_int i) i 
     #.add (string_of_int i) i
-*)    
+    #.add (string_of_int i) i
+*)
 module M = Belt.HashMap
-let bench2 (type t) (m : (string,t) Belt.Id.hashable) = 
-  let empty = 
+let bench2 (type t) (m : (string,t) Belt.Id.hashable) =
+  let empty =
     M.make ~id:m ~hintSize:initial_size in
-  let module String = (val m) in     
-  (* let hash = String.hash in 
+  let module String = (val m) in
+  (* let hash = String.hash in
   let eq = String.eq in  *)
   (* let table = M.getData empty in  *)
-  for i  = 0 to  count do  
+  for i  = 0 to  count do
      M.set
-      empty (string_of_int i) i 
+      empty (string_of_int i) i
   done ;
-  for i = 0 to count do 
+  for i = 0 to count do
     assert (M.has
               empty (string_of_int i))
-  done; 
-  for i = 0 to count do 
+  done;
+  for i = 0 to count do
     M.remove empty (string_of_int i)
   done ;
-  assert (M.size empty = 0)  
+  assert (M.size empty = 0)
 
 (* Belt.HashMap.logStats empty *)
-module Md = Belt.Map 
+module Md = Belt.Map
 module Md0 = Belt.Map.Dict
-let bench3 (type t) (m : (string,t) Belt.Id.comparable) = 
-  
+let bench3 (type t) (m : (string,t) Belt.Id.comparable) =
+
   let empty = Md.make m in
-  let module String = (val m) in 
-  let cmp = String.cmp in 
-  let table = ref (Md.getData empty) in 
-  for i  = 0 to  count do  
+  let module String = (val m) in
+  let cmp = String.cmp in
+  let table = ref (Md.getData empty) in
+  for i  = 0 to  count do
     table := Md0.set ~cmp !table
-        (string_of_int i) i 
+        (string_of_int i) i
   done ;
-  for i = 0 to count do 
+  for i = 0 to count do
     assert (Md0.has ~cmp
               !table
               (string_of_int i) )
-  done; 
-  for i = 0 to count do  
-    table := Md0.remove ~cmp !table (string_of_int i) 
+  done;
+  for i = 0 to count do
+    table := Md0.remove ~cmp !table (string_of_int i)
   done ;
   assert (Md0.size !table = 0)
 
-module Sx = (val Belt.Id.comparable (fun  (x : string) y -> compare x y )) 
+module Sx = (val Belt.Id.comparable ~cmp:(fun  (x : string) y -> compare x y ))
 module H = Belt.HashMap.String
-let bench4 () = 
-  let table = 
+let bench4 () =
+  let table =
     H.make initial_size in
 
-  for i  = 0 to  count do  
+  for i  = 0 to  count do
     H.set
-      table (string_of_int i) i 
+      table (string_of_int i) i
   done ;
-  for i = 0 to count do 
+  for i = 0 to count do
     assert (H.has
               table (string_of_int i))
-  done; 
-  for i = 0 to count do 
+  done;
+  for i = 0 to count do
     H.remove table (string_of_int i)
   done ;
-  assert (H.isEmpty table)  
+  assert (H.isEmpty table)
 
 module H0 = Belt.HashMap
-let bench5 () =   
-  let table = 
-    H0.make ~id:(module Int) ~hintSize:initial_size in 
+let bench5 () =
+  let table =
+    H0.make ~id:(module Int) ~hintSize:initial_size in
   (* let table_data = M.getData table in    *)
-  (* let hash = Int.hash in 
+  (* let hash = Int.hash in
   let eq = Int.eq in  *)
-  [%time for i  = 0 to  count do  
-      H0.set 
-        table i i 
+  [%time for i  = 0 to  count do
+      H0.set
+        table i i
     done] ;
-  [%time for i = 0 to count do 
+  [%time for i = 0 to count do
       assert (H0.has
                 table i)
-    done]; 
-  [%time for i = 0 to count do 
+    done];
+  [%time for i = 0 to count do
       H0.remove  table i
     done ];
-  assert (H0.isEmpty table)   
+  assert (H0.isEmpty table)
 
 module HI = Belt.HashMap.Int
-let bench6 () = 
-  let table = 
+let bench6 () =
+  let table =
     HI.make initial_size in
 
-  for i  = 0 to  count do  
+  for i  = 0 to  count do
     HI.set
-      table i i 
+      table i i
   done ;
-  for i = 0 to count do 
+  for i = 0 to count do
     assert (HI.has
               table i)
-  done; 
-  for i = 0 to count do 
+  done;
+  for i = 0 to count do
     HI.remove table i
   done ;
-  assert (HI.size table = 0)  
+  assert (HI.size table = 0)
 
 module S = Belt.HashSet.Int
-let bench7 () = 
-  let table = 
+let bench7 () =
+  let table =
     (* [%time  *)
     S.make (initial_size* 2)
     (* ]  *)
     in
 
   (* [%time  *)
-  for i  = 0 to  count do  
+  for i  = 0 to  count do
     S.add
-      table i 
-  done 
+      table i
+  done
   (* ] *)
   ;
   (* [%time  *)
-  for i = 0 to count do 
+  for i = 0 to count do
     assert (S.has
               table i)
   done
   (* ] *)
-  ; 
+  ;
   (* [%time *)
-   for i = 0 to count do 
+   for i = 0 to count do
     S.remove table i
-  done 
+  done
   (* ] *)
   ;
-  assert (S.size table = 0)  
+  assert (S.size table = 0)
 
 
 (* ;; [%time bench4 ()]
@@ -197,7 +197,7 @@ let bench7 () =
    ;; [%time bench2 (module String1)]
    ;; [%time bench2 (module String2)]
 
-   ;; [%time bench3 (module S)] 
+   ;; [%time bench3 (module S)]
    ;; [%time bench5()] *)
 (* ;; [%time bench6 ()] *)
 ;; [%time bench7 ()]

--- a/jscomp/test/bs_map_set_dict_test.ml
+++ b/jscomp/test/bs_map_set_dict_test.ml
@@ -1,86 +1,86 @@
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
-let eq loc x y = Mt.eq_suites ~suites ~test_id loc x y 
-let b loc v  = Mt.bool_suites ~suites ~test_id loc v 
+let eq loc x y = Mt.eq_suites ~suites ~test_id loc x y
+let b loc v  = Mt.bool_suites ~suites ~test_id loc v
 
-module Icmp = 
+module Icmp =
   (val Belt.Id.comparable
-    (fun (x : int) y -> 
+    (fun (x : int) y ->
       compare x y
      )
   )
-module Icmp2 = 
-(val Belt.Id.comparable (fun  (x : int) y ->
+module Icmp2 =
+(val Belt.Id.comparable ~cmp:(fun  (x : int) y ->
       compare x y ))
-  
+
 module M = Belt.Map
 module MI = Belt.Map.Int
 (* module B = Belt.Bag *)
 module I = Array_data_util
 module A = Belt.Array
 module L = Belt.List
-let m0 : (_,string,_) M.t = M.make (module Icmp)   
+let m0 : (_,string,_) M.t = M.make (module Icmp)
 
-  
-module I2 = 
-(val Belt.Id.comparable (fun  (x : int) y -> compare y x ))
 
-  
+module I2 =
+(val Belt.Id.comparable ~cmp:(fun  (x : int) y -> compare y x ))
+
+
 let m = M.make (module Icmp2)
 let m2 : (int, string, _) M.t = M.make (module I2)
-let vv = MI.empty 
+let vv = MI.empty
 let vv2 = MI.empty
 module Md0 = Belt.Map.Dict
-let () = 
-  let count = 1_000_00 in 
-  let data = ref (M.getData m) in 
-  let m2_dict, m_dict = M.(getId m2, getId m) in 
-  let module N = (val m2_dict) in 
+let () =
+  let count = 1_000_00 in
+  let data = ref (M.getData m) in
+  let m2_dict, m_dict = M.(getId m2, getId m) in
+  let module N = (val m2_dict) in
   let module Mm = ( val m_dict) in
-  for i = 0 to count do 
-    data := 
-      Md0.set !data 
+  for i = 0 to count do
+    data :=
+      Md0.set !data
       ~cmp:  Mm.cmp
-      i i 
+      i i
   done ;
-  let newm = M.packIdData ~data:!data ~id:m_dict in 
+  let newm = M.packIdData ~data:!data ~id:m_dict in
   Js.log newm
-module ISet = Belt.Set 
-let () =     
-  let  m = Md0.empty in 
-  let m11 = 
+module ISet = Belt.Set
+let () =
+  let  m = Md0.empty in
+  let m11 =
     Md0.set ~cmp:Icmp.cmp m
-    1 1 
-  in  
-  let _m20 = M.make (module Icmp) in 
+    1 1
+  in
+  let _m20 = M.make (module Icmp) in
   Js.log m11
 
-module S0 = Belt.Set.Dict  
-let () =   
- let count = 100_000 in 
-  let v = ISet.make (module Icmp2) in 
-  let m_dict = M.getId m in 
-  let module M = (val m_dict) in 
-  let cmp = M.cmp in 
-  let data = ref (ISet.getData v) in 
-  for i = 0 to count do 
-    data := S0.add ~cmp !data i 
+module S0 = Belt.Set.Dict
+let () =
+ let count = 100_000 in
+  let v = ISet.make (module Icmp2) in
+  let m_dict = M.getId m in
+  let module M = (val m_dict) in
+  let cmp = M.cmp in
+  let data = ref (ISet.getData v) in
+  for i = 0 to count do
+    data := S0.add ~cmp !data i
   done ;
-  Js.log !data  
+  Js.log !data
 
 let f = M.ofArray ~id:(module Icmp)
-let (=~) a b = M.eq a b  
+let (=~) a b = M.eq a b
 
-let () =   
-  let u0 =  f (A.map (I.randomRange 0 39) (fun x -> (x,x))) in  
-  let u1 = M.set u0 39 120 in 
+let () =
+  let u0 =  f (A.map (I.randomRange 0 39) (fun x -> (x,x))) in
+  let u1 = M.set u0 39 120 in
   b __LOC__
-  (A.every2 (M.toArray u0) 
+  (A.every2 (M.toArray u0)
    (A.map (I.range 0 39) (fun x -> (x,x)))
    (fun (x0,x1) (y0,y1) -> x0 = y0 && x1 = y1));
-  
+
   b __LOC__
-  (L.every2 
+  (L.every2
     (M.toList u0)
     (L.ofArray (A.map (I.range 0 39) (fun  x -> (x,x))))
     (fun (x0,x1) (y0,y1) -> x0 = y0 && x1 = y1));
@@ -88,12 +88,12 @@ let () =
   eq __LOC__ (M.get u1 39) (Some 120)
 
 
-let () =     
-  let u = f 
-    ((A.makeByAndShuffle 10_000 (fun x  -> (x,x)))) in 
- eq __LOC__    
+let () =
+  let u = f
+    ((A.makeByAndShuffle 10_000 (fun x  -> (x,x)))) in
+ eq __LOC__
   (A.makeBy 10_000 (fun x  -> (x,x)))
   (M.toArray u)
 
 
-;; Mt.from_pair_suites __FILE__ !suites  
+;; Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/bs_poly_map_test.ml
+++ b/jscomp/test/bs_poly_map_test.ml
@@ -1,72 +1,72 @@
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
-let eq loc x y = Mt.eq_suites ~suites ~test_id loc x y 
-let b loc v  = Mt.bool_suites ~suites ~test_id loc v 
+let eq loc x y = Mt.eq_suites ~suites ~test_id loc x y
+let b loc v  = Mt.bool_suites ~suites ~test_id loc v
 
-module Icmp = 
-  (val Belt.Id.comparable 
-      (fun (x : int) y ->  compare x y)
+module Icmp =
+  (val Belt.Id.comparable
+      ~cmp:(fun (x : int) y ->  compare x y)
   )
-module M = Belt.Map  
-module N = Belt.Set 
+module M = Belt.Map
+module N = Belt.Set
 
 module A = Belt.Array
 module I = Array_data_util
 
 
-let mapOfArray x = M.ofArray ~id:(module Icmp) x 
-let setOfArray x = N.ofArray ~id:(module Icmp) x 
+let mapOfArray x = M.ofArray ~id:(module Icmp) x
+let setOfArray x = N.ofArray ~id:(module Icmp) x
 let emptyMap () = M.make (module Icmp)
 
-let mergeInter s1 s2 = 
-  setOfArray @@ M.keysToArray (M.merge s1 s2 (fun   k v1 v2 -> 
-      match v1,v2 with 
+let mergeInter s1 s2 =
+  setOfArray @@ M.keysToArray (M.merge s1 s2 (fun   k v1 v2 ->
+      match v1,v2 with
       | Some _, Some _ -> Some ()
       | _, _ -> None
     ))
 
-let mergeUnion s1 s2 =    
-  setOfArray @@ M.keysToArray @@ M.merge s1 s2 (fun   k v1 v2 -> 
-      match v1,v2 with 
+let mergeUnion s1 s2 =
+  setOfArray @@ M.keysToArray @@ M.merge s1 s2 (fun   k v1 v2 ->
+      match v1,v2 with
       | None, None -> None
       | _, _ -> Some ()
     )
-let mergeDiff s1 s2 =    
-  setOfArray @@ M.keysToArray @@ M.merge s1 s2 (fun   k v1 v2 -> 
-      match v1,v2 with 
+let mergeDiff s1 s2 =
+  setOfArray @@ M.keysToArray @@ M.merge s1 s2 (fun   k v1 v2 ->
+      match v1,v2 with
       | Some _, None -> Some ()
       | Some _, Some _
-      | None, _ -> None   
+      | None, _ -> None
     )
 
-let randomRange i j = 
+let randomRange i j =
   A.map (I.randomRange i j) (fun x -> (x,x))
 
-let () =    
-  let u0 = mapOfArray (randomRange 0 100) in 
-  let u1 = mapOfArray (randomRange 30 120) in 
+let () =
+  let u0 = mapOfArray (randomRange 0 100) in
+  let u1 = mapOfArray (randomRange 30 120) in
   b __LOC__ (N.eq (mergeInter u0 u1) (setOfArray (I.range 30 100)));
   b __LOC__ (N.eq (mergeUnion u0 u1) (setOfArray (I.range 0 120)));
   b __LOC__ (N.eq (mergeDiff u0 u1) (setOfArray (I.range 0 29)));
   b __LOC__ (N.eq (mergeDiff u1 u0) (setOfArray (I.range 101 120)))
 
 
-let () =   
-  let a0 = mapOfArray (randomRange 0 10) in 
+let () =
+  let a0 = mapOfArray (randomRange 0 10) in
   let a1 = M.set a0 3 33 in (* (3,3) *)
   let a2 = M.remove a1 3 in  (* no 3 *)
-  let a3 = M.update a2 3 (fun    k -> 
-      match k with 
+  let a3 = M.update a2 3 (fun    k ->
+      match k with
       | Some k -> Some (k + 1)
       | None  ->  Some 11
     ) in  (* 3, 11 *)
-  let a4 = M.update a2 3 (fun    k -> 
-      match k with 
+  let a4 = M.update a2 3 (fun    k ->
+      match k with
       | Some k-> Some (k + 1)
       | None  ->  None
     ) in  (* no 3 *)
-  let a5 = M.remove a0 3 in   
-  let a6 = M.remove a5 3 in 
+  let a5 = M.remove a0 3 in
+  let a6 = M.remove a5 3 in
   b __LOC__ (a5 == a6);
   b __LOC__ (M.has a0 3);
   b __LOC__ (not (M.has a5 3));
@@ -77,52 +77,52 @@ let () =
   b __LOC__ (Js.eqUndefined 11 (M.getUndefined a3 3));
   b __LOC__ (Js.Undefined.test (M.getUndefined a4 3));
 
-  let a7 = M.removeMany a0 [|7;8;0;1;3;2;4;922;4;5;6;|] in 
+  let a7 = M.removeMany a0 [|7;8;0;1;3;2;4;922;4;5;6;|] in
   eq __LOC__ (M.keysToArray a7) [|9;10|];
-  let a8 = M.removeMany a7 (I.randomRange 0 100) in 
+  let a8 = M.removeMany a7 (I.randomRange 0 100) in
   b __LOC__ (M.isEmpty a8)
 
 
-let () =   
-  let module Array = M in 
-  let u0 = mapOfArray (randomRange 0 100) in 
-  let u1 = u0.(3) <- 32  in 
-  eq __LOC__ u1.(3) (Some 32); 
+let () =
+  let module Array = M in
+  let u0 = mapOfArray (randomRange 0 100) in
+  let u1 = u0.(3) <- 32  in
+  eq __LOC__ u1.(3) (Some 32);
   eq __LOC__ u0.(3) (Some 3)
 
 
-let acc m i =   
+let acc m i =
   M.update m i (fun   n -> match n with None -> Some 1 | Some acc -> Some (acc + 1))
 
-let acc m is : _ M.t =   
-  A.reduce is m (fun a i -> acc a i) 
+let acc m is : _ M.t =
+  A.reduce is m (fun a i -> acc a i)
 
-let () = 
-  let m = emptyMap () in 
-  let m1 = acc m (A.concat (I.randomRange 0 20) (I.randomRange 10 30)) in 
-  b __LOC__ 
-  (M.eq m1 
+let () =
+  let m = emptyMap () in
+  let m1 = acc m (A.concat (I.randomRange 0 20) (I.randomRange 10 30)) in
+  b __LOC__
+  (M.eq m1
   (mapOfArray (A.makeBy 31 (fun i -> i, if i >= 10 && i <= 20 then 2 else 1 )))
   (fun   x y -> x = y)
   )
 
-let () = 
-  let v0 = emptyMap () in 
-  let v1 = M.mergeMany v0 
-  (A.map (I.randomRange 0 10_000)  (fun x -> x , x)) in 
+let () =
+  let v0 = emptyMap () in
+  let v1 = M.mergeMany v0
+  (A.map (I.randomRange 0 10_000)  (fun x -> x , x)) in
 
-  let v2 = mapOfArray 
-  (A.map (I.randomRange 0 10_000) (fun x -> x, x)) in 
+  let v2 = mapOfArray
+  (A.map (I.randomRange 0 10_000) (fun x -> x, x)) in
 
   b __LOC__ (M.eq v1 v2 (fun    x y -> x = y ));
 
-  let inc = (fun    x -> 
+  let inc = (fun    x ->
   match x with None -> Some 0
   | Some  v -> Some (v +  1)
-  )  in 
-  let v3 = M.update v1 10 inc in 
-  let v4 = M.update v3 (-10) inc in 
-  let (v5, v6), pres = M.split v3 5_000 in  
+  )  in
+  let v3 = M.update v1 10 inc in
+  let v4 = M.update v3 (-10) inc in
+  let (v5, v6), pres = M.split v3 5_000 in
   b __LOC__ (match M.get v3 10 with Some 11 -> true | _ -> false);
   b __LOC__ (match M.get v3 (-10) with None -> true | _ -> false);
   b __LOC__ (match M.get v4 (-10) with Some 0 -> true | _ -> false);
@@ -132,12 +132,12 @@ let () =
   b __LOC__ (A.eq (M.keysToArray v5) (A.makeBy 5_000 (fun  i -> i))  (=) );
   b __LOC__ (A.eq (M.keysToArray v6) (A.makeBy 5_000 (fun  i -> 5_001 +i))  (=) );
 
-  let v7 = M.remove v3 5_000 in 
-  let (v8,v9), pres2 = M.split v7 5_000 in 
+  let v7 = M.remove v3 5_000 in
+  let (v8,v9), pres2 = M.split v7 5_000 in
   b __LOC__ (match pres2 with None -> true | _ -> false);
   b __LOC__ (A.eq (M.keysToArray v8) (A.makeBy 5_000 (fun  i -> i))  (=) );
   b __LOC__ (A.eq (M.keysToArray v9) (A.makeBy 5_000 (fun  i -> 5_001 +i))  (=) )
 
-  
-  
+
+
 ;; Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/bs_poly_mutable_map_test.ml
+++ b/jscomp/test/bs_poly_mutable_map_test.ml
@@ -1,28 +1,28 @@
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
-let eq loc x y = Mt.eq_suites ~suites ~test_id loc x y 
-let b loc v  = Mt.bool_suites ~suites ~test_id loc v 
+let eq loc x y = Mt.eq_suites ~suites ~test_id loc x y
+let b loc v  = Mt.bool_suites ~suites ~test_id loc v
 
-module Icmp = 
-  (val Belt.Id.comparable 
-      (fun (x : int) y ->  compare x y
+module Icmp =
+  (val Belt.Id.comparable
+      ~cmp:(fun (x : int) y ->  compare x y
       )
   )
 module M = Belt.MutableMap
-module N = Belt.Set 
+module N = Belt.Set
 
 module A = Belt.Array
 module I = Array_data_util
-let f x = M.ofArray ~id:(module Icmp) x 
-let ff x = N.ofArray ~id:(module Icmp) x 
+let f x = M.ofArray ~id:(module Icmp) x
+let ff x = N.ofArray ~id:(module Icmp) x
 
 
-let randomRange i j = 
+let randomRange i j =
   A.map (I.randomRange i j) (fun x -> (x,x))
 
 
-  let () = 
-    let a0 = f (randomRange 0 10) in 
+  let () =
+    let a0 = f (randomRange 0 10) in
     M.set a0 3 33;
     eq __LOC__ (M.getExn a0 3) 33 ;
     M.removeMany a0 [|7;8;0;1;3;2;4;922;4;5;6;|];
@@ -32,4 +32,4 @@ let randomRange i j =
 
 
 
-;; Mt.from_pair_suites __FILE__ !suites   
+;; Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/bs_poly_mutable_set_test.ml
+++ b/jscomp/test/bs_poly_mutable_set_test.ml
@@ -1,30 +1,30 @@
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
-let eq loc x y = Mt.eq_suites ~test_id ~suites loc x y 
-let b loc x =  Mt.bool_suites ~test_id ~suites loc x  
+let eq loc x y = Mt.eq_suites ~test_id ~suites loc x y
+let b loc x =  Mt.bool_suites ~test_id ~suites loc x
 
 module N = Belt.MutableSet
 module I = Array_data_util
 module A = Belt.Array
-module IntCmp = 
-  (val Belt.Id.comparable (fun (x:int) y -> compare x y))
+module IntCmp =
+  (val Belt.Id.comparable ~cmp:(fun (x:int) y -> compare x y))
 module L = Belt.List
 let ofArray = N.ofArray ~id:(module IntCmp)
 let empty () = N.make ~id:(module IntCmp)
 
 
-let () = 
-  let u =  ofArray (I.range 0 30) in 
+let () =
+  let u =  ofArray (I.range 0 30) in
   b __LOC__ (N.removeCheck u 0);
   b __LOC__ (not (N.removeCheck u 0));
   b __LOC__ (N.removeCheck u 30);
   b __LOC__ (N.removeCheck u 20);
   eq __LOC__ (N.size u) 28 ;
-  let r = I.randomRange 0 30 in 
+  let r = I.randomRange 0 30 in
   b __LOC__ (Js.eqUndefined 29 (N.maxUndefined u));
   b __LOC__ (Js.eqUndefined 1 (N.minUndefined u));
-  N.add u 3;  
-  for i = 0 to A.length r - 1 do 
+  N.add u 3;
+  for i = 0 to A.length r - 1 do
     N.remove u (A.getUnsafe r i)
   done ;
   b __LOC__ (N.isEmpty u);
@@ -34,8 +34,8 @@ let () =
   N.add u 0;
   eq __LOC__ (N.size u) 3;
   b __LOC__ (not (N.isEmpty u));
-  for i = 0 to 3 do 
-    N.remove u i 
+  for i = 0 to 3 do
+    N.remove u i
   done ;
   b __LOC__ (N.isEmpty u);
   N.mergeMany u (I.randomRange 0 20000);
@@ -56,20 +56,20 @@ let () =
   b __LOC__ (N.isEmpty u)
 
 
-let () = 
-  let v = ofArray (I.randomRange 1_000 2_000) in 
-  let bs = A.map (I.randomRange 500 1499) (fun  x -> N.removeCheck v x ) in 
-  let indeedRemoved = A.reduce bs 0 (fun  acc x -> if x then acc + 1 else acc) in 
+let () =
+  let v = ofArray (I.randomRange 1_000 2_000) in
+  let bs = A.map (I.randomRange 500 1499) (fun  x -> N.removeCheck v x ) in
+  let indeedRemoved = A.reduce bs 0 (fun  acc x -> if x then acc + 1 else acc) in
   eq __LOC__ indeedRemoved 500;
   eq __LOC__ (N.size v) 501;
-  let cs = A.map (I.randomRange 500 2_000) (fun  x -> N.addCheck v x) in 
-  let indeedAded = A.reduce cs 0 (fun acc x -> if x then acc + 1 else acc) in 
+  let cs = A.map (I.randomRange 500 2_000) (fun  x -> N.addCheck v x) in
+  let indeedAded = A.reduce cs 0 (fun acc x -> if x then acc + 1 else acc) in
   eq __LOC__ indeedAded 1000 ;
   eq __LOC__ (N.size v) 1_501;
   b __LOC__ (N.isEmpty (empty ()));
   eq __LOC__ (N.minimum v) (Some 500);
   eq __LOC__ (N.maximum v) (Some 2000);
-  eq __LOC__ (N.minUndefined v) (Js.Undefined.return 500); 
+  eq __LOC__ (N.minUndefined v) (Js.Undefined.return 500);
   eq __LOC__ (N.maxUndefined v) (Js.Undefined.return 2000);
   eq __LOC__ (N.reduce v 0 (fun x y -> x + y)) ((( 500 + 2000)/2) * 1501 );
   b __LOC__ (L.eq (N.toList v) (L.makeBy 1_501 (fun i -> i + 500)  ) (fun x y -> x = y) ) ;
@@ -77,92 +77,92 @@ let () =
   (N.checkInvariantInternal v);
   eq __LOC__ (N.get v 3) None;
   eq __LOC__ (N.get v 1_200) (Some 1_200);
-  let (aa, bb), pres = N.split v 1000 in 
+  let (aa, bb), pres = N.split v 1000 in
   b __LOC__ pres ;
   b __LOC__ (A.eq (N.toArray aa) (I.range 500 999) (=));
   b __LOC__ (A.eq (N.toArray bb) (I.range 1_001 2_000) (=));
-  b  __LOC__ (N.subset aa v); 
+  b  __LOC__ (N.subset aa v);
   b __LOC__ (N.subset bb v) ;
   b __LOC__ (N.isEmpty (N.intersect aa bb));
-  let c = N.removeCheck v 1_000 in 
+  let c = N.removeCheck v 1_000 in
   b __LOC__ c ;
-  let (aa,bb), pres = N.split v 1_000 in 
+  let (aa,bb), pres = N.split v 1_000 in
   b __LOC__ (not pres);
   b __LOC__ (A.eq (N.toArray aa) (I.range 500 999) (=));
   b __LOC__ (A.eq (N.toArray bb) (I.range 1_001 2_000) (=));
-  b  __LOC__ (N.subset aa v); 
+  b  __LOC__ (N.subset aa v);
   b __LOC__ (N.subset bb v);
   b __LOC__ (N.isEmpty (N.intersect aa bb))
 
 let (++) = N.union
-let f = ofArray 
-let (=~) = N.eq 
-let () =   
-  let aa =  f (I.randomRange 0 100) in 
+let f = ofArray
+let (=~) = N.eq
+let () =
+  let aa =  f (I.randomRange 0 100) in
   let bb = f  (I.randomRange 40 120) in
-  let cc = aa ++ bb in 
+  let cc = aa ++ bb in
   b __LOC__ (cc =~ f (I.randomRange 0 120));
 
-  b __LOC__ (N.eq 
+  b __LOC__ (N.eq
                ( N.union (f (I.randomRange 0 20))
                    (f (I.randomRange 21 40) ))
                (f( I.randomRange 0 40)));
-  let dd = N.intersect aa bb in 
+  let dd = N.intersect aa bb in
   b __LOC__ (dd =~ f (I.randomRange 40 100));
-  b __LOC__ 
-    (N.intersect 
+  b __LOC__
+    (N.intersect
        (f @@ I.randomRange 0 20)
        (f @@ I.randomRange 21 40)
      =~ (empty ())
     );
-  b __LOC__ 
-    (N.intersect 
+  b __LOC__
+    (N.intersect
        (f @@ I.randomRange 21 40)
-       (f @@ I.randomRange 0 20)      
+       (f @@ I.randomRange 0 20)
      =~ (empty ())
-    );  
-  b __LOC__  
-    (N.intersect 
+    );
+  b __LOC__
+    (N.intersect
        (f [|1;3;4;5;7;9|])
        (f [|2;4;5;6;8;10|])
-     =~ (f [|4;5|])  
+     =~ (f [|4;5|])
     );
   b __LOC__
     (N.diff aa bb =~ f (I.randomRange 0 39));
-  b __LOC__   
+  b __LOC__
     (N.diff bb aa =~ f (I.randomRange 101 120));
-  b __LOC__ 
+  b __LOC__
     (N.diff
        (f @@ I.randomRange 21 40)
-       (f @@ I.randomRange 0 20)      
+       (f @@ I.randomRange 0 20)
      =~ (f (I.randomRange 21 40))
-    );  
-  b __LOC__ 
+    );
+  b __LOC__
     (N.diff
        (f @@ I.randomRange 0 20)
-       (f @@ I.randomRange 21 40)      
+       (f @@ I.randomRange 21 40)
      =~ (f (I.randomRange 0 20))
-    );    
+    );
 
-  b __LOC__ 
+  b __LOC__
     (N.diff
        (f @@ I.randomRange 0 20)
-       (f @@ I.randomRange 0 40)      
+       (f @@ I.randomRange 0 40)
      =~ (f (I.randomRange 0 (-1)))
-    )     
+    )
 
-let () =   
-  let a0 = ofArray  (I.randomRange 0 1000) in 
-  let a1,a2 = 
+let () =
+  let a0 = ofArray  (I.randomRange 0 1000) in
+  let a1,a2 =
     (
       N.keep a0 (fun x -> x mod 2  = 0),
       N.keep a0 (fun  x -> x mod 2 <> 0)
-    ) in 
-  let a3, a4 = N.partition a0 (fun  x -> x mod 2 = 0) in   
+    ) in
+  let a3, a4 = N.partition a0 (fun  x -> x mod 2 = 0) in
   b __LOC__ (N.eq a1 a3);
   b __LOC__ (N.eq a2 a4);
   (L.forEach [a0;a1;a2;a3;a4] (fun  x -> N.checkInvariantInternal x))
 
 
 
-;; Mt.from_pair_suites __FILE__ !suites  
+;; Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/bs_poly_set_test.ml
+++ b/jscomp/test/bs_poly_set_test.ml
@@ -1,53 +1,53 @@
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
-let eq loc x y = Mt.eq_suites ~test_id ~suites loc x y 
-let b loc x =  Mt.bool_suites ~test_id ~suites loc x  
-let t loc x = Mt.throw_suites ~test_id ~suites loc x 
+let eq loc x y = Mt.eq_suites ~test_id ~suites loc x y
+let b loc x =  Mt.bool_suites ~test_id ~suites loc x
+let t loc x = Mt.throw_suites ~test_id ~suites loc x
 module N = Belt.Set
 module D = Belt.Set.Dict
 module I = Array_data_util
 module A = Belt.Array
 module S = Belt.SortArray
-module IntCmp = 
-  (val Belt.Id.comparable (fun (x:int) y -> compare x y))
+module IntCmp =
+  (val Belt.Id.comparable ~cmp:(fun (x:int) y -> compare x y))
 module L = Belt.List
 
-let () = 
-  let u0 = N.ofArray ~id:(module IntCmp) (I.range 0 30) in 
-  let u1 = N.remove u0 0 in 
-  let u2 = N.remove u1 0 in 
-  let u3 = N.remove u2 30 in 
-  let u4 = N.remove u3 20 in   
-  let r = I.randomRange 0 30 in 
-  
-  let u5  = N.add u4 3 in 
-  let u6 = N.removeMany u5 r in   
-  let u7 = N.mergeMany u6 [|0;1;2;0|] in 
-  let u8 = N.removeMany u7 [|0;1;2;3|] in 
-  let u9 = N.mergeMany u8 (I.randomRange 0 20000)  in 
-  let u10 = N.mergeMany u9 (I.randomRange 0 200) in 
-  let u11 = N.removeMany u10 (I.randomRange 0 200) in 
-  let u12 = N.removeMany u11 (I.randomRange 0 1000) in 
-  let u13 = N.removeMany u12 (I.randomRange 0 1000) in 
-  let u14 = N.removeMany u13 (I.randomRange 1000 10000) in 
-  let u15 = N.removeMany u14 (I.randomRange 10000 (20000 - 1)) in 
+let () =
+  let u0 = N.ofArray ~id:(module IntCmp) (I.range 0 30) in
+  let u1 = N.remove u0 0 in
+  let u2 = N.remove u1 0 in
+  let u3 = N.remove u2 30 in
+  let u4 = N.remove u3 20 in
+  let r = I.randomRange 0 30 in
+
+  let u5  = N.add u4 3 in
+  let u6 = N.removeMany u5 r in
+  let u7 = N.mergeMany u6 [|0;1;2;0|] in
+  let u8 = N.removeMany u7 [|0;1;2;3|] in
+  let u9 = N.mergeMany u8 (I.randomRange 0 20000)  in
+  let u10 = N.mergeMany u9 (I.randomRange 0 200) in
+  let u11 = N.removeMany u10 (I.randomRange 0 200) in
+  let u12 = N.removeMany u11 (I.randomRange 0 1000) in
+  let u13 = N.removeMany u12 (I.randomRange 0 1000) in
+  let u14 = N.removeMany u13 (I.randomRange 1000 10000) in
+  let u15 = N.removeMany u14 (I.randomRange 10000 (20000 - 1)) in
   let u16 = N.removeMany u15 (I.randomRange 20000 21000) in
-  b __LOC__ (u0 != u1);  
+  b __LOC__ (u0 != u1);
   b __LOC__ (u2 == u1);
-  eq __LOC__ (N.size u4) 28; 
+  eq __LOC__ (N.size u4) 28;
   b __LOC__ (Js.eqUndefined 29 (N.maxUndefined u4));
   b __LOC__ (Js.eqUndefined 1 (N.minUndefined u4));
-  b __LOC__ (u4 == u5);  
-  b __LOC__ (N.isEmpty u6);  
+  b __LOC__ (u4 == u5);
+  b __LOC__ (N.isEmpty u6);
   eq  __LOC__ (N.size u7) 3 ;
-  b __LOC__ (not (N.isEmpty u7));  
+  b __LOC__ (not (N.isEmpty u7));
   b __LOC__ (N.isEmpty u8);
   (* b __LOC__ (u9 == u10); *)
   (* addArray does not get reference equality guarantee *)
   b __LOC__ (N.has u10 20);
   b __LOC__ (N.has u10 21);
   eq __LOC__ (N.size u10) 20001;
-  eq __LOC__ (N.size u11) 19800;  
+  eq __LOC__ (N.size u11) 19800;
   eq __LOC__ (N.size u12) 19000;
   (* b __LOC__ (u12 == u13);   *)
   eq __LOC__ (N.size u13) (N.size u12);
@@ -56,23 +56,23 @@ let () =
   b __LOC__ (N.has u15 20000);
   b __LOC__ (not @@ N.has u15 2000);
   b __LOC__ (N.isEmpty u16);
-  let u17  = N.ofArray ~id:(module IntCmp) (I.randomRange 0 100) in 
-  let u18 = N.ofArray ~id:(module IntCmp) (I.randomRange 59 200) in 
-  let u19 = N.union u17 u18 in 
-  let u20 = N.ofArray ~id:(module IntCmp) (I.randomRange 0 200) in 
-  let u21 =  N.intersect u17 u18 in 
-  let u22 = N.diff u17 u18 in 
-  let u23 = N.diff u18 u17 in 
-  let u24 = N.union u18 u17 in 
-  let u25 = N.add u22 59 in 
-  let u26 = N.add (N.make ~id:(module IntCmp)) 3 in 
-  let ss = (A.makeByAndShuffle 100 (fun i -> i * 2 )) in 
-  let u27 = N.ofArray ~id:(module IntCmp)  ss in 
-  let u28, u29 = N.union u27 u26, N.union u26 u27 in 
+  let u17  = N.ofArray ~id:(module IntCmp) (I.randomRange 0 100) in
+  let u18 = N.ofArray ~id:(module IntCmp) (I.randomRange 59 200) in
+  let u19 = N.union u17 u18 in
+  let u20 = N.ofArray ~id:(module IntCmp) (I.randomRange 0 200) in
+  let u21 =  N.intersect u17 u18 in
+  let u22 = N.diff u17 u18 in
+  let u23 = N.diff u18 u17 in
+  let u24 = N.union u18 u17 in
+  let u25 = N.add u22 59 in
+  let u26 = N.add (N.make ~id:(module IntCmp)) 3 in
+  let ss = (A.makeByAndShuffle 100 (fun i -> i * 2 )) in
+  let u27 = N.ofArray ~id:(module IntCmp)  ss in
+  let u28, u29 = N.union u27 u26, N.union u26 u27 in
   b __LOC__ (N.eq u28 u29);
   b __LOC__ (N.toArray u29 = (S.stableSortBy (A.concat ss [|3|]) compare ));
-  b __LOC__ (N.eq u19 u20);  
-  eq __LOC__ (N.toArray u21) (I.range 59 100);  
+  b __LOC__ (N.eq u19 u20);
+  eq __LOC__ (N.toArray u21) (I.range 59 100);
   eq __LOC__ (N.toArray u22) (I.range 0 58);
   b __LOC__ (N.eq u24 u19);
   eq __LOC__ (N.toArray u23) (I.range 101 200);
@@ -92,20 +92,20 @@ let () =
   b __LOC__ (N.maxUndefined (N.make (module IntCmp)) = Js.undefined)
 
 
-let testIterToList  xs = 
-  let v = ref [] in 
-  N.forEach xs (fun x -> v := x :: !v ) ; 
+let testIterToList  xs =
+  let v = ref [] in
+  N.forEach xs (fun x -> v := x :: !v ) ;
   L.reverse !v
 
-let testIterToList2  xs = 
-  let v = ref [] in 
-  D.forEach (N.getData xs) (fun x -> v := x :: !v ) ; 
-  L.reverse !v  
-  
-let () =   
-  let u0 = N.ofArray ~id:(module IntCmp) (I.randomRange 0 20) in 
-  let u1 = N.remove u0 17 in  
-  let u2 = N.add u1 33 in 
+let testIterToList2  xs =
+  let v = ref [] in
+  D.forEach (N.getData xs) (fun x -> v := x :: !v ) ;
+  L.reverse !v
+
+let () =
+  let u0 = N.ofArray ~id:(module IntCmp) (I.randomRange 0 20) in
+  let u1 = N.remove u0 17 in
+  let u2 = N.add u1 33 in
   b __LOC__ (L.every2 (testIterToList u0) (L.makeBy 21 (fun i -> i)) (fun x y -> x = y));
   b __LOC__ (L.every2 (testIterToList2 u0) (L.makeBy 21 (fun i -> i)) (fun x y -> x = y));
   b __LOC__ (L.every2 (testIterToList u0) (N.toList u0) (fun  x y -> x = y));
@@ -117,29 +117,29 @@ let () =
   b __LOC__ ( not @@ N.every (N.ofArray ~id:(module IntCmp) [|1;2;3|]) (fun x -> x = 2));
   b __LOC__ (N.cmp u1 u0 < 0);
   b __LOC__ (N.cmp u0 u1 > 0)
-  
-let () =   
-  let a0 = N.ofArray ~id:(module IntCmp) (I.randomRange 0 1000) in 
-  let a1,a2 = 
+
+let () =
+  let a0 = N.ofArray ~id:(module IntCmp) (I.randomRange 0 1000) in
+  let a1,a2 =
     (
       N.keep a0 (fun x -> x mod 2  = 0),
       N.keep a0 (fun x -> x mod 2 <> 0)
-    ) in 
-  let a3, a4 = N.partition a0 (fun x -> x mod 2 = 0) in   
+    ) in
+  let a3, a4 = N.partition a0 (fun x -> x mod 2 = 0) in
   b __LOC__ (N.eq a1 a3);
   b __LOC__ (N.eq a2 a4);
   eq __LOC__ (N.getExn a0 3) 3 ;
-  eq __LOC__ (N.getExn a0 4) 4;   
+  eq __LOC__ (N.getExn a0 4) 4;
   t __LOC__ (fun _ -> ignore @@ N.getExn a0 1002 );
-  t __LOC__ (fun _ -> ignore @@ N.getExn a0 (-1) );  
+  t __LOC__ (fun _ -> ignore @@ N.getExn a0 (-1) );
   eq __LOC__ (N.size a0 ) 1001;
   b __LOC__ (not @@ N.isEmpty a0);
-  let (a5,a6), pres  = N.split a0 200 in 
+  let (a5,a6), pres  = N.split a0 200 in
   b __LOC__ pres ;
   eq __LOC__ (N.toArray a5) (A.makeBy 200 (fun i -> i));
   eq __LOC__ (N.toList a6) (L.makeBy 800 (fun i -> i + 201));
-  let a7 = N.remove a0 200 in 
-  let (a8,a9), pres  = N.split a7 200 in 
+  let a7 = N.remove a0 200 in
+  let (a8,a9), pres  = N.split a7 200 in
   b __LOC__ (not pres) ;
   eq __LOC__ (N.toArray a8) (A.makeBy 200 (fun i -> i));
   eq __LOC__ (N.toList a9) (L.makeBy 800 (fun i -> i + 201));
@@ -148,13 +148,13 @@ let () =
   L.forEach [a0;a1;a2;a3;a4] (fun  x -> N.checkInvariantInternal x)
 
 
-let () =   
-  let a = N.ofArray ~id:(module IntCmp) [||] in 
+let () =
+  let a = N.ofArray ~id:(module IntCmp) [||] in
   b __LOC__ (N.isEmpty (N.keep a (fun x -> x mod 2 = 0)))
 
-let () = 
-  let (aa,bb), pres = N.split (N.make  ~id:(module IntCmp)) 0 in 
+let () =
+  let (aa,bb), pres = N.split (N.make  ~id:(module IntCmp)) 0 in
   b __LOC__ (N.isEmpty aa);
   b __LOC__ (N.isEmpty bb);
   b __LOC__ (not pres)
-;; Mt.from_pair_suites __FILE__ !suites  
+;; Mt.from_pair_suites __FILE__ !suites


### PR DESCRIPTION
See #2565 which removed it. #2589 deprecates comparable, so we can just
put the label back to avoid unnecessary churn the next release

https://github.com/BuckleScript/bucklescript/pull/2602/files?w=1