### PR TITLE
Fix typos in Belt Module overview

### DIFF
--- a/docs/api/Belt.html
+++ b/docs/api/Belt.html
@@ -110,11 +110,11 @@
 
     The motivation of creating such library is to provide BuckleScript users a 
     better end-to-end user experience, since the original OCaml stdlib was not 
-    writte with JS platform in mind, below are a list of areas this lib aims to 
+    written with JS platform in mind, below are a list of areas this lib aims to
     improve: <OL>
 <li>1. Consistency in name convention: camlCase, and arguments order</li>
 <li>2. Exception thrown functions are all suffixed with <i>Exn</i>, e.g, <i>getExn</i></li>
-<li>3. Beter peformance and smaller code size running on JS platform</li>
+<li>3. Better performance and smaller code size running on JS platform</li>
 </OL>
 
 <p>
@@ -183,7 +183,7 @@
     <code class="code">I0.identity</code> and <code class="code">I1.identity</code> are not the same using our encoding scheme.
 <p>
 
-    <b>Collection Hierachy</b>
+    <b>Collection Hierarchy</b>
 <p>
 
     In general, we provide a generic collection module, but also create specialized
@@ -201,7 +201,7 @@
 <p>
 
     Currently, both <i>Belt_Set</i> and <i>Belt.Set</i> are accessible to users for some
-    technical rasons,
+    technical reasons,
     we <b>strongly recommend</b> users stick to qualified import, <i>Belt.Sort</i>, we may hide
     the internal, <i>i.e</i>, <i>Belt_Set</i> in the future<br>
  
@@ -216,11 +216,11 @@
                     <a href="Belt.Id.html"><code class="code">Belt.Id</code></a>
 <p>
 
-    Provide utiliites to create identified comparators or hashes for 
+    Provide utilities to create identified comparators or hashes for
     data structures used below. 
 <p>
 
-    It create a unique identifer per module of
+    It create a unique identifier per module of
     functions so that different data structures with slightly different 
     comparison functions won't mix<br>
  
@@ -231,7 +231,7 @@
                     <a href="Belt.Array.html"><code class="code">Belt.Array</code></a>
 <p>
 
-    <b>mutable array</b>: Utililites functions<br>
+    <b>mutable array</b>: Utilities functions<br>
  
                 </div>
                 </div> 
@@ -240,7 +240,7 @@
                     <a href="Belt.SortArray.html"><code class="code">Belt.SortArray</code></a>
 <p>
 
-    The toplevel provides some generic sort related utililties.
+    The top level provides some generic sort related utilities.
 <p>
 
     It also has two specialized inner modules
@@ -289,7 +289,7 @@
                     <a href="Belt.Set.html"><code class="code">Belt.Set</code></a>
 <p>
 
-    The toplevel provides generic <b>immutable</b> set operations.
+    The top level provides generic <b>immutable</b> set operations.
 <p>
 
     It also has three specialized inner modules
@@ -297,7 +297,7 @@
 <p>
 
     <code class="code">Belt.Set.Dict</code>: This module separate date from function
-    which is more verbbose but slightly more efficient<br>
+    which is more verbose but slightly more efficient<br>
  
                 </div>
                 </div> 
@@ -306,7 +306,7 @@
                     <a href="Belt.Map.html"><code class="code">Belt.Map</code></a>,
 <p>
 
-    The toplevel provides generic <b>immutable</b> map operations.
+    The top level provides generic <b>immutable</b> map operations.
 <p>
 
     It also has three specialized inner modules
@@ -314,7 +314,7 @@
 <p>
 
     <code class="code">Belt.Map.Dict</code>: This module separate date from function
-    which  is more verbbose but slightly more efficient<br>
+    which  is more verbose but slightly more efficient<br>
  
                 </div>
                 </div> 
@@ -323,7 +323,7 @@
                     <a href="Belt.MutableSet.html"><code class="code">Belt.MutableSet</code></a>
 <p>
 
-    The toplevel provides generic <b>mutable</b> set operations.
+    The top level provides generic <b>mutable</b> set operations.
 <p>
 
     It also has two specialized inner modules
@@ -336,7 +336,7 @@
                     <a href="Belt.MutableMap.html"><code class="code">Belt.MutableMap</code></a>
 <p>
 
-    The toplevel provides generic <b>mutable</b> map operations.
+    The top level provides generic <b>mutable</b> map operations.
 <p>
 
     It also has two specialized inner modules
@@ -349,7 +349,7 @@
                     <a href="Belt.HashSet.html"><code class="code">Belt.HashSet</code></a>
 <p>
 
-    The toplevel provides generic <b>mutable</b> hash set operations.
+    The top level provides generic <b>mutable</b> hash set operations.
 <p>
 
     It also has two specialized inner modules
@@ -362,7 +362,7 @@
                     <a href="Belt.HashMap.html"><code class="code">Belt.HashMap</code></a>
 <p>
 
-    The toplevel provides generic <b>mutable</b> hash map operations.
+    The top level provides generic <b>mutable</b> hash map operations.
 <p>
 
     It also has two specialized inner modules


### PR DESCRIPTION
Hi there! I found a few small typos in the documentation for the Belt module overview. I read through the contribution guidelines, but if I missed anything, I'd be glad to know.