### PR TITLE
[Super errors] Make the second worst ReasonReact error a bit shorter

### DIFF
--- a/jscomp/super_errors/super_reason_react.mli
+++ b/jscomp/super_errors/super_reason_react.mli
@@ -10,8 +10,8 @@ val state_escape_scope: (Types.type_expr * Types.type_expr) list -> bool
 val trace_both_component_spec: (Types.type_expr * Types.type_expr) list -> bool
 (** Used by super_typecore when we detect the message "The type constructor state would escape its scope" *)
 
-val is_array_wanted_reactElement: (Types.type_expr * Types.type_expr) list -> bool
+val is_array_wanted_react_element: (Types.type_expr * Types.type_expr) list -> bool
 (** Used by super_typecore when we detect the message "This has type array but expected reactElement" *)
 
-val is_component_spec_wanted_reactElement: (Types.type_expr * Types.type_expr) list -> bool
+val is_component_spec_wanted_react_element: (Types.type_expr * Types.type_expr) list -> bool
 (** Used by super_typecore when we detect the message "This has type componentSpec but expected reactElement" *)

--- a/jscomp/super_errors/super_reason_react.mli
+++ b/jscomp/super_errors/super_reason_react.mli
@@ -7,8 +7,11 @@ val component_spec_weak_type_variables_in_module_type: Types.module_type -> (boo
 val state_escape_scope: (Types.type_expr * Types.type_expr) list -> bool
 (** Used by super_typecore when we detect the message "The type constructor state would escape its scope" *)
 
+val trace_both_component_spec: (Types.type_expr * Types.type_expr) list -> bool
+(** Used by super_typecore when we detect the message "The type constructor state would escape its scope" *)
+
 val is_array_wanted_reactElement: (Types.type_expr * Types.type_expr) list -> bool
 (** Used by super_typecore when we detect the message "This has type array but expected reactElement" *)
 
-val is_componentSpec_wanted_reactElement: (Types.type_expr * Types.type_expr) list -> bool
+val is_component_spec_wanted_reactElement: (Types.type_expr * Types.type_expr) list -> bool
 (** Used by super_typecore when we detect the message "This has type componentSpec but expected reactElement" *)

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -112,13 +112,13 @@ let print_expr_type_clash env trace ppf =
     @]"
     (* This one above shouldn't catch any false positives, so we can safely not display the original type clash error. *)
   else begin
-    if Super_reason_react.is_array_wanted_reactElement trace then
+    if Super_reason_react.is_array_wanted_react_element trace then
     fprintf ppf "@[<v>\
       @[@{<info>Did you pass an array as a ReasonReact DOM (lower-case) component's children?@}@ If not, disregard this.@ \
       If so, please use `ReasonReact.createDomElement`:@ https://reasonml.github.io/reason-react/docs/en/children.html@]@,@,\
       @[@{<info>Here's the original error message@}@]@,\
     @]"
-    else if Super_reason_react.is_component_spec_wanted_reactElement trace then
+    else if Super_reason_react.is_component_spec_wanted_react_element trace then
       fprintf ppf "@[<v>\
         @[@{<info>Did you want to create a ReasonReact element without using JSX?@}@ If not, disregard this.@ \
         If so, don't forget to wrap this value in `ReasonReact.element` yourself:@ https://reasonml.github.io/reason-react/docs/en/jsx.html#capitalized@]@,@,\

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -104,25 +104,26 @@ let check_bs_arity_mismatch ppf trace =
 let print_expr_type_clash env trace ppf =
   (* this is the most frequent error. Do whatever we can to provide specific
     guidance to this generic error before giving up *)
-  if Super_reason_react.state_escape_scope trace then
+  if Super_reason_react.state_escape_scope trace && Super_reason_react.trace_both_component_spec trace then
     fprintf ppf "@[<v>\
       @[@{<info>Is this a ReasonReact reducerComponent or component with retained props?@}@ \
-      If so, is the type for state, retained props or action declared _after_ the component declaration?@ \
-      Moving these types above the component declaration should resolve this!@]@,@,\
-      @[@{<info>Here's the original error message@}@]@,\
+      If so, is the type for state, retained props or action declared _after_@ the component declaration?@ \
+      @{<info>Moving these types above the component declaration@} should resolve this!@]\
     @]"
-  else if Super_reason_react.is_array_wanted_reactElement trace then
+    (* This one above shouldn't catch any false positives, so we can safely not display the original type clash error. *)
+  else begin
+    if Super_reason_react.is_array_wanted_reactElement trace then
     fprintf ppf "@[<v>\
       @[@{<info>Did you pass an array as a ReasonReact DOM (lower-case) component's children?@}@ If not, disregard this.@ \
       If so, please use `ReasonReact.createDomElement`:@ https://reasonml.github.io/reason-react/docs/en/children.html@]@,@,\
       @[@{<info>Here's the original error message@}@]@,\
     @]"
-  else if Super_reason_react.is_componentSpec_wanted_reactElement trace then
-    fprintf ppf "@[<v>\
-      @[@{<info>Did you want to create a ReasonReact element without using JSX?@}@ If not, disregard this.@ \
-      If so, don't forget to wrap this value in `ReasonReact.element` yourself:@ https://reasonml.github.io/reason-react/docs/en/jsx.html#capitalized@]@,@,\
-      @[@{<info>Here's the original error message@}@]@,\
-    @]";
+    else if Super_reason_react.is_component_spec_wanted_reactElement trace then
+      fprintf ppf "@[<v>\
+        @[@{<info>Did you want to create a ReasonReact element without using JSX?@}@ If not, disregard this.@ \
+        If so, don't forget to wrap this value in `ReasonReact.element` yourself:@ https://reasonml.github.io/reason-react/docs/en/jsx.html#capitalized@]@,@,\
+        @[@{<info>Here's the original error message@}@]@,\
+      @]";
   begin
     let bottom_aliases_result = bottom_aliases trace in
     let missing_arguments = match bottom_aliases_result with
@@ -137,7 +138,7 @@ let print_expr_type_clash env trace ppf =
           else fprintf ppf "@[(~%s: %a)@]" label type_expr argtype
         )
     in
-    begin match missing_arguments with
+    match missing_arguments with
     | Some [singleArgument] ->
       (* btw, you can't say "final arguments". Intermediate labeled
         arguments might be the ones missing *)
@@ -170,7 +171,7 @@ let print_expr_type_clash env trace ppf =
         (function ppf ->
             fprintf ppf "But somewhere wanted:");
       show_extra_help ppf env trace;
-    end;
+    end
   end
 (* taken from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/typing/typecore.ml#L3769 *)
 (* modified branches are commented *)


### PR DESCRIPTION
The "state escape scope" one.

This one shouldn't catch any false positives, so we can safely remove
the original type clash error.

Also, we only detected state escaping scope, not that it's actually
related to ReasonReact.componentSpec. So every state escape scope error
ended up giving a ReasonReact error correction tip. This is fixed now.
Sorry about that.