### PR TITLE
[Docs][Belt] Cleanup; remove references to comparableU

### DIFF
--- a/jscomp/others/belt.ml
+++ b/jscomp/others/belt.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,22 +17,22 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
-(** A stdlib shipped with BuckleScript 
+(** A stdlib shipped with BuckleScript
 
-    This stdlib is still in {i beta} status, but we encourage you to try it out and 
+    This stdlib is still in {i beta} status, but we encourage you to try it out and
     provide feedback.
 
     {b Motivation }
 
-    The motivation of creating such library is to provide BuckleScript users a 
-    better end-to-end user experience, since the original OCaml stdlib was not 
-    written with JS platform in mind, below are a list of areas this lib aims to 
+    The motivation of creating such library is to provide BuckleScript users a
+    better end-to-end user experience, since the original OCaml stdlib was not
+    written with JS platform in mind, below are a list of areas this lib aims to
     improve: {ol
     {- 1. Consistency in name convention: camlCase, and arguments order}
     {- 2. Exception thrown functions are all suffixed with {i Exn}, e.g, {i getExn}}
@@ -55,7 +55,7 @@
    {b A special encoding for collection safety}
 
    When we create a collection library for a custom data type, take {i Set} for
-   example, suppose its element type is a pair of ints, 
+   example, suppose its element type is a pair of ints,
     it needs a custom {i compare} function. However, the {i Set} could not
     just be typed as [ Set.t (int * int) ],
     its customized {i compare} function needs to be
@@ -68,32 +68,36 @@
     We introduced a phantom type to solve the problem
 
     {[
-      type t = int * int 
-      module I0 =
-        (val Belt.Id.comparableU (fun[\@bs] ((a0,a1) : t) ((b0,b1) : t) ->
-             match compare a0 b0 with
-             | 0 -> compare a1 b1
-             | c -> c 
-           ))
-    let s0 = Belt.Set.make ~id:(module I0)
-    module I1 =
-      (val Belt.Id.comparableU (fun[\@bs] ((a0,a1) : t) ((b0,b1) : t) ->
-           match compare a1 b1 with
-           | 0 -> compare a0 b0
-           | c -> c 
-         ))
-    let s1 = Belt.Set.make ~id:(module I1)
+      module Comparable1 = Belt.Id.MakeComparable(struct
+        type t = int * int
+        let cmp (a0, a1) (b0, b1) =
+          match Pervasives.compare a0 b0 with
+          | 0 -> Pervasives.compare a1 b1
+          | c -> c
+      end)
+
+    let mySet1 = Belt.Set.make ~id:(module Comparable1)
+
+    module Comparable2 = Belt.Id.MakeComparable(struct
+      type t = int * int
+      let cmp (a0, a1) (b0, b1) =
+        match Pervasives.compare a0 b0 with
+        | 0 -> Pervasives.compare a1 b1
+        | c -> c
+    end)
+
+    let mySet2 = Belt.Set.make ~id:(module Comparable2)
     ]}
 
-    Here the compiler would infer [s0] and [s1] having different type so that
-    it would not mix.
+    Here, the compiler would infer [mySet1] and [mySet2] having different type, so
+    e.g. a `merge` operation that tries to merge these two sets will correctly fail.
 
     {[
-      val s0 : ((int * int), I0.identity) t
-      val s1 : ((int * int), I1.identity) t
+      val mySet1 : ((int * int), Comparable1.identity) t
+      val mySet2 : ((int * int), Comparable2.identity) t
     ]}
 
-    [I0.identity] and [I1.identity] are not the same using our encoding scheme.
+    [Comparable1.identity] and [Comparable2.identity] are not the same using our encoding scheme.
 
     {b Collection Hierarchy}
 
@@ -113,16 +117,16 @@
     technical reasons,
     we {b strongly recommend} users stick to qualified import, {i Belt.Sort}, we may hide
     the internal, {i i.e}, {i Belt_Set} in the future
-    
+
 *)
 
 (** {!Belt.Id}
 
-    Provide utilities to create identified comparators or hashes for 
-    data structures used below. 
-    
+    Provide utilities to create identified comparators or hashes for
+    data structures used below.
+
     It create a unique identifier per module of
-    functions so that different data structures with slightly different 
+    functions so that different data structures with slightly different
     comparison functions won't mix
 *)
 module Id = Belt_Id
@@ -134,34 +138,34 @@ module Id = Belt_Id
 module Array = Belt_Array
 
 (** {!Belt.SortArray}
-    
+
     The top level provides some generic sort related utilities.
-    
+
     It also has two specialized inner modules
     {!Belt.SortArray.Int} and {!Belt.SortArray.String}
 *)
 module SortArray = Belt_SortArray
 
 (** {!Belt.MutableQueue}
-    
+
     An FIFO(first in first out) queue data structure
 *)
 module MutableQueue = Belt_MutableQueue
 
 (** {!Belt.MutableStack}
-    
+
     An FILO(first in last out) stack data structure
 *)
-module MutableStack = Belt_MutableStack 
+module MutableStack = Belt_MutableStack
 
 (** {!Belt.List}
-    
+
     Utilities for List data type
 *)
 module List = Belt_List
 
 (** {!Belt.Range}
-    
+
     Utilities for a closed range [(from, start)]
 *)
 module Range = Belt_Range
@@ -183,29 +187,29 @@ module Set = Belt_Set
 (** {!Belt.Map},
 
     The top level provides generic {b immutable} map operations.
-    
+
     It also has three specialized inner modules
     {!Belt.Map.Int} and {!Belt.Map.String}
 
     {!Belt.Map.Dict}: This module separate date from function
     which  is more verbose but slightly more efficient
-*)    
+*)
 module Map = Belt_Map
 
 
 (** {!Belt.MutableSet}
-    
+
     The top level provides generic {b mutable} set operations.
-    
+
     It also has two specialized inner modules
     {!Belt.MutableSet.Int} and {!Belt.MutableSet.String}
 *)
 module MutableSet = Belt_MutableSet
 
 (** {!Belt.MutableMap}
-    
+
     The top level provides generic {b mutable} map operations.
-    
+
     It also has two specialized inner modules
     {!Belt.MutableMap.Int} and {!Belt.MutableMap.String}
 
@@ -214,9 +218,9 @@ module MutableMap = Belt_MutableMap
 
 
 (** {!Belt.HashSet}
-    
+
     The top level provides generic {b mutable} hash set operations.
-    
+
     It also has two specialized inner modules
     {!Belt.HashSet.Int} and {!Belt.HashSet.String}
 *)
@@ -224,14 +228,14 @@ module HashSet = Belt_HashSet
 
 
 (** {!Belt.HashMap}
-    
+
     The top level provides generic {b mutable} hash map operations.
-    
+
     It also has two specialized inner modules
     {!Belt.HashMap.Int} and {!Belt.HashMap.String}
 *)
 module HashMap = Belt_HashMap
-  
+
 
 
 

--- a/jscomp/others/belt_Map.mli
+++ b/jscomp/others/belt_Map.mli
@@ -17,50 +17,25 @@
    The implementation uses balanced binary trees, and therefore searching
    and insertion take time logarithmic in the size of the map.
 
-   All data are parameterized by not its only type but also a unique identity in
-   the time of initialization, so that two {i Map of int keys} initialized with different
-   {i compare} functions will have different type.
+  For more info on this module's usage of identity, `make` and others, please see
+  the top level documentation of Belt, {b A special encoding for collection safety}.
 
-   For example:
-   {[
-     type t = int * int 
-      module I0 =
-        (val Belt.Id.comparableU (fun[\@bs] ((a0,a1) : t) ((b0,b1) : t) ->
-             match Pervasives.compare a0 b0 with
-             | 0 -> Pervasives.compare a1 b1
-             | c -> c 
-           ))
-    let s0 : (_, string, _) t = make ~id:(module I0) (* value is of type string *)
-    module I1 =
-      (val Belt.Id.comparableU (fun[\@bs] ((a0,a1) : t) ((b0,b1) : t) ->
-           match compare a1 b1 with
-           | 0 -> compare a0 b0
-           | c -> c 
-         ))
-    let s1 : (_, string, _) t = make ~id:(module I1)
-   ]}
+  Example usage:
 
+   @example {[
+    module PairComparator = Belt.Id.MakeComparable(struct
+      type t = int * int
+      let cmp (a0, a1) (b0, b1) =
+        match Pervasives.compare a0 b0 with
+        | 0 -> Pervasives.compare a1 b1
+        | c -> c
+    end)
 
-   Here the compiler would infer [s0] and [s1] having different type so that
-    it would not mix.
+    let myMap = Belt.Map.make ~id:(module PairComparator)
+    let myMap2 = Belt.Map.set myMap (1, 2) "myValue"
+  ]}
 
-   {[
-     val s0 : ((int * int), string,  I0.identity) t 
-     val s1 : ((int * int), string,  I1.identity) t
-   ]}
-
-   We can add elements to the collection:
-
-   {[
-
-     let s2 = add s1 (0,0) "a"
-     let s3 = add s2 (1,1) "b"
-   ]}
-
-   Since this is an immutable data strucure, [s1] will be an empty map
-   while [s2] will contain one pair, [s3] will contain two.
-
-   The [merge s0 s3 callback] will result in a type error, since their identity mismatch
+  The API documentation below will assume a predeclared comparator module for integers, IntCmp
 *)
 
 
@@ -70,7 +45,7 @@
 module Int = Belt_MapInt
 
 (** specalized when key type is [string], more efficient
-    than the gerneic type, its compare behavior is fixed using the built-in comparison *)  
+    than the gerneic type, its compare behavior is fixed using the built-in comparison *)
 module String = Belt_MapString
 
 (** This module seprate identity from data, it is a bit more verbsoe but slightly
@@ -78,7 +53,7 @@ module String = Belt_MapString
     after each operation
 
     {b Advanced usage only}
-*)  
+*)
 module Dict = Belt_MapDict
 
 
@@ -99,54 +74,48 @@ type ('key, 'id) id = ('key, 'id) Belt_Id.comparable
 
 (*
     How we retain soundness:
-    The only way to create a value of type [_ t] from scratch 
+    The only way to create a value of type [_ t] from scratch
     is through [empty] which requires [_ Belt_Id.t]
     The only way to create [_ Belt_Id.t] is using [Belt_Id.Make] which
     will create a fresh type [id] per module
 
-    Generic operations over tree without [cmp] are still exported 
+    Generic operations over tree without [cmp] are still exported
     (for efficient reasons) so that [data] does not need be boxed and unboxed.
 
     The soundness is guaranteed in two aspects:
     When create a value of [_ t] it needs both [_ Belt_Id.t] and [_ t0].
-    [_ Belt_Id.t] is an abstract type. Note [add0] requires [_ Belt_Id.cmp] which 
+    [_ Belt_Id.t] is an abstract type. Note [add0] requires [_ Belt_Id.cmp] which
     is also an abstract type which can only come from [_ Belt_Id.t]
 
     When destructing a value of [_ t], the ['id] parameter is threaded.
 
 *)
 
-(* should not export [Belt_Id.compare]. 
+(* should not export [Belt_Id.compare].
    should only export [Belt_Id.t] or [Belt_Id.cmp] instead *)
 
 
 val make: id:('k, 'id) id -> ('k, 'v, 'id) t
-(** [make ~id]
-   
-     @example {[
-     module IntCmp = (val Belt.Id.comparable (fun (x:int) y -> Pervasives.compare x y));;
-     let s = make ~id:(module IntCmp)
+(** [make ~id] creates a new map by taking in the comparator
+    @example {[
+      let m = Belt.Map.make ~id:(module IntCmp)
     ]}
-
-*)
+ *)
 
 
 val isEmpty: _ t -> bool
-(** [isEmpty s0]
+(** [isEmpty m] checks whether a map m is empty
     @example {[
-      module IntCmp = (val Belt.Id.comparable (fun (x:int) y -> Pervasives.compare x y));;
-      isEmpty (fromArray [|1,"1"|] ~id:(module IntCmp)) = false;;
+      isEmpty (fromArray [|1,"1"|] ~id:(module IntCmp)) = false
     ]}
 *)
 
 val has: ('k, 'v, 'id) t -> 'k  -> bool
-(** [has s k]
-
+(** [has m k] checks whether m has the key k
     @example {[
-      module IntCmp = (val Belt.Id.comparable (fun (x:int) y -> Pervasives.compare x y));;
-      has (fromArray [|1,"1"|] ~id:(module IntCmp)) 1 = true;;
+      has (fromArray [|1,"1"|] ~id:(module IntCmp)) 1 = true
     ]}
-*)  
+  *)
 
 val cmpU:
     ('k, 'v, 'id) t ->
@@ -158,22 +127,22 @@ val cmp:
     ('k, 'v, 'id) t ->
     ('v -> 'v -> int ) ->
      int
-(** [cmp s0 s1 vcmp]
+(** [cmp m0 m1 vcmp]
 
-    Totoal ordering of map given total ordering of value function.
+    Total ordering of map given total ordering of value function.
 
     It will compare size first and each element following the order one by one.
 *)
 
-val eqU:  
-    ('k, 'v, 'id) t -> 
-    ('k, 'v, 'id) t -> 
-    ('v -> 'v -> bool [@bs]) -> 
+val eqU:
+    ('k, 'v, 'id) t ->
+    ('k, 'v, 'id) t ->
+    ('v -> 'v -> bool [@bs]) ->
     bool
-val eq:  
-    ('k, 'v, 'id) t -> 
-    ('k, 'v, 'id) t -> 
-    ('v -> 'v -> bool) -> 
+val eq:
+    ('k, 'v, 'id) t ->
+    ('k, 'v, 'id) t ->
+    ('v -> 'v -> bool) ->
     bool
 (** [eq m1 m2 veq] tests whether the maps [m1] and [m2] are
     equal, that is, contain equal keys and associate them with
@@ -188,9 +157,6 @@ val forEach:  ('k, 'v, 'id) t -> ('k -> 'v -> unit) -> unit
     order with respect to the ordering over the type of the keys.
 
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
-
       let s0 = fromArray ~id:(module IntCmp) [|4,"4";1,"1";2,"2,"3""|];;
       let acc = ref [] ;;
       forEach s0 (fun k v -> acc := (k,v) :: !acc);;
@@ -206,9 +172,6 @@ val reduce: ('k, 'v, 'id) t -> 'acc -> ('acc -> 'k -> 'v -> 'acc) -> 'acc
     (in increasing order), and [d1 ... dN] are the associated data.
 
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
-
       let s0 = fromArray ~id:(module IntCmp) [|4,"4";1,"1";2,"2,"3""|];;
       reduce s0 [] (fun acc k v -> (k,v) acc ) = [4,"4";3,"3";2,"2";1,"1"];;
     ]}
@@ -228,8 +191,6 @@ val size: ('k, 'v, 'id) t -> int
 (** [size s]
 
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
       size (fromArray [2,"2"; 2,"1"; 3,"3"] ~id:(module IntCmp)) = 2 ;;
     ]}
 *)
@@ -237,8 +198,6 @@ val toArray: ('k, 'v, 'id) t -> ('k * 'v) array
 (** [toArray s]
 
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
       toArray (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) = [1,"1";2,"2";3,"3"]
     ]}
 
@@ -248,91 +207,81 @@ val toList: ('k, 'v, 'id) t -> ('k * 'v) list
 
     {b See} {!toArray}
 *)
-    
+
 val ofArray:  ('k * 'v) array -> id:('k,'id) id -> ('k,'v,'id) t
 [@@ocaml.deprecated "Use fromArray instead"]
 
 val fromArray:  ('k * 'v) array -> id:('k,'id) id -> ('k,'v,'id) t
 (** [fromArray kvs ~id]
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
       toArray (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) = [1,"1";2,"2";3,"3"]
     ]}
-*)    
+*)
 val keysToArray: ('k, 'v, 'id) t -> 'k  array
 (** [keysToArray s]
-
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
       keysToArray (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) =
       [|1;2;3|];;
     ]}
-*)    
+*)
 val valuesToArray: ('k, 'v, 'id) t -> 'v  array
 (** [valuesToArray s]
-
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
       valuesToArray (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) =
       [|"1";"2";"3"|];;
     ]}
 
 *)
-    
+
 val minKey: ('k, _, _) t -> 'k option
 (** [minKey s]
-    @return thte minimum key, None if not exist 
-*)    
+    @return the minimum key, None if not exist
+*)
 
 val minKeyUndefined: ('k, _, _) t -> 'k Js.undefined
-(** {b See} {!minKey}*)    
+(** {b See} {!minKey}*)
 
 val maxKey: ('k, _, _) t -> 'k option
 (** [maxKey s]
-    @return thte maximum key, None if not exist 
-*)    
-    
+    @return the maximum key, None if not exist
+*)
+
 val maxKeyUndefined: ('k, _, _) t -> 'k Js.undefined
-(** {b See} {!maxKey} *)    
+(** {b See} {!maxKey} *)
 
 val minimum: ('k, 'v,  _) t -> ('k * 'v) option
 (** [minimum s]
-    @return thte minimum key value pair, None if not exist 
-*)    
-    
+    @return the minimum key value pair, None if not exist
+*)
+
 val minUndefined: ('k, 'v, _) t -> ('k * 'v) Js.undefined
-(** {b See} {!minimum} *)    
+(** {b See} {!minimum} *)
 
 val maximum: ('k, 'v, _) t -> ('k * 'v) option
 (** [maximum s]
-    @return thte maximum key value pair, None if not exist 
-*)    
+    @return the maximum key value pair, None if not exist
+*)
 
 val maxUndefined:('k, 'v, _) t -> ('k * 'v) Js.undefined
 (** {b See} {!maximum}
 *)
-    
+
 val get:  ('k, 'v, 'id) t -> 'k -> 'v option
 (** [get s k]
 
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
       get (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) 2 =
       Some "2";;
       get (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) 2 =
       None;;
     ]}
 *)
-    
+
 val getUndefined: ('k, 'v, 'id) t -> 'k ->  'v Js.undefined
 (** {b See} {!get}
 
     @return [undefined] when not found
-*)    
+*)
 val getWithDefault:
     ('k, 'v, 'id) t -> 'k ->  'v -> 'v
 (** [getWithDefault s k default]
@@ -340,9 +289,9 @@ val getWithDefault:
    {b See} {!get}
 
     @return [default] when [k] is not found
-    
-*)    
-val getExn:  ('k, 'v, 'id) t -> 'k -> 'v 
+
+*)
+val getExn:  ('k, 'v, 'id) t -> 'k -> 'v
 (** [getExn s k]
 
    {b See} {!getExn}
@@ -356,9 +305,6 @@ val remove:  ('k, 'v, 'id) t -> 'k -> ('k, 'v, 'id) t
 (** [remove m x] when [x] is not in [m], [m] is returned reference unchanged.
 
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
-      
       let s0 =  (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp));;
 
       let s1 = remove s0 1;;
@@ -366,27 +312,24 @@ val remove:  ('k, 'v, 'id) t -> 'k -> ('k, 'v, 'id) t
       s1 == s2 ;;
       keysToArray s1 = [|2;3|];;
     ]}
-    
+
 *)
-    
-val removeMany: ('k, 'v, 'id) t -> 'k array -> ('k, 'v, 'id) t  
+
+val removeMany: ('k, 'v, 'id) t -> 'k array -> ('k, 'v, 'id) t
 (** [removeMany s xs]
 
     Removing each of [xs] to [s], note unlike {!remove},
     the reference of return value might be changed even if none in [xs]
     exists [s]
-*)    
-  
-val set: 
+*)
+
+val set:
     ('k, 'v, 'id) t -> 'k -> 'v ->  ('k, 'v, 'id) t
 (** [set m x y ] returns a map containing the same bindings as
     [m], with a new binding of [x] to [y]. If [x] was already bound
     in [m], its previous binding disappears.
 
     @example {[
-      module IntCmp =
-        (val Belt.Id.comparableU (fun[\@bs] (x:int) y -> Pervasives.compare x y));;
-      
       let s0 =  (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp));;
 
       let s1 = set s0 2 "3";;
@@ -394,16 +337,16 @@ val set:
       valuesToArray s1 =  ["1";"3";"3"];;
     ]}
 *)
-      
-val updateU: ('k, 'v, 'id) t -> 'k -> ('v option -> 'v option [@bs]) -> ('k, 'v, 'id) t      
-val update: ('k, 'v, 'id) t -> 'k -> ('v option -> 'v option) -> ('k, 'v, 'id) t      
+
+val updateU: ('k, 'v, 'id) t -> 'k -> ('v option -> 'v option [@bs]) -> ('k, 'v, 'id) t
+val update: ('k, 'v, 'id) t -> 'k -> ('v option -> 'v option) -> ('k, 'v, 'id) t
 (** [update m x f] returns a map containing the same bindings as
     [m], except for the binding of [x].
     Depending on the value of
     [y] where [y] is [f (get x m)], the binding of [x] is
     added, removed or updated. If [y] is [None], the binding is
     removed if it exists; otherwise, if [y] is [Some z] then [x]
-    is associated to [z] in the resulting map. 
+    is associated to [z] in the resulting map.
 *)
 
 val mergeMany:
@@ -416,39 +359,39 @@ val mergeMany:
 *)
 
 val mergeU:
-   ('k, 'v, 'id ) t -> 
+   ('k, 'v, 'id ) t ->
    ('k, 'v2, 'id) t ->
-   ('k -> 'v option -> 'v2 option -> 'v3 option [@bs]) -> 
+   ('k -> 'v option -> 'v2 option -> 'v3 option [@bs]) ->
    ('k, 'v3, 'id) t
 val merge:
-   ('k, 'v, 'id ) t -> 
+   ('k, 'v, 'id ) t ->
    ('k, 'v2, 'id) t ->
-   ('k -> 'v option -> 'v2 option -> 'v3 option) -> 
+   ('k -> 'v option -> 'v2 option -> 'v3 option) ->
    ('k, 'v3, 'id) t
 (** [merge m1 m2 f] computes a map whose keys is a subset of keys of [m1]
     and of [m2]. The presence of each such binding, and the corresponding
     value, is determined with the function [f].
-*)    
+*)
 
 
-val keepU: 
-    ('k, 'v, 'id) t -> 
-    ('k -> 'v -> bool [@bs]) -> 
+val keepU:
+    ('k, 'v, 'id) t ->
+    ('k -> 'v -> bool [@bs]) ->
     ('k, 'v, 'id) t
-val keep: 
-    ('k, 'v, 'id) t -> 
-    ('k -> 'v -> bool) -> 
+val keep:
+    ('k, 'v, 'id) t ->
+    ('k -> 'v -> bool) ->
     ('k, 'v, 'id) t
 (** [keep m p] returns the map with all the bindings in [m]
     that satisfy predicate [p]. *)
-    
-val partitionU: 
+
+val partitionU:
     ('k, 'v, 'id) t ->
-    ('k -> 'v -> bool [@bs]) -> 
+    ('k -> 'v -> bool [@bs]) ->
     ('k, 'v, 'id) t * ('k, 'v, 'id) t
-val partition: 
+val partition:
     ('k, 'v, 'id) t ->
-    ('k -> 'v -> bool) -> 
+    ('k -> 'v -> bool) ->
     ('k, 'v, 'id) t * ('k, 'v, 'id) t
 (** [partition m p] returns a pair of maps [(m1, m2)], where
     [m1] contains all the bindings of [s] that satisfy the
@@ -456,9 +399,9 @@ val partition:
     [s] that do not satisfy [p].
 *)
 
-val split: 
-    ('k, 'v, 'id) t -> 'k -> 
-    (('k, 'v, 'id) t * ('k, 'v, 'id) t )* 'v option 
+val split:
+    ('k, 'v, 'id) t -> 'k ->
+    (('k, 'v, 'id) t * ('k, 'v, 'id) t )* 'v option
 (** [split x m] returns a tuple [(l r), data], where
       [l] is the map with all the bindings of [m] whose 'k
     is strictly less than [x];
@@ -480,9 +423,7 @@ val mapWithKeyU: ('k, 'v, 'id) t -> ('k -> 'v -> 'v2 [@bs]) -> ('k, 'v2, 'id) t
 val mapWithKey: ('k, 'v, 'id) t -> ('k -> 'v -> 'v2) -> ('k, 'v2, 'id) t
 (** [mapWithKey m f]
 
-    The same as {!map} except that [f] is supplied with one more argument: the key 
-
-    
+    The same as {!map} except that [f] is supplied with one more argument: the key
 *)
 
 
@@ -491,7 +432,7 @@ val getData: ('k, 'v, 'id) t -> ('k, 'v, 'id) Belt_MapDict.t
 (** [getData s0]
 
     {b Advanced usage only}
-    
+
     @return the raw data (detached from comparator),
     but its type is still manifested, so that user can pass identity directly
     without boxing
@@ -501,7 +442,7 @@ val getId: ('k, 'v, 'id) t -> ('k, 'id) id
 (** [getId s0]
 
     {b Advanced usage only}
-    
+
     @return the identity of [s0]
 *)
 
@@ -509,13 +450,13 @@ val packIdData: id:('k, 'id) id -> data:('k, 'v, 'id) Belt_MapDict.t -> ('k, 'v,
 (** [packIdData ~id ~data]
 
     {b Advanced usage only}
-    
+
     @return the packed collection
-*)    
+*)
 
 (**/**)
 val checkInvariantInternal: _ t -> unit
 (**
    {b raise} when invariant is not held
-*)  
+*)
 (**/**)

--- a/jscomp/others/belt_MutableMap.mli
+++ b/jscomp/others/belt_MutableMap.mli
@@ -1,6 +1,5 @@
-
 (* Copyright (C) 2017 Authors of BuckleScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -18,116 +17,69 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-(** A {b mutable} sorted map module which allows customize {i compare} behavior.
-
-   The implementation uses balanced binary trees, and therefore searching
-   and insertion take time logarithmic in the size of the map.
-
-   All data are parameterized by not its only type but also a unique identity in
-   the time of initialization, so that two {i Sets of ints} initialized with different
-   {i compare} functions will have different type.
-
-   For example:
-   {[
-     type t = int * int 
-      module I0 =
-        (val Belt.Id.comparableU (fun[\@bs] ((a0,a1) : t) ((b0,b1) : t) ->
-             match Pervasives.compare a0 b0 with
-             | 0 -> Pervasives.compare a1 b1
-             | c -> c 
-           ))
-    let s0 : (_, string,_) t = make ~id:(module I0)
-    module I1 =
-      (val Belt.Id.comparableU (fun[\@bs] ((a0,a1) : t) ((b0,b1) : t) ->
-           match compare a1 b1 with
-           | 0 -> compare a0 b0
-           | c -> c 
-         ))
-    let s1 : (_, string, _) t = make ~id:(module I1)
-   ]}
-
-
-   Here the compiler would infer [s0] and [s1] having different type so that
-    it would not mix.
-
-   {[
-     val s0 : ((int * int), string, I0.identity) t 
-     val s1 : ((int * int), string, I1.identity) t 
-   ]}
-
-   We can add elements to the collection:
-
-   {[
-
-     let () =
-       add s1 (0,0) "a";
-       add s1 (1,1) "b"
-   ]}
-
-   Since this is an mutable data strucure, [s1] will contain two pairs.
-
-*)
-
-
 
 module Int = Belt_MutableMapInt
 
 module String = Belt_MutableMapString
 
 
+(** A {b mutable} sorted map module which allows customize {i compare} behavior.
+
+   Same as Belt.Map, but mutable.
+*)
+
 type ('k,'v,'id) t
 type ('key, 'id) id = ('key, 'id) Belt_Id.comparable
-    
+
 val make: id:('k, 'id) id -> ('k, 'a, 'id) t
-val clear: _ t -> unit 
+val clear: _ t -> unit
 val isEmpty: _ t -> bool
 val has: ('k, _, _) t -> 'k  -> bool
 
-val cmpU: 
-    ('k, 'a, 'id) t -> 
+val cmpU:
     ('k, 'a, 'id) t ->
-    ('a -> 'a -> int [@bs]) -> 
+    ('k, 'a, 'id) t ->
+    ('a -> 'a -> int [@bs]) ->
      int
-val cmp: 
-    ('k, 'a, 'id) t -> 
+val cmp:
     ('k, 'a, 'id) t ->
-    ('a -> 'a -> int ) -> 
-     int     
+    ('k, 'a, 'id) t ->
+    ('a -> 'a -> int ) ->
+     int
 (** [cmp m1 m2 cmp]
     First compare by size, if size is the same,
     compare by key, value pair
-*)     
+*)
 val eqU:  ('k, 'a, 'id) t -> ('k, 'a, 'id) t -> ('a -> 'a -> bool [@bs]) -> bool
-val eq:  ('k, 'a, 'id) t -> ('k, 'a, 'id) t -> ('a -> 'a -> bool) -> bool  
+val eq:  ('k, 'a, 'id) t -> ('k, 'a, 'id) t -> ('a -> 'a -> bool) -> bool
 (** [eq m1 m2 eqf] tests whether the maps [m1] and [m2] are
     equal, that is, contain equal keys and associate them with
     equal data.  [eqf] is the equality predicate used to compare
     the data associated with the keys. *)
-    
+
 val forEachU:  ('k, 'a, 'id) t -> ('k -> 'a -> unit [@bs]) -> unit
-val forEach:  ('k, 'a, 'id) t -> ('k -> 'a -> unit) -> unit  
+val forEach:  ('k, 'a, 'id) t -> ('k -> 'a -> unit) -> unit
 (** [forEach m f] applies [f] to all bindings in map [m].
     [f] receives the 'k as first argument, and the associated value
     as second argument.  The bindings are passed to [f] in increasing
     order with respect to the ordering over the type of the keys. *)
-    
+
 val reduceU: ('k, 'a, 'id) t -> 'b ->  ('b -> 'k -> 'a -> 'b [@bs]) ->  'b
-val reduce: ('k, 'a, 'id) t -> 'b ->  ('b -> 'k -> 'a -> 'b) ->  'b 
+val reduce: ('k, 'a, 'id) t -> 'b ->  ('b -> 'k -> 'a -> 'b) ->  'b
 (** [reduce m a f] computes [(f kN dN ... (f k1 d1 a)...)],
     where [k1 ... kN] are the keys of all bindings in [m]
     (in increasing order), and [d1 ... dN] are the associated data. *)
 
 val everyU: ('k, 'a, 'id) t -> ('k -> 'a -> bool [@bs]) ->  bool
-val every: ('k, 'a, 'id) t -> ('k -> 'a -> bool) ->  bool  
+val every: ('k, 'a, 'id) t -> ('k -> 'a -> bool) ->  bool
 (** [every m p] checks if all the bindings of the map
     satisfy the predicate [p].
 *)
-    
+
 
 val someU: ('k, 'a, 'id) t -> ('k -> 'a -> bool [@bs]) ->  bool
 val some: ('k, 'a, 'id) t -> ('k -> 'a -> bool) ->  bool
@@ -140,8 +92,8 @@ val size: ('k, 'a, 'id) t -> int
 val toList: ('k, 'a, 'id) t -> ('k * 'a) list
 (** In increasing order*)
 val toArray: ('k, 'a, 'id) t -> ('k * 'a) array
-val fromArray: ('k * 'a) array -> id:('k,'id) id ->  ('k,'a,'id) t    
-val keysToArray: ('k, _, _) t -> 'k array 
+val fromArray: ('k * 'a) array -> id:('k,'id) id ->  ('k,'a,'id) t
+val keysToArray: ('k, _, _) t -> 'k array
 val valuesToArray: (_, 'a, _) t -> 'a array
 val minKey: ('k, _,  _) t -> 'k option
 val minKeyUndefined: ('k, _,  _) t -> 'k Js.undefined
@@ -154,14 +106,14 @@ val maxUndefined:('k, 'a, _) t -> ('k * 'a) Js.undefined
 val get:  ('k, 'a, 'id) t -> 'k -> 'a option
 val getUndefined: ('k, 'a, 'id) t -> 'k ->  'a Js.undefined
 val getWithDefault:
-    ('k, 'a, 'id) t -> 'k ->  'a -> 'a 
-val getExn:  ('k, 'a, 'id) t -> 'k ->  'a 
+    ('k, 'a, 'id) t -> 'k ->  'a -> 'a
+val getExn:  ('k, 'a, 'id) t -> 'k ->  'a
 val checkInvariantInternal: _ t -> unit
 (**
    {b raise} when invariant is not held
-*)  
-  
-val ofArray: ('k * 'a) array -> id:('k,'id) id ->  ('k,'a,'id) t    
+*)
+
+val ofArray: ('k * 'a) array -> id:('k,'id) id ->  ('k,'a,'id) t
 [@@ocaml.deprecated "Use fromArray instead"]
 
 (****************************************************************************)
@@ -171,8 +123,8 @@ val ofArray: ('k * 'a) array -> id:('k,'id) id ->  ('k,'a,'id) t
 val remove:  ('k, 'a, 'id) t -> 'k -> unit
 (** [remove m x] do the in-place modification,
 *)
-val removeMany: ('k, 'a, 'id) t -> 'k array -> unit    
-  
+val removeMany: ('k, 'a, 'id) t -> 'k array -> unit
+
 val set: ('k, 'a, 'id) t -> 'k -> 'a ->  unit
 (** [set m x y ] do the in-place modification *)
 
@@ -191,6 +143,6 @@ val map: ('k, 'a, 'id) t -> ('a -> 'b) ->  ('k ,'b,'id ) t
 
 val mapWithKeyU: ('k, 'a, 'id) t -> ('k -> 'a -> 'b [@bs]) -> ('k, 'b, 'id) t
 val mapWithKey: ('k, 'a, 'id) t -> ('k -> 'a -> 'b) -> ('k, 'b, 'id) t
-    
+
 
 

--- a/jscomp/others/belt_MutableSet.mli
+++ b/jscomp/others/belt_MutableSet.mli
@@ -1,6 +1,6 @@
 
 (* Copyright (C) 2017 Authors of BuckleScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -18,59 +18,14 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 (** A {i mutable} sorted set module which allows customize {i compare} behavior.
 
-   The implementation uses balanced binary trees, and therefore searching
-   and insertion take time logarithmic in the size of the map.
-
-   All data are parameterized by not its only type but also a unique identity in
-   the time of initialization, so that two {i Sets of ints} initialized with different
-   {i compare} functions will have different type.
-
-   For example:
-   {[
-     type t = int * int 
-      module I0 =
-        (val Belt.Id.comparableU (fun[\@bs] ((a0,a1) : t) ((b0,b1) : t) ->
-             match Pervasives.compare a0 b0 with
-             | 0 -> Pervasives.compare a1 b1
-             | c -> c 
-           ))
-    let s0 = make ~id:(module I0)
-    module I1 =
-      (val Belt.Id.comparableU (fun[\@bs] ((a0,a1) : t) ((b0,b1) : t) ->
-           match compare a1 b1 with
-           | 0 -> compare a0 b0
-           | c -> c 
-         ))
-    let s1 = make ~id:(module I1)
-   ]}
-
-
-   Here the compiler would infer [s0] and [s1] having different type so that
-    it would not mix.
-
-   {[
-     val s0 : ((int * int), I0.identity) t 
-     val s1 : ((int * int), I1.identity) t 
-   ]}
-
-   We can add elements to the collection:
-
-   {[
-
-     let () =
-       add s1 (0,0);
-       add s1 (1,1)
-   ]}
-
-   Since this is an mutable data strucure, [s1] will contain two pairs.
-
+   Same as Belt.Set, but mutable.
 *)
 
 
@@ -80,10 +35,10 @@
 module Int = Belt_MutableSetInt
 
 (** Specalized when key type is [string], more efficient
-    than the gerneic type *)  
+    than the gerneic type *)
 module String = Belt_MutableSetString
 
-type ('k,'id) t 
+type ('k,'id) t
 
 type ('k, 'id) id = ('k, 'id) Belt_Id.comparable
 
@@ -91,69 +46,69 @@ val make: id:('value, 'id) id -> ('value, 'id) t
 
 val fromArray: 'k array -> id:('k, 'id) id ->   ('k, 'id) t
 val fromSortedArrayUnsafe: 'value array -> id:('value, 'id) id ->  ('value,'id) t
-val copy: ('k, 'id) t -> ('k, 'id) t     
+val copy: ('k, 'id) t -> ('k, 'id) t
 val isEmpty: _ t -> bool
 val has:  ('value, _) t -> 'value ->  bool
 
-val add: ('value, 'id) t -> 'value -> unit 
+val add: ('value, 'id) t -> 'value -> unit
 
 val addCheck:
-  ('value, 'id) t -> 'value -> bool 
+  ('value, 'id) t -> 'value -> bool
 
 val mergeMany:
-  ('value, 'id) t -> 'value array -> unit 
+  ('value, 'id) t -> 'value array -> unit
 
-val remove: ('value, 'id) t -> 'value -> unit 
+val remove: ('value, 'id) t -> 'value -> unit
 
 val removeCheck: ('value, 'id) t -> 'value -> bool
-   (* [b = removeCheck s e] [b] is true means one element removed *)      
+   (* [b = removeCheck s e] [b] is true means one element removed *)
 
 val removeMany:
-  ('value, 'id) t -> 'value array -> unit 
+  ('value, 'id) t -> 'value array -> unit
 
 val union: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
-val intersect: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t 
-val diff: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t 
-val subset: ('value, 'id) t -> ('value, 'id) t -> bool     
+val intersect: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
+val diff: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
+val subset: ('value, 'id) t -> ('value, 'id) t -> bool
 
-val cmp:  
+val cmp:
   ('value, 'id) t -> ('value, 'id) t -> int
-val eq:  
+val eq:
   ('value, 'id) t -> ('value, 'id) t -> bool
 
 val forEachU: ('value, 'id) t -> ('value -> unit [@bs]) ->  unit
 val forEach: ('value, 'id) t -> ('value -> unit) ->  unit
 (** [forEach m f] applies [f] in turn to all elements of [m].
     In increasing order *)
-  
+
 val reduceU: ('value, 'id) t -> 'a -> ('a -> 'value -> 'a [@bs]) -> 'a
-val reduce: ('value, 'id) t -> 'a -> ('a -> 'value -> 'a) -> 'a  
+val reduce: ('value, 'id) t -> 'a -> ('a -> 'value -> 'a) -> 'a
 (** In increasing order. *)
-  
+
 val everyU: ('value, 'id) t -> ('value -> bool [@bs]) -> bool
-val every: ('value, 'id) t -> ('value -> bool) -> bool  
+val every: ('value, 'id) t -> ('value -> bool) -> bool
 (** [every s p] checks if all elements of the set
     satisfy the predicate [p]. Order unspecified *)
 
 val someU: ('value, 'id) t ->  ('value -> bool [@bs]) -> bool
-val some: ('value, 'id) t ->  ('value -> bool) -> bool  
+val some: ('value, 'id) t ->  ('value -> bool) -> bool
 (** [some p s] checks if at least one element of
     the set satisfies the predicate [p]. *)
 
 val keepU: ('value, 'id) t -> ('value -> bool [@bs]) -> ('value, 'id) t
-val keep: ('value, 'id) t -> ('value -> bool) -> ('value, 'id) t    
+val keep: ('value, 'id) t -> ('value -> bool) -> ('value, 'id) t
 (** [keep s p] returns the set of all elements in [s]
-    that satisfy predicate [p]. *)    
+    that satisfy predicate [p]. *)
 
 val partitionU: ('value, 'id) t -> ('value -> bool [@bs]) -> ('value, 'id) t * ('value, 'id) t
-val partition: ('value, 'id) t -> ('value -> bool) -> ('value, 'id) t * ('value, 'id) t                                                           
+val partition: ('value, 'id) t -> ('value -> bool) -> ('value, 'id) t * ('value, 'id) t
 (** [partition p s] returns a pair of sets [(s1, s2)], where
     [s1] is the set of all the elements of [s] that satisfy the
     predicate [p], and [s2] is the set of all the elements of
     [s] that do not satisfy [p]. *)
 
 
-val size:  ('value, 'id) t -> int    
+val size:  ('value, 'id) t -> int
 val toList: ('value, 'id) t -> 'value list
 (** In increasing order*)
 val toArray: ('value, 'id) t -> 'value array
@@ -163,9 +118,9 @@ val minUndefined: ('value, 'id) t -> 'value Js.undefined
 val maximum: ('value, 'id) t -> 'value option
 val maxUndefined: ('value, 'id) t -> 'value Js.undefined
 
-val get: ('value, 'id) t -> 'value -> 'value option 
+val get: ('value, 'id) t -> 'value -> 'value option
 val getUndefined: ('value, 'id) t -> 'value -> 'value Js.undefined
-val getExn: ('value, 'id) t -> 'value -> 'value 
+val getExn: ('value, 'id) t -> 'value -> 'value
 
 
 val split: ('value, 'id) t -> 'value ->  (('value, 'id) t * ('value, 'id) t) * bool
@@ -176,19 +131,19 @@ val split: ('value, 'id) t -> 'value ->  (('value, 'id) t * ('value, 'id) t) * b
       strictly greater than [x];
       [present] is [false] if [s] contains no element equal to [x],
       or [true] if [s] contains an element equal to [x].
-    [l,r] are freshly made, no sharing with [s]   
+    [l,r] are freshly made, no sharing with [s]
 *)
 
 val checkInvariantInternal: _ t -> unit
 (**
    {b raise} when invariant is not held
-*)  
+*)
 
 (*
   [add0] was not exposed for various reasons:
   1. such api is dangerious
-  [ cmp: ('value,'id) Belt_Cmp.cmp -> 
-    ('value, 'id) t0 -> 'value ->  
+  [ cmp: ('value,'id) Belt_Cmp.cmp ->
+    ('value, 'id) t0 -> 'value ->
     ('value, 'id) t0]
   2. It is not really significantly more *)
 


### PR DESCRIPTION
https://github.com/BuckleScript/bucklescript/pull/2618/files?w=1

This is a first round of cleanup. It fixes typos, removes redundant (and
sometimes wrong) examples and rewords a few things. This reduces the
verbosity of pages like Set and Map, where lots of helpers repeated the
creation of e.g. IntCmp, which becomes verbose after a few times.

Later I'll be properly sectionning each page too, just like how stdlib
docs have section in List for e.g. "list scanning", "iterators", etc.