### PR TITLE
tentative pipe syntax #2342

### DIFF
--- a/jscomp/syntax/ast_exp_apply.ml
+++ b/jscomp/syntax/ast_exp_apply.ml
@@ -31,28 +31,50 @@ let handle_exp_apply
     (args : (Asttypes.label * Parsetree.expression) list)
   = 
   let loc = e.pexp_loc in 
-  begin match fn with 
-    | {pexp_desc = 
-         Pexp_apply (
+  begin match fn.pexp_desc with 
+    | Pexp_apply (
            {pexp_desc = 
               Pexp_ident  {txt = Lident "##"  ; loc} ; _},
            [("", obj) ;
             ("", {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _} )
-           ]);
-       _} ->  (* f##paint 1 2 *)
+           ])
+        ->  (* f##paint 1 2 *)
       {e with pexp_desc = Ast_util.method_apply loc self obj name args }
-    | {pexp_desc = 
-         Pexp_apply (
+    | Pexp_apply (
            {pexp_desc = 
               Pexp_ident  {txt = Lident "#@"  ; loc} ; _},
            [("", obj) ;
             ("", {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _} )
-           ]);
-       _} ->  (* f##paint 1 2 *)
+           ])
+        ->  (* f##paint 1 2 *)
       {e with pexp_desc = Ast_util.property_apply loc self obj name args  }
+    | Pexp_ident {txt = Lident "|."} -> 
+      (* a |. f b c [@bs]  --> f a b c [@bs]
+      *)
+      begin match args with 
+      |  [ "", obj_arg;
+           "", ({pexp_desc = Pexp_apply (fn, args)} as app )           
+        ] -> 
+          let obj_arg = self.expr self obj_arg in 
+          let fn = self.expr self fn in 
+          let args = Ext_list.map (fun (lab,exp) -> lab, self.expr self exp ) args in           
+          Bs_ast_invariant.warn_unused_attributes app.pexp_attributes;
+          { app 
+            with pexp_desc = Pexp_apply(fn, ("", obj_arg) :: args);
+               pexp_attributes = []
+          }
+       (* a |. f [@bs] 
+       *)   
+      | [ "", obj_arg ; 
+          "", fn
+        ] -> 
+          Exp.apply ~loc (self.expr self fn) ["", self.expr self obj_arg]
+      | _ -> 
+        Location.raise_errorf ~loc
+            "invalid |. syntax "
+    end 
 
-    | {pexp_desc = 
-         Pexp_ident  {txt = Lident "##" ; loc} ; _} 
+    | Pexp_ident  {txt = Lident "##" ; loc}
       -> 
       begin match args with 
         | [("", obj) ;
@@ -96,9 +118,7 @@ let handle_exp_apply
          end
        ]}
     *)
-    | {pexp_desc = 
-         Pexp_ident {txt = Lident  ("#=" )}
-      } -> 
+    | Pexp_ident {txt = Lident "#=" } -> 
       begin match args with 
         | ["", 
            {pexp_desc = 

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -481,6 +481,7 @@ offset.cmj : ../stdlib/string.cmj ../stdlib/set.cmj
 oo_js_test_date.cmj : mt.cmj ../runtime/js.cmj
 optional_ffi_test.cmj : mt.cmj
 pipe_send_readline.cmj : ../runtime/js.cmj
+pipe_syntax.cmj :
 poly_type.cmj : ../runtime/js.cmj
 poly_variant_test.cmj : mt.cmj ../runtime/js.cmj poly_variant_test.cmi
 polymorphism_test.cmj : polymorphism_test.cmi

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -242,6 +242,7 @@ OTHERS := test_literals a test_ari test_export2 test_internalOO test_obj_simple_
 	gpr_2503_test\
 	block_alias_test\
 	gpr_2608_test\
+	pipe_syntax\
 # bs_uncurry_test
 # needs Lam to get rid of Uncurry arity first
 # simple_derive_test

--- a/jscomp/test/bs_list_test.js
+++ b/jscomp/test/bs_list_test.js
@@ -1982,7 +1982,21 @@ function makeTest(n) {
                   })));
 }
 
-b("File \"bs_list_test.ml\", line 295, characters 4-11", +(Belt_List.cmp(/* :: */[
+eq("File \"bs_list_test.ml\", line 293, characters 5-12", /* :: */[
+      2,
+      /* :: */[
+        3,
+        /* [] */0
+      ]
+    ], /* :: */[
+      2,
+      /* :: */[
+        3,
+        /* [] */0
+      ]
+    ]);
+
+b("File \"bs_list_test.ml\", line 299, characters 4-11", +(Belt_List.cmp(/* :: */[
             1,
             /* :: */[
               2,
@@ -2005,7 +2019,7 @@ b("File \"bs_list_test.ml\", line 295, characters 4-11", +(Belt_List.cmp(/* :: *
             ]
           ], Caml_obj.caml_compare) > 0));
 
-b("File \"bs_list_test.ml\", line 296, characters 4-11", +(Belt_List.cmp(/* :: */[
+b("File \"bs_list_test.ml\", line 300, characters 4-11", +(Belt_List.cmp(/* :: */[
             1,
             /* :: */[
               2,
@@ -2028,7 +2042,7 @@ b("File \"bs_list_test.ml\", line 296, characters 4-11", +(Belt_List.cmp(/* :: *
             ]
           ], Caml_obj.caml_compare) > 0));
 
-b("File \"bs_list_test.ml\", line 297, characters 4-11", +(Belt_List.cmp(/* :: */[
+b("File \"bs_list_test.ml\", line 301, characters 4-11", +(Belt_List.cmp(/* :: */[
             1,
             /* :: */[
               2,
@@ -2051,7 +2065,7 @@ b("File \"bs_list_test.ml\", line 297, characters 4-11", +(Belt_List.cmp(/* :: *
             ]
           ], Caml_obj.caml_compare) < 0));
 
-b("File \"bs_list_test.ml\", line 298, characters 4-11", +(Belt_List.cmp(/* :: */[
+b("File \"bs_list_test.ml\", line 302, characters 4-11", +(Belt_List.cmp(/* :: */[
             1,
             /* :: */[
               2,
@@ -2071,7 +2085,7 @@ b("File \"bs_list_test.ml\", line 298, characters 4-11", +(Belt_List.cmp(/* :: *
             ]
           ], Caml_primitive.caml_int_compare) > 0));
 
-b("File \"bs_list_test.ml\", line 299, characters 4-11", +(Belt_List.cmp(/* :: */[
+b("File \"bs_list_test.ml\", line 303, characters 4-11", +(Belt_List.cmp(/* :: */[
             1,
             /* :: */[
               2,
@@ -2091,7 +2105,7 @@ b("File \"bs_list_test.ml\", line 299, characters 4-11", +(Belt_List.cmp(/* :: *
             ]
           ], Caml_primitive.caml_int_compare) === 0));
 
-b("File \"bs_list_test.ml\", line 300, characters 4-11", +(Belt_List.cmp(/* :: */[
+b("File \"bs_list_test.ml\", line 304, characters 4-11", +(Belt_List.cmp(/* :: */[
             1,
             /* :: */[
               2,
@@ -2111,19 +2125,19 @@ b("File \"bs_list_test.ml\", line 300, characters 4-11", +(Belt_List.cmp(/* :: *
             ]
           ], Caml_primitive.caml_int_compare) > 0));
 
-b("File \"bs_list_test.ml\", line 301, characters 4-11", +(Belt_List.cmpByLength(/* [] */0, /* [] */0) === 0));
+b("File \"bs_list_test.ml\", line 305, characters 4-11", +(Belt_List.cmpByLength(/* [] */0, /* [] */0) === 0));
 
-b("File \"bs_list_test.ml\", line 302, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
+b("File \"bs_list_test.ml\", line 306, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
             1,
             /* [] */0
           ], /* [] */0) > 0));
 
-b("File \"bs_list_test.ml\", line 303, characters 4-11", +(Belt_List.cmpByLength(/* [] */0, /* :: */[
+b("File \"bs_list_test.ml\", line 307, characters 4-11", +(Belt_List.cmpByLength(/* [] */0, /* :: */[
             1,
             /* [] */0
           ]) < 0));
 
-b("File \"bs_list_test.ml\", line 304, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
+b("File \"bs_list_test.ml\", line 308, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
             1,
             /* :: */[
               2,
@@ -2134,7 +2148,7 @@ b("File \"bs_list_test.ml\", line 304, characters 4-11", +(Belt_List.cmpByLength
             /* [] */0
           ]) > 0));
 
-b("File \"bs_list_test.ml\", line 305, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
+b("File \"bs_list_test.ml\", line 309, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
             1,
             /* [] */0
           ], /* :: */[
@@ -2145,7 +2159,7 @@ b("File \"bs_list_test.ml\", line 305, characters 4-11", +(Belt_List.cmpByLength
             ]
           ]) < 0));
 
-b("File \"bs_list_test.ml\", line 306, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
+b("File \"bs_list_test.ml\", line 310, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
             1,
             /* :: */[
               3,
@@ -2167,7 +2181,7 @@ makeTest(2);
 
 makeTest(3);
 
-b("File \"bs_list_test.ml\", line 316, characters 4-11", 1 - Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 320, characters 4-11", 1 - Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2186,7 +2200,7 @@ b("File \"bs_list_test.ml\", line 316, characters 4-11", 1 - Belt_List.eq(/* :: 
             return +(x === y);
           })));
 
-b("File \"bs_list_test.ml\", line 317, characters 4-11", Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 321, characters 4-11", Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2208,7 +2222,7 @@ b("File \"bs_list_test.ml\", line 317, characters 4-11", Belt_List.eq(/* :: */[
             return +(x === y);
           })));
 
-b("File \"bs_list_test.ml\", line 318, characters 4-11", 1 - Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 322, characters 4-11", 1 - Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2230,7 +2244,7 @@ b("File \"bs_list_test.ml\", line 318, characters 4-11", 1 - Belt_List.eq(/* :: 
             return +(x === y);
           })));
 
-b("File \"bs_list_test.ml\", line 319, characters 4-11", 1 - Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 323, characters 4-11", 1 - Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2265,7 +2279,7 @@ var u1 = Belt_List.keepMap(u0, (function (x) {
         }
       }));
 
-eq("File \"bs_list_test.ml\", line 324, characters 5-12", u1, /* :: */[
+eq("File \"bs_list_test.ml\", line 327, characters 5-12", u1, /* :: */[
       1,
       /* :: */[
         8,
@@ -2276,7 +2290,7 @@ eq("File \"bs_list_test.ml\", line 324, characters 5-12", u1, /* :: */[
       ]
     ]);
 
-b("File \"bs_list_test.ml\", line 325, characters 4-11", Caml_obj.caml_equal(Belt_List.keepMap(/* :: */[
+b("File \"bs_list_test.ml\", line 328, characters 4-11", Caml_obj.caml_equal(Belt_List.keepMap(/* :: */[
               1,
               /* :: */[
                 2,
@@ -2302,7 +2316,7 @@ b("File \"bs_list_test.ml\", line 325, characters 4-11", Caml_obj.caml_equal(Bel
           ]
         ]));
 
-b("File \"bs_list_test.ml\", line 329, characters 4-11", +(Belt_List.keepMap(/* :: */[
+b("File \"bs_list_test.ml\", line 332, characters 4-11", +(Belt_List.keepMap(/* :: */[
             1,
             /* :: */[
               2,

--- a/jscomp/test/bs_list_test.ml
+++ b/jscomp/test/bs_list_test.ml
@@ -289,7 +289,11 @@ let () =
 let makeTest n =  
   eq __LOC__ (N.make n 3) (N.makeBy n (fun  _ -> 3))
 
-
+let () = 
+  eq __LOC__
+   ([]
+   |. N.add 3 
+   |. N.add 2 )  [2;3]
 let () =
   
   b __LOC__ (N.cmp [1;2;3] [0;1;2;3] compare > 0) ; 
@@ -319,13 +323,12 @@ let () =
   b __LOC__ (not @@ N.eq [1;2;3] [1;2;3;4] (=))
 let () = 
   let u0 = N.makeBy 20 (fun  x -> x) in   
-  let u1 = N.keepMap u0
-      (fun   x -> if x mod 7 = 0 then Some (x+1) else None) in 
+  let u1 = u0 |. N.keepMap (fun   x -> if x mod 7 = 0 then Some (x+1) else None) in 
   eq __LOC__ u1 [1;8;15];
   b __LOC__
-    N.(  keepMap [1;2;3;4] (fun x -> if x mod 2  = 0 then Some (-x ) else None)
-      =
-      [-2;-4]);
+    N.(  
+      
+    [1;2;3;4] |. keepMap  (fun x -> if x mod 2  = 0 then Some (-x ) else None)  =  [-2;-4]);
   b __LOC__ (
     N.keepMap [1;2;3;4] (fun x -> if x mod 5 = 0 then Some x else None) = []
   ) 

--- a/jscomp/test/pipe_syntax.js
+++ b/jscomp/test/pipe_syntax.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var Curry = require("../../lib/js/curry.js");
+
+function t0(x, f) {
+  return Curry._1(f, Curry._1(f, Curry._1(f, x)));
+}
+
+function t1(x, f) {
+  return Curry._1(f, x);
+}
+
+function t2(x, f, g) {
+  return Curry._2(f, Curry._3(g, Curry._1(f, x), x, x), x);
+}
+
+function t3(x, f) {
+  return Curry._3(f, x, 1, 2);
+}
+
+exports.t0 = t0;
+exports.t1 = t1;
+exports.t2 = t2;
+exports.t3 = t3;
+/* No side effect */

--- a/jscomp/test/pipe_syntax.ml
+++ b/jscomp/test/pipe_syntax.ml
@@ -1,0 +1,23 @@
+
+include (
+  struct
+
+let t0 x f = 
+  x |. f  |. f |. f 
+
+let t1 x f =   
+  x |. f 
+
+let t2 x f g =   
+  x |. f |. g x x |. f x 
+
+ let t3 x f =   
+   x |. f ~h:1 ~x:2 
+end : sig 
+
+  val t0 : 'a -> ('a -> 'a) -> 'a
+  val t1 : 'a -> ('a -> 'b) -> 'b
+  val t2 : 'a -> ('a -> 'a -> 'b) -> (('a -> 'b) -> 'a -> 'a -> 'a) -> 'b
+  val t3 : 'a -> ('a -> h:int -> x:int -> 'b) -> 'b
+end 
+)

--- a/lib/bsdep.ml
+++ b/lib/bsdep.ml
@@ -36001,28 +36001,50 @@ let handle_exp_apply
     (args : (Asttypes.label * Parsetree.expression) list)
   = 
   let loc = e.pexp_loc in 
-  begin match fn with 
-    | {pexp_desc = 
-         Pexp_apply (
+  begin match fn.pexp_desc with 
+    | Pexp_apply (
            {pexp_desc = 
               Pexp_ident  {txt = Lident "##"  ; loc} ; _},
            [("", obj) ;
             ("", {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _} )
-           ]);
-       _} ->  (* f##paint 1 2 *)
+           ])
+        ->  (* f##paint 1 2 *)
       {e with pexp_desc = Ast_util.method_apply loc self obj name args }
-    | {pexp_desc = 
-         Pexp_apply (
+    | Pexp_apply (
            {pexp_desc = 
               Pexp_ident  {txt = Lident "#@"  ; loc} ; _},
            [("", obj) ;
             ("", {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _} )
-           ]);
-       _} ->  (* f##paint 1 2 *)
+           ])
+        ->  (* f##paint 1 2 *)
       {e with pexp_desc = Ast_util.property_apply loc self obj name args  }
+    | Pexp_ident {txt = Lident "|."} -> 
+      (* a |. f b c [@bs]  --> f a b c [@bs]
+      *)
+      begin match args with 
+      |  [ "", obj_arg;
+           "", ({pexp_desc = Pexp_apply (fn, args)} as app )           
+        ] -> 
+          let obj_arg = self.expr self obj_arg in 
+          let fn = self.expr self fn in 
+          let args = Ext_list.map (fun (lab,exp) -> lab, self.expr self exp ) args in           
+          Bs_ast_invariant.warn_unused_attributes app.pexp_attributes;
+          { app 
+            with pexp_desc = Pexp_apply(fn, ("", obj_arg) :: args);
+               pexp_attributes = []
+          }
+       (* a |. f [@bs] 
+       *)   
+      | [ "", obj_arg ; 
+          "", fn
+        ] -> 
+          Exp.apply ~loc (self.expr self fn) ["", self.expr self obj_arg]
+      | _ -> 
+        Location.raise_errorf ~loc
+            "invalid |. syntax "
+    end 
 
-    | {pexp_desc = 
-         Pexp_ident  {txt = Lident "##" ; loc} ; _} 
+    | Pexp_ident  {txt = Lident "##" ; loc}
       -> 
       begin match args with 
         | [("", obj) ;
@@ -36066,9 +36088,7 @@ let handle_exp_apply
          end
        ]}
     *)
-    | {pexp_desc = 
-         Pexp_ident {txt = Lident  ("#=" )}
-      } -> 
+    | Pexp_ident {txt = Lident "#=" } -> 
       begin match args with 
         | ["", 
            {pexp_desc = 


### PR DESCRIPTION
Note we only implement part of the proposal(#2342) in this PR:

```ocaml
x |. f --> f x 
x |. f a0 a1 --> f x a0 a1 
x |. f ~h:a0 a1 -> f x ~h:a0 a1 
```

Currently, the [@bs] will result in an unused attribute in such cases:

```ocaml
x |. f [@bs]
x |. f a0 a1 [@bs]
```

To keep things simple, we simply warn when in  `x |. f  [@attrs]`, attirs is not empty, otherwise 
- if we carry such attrs while not process it, (a warning produced but not idempotent)
- process again --> complicated not obvious benefit?