### PR TITLE
Add option module to Belt

### DIFF
--- a/jscomp/others/Makefile
+++ b/jscomp/others/Makefile
@@ -34,6 +34,7 @@ SOURCE_LIST= node_path node_fs node_process dict node_module js_array js_string 
 	belt_internalMapString\
 	belt_MapString \
 	belt_MapInt\
+  belt_Option\
 	belt_internalSet\
 	belt_Set\
 	belt_MutableSet\

--- a/jscomp/others/Makefile
+++ b/jscomp/others/Makefile
@@ -34,7 +34,7 @@ SOURCE_LIST= node_path node_fs node_process dict node_module js_array js_string 
 	belt_internalMapString\
 	belt_MapString \
 	belt_MapInt\
-  belt_Option\
+	belt_Option\
 	belt_internalSet\
 	belt_Set\
 	belt_MutableSet\

--- a/jscomp/others/belt.ml
+++ b/jscomp/others/belt.ml
@@ -232,7 +232,11 @@ module HashSet = Belt_HashSet
 *)
 module HashMap = Belt_HashMap
   
+(** {!Belt.Option}
 
+    Utilities for option data type
+*)
 
+module Option = Belt_Option
 
 

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -2,17 +2,23 @@ let getExn = function
   | Some x -> x
   | None -> [%assert "getExn"]
 
-let fold opt default f = match opt with
-  | Some x -> f x
+let foldU opt default f = match opt with
+  | Some x -> (f x [@bs])
   | None -> default
 
-let map opt f = match opt with
-  | Some x -> Some (f x)
+let fold opt default f = foldU opt default (fun[@bs] x -> f x)
+
+let mapU opt f = match opt with
+  | Some x -> Some (f x [@bs])
   | None -> None
 
-let flatMap opt f = match opt with
-  | Some x -> f x
+let map opt f = mapU opt (fun[@bs] x -> f x)
+
+let flatMapU opt f = match opt with
+  | Some x -> (f x [@bs])
   | None -> None
+
+let flatMap opt f = flatMapU opt (fun[@bs] x -> f x)
 
 let getOrElse opt default = match opt with
   | Some x -> x

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -56,3 +56,19 @@ let isSome = function
 let isNone = function
   | Some _ -> false
   | None -> true
+
+let eqU a b f = match (a, b) with
+  | (Some a, Some b) -> f a b [@bs]
+  | (None, Some _)
+  | (Some _, None) -> false
+  | (None, None) -> true
+
+let eq a b f = eqU a b (fun[@bs] x y -> f x y)
+
+let cmpU a b f = match (a, b) with
+  | (Some a, Some b) -> f a b [@bs]
+  | (None, Some _) -> -1
+  | (Some _, None) -> 1
+  | (None, None) -> 0
+
+let cmp a b f = cmpU a b (fun[@bs] x y -> f x y)

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -1,0 +1,27 @@
+let getExn = function
+  | Some x -> x
+  | None -> assert false
+
+let fold opt default f = match opt with
+  | Some x -> f x
+  | None -> default
+
+let map opt f = match opt with
+  | Some x -> Some (f x)
+  | None -> None
+
+let flatMap opt f = match opt with
+  | Some x -> f x
+  | None -> None
+
+let getOrElse opt default = match opt with
+  | Some x -> x
+  | None -> default
+
+let exists = function
+  | Some _ -> true
+  | None -> false
+
+let empty = function
+  | Some _ -> false
+  | None -> true

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -18,7 +18,7 @@ let getOrElse opt default = match opt with
   | Some x -> x
   | None -> default
 
-let exists = function
+let has = function
   | Some _ -> true
   | None -> false
 

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -45,14 +45,14 @@ let flatMapU opt f = match opt with
 
 let flatMap opt f = flatMapU opt (fun[@bs] x -> f x)
 
-let getOrElse opt default = match opt with
+let getWithDefault opt default = match opt with
   | Some x -> x
   | None -> default
 
-let has = function
+let isSome = function
   | Some _ -> true
   | None -> false
 
-let isEmpty = function
+let isNone = function
   | Some _ -> false
   | None -> true

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -22,6 +22,6 @@ let exists = function
   | Some _ -> true
   | None -> false
 
-let empty = function
+let isEmpty = function
   | Some _ -> false
   | None -> true

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -1,6 +1,6 @@
 let getExn = function
   | Some x -> x
-  | None -> assert false
+  | None -> [%assert "getExn"]
 
 let fold opt default f = match opt with
   | Some x -> f x

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -27,11 +27,11 @@ let getExn = function
   | Some x -> x
   | None -> [%assert "getExn"]
 
-let foldU opt default f = match opt with
+let mapWithDefaultU opt default f = match opt with
   | Some x -> (f x [@bs])
   | None -> default
 
-let fold opt default f = foldU opt default (fun[@bs] x -> f x)
+let mapWithDefault opt default f = mapWithDefaultU opt default (fun[@bs] x -> f x)
 
 let mapU opt f = match opt with
   | Some x -> Some (f x [@bs])

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -1,3 +1,28 @@
+(* Copyright (C) 2017 Authors of BuckleScript
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
 let getExn = function
   | Some x -> x
   | None -> [%assert "getExn"]

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -3,5 +3,5 @@ val fold : 'a option -> 'b -> ('a -> 'b) -> 'b
 val map : 'a option -> ('a -> 'b) -> 'b option
 val flatMap : 'a option -> ('a -> 'b option) -> 'b option
 val getOrElse : 'a option -> 'a -> 'a
-val exists : 'a option -> bool
+val has : 'a option -> bool
 val isEmpty : 'a option -> bool

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -1,6 +1,9 @@
 val getExn : 'a option -> 'a
+val foldU : 'a option -> 'b -> ('a -> 'b [@bs]) -> 'b
 val fold : 'a option -> 'b -> ('a -> 'b) -> 'b
+val mapU : 'a option -> ('a -> 'b [@bs]) -> 'b option
 val map : 'a option -> ('a -> 'b) -> 'b option
+val flatMapU : 'a option -> ('a -> 'b option [@bs]) -> 'b option
 val flatMap : 'a option -> ('a -> 'b option) -> 'b option
 val getOrElse : 'a option -> 'a -> 'a
 val has : 'a option -> bool

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -28,8 +28,8 @@
 *)
 
 val getExn : 'a option -> 'a
-val foldU : 'a option -> 'b -> ('a -> 'b [@bs]) -> 'b
-val fold : 'a option -> 'b -> ('a -> 'b) -> 'b
+val mapWithDefaultU : 'a option -> 'b -> ('a -> 'b [@bs]) -> 'b
+val mapWithDefault : 'a option -> 'b -> ('a -> 'b) -> 'b
 val mapU : 'a option -> ('a -> 'b [@bs]) -> 'b option
 val map : 'a option -> ('a -> 'b) -> 'b option
 val flatMapU : 'a option -> ('a -> 'b option [@bs]) -> 'b option

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -1,3 +1,32 @@
+(* Copyright (C) 2017 Authors of BuckleScript
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+(** {!Belt.Option}
+
+    Utilities for option data type
+*)
+
 val getExn : 'a option -> 'a
 val foldU : 'a option -> 'b -> ('a -> 'b [@bs]) -> 'b
 val fold : 'a option -> 'b -> ('a -> 'b) -> 'b

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -34,6 +34,6 @@ val mapU : 'a option -> ('a -> 'b [@bs]) -> 'b option
 val map : 'a option -> ('a -> 'b) -> 'b option
 val flatMapU : 'a option -> ('a -> 'b option [@bs]) -> 'b option
 val flatMap : 'a option -> ('a -> 'b option) -> 'b option
-val getOrElse : 'a option -> 'a -> 'a
-val has : 'a option -> bool
-val isEmpty : 'a option -> bool
+val getWithDefault : 'a option -> 'a -> 'a
+val isSome : 'a option -> bool
+val isNone : 'a option -> bool

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -1,0 +1,7 @@
+val getExn : 'a option -> 'a
+val fold : 'a option -> 'b -> ('a -> 'b) -> 'b
+val map : 'a option -> ('a -> 'b) -> 'b option
+val flatMap : 'a option -> ('a -> 'b option) -> 'b option
+val getOrElse : 'a option -> 'a -> 'a
+val exists : 'a option -> bool
+val empty : 'a option -> bool

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -4,4 +4,4 @@ val map : 'a option -> ('a -> 'b) -> 'b option
 val flatMap : 'a option -> ('a -> 'b option) -> 'b option
 val getOrElse : 'a option -> 'a -> 'a
 val exists : 'a option -> bool
-val empty : 'a option -> bool
+val isEmpty : 'a option -> bool

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -37,3 +37,7 @@ val flatMap : 'a option -> ('a -> 'b option) -> 'b option
 val getWithDefault : 'a option -> 'a -> 'a
 val isSome : 'a option -> bool
 val isNone : 'a option -> bool
+val eqU : 'a option -> 'b option -> ('a -> 'b -> bool [@bs]) -> bool
+val eq : 'a option -> 'b option -> ('a -> 'b -> bool) -> bool
+val cmpU : 'a option -> 'b option -> ('a -> 'b -> int [@bs]) -> int
+val cmp : 'a option -> 'b option -> ('a -> 'b -> int) -> int

--- a/lib/js/belt.js
+++ b/lib/js/belt.js
@@ -27,6 +27,8 @@ var HashSet = 0;
 
 var HashMap = 0;
 
+var Option = 0;
+
 exports.Id = Id;
 exports.$$Array = $$Array;
 exports.SortArray = SortArray;
@@ -40,4 +42,5 @@ exports.MutableSet = MutableSet;
 exports.MutableMap = MutableMap;
 exports.HashSet = HashSet;
 exports.HashMap = HashMap;
+exports.Option = Option;
 /* No side effect */

--- a/lib/js/belt_Option.js
+++ b/lib/js/belt_Option.js
@@ -10,7 +10,7 @@ function getExn(param) {
   }
 }
 
-function foldU(opt, $$default, f) {
+function mapWithDefaultU(opt, $$default, f) {
   if (opt) {
     return f(opt[0]);
   } else {
@@ -18,8 +18,8 @@ function foldU(opt, $$default, f) {
   }
 }
 
-function fold(opt, $$default, f) {
-  return foldU(opt, $$default, Curry.__1(f));
+function mapWithDefault(opt, $$default, f) {
+  return mapWithDefaultU(opt, $$default, Curry.__1(f));
 }
 
 function mapU(opt, f) {
@@ -107,8 +107,8 @@ function cmp(a, b, f) {
 }
 
 exports.getExn = getExn;
-exports.foldU = foldU;
-exports.fold = fold;
+exports.mapWithDefaultU = mapWithDefaultU;
+exports.mapWithDefault = mapWithDefault;
 exports.mapU = mapU;
 exports.map = map;
 exports.flatMapU = flatMapU;

--- a/lib/js/belt_Option.js
+++ b/lib/js/belt_Option.js
@@ -6,32 +6,44 @@ function getExn(param) {
   if (param) {
     return param[0];
   } else {
-    return /* assert false */0;
+    throw new Error("getExn");
   }
 }
 
-function fold(opt, $$default, f) {
+function foldU(opt, $$default, f) {
   if (opt) {
-    return Curry._1(f, opt[0]);
+    return f(opt[0]);
   } else {
     return $$default;
   }
 }
 
-function map(opt, f) {
+function fold(opt, $$default, f) {
+  return foldU(opt, $$default, Curry.__1(f));
+}
+
+function mapU(opt, f) {
   if (opt) {
-    return /* Some */[Curry._1(f, opt[0])];
+    return /* Some */[f(opt[0])];
+  } else {
+    return /* None */0;
+  }
+}
+
+function map(opt, f) {
+  return mapU(opt, Curry.__1(f));
+}
+
+function flatMapU(opt, f) {
+  if (opt) {
+    return f(opt[0]);
   } else {
     return /* None */0;
   }
 }
 
 function flatMap(opt, f) {
-  if (opt) {
-    return Curry._1(f, opt[0]);
-  } else {
-    return /* None */0;
-  }
+  return flatMapU(opt, Curry.__1(f));
 }
 
 function getOrElse(opt, $$default) {
@@ -42,7 +54,7 @@ function getOrElse(opt, $$default) {
   }
 }
 
-function exists(param) {
+function has(param) {
   if (param) {
     return /* true */1;
   } else {
@@ -50,7 +62,7 @@ function exists(param) {
   }
 }
 
-function empty(param) {
+function isEmpty(param) {
   if (param) {
     return /* false */0;
   } else {
@@ -59,10 +71,13 @@ function empty(param) {
 }
 
 exports.getExn = getExn;
+exports.foldU = foldU;
 exports.fold = fold;
+exports.mapU = mapU;
 exports.map = map;
+exports.flatMapU = flatMapU;
 exports.flatMap = flatMap;
 exports.getOrElse = getOrElse;
-exports.exists = exists;
-exports.empty = empty;
+exports.has = has;
+exports.isEmpty = isEmpty;
 /* No side effect */

--- a/lib/js/belt_Option.js
+++ b/lib/js/belt_Option.js
@@ -1,0 +1,68 @@
+'use strict';
+
+var Curry = require("./curry.js");
+
+function getExn(param) {
+  if (param) {
+    return param[0];
+  } else {
+    return /* assert false */0;
+  }
+}
+
+function fold(opt, $$default, f) {
+  if (opt) {
+    return Curry._1(f, opt[0]);
+  } else {
+    return $$default;
+  }
+}
+
+function map(opt, f) {
+  if (opt) {
+    return /* Some */[Curry._1(f, opt[0])];
+  } else {
+    return /* None */0;
+  }
+}
+
+function flatMap(opt, f) {
+  if (opt) {
+    return Curry._1(f, opt[0]);
+  } else {
+    return /* None */0;
+  }
+}
+
+function getOrElse(opt, $$default) {
+  if (opt) {
+    return opt[0];
+  } else {
+    return $$default;
+  }
+}
+
+function exists(param) {
+  if (param) {
+    return /* true */1;
+  } else {
+    return /* false */0;
+  }
+}
+
+function empty(param) {
+  if (param) {
+    return /* false */0;
+  } else {
+    return /* true */1;
+  }
+}
+
+exports.getExn = getExn;
+exports.fold = fold;
+exports.map = map;
+exports.flatMap = flatMap;
+exports.getOrElse = getOrElse;
+exports.exists = exists;
+exports.empty = empty;
+/* No side effect */

--- a/lib/js/belt_Option.js
+++ b/lib/js/belt_Option.js
@@ -46,7 +46,7 @@ function flatMap(opt, f) {
   return flatMapU(opt, Curry.__1(f));
 }
 
-function getOrElse(opt, $$default) {
+function getWithDefault(opt, $$default) {
   if (opt) {
     return opt[0];
   } else {
@@ -54,7 +54,7 @@ function getOrElse(opt, $$default) {
   }
 }
 
-function has(param) {
+function isSome(param) {
   if (param) {
     return /* true */1;
   } else {
@@ -62,7 +62,7 @@ function has(param) {
   }
 }
 
-function isEmpty(param) {
+function isNone(param) {
   if (param) {
     return /* false */0;
   } else {

--- a/lib/js/belt_Option.js
+++ b/lib/js/belt_Option.js
@@ -70,6 +70,42 @@ function isNone(param) {
   }
 }
 
+function eqU(a, b, f) {
+  if (a) {
+    if (b) {
+      return f(a[0], b[0]);
+    } else {
+      return /* false */0;
+    }
+  } else if (b) {
+    return /* false */0;
+  } else {
+    return /* true */1;
+  }
+}
+
+function eq(a, b, f) {
+  return eqU(a, b, Curry.__2(f));
+}
+
+function cmpU(a, b, f) {
+  if (a) {
+    if (b) {
+      return f(a[0], b[0]);
+    } else {
+      return 1;
+    }
+  } else if (b) {
+    return -1;
+  } else {
+    return 0;
+  }
+}
+
+function cmp(a, b, f) {
+  return cmpU(a, b, Curry.__2(f));
+}
+
 exports.getExn = getExn;
 exports.foldU = foldU;
 exports.fold = fold;
@@ -77,7 +113,11 @@ exports.mapU = mapU;
 exports.map = map;
 exports.flatMapU = flatMapU;
 exports.flatMap = flatMap;
-exports.getOrElse = getOrElse;
-exports.has = has;
-exports.isEmpty = isEmpty;
+exports.getWithDefault = getWithDefault;
+exports.isSome = isSome;
+exports.isNone = isNone;
+exports.eqU = eqU;
+exports.eq = eq;
+exports.cmpU = cmpU;
+exports.cmp = cmp;
 /* No side effect */


### PR DESCRIPTION
This adds the following utility functions for the option data type to belt.

```ocaml
val getExn : 'a option -> 'a
val mapWithDefaultU : 'a option -> 'b -> ('a -> 'b [@bs]) -> 'b
val mapWithDefault : 'a option -> 'b -> ('a -> 'b) -> 'b
val mapU : 'a option -> ('a -> 'b [@bs]) -> 'b option
val map : 'a option -> ('a -> 'b) -> 'b option
val flatMapU : 'a option -> ('a -> 'b option [@bs]) -> 'b option
val flatMap : 'a option -> ('a -> 'b option) -> 'b option
val getWithDefault : 'a option -> 'a -> 'a
val isSome : 'a option -> bool
val isNone : 'a option -> bool
val eqU : 'a option -> 'b option -> ('a -> 'b -> bool [@bs]) -> bool
val eq : 'a option -> 'b option -> ('a -> 'b -> bool) -> bool
val cmpU : 'a option -> 'b option -> ('a -> 'b -> int [@bs]) -> int
val cmp : 'a option -> 'b option -> ('a -> 'b -> int) -> int
```