### PR TITLE
Adding belt_Option to some files

### DIFF
--- a/jscomp/others/.depend
+++ b/jscomp/others/.depend
@@ -57,6 +57,7 @@ belt_MapString.cmj : belt_internalMapString.cmj belt_internalAVLtree.cmj \
     belt_Array.cmj belt_MapString.cmi
 belt_MapInt.cmj : belt_internalMapInt.cmj belt_internalAVLtree.cmj \
     belt_Array.cmj belt_MapInt.cmi
+belt_Option.cmj : belt_Option.cmi
 belt_Set.cmj : belt_SetString.cmj belt_SetInt.cmj belt_SetDict.cmj \
     belt_Id.cmj belt_Array.cmj belt_Set.cmi
 belt_MutableSet.cmj : belt_internalAVLset.cmj belt_SortArray.cmj \

--- a/jscomp/outcome_printer/outcome_printer_ns.ml
+++ b/jscomp/outcome_printer/outcome_printer_ns.ml
@@ -96,6 +96,8 @@ let out_ident ppf s =
     | "Belt_MapInt" -> "Belt.Map.Int"
     | "Belt_MapString" -> "Belt.Map.String"
 
+    | "Belt_Option" -> "Belt.Option"
+
     | "Belt_MutableSet" -> "Belt.MutableSet"
     | "Belt_MutableSetInt" -> "Belt.MutableSet.Int"
     | "Belt_MutableSetString" -> "Belt.MutableSet.String"

--- a/jscomp/repl.js
+++ b/jscomp/repl.js
@@ -103,6 +103,7 @@ var cmi_files =
         `belt_SetString`,
         `belt_Map`,
         `belt_MapInt`,
+        `belt_Option`,
         `belt_MapString`,
         `belt_MutableSet`,
         `belt_MutableSetInt`,


### PR DESCRIPTION
Adding `Belt_Option` to some files as calling `make` in `master` was failing locally.

There are a few more files besides these that are missing `Belt_Option`, but I'm unsure as they seem auto generated:

- `scripts/win_build.bat`
- `jscomp/core/js_cmi_datasets.ml`
- `jscomp/core/js_cmj_datasets.ml`