### PR TITLE
Extend polymorphic compare to support objects.

### DIFF
--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -132,8 +132,7 @@ let caml_update_dummy x y =
 type 'a selector = 'a -> 'a -> 'a 
 
 module O = struct
-  external object_ : Obj.t = "Object" [@@bs.val]
-  let is_object : Obj.t -> bool = fun x -> (Obj.magic x)##constructor == object_
+  external isArray : 'a -> bool = "Array.isArray" [@@bs.val]
   type key = string
   let for_in : (Obj.t -> (key -> unit) -> unit) [@bs] = [%bs.raw
     {|function (o, foo) {
@@ -212,9 +211,9 @@ let rec caml_compare (a : Obj.t) (b : Obj.t) : int =
           let len_a = Bs_obj.length a in
           let len_b = Bs_obj.length b in
           if len_a = len_b then
-            if O.is_object a && O.is_object b
-            then aux_obj_compare a b
-            else aux_same_length a b 0 len_a
+            if O.isArray(a)
+            then aux_same_length a b 0 len_a
+            else aux_obj_compare a b
           else if len_a < len_b then
             aux_length_a_short a b 0 len_a
           else
@@ -304,9 +303,9 @@ let rec caml_equal (a : Obj.t) (b : Obj.t) : bool =
           let len_a = Bs_obj.length a in
           let len_b = Bs_obj.length b in
           if len_a = len_b then
-            if O.is_object a && O.is_object b
-            then aux_obj_equal a b
-            else aux_equal_length a b 0 len_a
+            if O.isArray(a)
+            then aux_equal_length a b 0 len_a
+            else aux_obj_equal a b
           else false
 and aux_equal_length  (a : Obj.t) (b : Obj.t) i same_length =
   if i = same_length then

--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -258,29 +258,6 @@ and aux_obj_compare (a: Obj.t) (b: Obj.t) =
     | None, (Some _) -> 1
     | (Some x), (Some y) -> compare x y in
   res
-(*
-and aux_obj_compare (a: Obj.t) (b: Obj.t) : int = [%bs.raw {|
-  function (a, b) {
-    var min_key_lhs;
-    var min_key_rhs;
-    for (var key in a) {
-      if (!b.hasOwnProperty(key) || caml_compare(a[key], b[key]) > 0) {
-        if (!min_key_rhs || key < min_key_rhs) { min_key_rhs = key }
-      }
-    }
-    for (var key in b) {
-      if (!a.hasOwnProperty(key) || caml_compare(b[key], a[key]) > 0) {
-        if (!min_key_lhs || key < min_key_lhs) { min_key_lhs = key }
-      }
-    }
-    if (!min_key_lhs) { return !min_key_rhs ? 0 : 1}
-    if (!min_key_rhs) { return -1 }
-    return min_key_lhs < min_key_rhs ? -1 : 1
-  }
-  |}]
-  a b [@bs]
-*)
-
 
 type eq = Obj.t -> Obj.t -> bool
 
@@ -348,24 +325,6 @@ and aux_obj_equal (a: Obj.t) (b: Obj.t) =
   O.for_in a do_key_a [@bs];
   if !result then O.for_in b do_key_b [@bs];
   !result
-(*
-and aux_obj_equal (a: Obj.t) (b: Obj.t) : bool = [%bs.raw {|
-  function (a, b) {
-    for (var key in a) {
-      if (!b.hasOwnProperty(key)) {
-        return false
-      }
-    }
-    for (var key in b) {
-      if (!a.hasOwnProperty(key) || !caml_equal(a[key], b[key])) {
-        return false
-      }
-    }
-    return true
-  }
-  |}]
-  a b [@bs]
-*)
 
 let caml_equal_null (x : Obj.t) (y : Obj.t Js.null) = 
   match Js.nullToOption y with    

--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -258,6 +258,29 @@ and aux_obj_compare (a: Obj.t) (b: Obj.t) =
     | None, (Some _) -> 1
     | (Some x), (Some y) -> compare x y in
   res
+(*
+and aux_obj_compare (a: Obj.t) (b: Obj.t) : int = [%bs.raw {|
+  function (a, b) {
+    var min_key_lhs;
+    var min_key_rhs;
+    for (var key in a) {
+      if (!b.hasOwnProperty(key) || caml_compare(a[key], b[key]) > 0) {
+        if (!min_key_rhs || key < min_key_rhs) { min_key_rhs = key }
+      }
+    }
+    for (var key in b) {
+      if (!a.hasOwnProperty(key) || caml_compare(b[key], a[key]) > 0) {
+        if (!min_key_lhs || key < min_key_lhs) { min_key_lhs = key }
+      }
+    }
+    if (!min_key_lhs) { return !min_key_rhs ? 0 : 1}
+    if (!min_key_rhs) { return -1 }
+    return min_key_lhs < min_key_rhs ? -1 : 1
+  }
+  |}]
+  a b [@bs]
+*)
+
 
 type eq = Obj.t -> Obj.t -> bool
 
@@ -325,6 +348,24 @@ and aux_obj_equal (a: Obj.t) (b: Obj.t) =
   O.for_in a do_key_a [@bs];
   if !result then O.for_in b do_key_b [@bs];
   !result
+(*
+and aux_obj_equal (a: Obj.t) (b: Obj.t) : bool = [%bs.raw {|
+  function (a, b) {
+    for (var key in a) {
+      if (!b.hasOwnProperty(key)) {
+        return false
+      }
+    }
+    for (var key in b) {
+      if (!a.hasOwnProperty(key) || !caml_equal(a[key], b[key])) {
+        return false
+      }
+    }
+    return true
+  }
+  |}]
+  a b [@bs]
+*)
 
 let caml_equal_null (x : Obj.t) (y : Obj.t Js.null) = 
   match Js.nullToOption y with    

--- a/jscomp/test/caml_compare_test.js
+++ b/jscomp/test/caml_compare_test.js
@@ -497,7 +497,419 @@ var suites_001 = /* :: */[
                                               ]);
                                     })
                                 ],
-                                /* [] */0
+                                /* :: */[
+                                  /* tuple */[
+                                    "cmp_id",
+                                    (function () {
+                                        return /* Eq */Block.__(0, [
+                                                  Caml_obj.caml_compare({
+                                                        x: 1,
+                                                        y: 2
+                                                      }, {
+                                                        x: 1,
+                                                        y: 2
+                                                      }),
+                                                  0
+                                                ]);
+                                      })
+                                  ],
+                                  /* :: */[
+                                    /* tuple */[
+                                      "cmp_val",
+                                      (function () {
+                                          return /* Eq */Block.__(0, [
+                                                    Caml_obj.caml_compare({
+                                                          x: 1
+                                                        }, {
+                                                          x: 2
+                                                        }),
+                                                    -1
+                                                  ]);
+                                        })
+                                    ],
+                                    /* :: */[
+                                      /* tuple */[
+                                        "cmp_val2",
+                                        (function () {
+                                            return /* Eq */Block.__(0, [
+                                                      Caml_obj.caml_compare({
+                                                            x: 2
+                                                          }, {
+                                                            x: 1
+                                                          }),
+                                                      1
+                                                    ]);
+                                          })
+                                      ],
+                                      /* :: */[
+                                        /* tuple */[
+                                          "cmp_empty",
+                                          (function () {
+                                              return /* Eq */Block.__(0, [
+                                                        Caml_obj.caml_compare(({}), ({})),
+                                                        0
+                                                      ]);
+                                            })
+                                        ],
+                                        /* :: */[
+                                          /* tuple */[
+                                            "cmp_empty2",
+                                            (function () {
+                                                return /* Eq */Block.__(0, [
+                                                          Caml_obj.caml_compare(({}), ({x:1})),
+                                                          -1
+                                                        ]);
+                                              })
+                                          ],
+                                          /* :: */[
+                                            /* tuple */[
+                                              "cmp_swap",
+                                              (function () {
+                                                  return /* Eq */Block.__(0, [
+                                                            Caml_obj.caml_compare({
+                                                                  x: 1,
+                                                                  y: 2
+                                                                }, {
+                                                                  y: 2,
+                                                                  x: 1
+                                                                }),
+                                                            0
+                                                          ]);
+                                                })
+                                            ],
+                                            /* :: */[
+                                              /* tuple */[
+                                                "cmp_size",
+                                                (function () {
+                                                    return /* Eq */Block.__(0, [
+                                                              Caml_obj.caml_compare(({x:1}), ({x:1, y:2})),
+                                                              -1
+                                                            ]);
+                                                  })
+                                              ],
+                                              /* :: */[
+                                                /* tuple */[
+                                                  "cmp_size2",
+                                                  (function () {
+                                                      return /* Eq */Block.__(0, [
+                                                                Caml_obj.caml_compare(({x:1, y:2}), ({x:1})),
+                                                                1
+                                                              ]);
+                                                    })
+                                                ],
+                                                /* :: */[
+                                                  /* tuple */[
+                                                    "cmp_order",
+                                                    (function () {
+                                                        return /* Eq */Block.__(0, [
+                                                                  Caml_obj.caml_compare({
+                                                                        x: 0,
+                                                                        y: 1
+                                                                      }, {
+                                                                        x: 1,
+                                                                        y: 0
+                                                                      }),
+                                                                  -1
+                                                                ]);
+                                                      })
+                                                  ],
+                                                  /* :: */[
+                                                    /* tuple */[
+                                                      "cmp_order2",
+                                                      (function () {
+                                                          return /* Eq */Block.__(0, [
+                                                                    Caml_obj.caml_compare({
+                                                                          x: 1,
+                                                                          y: 0
+                                                                        }, {
+                                                                          x: 0,
+                                                                          y: 1
+                                                                        }),
+                                                                    1
+                                                                  ]);
+                                                        })
+                                                    ],
+                                                    /* :: */[
+                                                      /* tuple */[
+                                                        "cmp_in_list",
+                                                        (function () {
+                                                            return /* Eq */Block.__(0, [
+                                                                      Caml_obj.caml_compare(/* :: */[
+                                                                            {
+                                                                              x: 1
+                                                                            },
+                                                                            /* [] */0
+                                                                          ], /* :: */[
+                                                                            {
+                                                                              x: 2
+                                                                            },
+                                                                            /* [] */0
+                                                                          ]),
+                                                                      -1
+                                                                    ]);
+                                                          })
+                                                      ],
+                                                      /* :: */[
+                                                        /* tuple */[
+                                                          "cmp_in_list2",
+                                                          (function () {
+                                                              return /* Eq */Block.__(0, [
+                                                                        Caml_obj.caml_compare(/* :: */[
+                                                                              {
+                                                                                x: 2
+                                                                              },
+                                                                              /* [] */0
+                                                                            ], /* :: */[
+                                                                              {
+                                                                                x: 1
+                                                                              },
+                                                                              /* [] */0
+                                                                            ]),
+                                                                        1
+                                                                      ]);
+                                                            })
+                                                        ],
+                                                        /* :: */[
+                                                          /* tuple */[
+                                                            "cmp_with_list",
+                                                            (function () {
+                                                                return /* Eq */Block.__(0, [
+                                                                          Caml_obj.caml_compare({
+                                                                                x: /* :: */[
+                                                                                  0,
+                                                                                  /* [] */0
+                                                                                ]
+                                                                              }, {
+                                                                                x: /* :: */[
+                                                                                  1,
+                                                                                  /* [] */0
+                                                                                ]
+                                                                              }),
+                                                                          -1
+                                                                        ]);
+                                                              })
+                                                          ],
+                                                          /* :: */[
+                                                            /* tuple */[
+                                                              "cmp_with_list2",
+                                                              (function () {
+                                                                  return /* Eq */Block.__(0, [
+                                                                            Caml_obj.caml_compare({
+                                                                                  x: /* :: */[
+                                                                                    1,
+                                                                                    /* [] */0
+                                                                                  ]
+                                                                                }, {
+                                                                                  x: /* :: */[
+                                                                                    0,
+                                                                                    /* [] */0
+                                                                                  ]
+                                                                                }),
+                                                                            1
+                                                                          ]);
+                                                                })
+                                                            ],
+                                                            /* :: */[
+                                                              /* tuple */[
+                                                                "eq_id",
+                                                                (function () {
+                                                                    return /* Ok */Block.__(4, [Caml_obj.caml_equal({
+                                                                                    x: 1,
+                                                                                    y: 2
+                                                                                  }, {
+                                                                                    x: 1,
+                                                                                    y: 2
+                                                                                  })]);
+                                                                  })
+                                                              ],
+                                                              /* :: */[
+                                                                /* tuple */[
+                                                                  "eq_val",
+                                                                  (function () {
+                                                                      return /* Eq */Block.__(0, [
+                                                                                Caml_obj.caml_equal({
+                                                                                      x: 1
+                                                                                    }, {
+                                                                                      x: 2
+                                                                                    }),
+                                                                                /* false */0
+                                                                              ]);
+                                                                    })
+                                                                ],
+                                                                /* :: */[
+                                                                  /* tuple */[
+                                                                    "eq_val2",
+                                                                    (function () {
+                                                                        return /* Eq */Block.__(0, [
+                                                                                  Caml_obj.caml_equal({
+                                                                                        x: 2
+                                                                                      }, {
+                                                                                        x: 1
+                                                                                      }),
+                                                                                  /* false */0
+                                                                                ]);
+                                                                      })
+                                                                  ],
+                                                                  /* :: */[
+                                                                    /* tuple */[
+                                                                      "eq_empty",
+                                                                      (function () {
+                                                                          return /* Eq */Block.__(0, [
+                                                                                    Caml_obj.caml_equal(({}), ({})),
+                                                                                    /* true */1
+                                                                                  ]);
+                                                                        })
+                                                                    ],
+                                                                    /* :: */[
+                                                                      /* tuple */[
+                                                                        "eq_empty2",
+                                                                        (function () {
+                                                                            return /* Eq */Block.__(0, [
+                                                                                      Caml_obj.caml_equal(({}), ({x:1})),
+                                                                                      /* false */0
+                                                                                    ]);
+                                                                          })
+                                                                      ],
+                                                                      /* :: */[
+                                                                        /* tuple */[
+                                                                          "eq_swap",
+                                                                          (function () {
+                                                                              return /* Ok */Block.__(4, [Caml_obj.caml_equal({
+                                                                                              x: 1,
+                                                                                              y: 2
+                                                                                            }, {
+                                                                                              y: 2,
+                                                                                              x: 1
+                                                                                            })]);
+                                                                            })
+                                                                        ],
+                                                                        /* :: */[
+                                                                          /* tuple */[
+                                                                            "eq_size",
+                                                                            (function () {
+                                                                                return /* Eq */Block.__(0, [
+                                                                                          Caml_obj.caml_equal(({x:1}), ({x:1, y:2})),
+                                                                                          /* false */0
+                                                                                        ]);
+                                                                              })
+                                                                          ],
+                                                                          /* :: */[
+                                                                            /* tuple */[
+                                                                              "eq_size2",
+                                                                              (function () {
+                                                                                  return /* Eq */Block.__(0, [
+                                                                                            Caml_obj.caml_equal(({x:1, y:2}), ({x:1})),
+                                                                                            /* false */0
+                                                                                          ]);
+                                                                                })
+                                                                            ],
+                                                                            /* :: */[
+                                                                              /* tuple */[
+                                                                                "eq_in_list",
+                                                                                (function () {
+                                                                                    return /* Eq */Block.__(0, [
+                                                                                              Caml_obj.caml_equal(/* :: */[
+                                                                                                    {
+                                                                                                      x: 1
+                                                                                                    },
+                                                                                                    /* [] */0
+                                                                                                  ], /* :: */[
+                                                                                                    {
+                                                                                                      x: 2
+                                                                                                    },
+                                                                                                    /* [] */0
+                                                                                                  ]),
+                                                                                              /* false */0
+                                                                                            ]);
+                                                                                  })
+                                                                              ],
+                                                                              /* :: */[
+                                                                                /* tuple */[
+                                                                                  "eq_in_list2",
+                                                                                  (function () {
+                                                                                      return /* Eq */Block.__(0, [
+                                                                                                Caml_obj.caml_equal(/* :: */[
+                                                                                                      {
+                                                                                                        x: 2
+                                                                                                      },
+                                                                                                      /* [] */0
+                                                                                                    ], /* :: */[
+                                                                                                      {
+                                                                                                        x: 2
+                                                                                                      },
+                                                                                                      /* [] */0
+                                                                                                    ]),
+                                                                                                /* true */1
+                                                                                              ]);
+                                                                                    })
+                                                                                ],
+                                                                                /* :: */[
+                                                                                  /* tuple */[
+                                                                                    "eq_with_list",
+                                                                                    (function () {
+                                                                                        return /* Eq */Block.__(0, [
+                                                                                                  Caml_obj.caml_equal({
+                                                                                                        x: /* :: */[
+                                                                                                          0,
+                                                                                                          /* [] */0
+                                                                                                        ]
+                                                                                                      }, {
+                                                                                                        x: /* :: */[
+                                                                                                          0,
+                                                                                                          /* [] */0
+                                                                                                        ]
+                                                                                                      }),
+                                                                                                  /* true */1
+                                                                                                ]);
+                                                                                      })
+                                                                                  ],
+                                                                                  /* :: */[
+                                                                                    /* tuple */[
+                                                                                      "eq_with_list2",
+                                                                                      (function () {
+                                                                                          return /* Eq */Block.__(0, [
+                                                                                                    Caml_obj.caml_equal({
+                                                                                                          x: /* :: */[
+                                                                                                            0,
+                                                                                                            /* [] */0
+                                                                                                          ]
+                                                                                                        }, {
+                                                                                                          x: /* :: */[
+                                                                                                            1,
+                                                                                                            /* [] */0
+                                                                                                          ]
+                                                                                                        }),
+                                                                                                    /* false */0
+                                                                                                  ]);
+                                                                                        })
+                                                                                    ],
+                                                                                    /* [] */0
+                                                                                  ]
+                                                                                ]
+                                                                              ]
+                                                                            ]
+                                                                          ]
+                                                                        ]
+                                                                      ]
+                                                                    ]
+                                                                  ]
+                                                                ]
+                                                              ]
+                                                            ]
+                                                          ]
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
                               ]
                             ]
                           ]

--- a/jscomp/test/caml_compare_test.ml
+++ b/jscomp/test/caml_compare_test.ml
@@ -50,7 +50,33 @@ let suites = Mt.[
     __LOC__ , begin fun _ -> 
         Eq(false,  [2;6;1;1;2;1;4;2;1;409] = [2;6;1;1;2;1;4;2;1])
     end;
-    
+
+    "cmp_id", (fun _ -> Eq (compare [%bs.obj {x=1; y=2}] [%bs.obj {x=1; y=2}], 0));
+    "cmp_val", (fun _ -> Eq (compare [%bs.obj {x=1}] [%bs.obj {x=2}], -1));
+    "cmp_val2", (fun _ -> Eq (compare [%bs.obj {x=2}] [%bs.obj {x=1}], 1));
+    "cmp_empty", (fun _ -> Eq (compare [%bs.raw "{}"] [%bs.raw "{}"], 0));
+    "cmp_empty2", (fun _ -> Eq (compare [%bs.raw "{}"] [%bs.raw "{x:1}"], -1));
+    "cmp_swap", (fun _ -> Eq (compare [%bs.obj {x=1; y=2}] [%bs.obj {y=2; x=1}], 0));
+    "cmp_size", (fun _ -> Eq (compare [%bs.raw "{x:1}"] [%bs.raw "{x:1, y:2}"], -1));
+    "cmp_size2", (fun _ -> Eq (compare [%bs.raw "{x:1, y:2}"] [%bs.raw "{x:1}"], 1));
+    "cmp_order", (fun _ -> Eq (compare [%bs.obj {x=0; y=1}] [%bs.obj {x=1; y=0}], -1));
+    "cmp_order2", (fun _ -> Eq (compare [%bs.obj {x=1; y=0}] [%bs.obj {x=0; y=1}], 1));
+    "cmp_in_list", (fun _ -> Eq (compare [[%bs.obj {x=1}]] [[%bs.obj {x=2}]], -1));
+    "cmp_in_list2", (fun _ -> Eq (compare [[%bs.obj {x=2}]] [[%bs.obj {x=1}]], 1));
+    "cmp_with_list", (fun _ -> Eq (compare [%bs.obj {x=[0]}] [%bs.obj {x=[1]}], -1));
+    "cmp_with_list2", (fun _ -> Eq (compare [%bs.obj {x=[1]}] [%bs.obj {x=[0]}], 1));
+    "eq_id", (fun _ -> Ok ([%bs.obj {x=1; y=2}] = [%bs.obj {x=1; y=2}]));
+    "eq_val", (fun _ -> Eq ([%bs.obj {x=1}] = [%bs.obj {x=2}], false));
+    "eq_val2", (fun _ -> Eq ([%bs.obj {x=2}] = [%bs.obj {x=1}], false));
+    "eq_empty", (fun _ -> Eq ([%bs.raw "{}"] = [%bs.raw "{}"], true));
+    "eq_empty2", (fun _ -> Eq ([%bs.raw "{}"] = [%bs.raw "{x:1}"], false));
+    "eq_swap", (fun _ -> Ok ([%bs.obj {x=1; y=2}] = [%bs.obj {y=2; x=1}]));
+    "eq_size", (fun _ -> Eq ([%bs.raw "{x:1}"] = [%bs.raw "{x:1, y:2}"], false));
+    "eq_size2", (fun _ -> Eq ([%bs.raw "{x:1, y:2}"] = [%bs.raw "{x:1}"], false));
+    "eq_in_list", (fun _ -> Eq ([[%bs.obj {x=1}]] = [[%bs.obj {x=2}]], false));
+    "eq_in_list2", (fun _ -> Eq ([[%bs.obj {x=2}]] = [[%bs.obj {x=2}]], true));
+    "eq_with_list", (fun _ -> Eq ([%bs.obj {x=[0]}] = [%bs.obj {x=[0]}], true));
+    "eq_with_list2", (fun _ -> Eq ([%bs.obj {x=[0]}] = [%bs.obj {x=[1]}], false));
 ]
 ;;
 

--- a/jscomp/test/record_with_test.ml
+++ b/jscomp/test/record_with_test.ml
@@ -32,46 +32,6 @@ let u_v = {v with imports = 0}
 
 let f g h = { (g h) with imports = 0 }
 
-(*
-
-module O = struct
-  external object_ : Obj.t = "Object" [@@bs.val]
-  let is_object : Obj.t -> bool = fun x -> (Obj.magic x)##constructor == object_
-  type keys
-  type key = Obj.t
-  external keys : Obj.t -> keys = "Object.keys" [@@bs.val]
-  external length : keys -> int = "%array_length"
-  external get_key : keys -> int -> key = "%array_unsafe_get"
-  external get_value : Obj.t -> key -> Obj.t = "%array_unsafe_get"
-end
-
-let o1 = [%bs.obj {x=1; y=2}]
-let o2 = [%bs.obj {x=3; y=4}]
-let o3 = [%bs.obj {x=3; y=4}]
-
-
-let o1_is_object = O.is_object(Obj.repr o1)
-let list_is_object = O.is_object(Obj.repr [1;2;3])
-let () = Js.log2 "o1_is_object: " o1_is_object
-let () = Js.log2 "list_is_object: " list_is_object
-
-let keys1 = O.keys(Obj.repr o1)
-let () = Js.log2 "keys1: " keys1
-
-let cmp1 = compare o1 o2
-let cmp2 = compare o2 o1
-let cmp3 = compare o2 o3
-
-let () = Js.log2 "cmp1: " cmp1
-let () = Js.log2 "cmp2: " cmp2
-let () = Js.log2 "cmp3: " cmp3
-
-let () = for i = 0 to O.length keys1 - 1 do
-  Js.log2 ("key" ^ string_of_int i ^ ": ") (O.get_key keys1 i);
-  Js.log2 ("val" ^ string_of_int i ^ ": ") (O.get_value (Obj.repr o1) (O.get_key keys1 i))  
-  done
-*)
-
 let suites = Mt.[
     "eq_with", (fun _ -> Eq (v, u_v))    
 ]

--- a/jscomp/test/record_with_test.ml
+++ b/jscomp/test/record_with_test.ml
@@ -32,6 +32,46 @@ let u_v = {v with imports = 0}
 
 let f g h = { (g h) with imports = 0 }
 
+(*
+
+module O = struct
+  external object_ : Obj.t = "Object" [@@bs.val]
+  let is_object : Obj.t -> bool = fun x -> (Obj.magic x)##constructor == object_
+  type keys
+  type key = Obj.t
+  external keys : Obj.t -> keys = "Object.keys" [@@bs.val]
+  external length : keys -> int = "%array_length"
+  external get_key : keys -> int -> key = "%array_unsafe_get"
+  external get_value : Obj.t -> key -> Obj.t = "%array_unsafe_get"
+end
+
+let o1 = [%bs.obj {x=1; y=2}]
+let o2 = [%bs.obj {x=3; y=4}]
+let o3 = [%bs.obj {x=3; y=4}]
+
+
+let o1_is_object = O.is_object(Obj.repr o1)
+let list_is_object = O.is_object(Obj.repr [1;2;3])
+let () = Js.log2 "o1_is_object: " o1_is_object
+let () = Js.log2 "list_is_object: " list_is_object
+
+let keys1 = O.keys(Obj.repr o1)
+let () = Js.log2 "keys1: " keys1
+
+let cmp1 = compare o1 o2
+let cmp2 = compare o2 o1
+let cmp3 = compare o2 o3
+
+let () = Js.log2 "cmp1: " cmp1
+let () = Js.log2 "cmp2: " cmp2
+let () = Js.log2 "cmp3: " cmp3
+
+let () = for i = 0 to O.length keys1 - 1 do
+  Js.log2 ("key" ^ string_of_int i ^ ": ") (O.get_key keys1 i);
+  Js.log2 ("val" ^ string_of_int i ^ ": ") (O.get_value (Obj.repr o1) (O.get_key keys1 i))  
+  done
+*)
+
 let suites = Mt.[
     "eq_with", (fun _ -> Eq (v, u_v))    
 ]

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -56,6 +56,11 @@ function caml_update_dummy(x, y) {
   }
 }
 
+var for_in = (function (o, foo) {
+        for (var x in o) { foo(x) }
+      }
+    );
+
 function caml_compare(_a, _b) {
   while(true) {
     var b = _b;
@@ -118,77 +123,102 @@ function caml_compare(_a, _b) {
           } else {
             var len_a = a.length | 0;
             var len_b = b.length | 0;
-            if (len_a === 0 && len_b === 0 && a.constructor === Object && b.constructor === Object) {
-              var keys_a = Object.keys(a);
-              var keys_b = Object.keys(b);
-              keys_a.sort();
-              keys_b.sort();
-              var len_a$1 = keys_a.length;
-              var len_b$1 = keys_b.length;
-              var min_len = len_a$1 < len_b$1 ? len_a$1 : len_b$1;
-              var default_res = len_a$1 - len_b$1 | 0;
-              var a$1 = a;
-              var keys_a$1 = keys_a;
-              var b$1 = b;
-              var keys_b$1 = keys_b;
-              var _i = 0;
-              var min_len$1 = min_len;
-              var default_res$1 = default_res;
-              while(true) {
-                var i = _i;
-                if (i === min_len$1) {
-                  return default_res$1;
-                } else {
-                  var key_a = keys_a$1[i];
-                  var key_b = keys_b$1[i];
-                  var res = caml_compare(key_a, key_b);
-                  if (res !== 0) {
-                    return res;
+            if (len_a === len_b) {
+              if (a.constructor === Object && b.constructor === Object) {
+                var a$1 = a;
+                var b$1 = b;
+                var min_key_lhs = [/* None */0];
+                var min_key_rhs = [/* None */0];
+                var do_key = function (param, key) {
+                  var min_key = param[2];
+                  var b = param[1];
+                  if (!b.hasOwnProperty(key) || caml_compare(param[0][key], b[key]) > 0) {
+                    var match = min_key[0];
+                    if (match) {
+                      if (key < match[0]) {
+                        min_key[0] = /* Some */[key];
+                        return /* () */0;
+                      } else {
+                        return 0;
+                      }
+                    } else {
+                      min_key[0] = /* Some */[key];
+                      return /* () */0;
+                    }
                   } else {
-                    var res$1 = caml_compare(a$1[key_a], b$1[key_b]);
-                    if (res$1 !== 0) {
-                      return res$1;
+                    return 0;
+                  }
+                };
+                var partial_arg = /* tuple */[
+                  a$1,
+                  b$1,
+                  min_key_rhs
+                ];
+                var do_key_a = (function(partial_arg){
+                return function do_key_a(param) {
+                  return do_key(partial_arg, param);
+                }
+                }(partial_arg));
+                var partial_arg$1 = /* tuple */[
+                  b$1,
+                  a$1,
+                  min_key_lhs
+                ];
+                var do_key_b = (function(partial_arg$1){
+                return function do_key_b(param) {
+                  return do_key(partial_arg$1, param);
+                }
+                }(partial_arg$1));
+                for_in(a$1, do_key_a);
+                for_in(b$1, do_key_b);
+                var match = min_key_lhs[0];
+                var match$1 = min_key_rhs[0];
+                if (match) {
+                  if (match$1) {
+                    return Caml_primitive.caml_string_compare(match[0], match$1[0]);
+                  } else {
+                    return -1;
+                  }
+                } else if (match$1) {
+                  return 1;
+                } else {
+                  return 0;
+                }
+              } else {
+                var a$2 = a;
+                var b$2 = b;
+                var _i = 0;
+                var same_length = len_a;
+                while(true) {
+                  var i = _i;
+                  if (i === same_length) {
+                    return 0;
+                  } else {
+                    var res = caml_compare(a$2[i], b$2[i]);
+                    if (res !== 0) {
+                      return res;
                     } else {
                       _i = i + 1 | 0;
                       continue ;
                     }
                   }
-                }
-              };
-            } else if (len_a === len_b) {
-              var a$2 = a;
-              var b$2 = b;
-              var _i$1 = 0;
-              var same_length = len_a;
-              while(true) {
-                var i$1 = _i$1;
-                if (i$1 === same_length) {
-                  return 0;
-                } else {
-                  var res$2 = caml_compare(a$2[i$1], b$2[i$1]);
-                  if (res$2 !== 0) {
-                    return res$2;
-                  } else {
-                    _i$1 = i$1 + 1 | 0;
-                    continue ;
-                  }
-                }
-              };
+                };
+              }
             } else if (len_a < len_b) {
               var a$3 = a;
               var b$3 = b;
-              var _i$2 = 0;
+              var _i$1 = 0;
               var short_length = len_a;
               while(true) {
-                var i$2 = _i$2;
-                if (i$2 === short_length) {
+                var i$1 = _i$1;
+                if (i$1 === short_length) {
                   return -1;
                 } else {
-                  var res$3 = caml_compare(a$3[i$2], b$3[i$2]);
-                  if (res$3 !== 0) {
-                    return res$3;
+                  var res$1 = caml_compare(a$3[i$1], b$3[i$1]);
+                  if (res$1 !== 0) {
+                    return res$1;
                   } else {
-                    _i$2 = i$2 + 1 | 0;
+                    _i$1 = i$1 + 1 | 0;
                     continue ;
                   }
                 }
@@ -196,18 +226,18 @@ function caml_compare(_a, _b) {
             } else {
               var a$4 = a;
               var b$4 = b;
-              var _i$3 = 0;
+              var _i$2 = 0;
               var short_length$1 = len_b;
               while(true) {
-                var i$3 = _i$3;
-                if (i$3 === short_length$1) {
+                var i$2 = _i$2;
+                if (i$2 === short_length$1) {
                   return 1;
                 } else {
-                  var res$4 = caml_compare(a$4[i$3], b$4[i$3]);
-                  if (res$4 !== 0) {
-                    return res$4;
+                  var res$2 = caml_compare(a$4[i$2], b$4[i$2]);
+                  if (res$2 !== 0) {
+                    return res$2;
                   } else {
-                    _i$3 = i$3 + 1 | 0;
+                    _i$2 = i$2 + 1 | 0;
                     continue ;
                   }
                 }
@@ -260,54 +290,53 @@ function caml_equal(_a, _b) {
           } else {
             var len_a = a.length | 0;
             var len_b = b.length | 0;
-            if (len_a === 0 && len_b === 0 && a.constructor === Object && b.constructor === Object) {
-              var keys_a = Object.keys(a);
-              var keys_b = Object.keys(b);
-              var len_a$1 = keys_a.length;
-              var len_b$1 = keys_b.length;
-              if (len_a$1 === len_b$1) {
-                keys_a.sort();
-                keys_b.sort();
+            if (len_a === len_b) {
+              if (a.constructor === Object && b.constructor === Object) {
                 var a$1 = a;
-                var keys_a$1 = keys_a;
                 var b$1 = b;
-                var keys_b$1 = keys_b;
+                var result = [/* true */1];
+                var do_key_a = (function(b$1,result){
+                return function do_key_a(key) {
+                  if (b$1.hasOwnProperty(key)) {
+                    return 0;
+                  } else {
+                    result[0] = /* false */0;
+                    return /* () */0;
+                  }
+                }
+                }(b$1,result));
+                var do_key_b = (function(a$1,b$1,result){
+                return function do_key_b(key) {
+                  if (!a$1.hasOwnProperty(key) || !caml_equal(b$1[key], a$1[key])) {
+                    result[0] = /* false */0;
+                    return /* () */0;
+                  } else {
+                    return 0;
+                  }
+                }
+                }(a$1,b$1,result));
+                for_in(a$1, do_key_a);
+                if (result[0]) {
+                  for_in(b$1, do_key_b);
+                }
+                return result[0];
+              } else {
+                var a$2 = a;
+                var b$2 = b;
                 var _i = 0;
-                var length = len_a$1;
+                var same_length = len_a;
                 while(true) {
                   var i = _i;
-                  if (i === length) {
+                  if (i === same_length) {
                     return /* true */1;
+                  } else if (caml_equal(a$2[i], b$2[i])) {
+                    _i = i + 1 | 0;
+                    continue ;
                   } else {
-                    var key_a = keys_a$1[i];
-                    var key_b = keys_b$1[i];
-                    if (caml_equal(key_a, key_b) && caml_equal(a$1[key_a], b$1[key_b])) {
-                      _i = i + 1 | 0;
-                      continue ;
-                    } else {
-                      return /* false */0;
-                    }
+                    return /* false */0;
                   }
                 };
-              } else {
-                return /* false */0;
               }
-            } else if (len_a === len_b) {
-              var a$2 = a;
-              var b$2 = b;
-              var _i$1 = 0;
-              var same_length = len_a;
-              while(true) {
-                var i$1 = _i$1;
-                if (i$1 === same_length) {
-                  return /* true */1;
-                } else if (caml_equal(a$2[i$1], b$2[i$1])) {
-                  _i$1 = i$1 + 1 | 0;
-                  continue ;
-                } else {
-                  return /* false */0;
-                }
-              };
             } else {
               return /* false */0;
             }
@@ -395,4 +424,4 @@ exports.caml_lessthan = caml_lessthan;
 exports.caml_lessequal = caml_lessequal;
 exports.caml_min = caml_min;
 exports.caml_max = caml_max;
-/* No side effect */
+/* for_in Not a pure module */

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -121,6 +121,8 @@ function caml_compare(_a, _b) {
             if (len_a === 0 && len_b === 0 && a.constructor === Object && b.constructor === Object) {
               var keys_a = Object.keys(a);
               var keys_b = Object.keys(b);
+              keys_a.sort();
+              keys_b.sort();
               var len_a$1 = keys_a.length;
               var len_b$1 = keys_b.length;
               var min_len = len_a$1 < len_b$1 ? len_a$1 : len_b$1;
@@ -258,17 +260,49 @@ function caml_equal(_a, _b) {
           } else {
             var len_a = a.length | 0;
             var len_b = b.length | 0;
-            if (len_a === len_b) {
-              var a$1 = a;
-              var b$1 = b;
-              var _i = 0;
+            if (len_a === 0 && len_b === 0 && a.constructor === Object && b.constructor === Object) {
+              var keys_a = Object.keys(a);
+              var keys_b = Object.keys(b);
+              var len_a$1 = keys_a.length;
+              var len_b$1 = keys_b.length;
+              if (len_a$1 === len_b$1) {
+                keys_a.sort();
+                keys_b.sort();
+                var a$1 = a;
+                var keys_a$1 = keys_a;
+                var b$1 = b;
+                var keys_b$1 = keys_b;
+                var _i = 0;
+                var length = len_a$1;
+                while(true) {
+                  var i = _i;
+                  if (i === length) {
+                    return /* true */1;
+                  } else {
+                    var key_a = keys_a$1[i];
+                    var key_b = keys_b$1[i];
+                    if (caml_equal(key_a, key_b) && caml_equal(a$1[key_a], b$1[key_b])) {
+                      _i = i + 1 | 0;
+                      continue ;
+                    } else {
+                      return /* false */0;
+                    }
+                  }
+                };
+              } else {
+                return /* false */0;
+              }
+            } else if (len_a === len_b) {
+              var a$2 = a;
+              var b$2 = b;
+              var _i$1 = 0;
               var same_length = len_a;
               while(true) {
-                var i = _i;
-                if (i === same_length) {
+                var i$1 = _i$1;
+                if (i$1 === same_length) {
                   return /* true */1;
-                } else if (caml_equal(a$1[i], b$1[i])) {
-                  _i = i + 1 | 0;
+                } else if (caml_equal(a$2[i$1], b$2[i$1])) {
+                  _i$1 = i$1 + 1 | 0;
                   continue ;
                 } else {
                   return /* false */0;

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -124,9 +124,28 @@ function caml_compare(_a, _b) {
             var len_a = a.length | 0;
             var len_b = b.length | 0;
             if (len_a === len_b) {
-              if (a.constructor === Object && b.constructor === Object) {
+              if (Array.isArray(a)) {
                 var a$1 = a;
                 var b$1 = b;
+                var _i = 0;
+                var same_length = len_a;
+                while(true) {
+                  var i = _i;
+                  if (i === same_length) {
+                    return 0;
+                  } else {
+                    var res = caml_compare(a$1[i], b$1[i]);
+                    if (res !== 0) {
+                      return res;
+                    } else {
+                      _i = i + 1 | 0;
+                      continue ;
+                    }
+                  }
+                };
+              } else {
+                var a$2 = a;
+                var b$2 = b;
                 var min_key_lhs = [/* None */0];
                 var min_key_rhs = [/* None */0];
                 var do_key = function (param, key) {
@@ -150,8 +169,8 @@ function caml_compare(_a, _b) {
                   }
                 };
                 var partial_arg = /* tuple */[
-                  a$1,
-                  b$1,
+                  a$2,
+                  b$2,
                   min_key_rhs
                 ];
                 var do_key_a = (function(partial_arg){
@@ -160,8 +179,8 @@ function caml_compare(_a, _b) {
                 }
                 }(partial_arg));
                 var partial_arg$1 = /* tuple */[
-                  b$1,
-                  a$1,
+                  b$2,
+                  a$2,
                   min_key_lhs
                 ];
                 var do_key_b = (function(partial_arg$1){
@@ -169,8 +188,8 @@ function caml_compare(_a, _b) {
                   return do_key(partial_arg$1, param);
                 }
                 }(partial_arg$1));
-                for_in(a$1, do_key_a);
-                for_in(b$1, do_key_b);
+                for_in(a$2, do_key_a);
+                for_in(b$2, do_key_b);
                 var match = min_key_lhs[0];
                 var match$1 = min_key_rhs[0];
                 if (match) {
@@ -184,25 +203,6 @@ function caml_compare(_a, _b) {
                 } else {
                   return 0;
                 }
-              } else {
-                var a$2 = a;
-                var b$2 = b;
-                var _i = 0;
-                var same_length = len_a;
-                while(true) {
-                  var i = _i;
-                  if (i === same_length) {
-                    return 0;
-                  } else {
-                    var res = caml_compare(a$2[i], b$2[i]);
-                    if (res !== 0) {
-                      return res;
-                    } else {
-                      _i = i + 1 | 0;
-                      continue ;
-                    }
-                  }
-                };
               }
             } else if (len_a < len_b) {
               var a$3 = a;
@@ -291,51 +291,51 @@ function caml_equal(_a, _b) {
             var len_a = a.length | 0;
             var len_b = b.length | 0;
             if (len_a === len_b) {
-              if (a.constructor === Object && b.constructor === Object) {
+              if (Array.isArray(a)) {
                 var a$1 = a;
                 var b$1 = b;
-                var result = [/* true */1];
-                var do_key_a = (function(b$1,result){
-                return function do_key_a(key) {
-                  if (b$1.hasOwnProperty(key)) {
-                    return 0;
-                  } else {
-                    result[0] = /* false */0;
-                    return /* () */0;
-                  }
-                }
-                }(b$1,result));
-                var do_key_b = (function(a$1,b$1,result){
-                return function do_key_b(key) {
-                  if (!a$1.hasOwnProperty(key) || !caml_equal(b$1[key], a$1[key])) {
-                    result[0] = /* false */0;
-                    return /* () */0;
-                  } else {
-                    return 0;
-                  }
-                }
-                }(a$1,b$1,result));
-                for_in(a$1, do_key_a);
-                if (result[0]) {
-                  for_in(b$1, do_key_b);
-                }
-                return result[0];
-              } else {
-                var a$2 = a;
-                var b$2 = b;
                 var _i = 0;
                 var same_length = len_a;
                 while(true) {
                   var i = _i;
                   if (i === same_length) {
                     return /* true */1;
-                  } else if (caml_equal(a$2[i], b$2[i])) {
+                  } else if (caml_equal(a$1[i], b$1[i])) {
                     _i = i + 1 | 0;
                     continue ;
                   } else {
                     return /* false */0;
                   }
                 };
+              } else {
+                var a$2 = a;
+                var b$2 = b;
+                var result = [/* true */1];
+                var do_key_a = (function(b$2,result){
+                return function do_key_a(key) {
+                  if (b$2.hasOwnProperty(key)) {
+                    return 0;
+                  } else {
+                    result[0] = /* false */0;
+                    return /* () */0;
+                  }
+                }
+                }(b$2,result));
+                var do_key_b = (function(a$2,b$2,result){
+                return function do_key_b(key) {
+                  if (!a$2.hasOwnProperty(key) || !caml_equal(b$2[key], a$2[key])) {
+                    result[0] = /* false */0;
+                    return /* () */0;
+                  } else {
+                    return 0;
+                  }
+                }
+                }(a$2,b$2,result));
+                for_in(a$2, do_key_a);
+                if (result[0]) {
+                  for_in(b$2, do_key_b);
+                }
+                return result[0];
               }
             } else {
               return /* false */0;

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -118,59 +118,94 @@ function caml_compare(_a, _b) {
           } else {
             var len_a = a.length | 0;
             var len_b = b.length | 0;
-            if (len_a === len_b) {
+            if (len_a === 0 && len_b === 0 && a.constructor === Object && b.constructor === Object) {
+              var keys_a = Object.keys(a);
+              var keys_b = Object.keys(b);
+              var len_a$1 = keys_a.length;
+              var len_b$1 = keys_b.length;
+              var min_len = len_a$1 < len_b$1 ? len_a$1 : len_b$1;
+              var default_res = len_a$1 - len_b$1 | 0;
               var a$1 = a;
+              var keys_a$1 = keys_a;
               var b$1 = b;
+              var keys_b$1 = keys_b;
               var _i = 0;
-              var same_length = len_a;
+              var min_len$1 = min_len;
+              var default_res$1 = default_res;
               while(true) {
                 var i = _i;
-                if (i === same_length) {
-                  return 0;
+                if (i === min_len$1) {
+                  return default_res$1;
                 } else {
-                  var res = caml_compare(a$1[i], b$1[i]);
+                  var key_a = keys_a$1[i];
+                  var key_b = keys_b$1[i];
+                  var res = caml_compare(key_a, key_b);
                   if (res !== 0) {
                     return res;
                   } else {
-                    _i = i + 1 | 0;
-                    continue ;
+                    var res$1 = caml_compare(a$1[key_a], b$1[key_b]);
+                    if (res$1 !== 0) {
+                      return res$1;
+                    } else {
+                      _i = i + 1 | 0;
+                      continue ;
+                    }
                   }
                 }
               };
-            } else if (len_a < len_b) {
+            } else if (len_a === len_b) {
               var a$2 = a;
               var b$2 = b;
               var _i$1 = 0;
-              var short_length = len_a;
+              var same_length = len_a;
               while(true) {
                 var i$1 = _i$1;
-                if (i$1 === short_length) {
-                  return -1;
+                if (i$1 === same_length) {
+                  return 0;
                 } else {
-                  var res$1 = caml_compare(a$2[i$1], b$2[i$1]);
-                  if (res$1 !== 0) {
-                    return res$1;
+                  var res$2 = caml_compare(a$2[i$1], b$2[i$1]);
+                  if (res$2 !== 0) {
+                    return res$2;
                   } else {
                     _i$1 = i$1 + 1 | 0;
                     continue ;
                   }
                 }
               };
-            } else {
+            } else if (len_a < len_b) {
               var a$3 = a;
               var b$3 = b;
               var _i$2 = 0;
-              var short_length$1 = len_b;
+              var short_length = len_a;
               while(true) {
                 var i$2 = _i$2;
-                if (i$2 === short_length$1) {
-                  return 1;
+                if (i$2 === short_length) {
+                  return -1;
                 } else {
-                  var res$2 = caml_compare(a$3[i$2], b$3[i$2]);
-                  if (res$2 !== 0) {
-                    return res$2;
+                  var res$3 = caml_compare(a$3[i$2], b$3[i$2]);
+                  if (res$3 !== 0) {
+                    return res$3;
                   } else {
                     _i$2 = i$2 + 1 | 0;
+                    continue ;
+                  }
+                }
+              };
+            } else {
+              var a$4 = a;
+              var b$4 = b;
+              var _i$3 = 0;
+              var short_length$1 = len_b;
+              while(true) {
+                var i$3 = _i$3;
+                if (i$3 === short_length$1) {
+                  return 1;
+                } else {
+                  var res$4 = caml_compare(a$4[i$3], b$4[i$3]);
+                  if (res$4 !== 0) {
+                    return res$4;
+                  } else {
+                    _i$3 = i$3 + 1 | 0;
                     continue ;
                   }
                 }


### PR DESCRIPTION
Extend polymorphic compare to support objects created as e.g. `[%bs.obj {x=1; y=2}]`.

The comparison of `{x:1, y:2}` and `{x:3, y:4}` is defined logically as if the objects were lists of pairs: the first keys are compared, then the first values, then the second keys, then the second values, etc.
In particular, the order of keys matters, and `{x:1, y:2}` is different from `{y:2, x:1}`.

TODO: equality and hash.

Objects, when viewed as blocks, have size 0 and no tag.
Here an object `o` is recognized by checking that `o.constructor === Object`.
Then, the keys and values can be extracted.

The compare function keeps the same structure, with one extra while loop, and does not change unless objects are encountered. Presumably `Object.keys(o)` performs some allocation.