### PR TITLE
allow customize label name

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -247,13 +247,13 @@ SYNTAX_SRCS= \
 	ast_core_type\
 	bs_ast_invariant\
 	ast_attributes\
-	ast_derive_abstract\
 	ast_polyvar\
+	external_ffi_types\
+	external_process\
+	ast_derive_abstract\
 	ast_derive_dyn\
 	ast_derive_projector \
 	ast_derive_js_mapper\
-	external_ffi_types\
-	external_process\
 	ast_util\
 	ast_tdcls\
 	ast_primitive\

--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -207,22 +207,9 @@ syntax/bs_ast_invariant.cmx : ext/literals.cmx ext/hash_set_poly.cmx \
 syntax/ast_attributes.cmx : ext/ext_string.cmx syntax/bs_syntaxerr.cmx \
     syntax/bs_ast_invariant.cmx syntax/ast_payload.cmx \
     syntax/ast_attributes.cmi
-syntax/ast_derive_abstract.cmx : ext/ext_list.cmx syntax/ast_literal.cmx \
-    syntax/ast_derive_util.cmx syntax/ast_attributes.cmx \
-    syntax/ast_derive_abstract.cmi
 syntax/ast_polyvar.cmx : syntax/external_arg_spec.cmx ext/ext_pervasives.cmx \
     ext/ext_list.cmx syntax/bs_syntaxerr.cmx syntax/ast_attributes.cmx \
     syntax/ast_polyvar.cmi
-syntax/ast_derive_dyn.cmx : ext/ext_list.cmx syntax/bs_syntaxerr.cmx \
-    syntax/ast_structure.cmx syntax/ast_derive_util.cmx syntax/ast_derive.cmx \
-    syntax/ast_attributes.cmx syntax/ast_derive_dyn.cmi
-syntax/ast_derive_projector.cmx : ext/ext_list.cmx \
-    syntax/ast_derive_util.cmx syntax/ast_derive.cmx syntax/ast_comb.cmx \
-    syntax/ast_derive_projector.cmi
-syntax/ast_derive_js_mapper.cmx : ext/ext_list.cmx syntax/ast_polyvar.cmx \
-    syntax/ast_literal.cmx syntax/ast_derive_util.cmx syntax/ast_derive.cmx \
-    syntax/ast_core_type.cmx syntax/ast_comb.cmx \
-    syntax/ast_derive_js_mapper.cmi
 syntax/external_ffi_types.cmx : syntax/external_arg_spec.cmx \
     ext/ext_string.cmx ext/ext_pervasives.cmx common/bs_version.cmx \
     syntax/external_ffi_types.cmi
@@ -233,6 +220,19 @@ syntax/external_process.cmx : common/lam_methname.cmx \
     syntax/ast_polyvar.cmx syntax/ast_payload.cmx syntax/ast_literal.cmx \
     syntax/ast_core_type.cmx syntax/ast_comb.cmx syntax/ast_attributes.cmx \
     syntax/external_process.cmi
+syntax/ast_derive_abstract.cmx : syntax/external_process.cmx \
+    ext/ext_list.cmx syntax/ast_literal.cmx syntax/ast_derive_util.cmx \
+    syntax/ast_attributes.cmx syntax/ast_derive_abstract.cmi
+syntax/ast_derive_dyn.cmx : ext/ext_list.cmx syntax/bs_syntaxerr.cmx \
+    syntax/ast_structure.cmx syntax/ast_derive_util.cmx syntax/ast_derive.cmx \
+    syntax/ast_attributes.cmx syntax/ast_derive_dyn.cmi
+syntax/ast_derive_projector.cmx : ext/ext_list.cmx \
+    syntax/ast_derive_util.cmx syntax/ast_derive.cmx syntax/ast_comb.cmx \
+    syntax/ast_derive_projector.cmi
+syntax/ast_derive_js_mapper.cmx : ext/ext_list.cmx syntax/ast_polyvar.cmx \
+    syntax/ast_literal.cmx syntax/ast_derive_util.cmx syntax/ast_derive.cmx \
+    syntax/ast_core_type.cmx syntax/ast_comb.cmx \
+    syntax/ast_derive_js_mapper.cmi
 syntax/ast_util.cmx : ext/literals.cmx syntax/external_process.cmx \
     ext/ext_string.cmx ext/ext_list.cmx syntax/bs_syntaxerr.cmx \
     syntax/bs_ast_mapper.cmx syntax/ast_payload.cmx syntax/ast_pat.cmx \
@@ -288,14 +288,14 @@ syntax/ast_comb.cmi :
 syntax/ast_core_type.cmi :
 syntax/bs_ast_invariant.cmi : syntax/bs_ast_iterator.cmi
 syntax/ast_attributes.cmi : syntax/ast_payload.cmi
-syntax/ast_derive_abstract.cmi :
 syntax/ast_polyvar.cmi : syntax/external_arg_spec.cmi
-syntax/ast_derive_dyn.cmi :
-syntax/ast_derive_projector.cmi :
-syntax/ast_derive_js_mapper.cmi :
 syntax/external_ffi_types.cmi : syntax/external_arg_spec.cmi
 syntax/external_process.cmi : common/bs_loc.cmi syntax/ast_core_type.cmi \
     syntax/ast_attributes.cmi
+syntax/ast_derive_abstract.cmi :
+syntax/ast_derive_dyn.cmi :
+syntax/ast_derive_projector.cmi :
+syntax/ast_derive_js_mapper.cmi :
 syntax/ast_util.cmi : syntax/bs_ast_mapper.cmi syntax/ast_payload.cmi
 syntax/ast_tdcls.cmi : syntax/bs_ast_mapper.cmi syntax/ast_structure.cmi \
     syntax/ast_signature.cmi

--- a/jscomp/syntax/ast_attributes.ml
+++ b/jscomp/syntax/ast_attributes.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,84 +17,84 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 type attr =  Parsetree.attribute
-type t =  attr list 
+type t =  attr list
 
-type ('a,'b) st = 
-  { get : 'a option ; 
+type ('a,'b) st =
+  { get : 'a option ;
     set : 'b option }
 
 
-let process_method_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st,acc) (({txt ; loc}, payload) as attr : attr) -> 
+let process_method_attributes_rev (attrs : t) =
+  List.fold_left (fun (st,acc) (({txt ; loc}, payload) as attr : attr) ->
 
-      match txt  with 
+      match txt  with
       | "bs.get" (* [@@bs.get{null; undefined}]*)
-        -> 
-        let result = 
-          List.fold_left 
-            (fun 
+        ->
+        let result =
+          List.fold_left
+            (fun
               (null, undefined)
-              (({txt ; loc}, opt_expr) : Ast_payload.action) -> 
-              match txt with 
+              (({txt ; loc}, opt_expr) : Ast_payload.action) ->
+              match txt with
               | "null" ->
-                (match opt_expr with 
+                (match opt_expr with
                  | None -> true
-                 | Some e -> 
+                 | Some e ->
                    Ast_payload.assert_bool_lit e), undefined
 
               |  "undefined" ->
-                null, 
+                null,
                 (match opt_expr with
                  | None ->  true
-                 | Some e -> 
+                 | Some e ->
                    Ast_payload.assert_bool_lit e)
-              | "nullable" -> 
-                begin match opt_expr with 
-                  | None -> true, true 
+              | "nullable" ->
+                begin match opt_expr with
+                  | None -> true, true
                   | Some e ->
-                    let v = Ast_payload.assert_bool_lit e in 
+                    let v = Ast_payload.assert_bool_lit e in
                     v,v
                 end
               | _ -> Bs_syntaxerr.err loc Unsupported_predicates
-            ) (false, false) 
-            (Ast_payload.ident_or_record_as_config loc payload)  in 
+            ) (false, false)
+            (Ast_payload.ident_or_record_as_config loc payload)  in
 
         ({st with get = Some result}, acc  )
 
       | "bs.set"
-        -> 
-        let result = 
-          List.fold_left 
-            (fun st (({txt ; loc}, opt_expr) : Ast_payload.action) -> 
-               if txt =  "no_get" then 
-                 match opt_expr with 
-                 | None -> `No_get 
-                 | Some e -> 
-                   if Ast_payload.assert_bool_lit e then 
+        ->
+        let result =
+          List.fold_left
+            (fun st (({txt ; loc}, opt_expr) : Ast_payload.action) ->
+               if txt =  "no_get" then
+                 match opt_expr with
+                 | None -> `No_get
+                 | Some e ->
+                   if Ast_payload.assert_bool_lit e then
                      `No_get
                    else `Get
                else Bs_syntaxerr.err loc Unsupported_predicates
-            ) `Get (Ast_payload.ident_or_record_as_config loc payload)  in 
-        (* properties -- void 
+            ) `Get (Ast_payload.ident_or_record_as_config loc payload)  in
+        (* properties -- void
               [@@bs.set{only}]
         *)
         {st with set = Some result }, acc
-      | _ -> 
+      | _ ->
         (st, attr::acc  )
     ) ( {get = None ; set = None}, []) attrs
 
 
-let process_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
-      | "bs", (`Nothing | `Uncurry) 
-        -> 
+let process_attributes_rev (attrs : t) =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
+      | "bs", (`Nothing | `Uncurry)
+        ->
         `Uncurry, acc
       | "bs.this", (`Nothing | `Meth_callback)
         ->  `Meth_callback, acc
@@ -103,34 +103,34 @@ let process_attributes_rev (attrs : t) =
       | "bs", _
       | "bs.this", _
         -> Bs_syntaxerr.err loc Conflict_bs_bs_this_bs_meth
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_pexp_fun_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
-      | "bs.open", (`Nothing | `Exn) 
-        -> 
+let process_pexp_fun_attributes_rev (attrs : t) =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
+      | "bs.open", (`Nothing | `Exn)
+        ->
         `Exn, acc
 
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_bs attrs = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
+let process_bs attrs =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
       | "bs", _
-        -> 
+        ->
         `Has, acc
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_external attrs = 
-  List.exists (fun (({txt; }, _)  : attr) -> 
-      if Ext_string.starts_with txt "bs." then true 
+let process_external attrs =
+  List.exists (fun (({txt; }, _)  : attr) ->
+      if Ext_string.starts_with txt "bs." then true
       else false
     ) attrs
 
@@ -141,57 +141,57 @@ type derive_attr = {
 }
 
 let process_derive_type attrs : derive_attr * t =
-  List.fold_left 
-    (fun (st, acc) 
+  List.fold_left
+    (fun (st, acc)
       (({txt ; loc}, payload  as attr): attr)  ->
       match  st, txt  with
       |  {bs_deriving = None}, "bs.deriving"
         ->
         {st with
          bs_deriving = Some
-             (Ast_payload.ident_or_record_as_config loc payload)}, acc 
+             (Ast_payload.ident_or_record_as_config loc payload)}, acc
       | {bs_deriving = Some _}, "bs.deriving"
-        -> 
+        ->
         Bs_syntaxerr.err loc Duplicated_bs_deriving
 
       | _ , _ ->
-        let st = 
-          if txt = "nonrec" then 
+        let st =
+          if txt = "nonrec" then
             { st with explict_nonrec = true }
-          else st in 
+          else st in
         st, attr::acc
     ) ( {explict_nonrec = false; bs_deriving = None }, []) attrs
 
 let iter_process_derive_type attrs =
-  let st = ref {explict_nonrec = false; bs_deriving = None } in 
+  let st = ref {explict_nonrec = false; bs_deriving = None } in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload  as attr): attr)  ->
       match  txt  with
       |  "bs.deriving"
         ->
-        let ost = !st in 
-        (match ost with 
-         | {bs_deriving = None } -> 
-           Bs_ast_invariant.mark_used_bs_attribute attr ; 
-           st := 
+        let ost = !st in
+        (match ost with
+         | {bs_deriving = None } ->
+           Bs_ast_invariant.mark_used_bs_attribute attr ;
+           st :=
              {ost with
               bs_deriving = Some
                   (Ast_payload.ident_or_record_as_config loc payload)}
-         | {bs_deriving = Some _} ->       
+         | {bs_deriving = Some _} ->
            Bs_syntaxerr.err loc Duplicated_bs_deriving)
 
       | "nonrec" ->
-        st :=         
+        st :=
           { !st with explict_nonrec = true }
-      (* non bs attribute, no need to mark its use *)  
+      (* non bs attribute, no need to mark its use *)
       | _ -> ()
     )  attrs;
-  !st 
+  !st
 
 
 let process_bs_string_int_unwrap_uncurry attrs =
-  List.fold_left 
+  List.fold_left
     (fun (st,attrs)
       (({txt ; loc}, (payload : _ ) ) as attr : attr)  ->
       match  txt, st  with
@@ -205,84 +205,84 @@ let process_bs_string_int_unwrap_uncurry attrs =
         -> `Unwrap, attrs
       | "bs.uncurry", `Nothing
         ->
-        `Uncurry (Ast_payload.is_single_int payload), attrs 
+        `Uncurry (Ast_payload.is_single_int payload), attrs
       (* Don't allow duplicated [bs.uncurry] since
          it may introduce inconsistency in arity
-      *)  
+      *)
       | "bs.int", _
       | "bs.string", _
       | "bs.ignore", _
       | "bs.unwrap", _
-        -> 
+        ->
         Bs_syntaxerr.err loc Conflict_attributes
       | _ , _ -> st, (attr :: attrs )
     ) (`Nothing, []) attrs
 
 
-let iter_process_bs_string_as  attrs = 
-  let st = ref None in 
-  List.iter 
-    (fun 
-      (({txt ; loc}, payload ) as attr : attr)  ->
-      match  txt with
-      | "bs.as"
-        ->
-        if !st = None then 
-          match Ast_payload.is_single_string payload with 
-          | None -> 
-            Bs_syntaxerr.err loc Expect_string_literal
-          | Some  (v,_dec) -> 
-            Bs_ast_invariant.mark_used_bs_attribute attr ; 
-            st:= Some v 
-        else 
-          Bs_syntaxerr.err loc Duplicated_bs_as 
-      | _  -> ()
-    ) attrs;
-  !st 
-
-let iter_process_bs_int_as  attrs = 
-  let st = ref None in 
+let iter_process_bs_string_as  (attrs : t) : string option =
+  let st = ref None in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload ) as attr : attr)  ->
       match  txt with
       | "bs.as"
         ->
-        if !st =  None then 
-          match Ast_payload.is_single_int payload with 
-          | None -> 
-            Bs_syntaxerr.err loc Expect_int_literal
-          | Some  _ as v->  
-            Bs_ast_invariant.mark_used_bs_attribute attr ; 
-            st := v
-        else 
+        if !st = None then
+          match Ast_payload.is_single_string payload with
+          | None ->
+            Bs_syntaxerr.err loc Expect_string_literal
+          | Some  (v,_dec) ->
+            Bs_ast_invariant.mark_used_bs_attribute attr ;
+            st:= Some v
+        else
           Bs_syntaxerr.err loc Duplicated_bs_as
       | _  -> ()
-    ) attrs; !st 
+    ) attrs;
+  !st
 
-
-let iter_process_bs_string_or_int_as attrs = 
-  let st = ref None in 
+let iter_process_bs_int_as  attrs =
+  let st = ref None in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload ) as attr : attr)  ->
       match  txt with
       | "bs.as"
         ->
-        if !st = None then 
-          (Bs_ast_invariant.mark_used_bs_attribute attr ; 
-           match Ast_payload.is_single_int payload with 
-           | None -> 
-             begin match Ast_payload.is_single_string payload with 
-               | Some (s,None) -> 
-                 st := Some (`Str (s))                
-               | Some (s, Some "json") -> 
+        if !st =  None then
+          match Ast_payload.is_single_int payload with
+          | None ->
+            Bs_syntaxerr.err loc Expect_int_literal
+          | Some  _ as v->
+            Bs_ast_invariant.mark_used_bs_attribute attr ;
+            st := v
+        else
+          Bs_syntaxerr.err loc Duplicated_bs_as
+      | _  -> ()
+    ) attrs; !st
+
+
+let iter_process_bs_string_or_int_as attrs =
+  let st = ref None in
+  List.iter
+    (fun
+      (({txt ; loc}, payload ) as attr : attr)  ->
+      match  txt with
+      | "bs.as"
+        ->
+        if !st = None then
+          (Bs_ast_invariant.mark_used_bs_attribute attr ;
+           match Ast_payload.is_single_int payload with
+           | None ->
+             begin match Ast_payload.is_single_string payload with
+               | Some (s,None) ->
+                 st := Some (`Str (s))
+               | Some (s, Some "json") ->
                  st := Some (`Json_str s )
-               | None | Some (_, Some _) -> 
+               | None | Some (_, Some _) ->
                  Bs_syntaxerr.err loc Expect_int_or_string_or_json_literal
 
              end
-           | Some   v->  
+           | Some   v->
              st := (Some (`Int v))
           )
         else
@@ -290,28 +290,28 @@ let iter_process_bs_string_or_int_as attrs =
       | _ -> ()
 
     ) attrs;
-  !st 
+  !st
 
 let bs : attr
   =  {txt = "bs" ; loc = Location.none}, Ast_payload.empty
 
-let is_bs (attr : attr) =   
-  match attr with 
-  | {Location.txt = "bs"; _}, _ -> true 
+let is_bs (attr : attr) =
+  match attr with
+  | {Location.txt = "bs"; _}, _ -> true
   | _ -> false
 
 let bs_this : attr
   =  {txt = "bs.this" ; loc = Location.none}, Ast_payload.empty
 
-let bs_method : attr 
+let bs_method : attr
   =  {txt = "bs.meth"; loc = Location.none}, Ast_payload.empty
 
-let bs_obj : attr  
+let bs_obj : attr
   =  {txt = "bs.obj"; loc = Location.none}, Ast_payload.empty
 
-let bs_get : attr  
+let bs_get : attr
   =  {txt = "bs.get"; loc = Location.none}, Ast_payload.empty
 
 let bs_set : attr
-  =  {txt = "bs.set"; loc = Location.none}, Ast_payload.empty 
+  =  {txt = "bs.set"; loc = Location.none}, Ast_payload.empty
 

--- a/jscomp/syntax/ast_derive_abstract.ml
+++ b/jscomp/syntax/ast_derive_abstract.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2017 Authors of BuckleScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -26,110 +26,112 @@
 let derivingName = "abstract"
 module U = Ast_derive_util
 open Ast_helper
-type tdcls = Parsetree.type_declaration list 
+type tdcls = Parsetree.type_declaration list
 
-let handle_config (config : Parsetree.expression option) = 
-  match config with 
-  | Some config -> 
+let handle_config (config : Parsetree.expression option) =
+  match config with
+  | Some config ->
     U.invalid_config config
   | None -> ()
 
-(* see #2337 
+(* see #2337
    TODO: relax it to allow (int -> int [@bs])
-*)  
-let rec checkNotFunciton (ty : Parsetree.core_type) = 
-  match ty.ptyp_desc with 
-  | Ptyp_poly (_,ty) -> checkNotFunciton ty 
-  | Ptyp_alias (ty,_) -> checkNotFunciton ty 
-  | Ptyp_arrow _ -> 
-    Location.raise_errorf 
-      ~loc:ty.ptyp_loc 
+*)
+let rec checkNotFunciton (ty : Parsetree.core_type) =
+  match ty.ptyp_desc with
+  | Ptyp_poly (_,ty) -> checkNotFunciton ty
+  | Ptyp_alias (ty,_) -> checkNotFunciton ty
+  | Ptyp_arrow _ ->
+    Location.raise_errorf
+      ~loc:ty.ptyp_loc
       "syntactic function type is not allowed when working with abstract bs.deriving, create a named type as work around"
-  | Ptyp_any 
+  | Ptyp_any
   | Ptyp_var _
-  | Ptyp_tuple _ 
+  | Ptyp_tuple _
   | Ptyp_constr _
-  | Ptyp_object _  
-  | Ptyp_class _ 
+  | Ptyp_object _
+  | Ptyp_class _
   | Ptyp_variant _
   | Ptyp_package _
-  | Ptyp_extension _ -> () 
-let handleTdcl (tdcl : Parsetree.type_declaration) =   
-  let core_type = U.core_type_of_type_declaration tdcl in 
-  let loc = tdcl.ptype_loc in 
-  let name = tdcl.ptype_name.txt in 
+  | Ptyp_extension _ -> ()
+
+
+let handleTdcl (tdcl : Parsetree.type_declaration) =
+  let core_type = U.core_type_of_type_declaration tdcl in
+  let loc = tdcl.ptype_loc in
+  let type_name = tdcl.ptype_name.txt in
   let newTdcl = {
-    tdcl with 
+    tdcl with
     ptype_kind = Ptype_abstract;
     ptype_attributes = [];
     (* avoid non-terminating*)
-  } in 
-  match tdcl.ptype_kind with 
-  | Ptype_record label_declarations -> 
-    let ty =   
-      Ext_list.fold_right (fun (label_declaration : Parsetree.label_declaration) acc -> 
-          Typ.arrow
-            label_declaration.pld_name.txt label_declaration.pld_type acc 
-        ) label_declarations  core_type in 
-    let setter_accessor =     
-      Ext_list.fold_right (fun (x: Parsetree.label_declaration) acc -> 
-          let pld_name = x.pld_name.txt in 
-          let pld_loc = x.pld_name.loc in 
+  } in
+  match tdcl.ptype_kind with
+  | Ptype_record label_declarations ->
+    let setter_accessor =
+      Ext_list.fold_right (fun (x: Parsetree.label_declaration) acc ->
+          let pld_name = x.pld_name.txt in
+          let pld_loc = x.pld_name.loc in
           let pld_type = x.pld_type in
-          let () = checkNotFunciton pld_type in 
-          let setter = 
-            Val.mk 
+          let () = checkNotFunciton pld_type in
+          let setter =
+            Val.mk
               {loc = pld_loc; txt = pld_name}
               ~attrs:[Ast_attributes.bs_get]
               ~prim:[pld_name]
-              (Typ.arrow "" core_type pld_type) :: acc in 
-          match x.pld_mutable with 
-          | Mutable -> 
-            Val.mk 
+              (Typ.arrow "" core_type pld_type) :: acc in
+          match x.pld_mutable with
+          | Mutable ->
+            Val.mk
               {loc = pld_loc; txt = pld_name ^ "Set"}
               ~attrs:[Ast_attributes.bs_set]
               ~prim:[pld_name]
               (Typ.arrow "" core_type (Typ.arrow "" pld_type (Ast_literal.type_unit ()))) :: setter
-          | Immutable -> setter 
+          | Immutable -> setter
         ) label_declarations []
-    in 
+    in
 
-    newTdcl, 
-    (match tdcl.ptype_private with 
+    newTdcl,
+    (match tdcl.ptype_private with
      | Private -> setter_accessor
-     | Public -> 
-       let maker =   
-         Val.mk  {loc; txt = name}
+     | Public ->
+       let ty =
+         Ext_list.fold_right (fun (label_declaration : Parsetree.label_declaration) acc ->
+             Typ.arrow
+               label_declaration.pld_name.txt label_declaration.pld_type acc
+           ) label_declarations  core_type in
+       let maker =
+         Val.mk  {loc; txt = type_name}
            ~attrs:[Ast_attributes.bs_obj]
-           ~prim:[""] ty in 
+           ~prim:[""] ty in
        (maker :: setter_accessor))
 
-  | Ptype_abstract 
-  | Ptype_variant _ 
-  | Ptype_open -> 
+  | Ptype_abstract
+  | Ptype_variant _
+  | Ptype_open ->
     (* Looks obvious that it does not make sense to warn *)
     (* U.notApplicable tdcl.ptype_loc derivingName;  *)
     tdcl, []
 
-let handleTdclsInStr tdcls =     
-  let tdcls, code = 
-    List.fold_right (fun tdcl (tdcls, sts)  -> 
-        match handleTdcl tdcl with 
-          ntdcl, value_descriptions -> 
-          ntdcl::tdcls, 
+let handleTdclsInStr tdcls =
+  let tdcls, code =
+    List.fold_right (fun tdcl (tdcls, sts)  ->
+        match handleTdcl tdcl with
+          ntdcl, value_descriptions ->
+          ntdcl::tdcls,
           Ext_list.map_append (fun x -> Str.primitive x) value_descriptions sts
 
-      ) tdcls ([],[])  in 
-  Str.type_ tdcls :: code    
+      ) tdcls ([],[])  in
+  Str.type_ tdcls :: code
 (* still need perform transformation for non-abstract type*)
 
-let handleTdclsInSig tdcls =     
-  let tdcls, code = 
-    List.fold_right (fun tdcl (tdcls, sts)  -> 
-        match handleTdcl tdcl with 
-          ntdcl, value_descriptions -> 
-          ntdcl::tdcls, 
+let handleTdclsInSig tdcls =
+  let tdcls, code =
+    List.fold_right (fun tdcl (tdcls, sts)  ->
+        match handleTdcl tdcl with
+          ntdcl, value_descriptions ->
+          ntdcl::tdcls,
           Ext_list.map_append (fun x -> Sig.value x) value_descriptions sts
 
-      ) tdcls ([],[])  in 
-  Sig.type_ tdcls :: code  
+      ) tdcls ([],[])  in
+  Sig.type_ tdcls :: code

--- a/jscomp/syntax/external_ffi_types.ml
+++ b/jscomp/syntax/external_ffi_types.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,76 +17,76 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type module_bind_name = 
-  | Phint_name of string 
+type module_bind_name =
+  | Phint_name of string
     (* explicit hint name *)
 
   | Phint_nothing
-  
 
-type external_module_name = 
-  { bundle : string ; 
+
+type external_module_name =
+  { bundle : string ;
     module_bind_name : module_bind_name
   }
 
-type pipe = bool 
-type js_call = { 
+type pipe = bool
+type js_call = {
   name : string;
   external_module_name : external_module_name option;
   splice : bool ;
-  scopes : string list ; 
+  scopes : string list ;
 }
 
-type js_send = { 
+type js_send = {
   name : string ;
-  splice : bool ; 
+  splice : bool ;
   pipe : pipe   ;
-  js_send_scopes : string list; 
+  js_send_scopes : string list;
 } (* we know it is a js send, but what will happen if you pass an ocaml objct *)
 
 type js_global_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   scopes : string list ;
 }
 
 type js_new_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   splice : bool ;
   scopes : string list;
 }
 
-type js_module_as_fn = 
+type js_module_as_fn =
   { external_module_name : external_module_name;
     splice : bool ;
 
   }
-type js_get =  
+type js_get =
   { js_get_name : string   ;
     js_get_scopes :  string list;
   }
 
-type js_set = 
+type js_set =
   { js_set_name : string  ;
-    js_set_scopes : string list 
+    js_set_scopes : string list
   }
 
 type js_get_index =   {
-  js_get_index_scopes : string list 
+  js_get_index_scopes : string list
 }
 
 type js_set_index = {
-  js_set_index_scopes : string list 
-}  
-(** TODO: information between [arg_type] and [arg_label] are duplicated, 
+  js_set_index_scopes : string list
+}
+(** TODO: information between [arg_type] and [arg_label] are duplicated,
   design a more compact representation so that it is also easy to seralize by hand
-*)  
+*)
 type arg_type = External_arg_spec.attr
 
 type arg_label = External_arg_spec.label
@@ -95,55 +95,55 @@ type arg_label = External_arg_spec.label
 (**TODO: maybe we can merge [arg_label] and [arg_type] *)
 type obj_create = External_arg_spec.t list
 
-type attr = 
-  | Js_global of js_global_val 
+type attr =
+  | Js_global of js_global_val
   | Js_module_as_var of  external_module_name
   | Js_module_as_fn of js_module_as_fn
-  | Js_module_as_class of external_module_name             
-  | Js_call of js_call 
+  | Js_module_as_class of external_module_name
+  | Js_call of js_call
   | Js_send of js_send
   | Js_new of js_new_val
   | Js_set of js_set
   | Js_get of js_get
   | Js_get_index of js_get_index
-  | Js_set_index of js_set_index 
+  | Js_set_index of js_set_index
 
 let name_of_ffi ffi =
-  match ffi with 
+  match ffi with
   | Js_get_index _scope -> "[@@bs.get_index ..]"
   | Js_set_index _scope -> "[@@bs.set_index ..]"
-  | Js_get { js_get_name = s} -> Printf.sprintf "[@@bs.get %S]" s 
-  | Js_set { js_set_name = s} -> Printf.sprintf "[@@bs.set %S]" s 
+  | Js_get { js_get_name = s} -> Printf.sprintf "[@@bs.get %S]" s
+  | Js_set { js_set_name = s} -> Printf.sprintf "[@@bs.set %S]" s
   | Js_call v  -> Printf.sprintf "[@@bs.val %S]" v.name
   | Js_send v  -> Printf.sprintf "[@@bs.send %S]" v.name
   | Js_module_as_fn v  -> Printf.sprintf "[@@bs.val %S]" v.external_module_name.bundle
-  | Js_new v  -> Printf.sprintf "[@@bs.new %S]" v.name                    
+  | Js_new v  -> Printf.sprintf "[@@bs.new %S]" v.name
   | Js_module_as_class v
     -> Printf.sprintf "[@@bs.module] %S " v.bundle
   | Js_module_as_var v
-    -> 
+    ->
     Printf.sprintf "[@@bs.module] %S " v.bundle
-  | Js_global v 
-    -> 
-    Printf.sprintf "[@@bs.val] %S " v.name                    
+  | Js_global v
+    ->
+    Printf.sprintf "[@@bs.val] %S " v.name
 
-type return_wrapper = 
-  | Return_unset 
+type return_wrapper =
+  | Return_unset
   | Return_identity
-  | Return_undefined_to_opt  
+  | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
   | Return_to_ocaml_bool
-  | Return_replaced_with_unit    
-type t  = 
+  | Return_replaced_with_unit
+type t  =
   | Ffi_bs of External_arg_spec.t list  *
-     return_wrapper * attr 
+     return_wrapper * attr
   (**  [Ffi_bs(args,return,attr) ]
-       [return] means return value is unit or not, 
-        [true] means is [unit]  
+       [return] means return value is unit or not,
+        [true] means is [unit]
   *)
   | Ffi_obj_create of obj_create
-  | Ffi_normal 
+  | Ffi_normal
   (* When it's normal, it is handled as normal c functional ffi call *)
 
 
@@ -155,7 +155,7 @@ let valid_js_char =
     ) in
   (fun c -> Array.unsafe_get a (Char.code c))
 
-let valid_first_js_char = 
+let valid_first_js_char =
   let a = Array.init 256 (fun i ->
       let c = Char.chr i in
       (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c = '_' || c = '$'
@@ -170,10 +170,10 @@ let valid_ident (s : string) =
    try
      for i = 1 to len - 1 do
        if not (valid_js_char (String.unsafe_get s i)) then
-         raise E.E         
+         raise E.E
      done ;
-     true     
-   with E.E -> false )  
+     true
+   with E.E -> false )
 
 let valid_global_name ?loc txt =
   if not (valid_ident txt) then
@@ -182,30 +182,36 @@ let valid_global_name ?loc txt =
       (fun s ->
          if not (valid_ident s) then
            Location.raise_errorf ?loc "Not a valid global name %s"  txt
-      ) v      
+      ) v
 
-let valid_method_name ?loc txt =         
-  if not (valid_ident txt) then
-    Location.raise_errorf ?loc "Not a valid method name %s"  txt
+(*
+  We loose such check (see #2583),
+  it also helps with the implementation deriving abstract [@bs.as]
+*)
+
+let valid_method_name ?loc txt =
+    ()
+  (* if not (valid_ident txt) then
+    Location.raise_errorf ?loc "Not a valid method name %s"  txt *)
 
 
 
-let check_external_module_name ?loc x = 
-  match x with 
-  | {bundle = ""; _ } 
-  | { module_bind_name = Phint_name "" } -> 
+let check_external_module_name ?loc x =
+  match x with
+  | {bundle = ""; _ }
+  | { module_bind_name = Phint_name "" } ->
     Location.raise_errorf ?loc "empty name encountered"
   | _ -> ()
-let check_external_module_name_opt ?loc x = 
-  match x with 
+let check_external_module_name_opt ?loc x =
+  match x with
   | None -> ()
-  | Some v -> check_external_module_name ?loc v 
+  | Some v -> check_external_module_name ?loc v
 
 
-let check_ffi ?loc ffi = 
-  match ffi with 
+let check_ffi ?loc ffi =
+  match ffi with
   | Js_global {name} -> valid_global_name ?loc  name
-  | Js_send {name } 
+  | Js_send {name }
   | Js_set  {js_set_name = name}
   | Js_get { js_get_name = name}
     ->  valid_method_name ?loc name
@@ -215,44 +221,44 @@ let check_ffi ?loc ffi =
 
   | Js_module_as_var external_module_name
   | Js_module_as_fn {external_module_name; _}
-  | Js_module_as_class external_module_name             
+  | Js_module_as_class external_module_name
     -> check_external_module_name external_module_name
   | Js_new {external_module_name ;  name}
   | Js_call {external_module_name ;  name ; _}
-    -> 
+    ->
     check_external_module_name_opt ?loc external_module_name ;
-    valid_global_name ?loc name     
+    valid_global_name ?loc name
 
 let bs_prefix = "BS:"
-let bs_prefix_length = String.length bs_prefix 
+let bs_prefix_length = String.length bs_prefix
 
 
 (** TODO: Make sure each version is not prefix of each other
     Solution:
-    1. fixed length 
+    1. fixed length
     2. non-prefix approach
 *)
-let bs_external = bs_prefix ^ Bs_version.version 
+let bs_external = bs_prefix ^ Bs_version.version
 
 
 let bs_external_length = String.length bs_external
 
 
-let to_string  t = 
+let to_string  t =
   bs_external ^ Marshal.to_string t []
 
 
 (* TODO:  better error message when version mismatch *)
-let from_string s : t = 
-  let s_len = String.length s in 
+let from_string s : t =
+  let s_len = String.length s in
   if s_len >= bs_prefix_length &&
      String.unsafe_get s 0 = 'B' &&
      String.unsafe_get s 1 = 'S' &&
-     String.unsafe_get s 2 = ':' then 
-    if Ext_string.starts_with s bs_external then 
-      Marshal.from_string s bs_external_length 
-    else 
-      Ext_pervasives.failwithf 
+     String.unsafe_get s 2 = ':' then
+    if Ext_string.starts_with s bs_external then
+      Marshal.from_string s bs_external_length
+    else
+      Ext_pervasives.failwithf
         ~loc:__LOC__
         "Compiler version mismatch. The project might have been built with one version of BuckleScript, and then with another. Please wipe the artifacts and do a clean build."
-  else Ffi_normal    
+  else Ffi_normal

--- a/jscomp/syntax/external_ffi_types.mli
+++ b/jscomp/syntax/external_ffi_types.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,119 +17,120 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type module_bind_name = 
-  | Phint_name of string 
+type module_bind_name =
+  | Phint_name of string
   (* explicit hint name *)
   | Phint_nothing
 
-type external_module_name = 
-  { bundle : string ; 
+type external_module_name =
+  { bundle : string ;
     module_bind_name : module_bind_name
   }
 
-type pipe = bool 
-type js_call = { 
+type pipe = bool
+type js_call = {
   name : string;
   external_module_name : external_module_name option;
   splice : bool ;
-  scopes : string list 
+  scopes : string list
 }
 
-type js_send = { 
+type js_send = {
   name : string ;
-  splice : bool ; 
+  splice : bool ;
   pipe : pipe  ;
-  js_send_scopes : string list; 
+  js_send_scopes : string list;
 } (* we know it is a js send, but what will happen if you pass an ocaml objct *)
 
 type js_global_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   scopes : string list
 }
 
 type js_new_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   splice : bool ;
   scopes : string list;
 }
 
-type js_module_as_fn = 
+type js_module_as_fn =
   { external_module_name : external_module_name;
-    splice : bool 
+    splice : bool
   }
 
 type arg_type = External_arg_spec.attr
 
-type arg_label = External_arg_spec.label 
+type arg_label = External_arg_spec.label
 
 
 type obj_create = External_arg_spec.t list
 
-type js_get =  
+type js_get =
   { js_get_name : string   ;
     js_get_scopes :  string list;
   }
 
-type js_set = 
+type js_set =
   { js_set_name : string  ;
-    js_set_scopes : string list 
+    js_set_scopes : string list
   }
 
 
 type js_get_index =   {
-  js_get_index_scopes : string list 
+  js_get_index_scopes : string list
 }
 
 type js_set_index = {
-  js_set_index_scopes : string list 
-} 
+  js_set_index_scopes : string list
+}
 
 
 
-type attr  = 
-  | Js_global of js_global_val 
+type attr  =
+  | Js_global of js_global_val
   | Js_module_as_var of  external_module_name
   | Js_module_as_fn of js_module_as_fn
-  | Js_module_as_class of external_module_name             
-  | Js_call of js_call 
+  | Js_module_as_class of external_module_name
+  | Js_call of js_call
   | Js_send of js_send
   | Js_new of js_new_val
   | Js_set of js_set
   | Js_get of js_get
   | Js_get_index of js_get_index
-  | Js_set_index of js_set_index 
+  | Js_set_index of js_set_index
 
-type return_wrapper = 
-  | Return_unset 
+type return_wrapper =
+  | Return_unset
   | Return_identity
-  | Return_undefined_to_opt  
+  | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
   | Return_to_ocaml_bool
-  | Return_replaced_with_unit    
+  | Return_replaced_with_unit
 
-type t  = 
-  | Ffi_bs of 
+type t  =
+  | Ffi_bs of
       External_arg_spec.t list  *
-      return_wrapper * attr
+      return_wrapper *
+      attr
   | Ffi_obj_create of obj_create
-  | Ffi_normal 
+  | Ffi_normal
   (* When it's normal, it is handled as normal c functional ffi call *)
 
 
 val name_of_ffi : attr -> string
 
-val check_ffi : ?loc:Location.t ->  attr -> unit 
+val check_ffi : ?loc:Location.t ->  attr -> unit
 
-val to_string : t -> string 
+val to_string : t -> string
 
 (** Note *)
-val from_string : string -> t 
+val from_string : string -> t
 

--- a/jscomp/syntax/external_process.ml
+++ b/jscomp/syntax/external_process.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -28,7 +28,7 @@
 
 
 let variant_can_bs_unwrap_fields row_fields =
-  let validity = 
+  let validity =
     List.fold_left
       begin fun st row ->
         match st, row with
@@ -52,7 +52,7 @@ let variant_can_bs_unwrap_fields row_fields =
 
 
 (** Given the type of argument, process its [bs.] attribute and new type,
-    The new type is currently used to reconstruct the external type 
+    The new type is currently used to reconstruct the external type
     and result type in [@@bs.obj]
     They are not the same though, for example
     {[
@@ -60,96 +60,96 @@ let variant_can_bs_unwrap_fields row_fields =
     ]}
     The result type would be [ hi:string ]
 *)
-let get_arg_type ~nolabel optional 
-    (ptyp : Ast_core_type.t) : 
-  External_arg_spec.attr * Ast_core_type.t  = 
-  let ptyp = if optional then Ast_core_type.extract_option_type_exn ptyp else ptyp in 
+let get_arg_type ~nolabel optional
+    (ptyp : Ast_core_type.t) :
+  External_arg_spec.attr * Ast_core_type.t  =
+  let ptyp = if optional then Ast_core_type.extract_option_type_exn ptyp else ptyp in
   if Ast_core_type.is_any ptyp then (* (_[@bs.as ])*)
-    if optional then 
+    if optional then
       Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
     else begin
-      let ptyp_attrs = 
-        ptyp.Parsetree.ptyp_attributes 
-      in   
-      let result = 
+      let ptyp_attrs =
+        ptyp.Parsetree.ptyp_attributes
+      in
+      let result =
         Ast_attributes.iter_process_bs_string_or_int_as ptyp_attrs
-      in   
+      in
       (* when ppx start dropping attributes
         we should warn, there is a trade off whether
         we should warn dropped non bs attribute or not
-      *) 
-      Bs_ast_invariant.warn_unused_attributes ptyp_attrs; 
-      match result with 
-      |  None -> 
+      *)
+      Bs_ast_invariant.warn_unused_attributes ptyp_attrs;
+      match result with
+      |  None ->
         Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
 
-      | Some (`Int i) -> 
-        Arg_cst(External_arg_spec.cst_int i), Ast_literal.type_int ~loc:ptyp.ptyp_loc ()  
-      | Some (`Str i)-> 
-        Arg_cst (External_arg_spec.cst_string i), Ast_literal.type_string ~loc:ptyp.ptyp_loc () 
+      | Some (`Int i) ->
+        Arg_cst(External_arg_spec.cst_int i), Ast_literal.type_int ~loc:ptyp.ptyp_loc ()
+      | Some (`Str i)->
+        Arg_cst (External_arg_spec.cst_string i), Ast_literal.type_string ~loc:ptyp.ptyp_loc ()
       | Some (`Json_str s) ->
         Arg_cst (External_arg_spec.cst_json ptyp.ptyp_loc s),
-        Ast_literal.type_string ~loc:ptyp.ptyp_loc () 
+        Ast_literal.type_string ~loc:ptyp.ptyp_loc ()
 
-    end 
+    end
   else (* ([`a|`b] [@bs.string]) *)
-    let ptyp_desc = ptyp.ptyp_desc in 
+    let ptyp_desc = ptyp.ptyp_desc in
     match Ast_attributes.process_bs_string_int_unwrap_uncurry ptyp.ptyp_attributes with
     | (`String, ptyp_attributes)
-      -> 
-      begin match ptyp_desc with 
+      ->
+      begin match ptyp_desc with
         | Ptyp_variant ( row_fields, Closed, None)
           ->
-          let attr = 
-            Ast_polyvar.map_row_fields_into_strings ptyp.ptyp_loc row_fields in 
-          attr, 
+          let attr =
+            Ast_polyvar.map_row_fields_into_strings ptyp.ptyp_loc row_fields in
+          attr,
           {ptyp with
-           ptyp_attributes 
+           ptyp_attributes
           }
         | _ ->
           Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
-      end 
-    | (`Ignore, ptyp_attributes)  -> 
+      end
+    | (`Ignore, ptyp_attributes)  ->
       (Ignore, {ptyp with ptyp_attributes})
-    | (`Int , ptyp_attributes) -> 
-      begin match ptyp_desc with 
-        | Ptyp_variant ( row_fields, Closed, None) -> 
-          let int_lists = 
-            Ast_polyvar.map_row_fields_into_ints ptyp.ptyp_loc row_fields in 
+    | (`Int , ptyp_attributes) ->
+      begin match ptyp_desc with
+        | Ptyp_variant ( row_fields, Closed, None) ->
+          let int_lists =
+            Ast_polyvar.map_row_fields_into_ints ptyp.ptyp_loc row_fields in
           Int int_lists ,
-          {ptyp with            
+          {ptyp with
            ptyp_attributes
           }
-        | _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type   
+        | _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
       end
-    | (`Unwrap, ptyp_attributes) -> 
+    | (`Unwrap, ptyp_attributes) ->
 
-      begin match ptyp_desc with 
+      begin match ptyp_desc with
         | (Ptyp_variant (row_fields, Closed, _) as ptyp_desc)
           when variant_can_bs_unwrap_fields row_fields ->
           Unwrap, {ptyp with ptyp_desc; ptyp_attributes}
         | _ ->
           Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_unwrap_type
-      end 
-    | (`Uncurry opt_arity, ptyp_attributes) -> 
-      let real_arity =  Ast_core_type.get_uncurry_arity ptyp in 
-      (begin match opt_arity, real_arity with 
-         | Some arity, `Not_function -> 
-           Fn_uncurry_arity arity 
+      end
+    | (`Uncurry opt_arity, ptyp_attributes) ->
+      let real_arity =  Ast_core_type.get_uncurry_arity ptyp in
+      (begin match opt_arity, real_arity with
+         | Some arity, `Not_function ->
+           Fn_uncurry_arity arity
          | None, `Not_function  ->
            Bs_syntaxerr.err ptyp.ptyp_loc Canot_infer_arity_by_syntax
-         | None, `Arity arity  ->         
+         | None, `Arity arity  ->
            Fn_uncurry_arity arity
-         | Some arity, `Arity n -> 
+         | Some arity, `Arity n ->
            if n <> arity then
              Bs_syntaxerr.err ptyp.ptyp_loc (Inconsistent_arity (arity,n))
-           else Fn_uncurry_arity arity 
+           else Fn_uncurry_arity arity
 
        end, {ptyp with ptyp_attributes})
     | (`Nothing, ptyp_attributes) ->
       begin match ptyp_desc with
         | Ptyp_constr ({txt = Lident "bool"; _}, [])
-          -> 
+          ->
           Bs_warnings.prerr_bs_ffi_warning ptyp.ptyp_loc Unsafe_ffi_bool_type;
           Nothing
         | Ptyp_constr ({txt = Lident "unit"; _}, [])
@@ -158,38 +158,38 @@ let get_arg_type ~nolabel optional
           -> Array
         | Ptyp_variant _ ->
           Bs_warnings.prerr_bs_ffi_warning ptyp.ptyp_loc Unsafe_poly_variant_type;
-          Nothing           
+          Nothing
         | _ ->
-          Nothing           
+          Nothing
       end, ptyp
 
 
 
-(** 
+(**
    [@@bs.module "react"]
    [@@bs.module "react"]
    ---
    [@@bs.module "@" "react"]
    [@@bs.module "@" "react"]
 
-   They should have the same module name 
+   They should have the same module name
 
-   TODO: we should emit an warning if we bind 
+   TODO: we should emit an warning if we bind
    two external files to the same module name
 *)
 type bundle_source =
   [`Nm_payload of string (* from payload [@@bs.val "xx" ]*)
   |`Nm_external of string (* from "" in external *)
-  | `Nm_val of string   (* from function name *)   
-  ]  
+  | `Nm_val of string   (* from function name *)
+  ]
 
 let string_of_bundle_source (x : bundle_source) =
   match x with
   | `Nm_payload x
   | `Nm_external x
-  | `Nm_val x -> x   
+  | `Nm_val x -> x
 type name_source =
-  [ bundle_source  
+  [ bundle_source
   | `Nm_na
 
   ]
@@ -197,14 +197,14 @@ type name_source =
 
 
 
-type st = 
+type st =
   { val_name : name_source;
     external_module_name : External_ffi_types.external_module_name option;
     module_as_val : External_ffi_types.external_module_name option;
     val_send : name_source ;
-    val_send_pipe : Ast_core_type.t option;    
+    val_send_pipe : Ast_core_type.t option;
     splice : bool ; (* mutable *)
-    scopes : string list ; 
+    scopes : string list ;
     set_index : bool; (* mutable *)
     get_index : bool;
     new_name : name_source ;
@@ -217,13 +217,13 @@ type st =
 
   }
 
-let init_st = 
+let init_st =
   {
-    val_name = `Nm_na; 
+    val_name = `Nm_na;
     external_module_name = None ;
     module_as_val = None;
     val_send = `Nm_na;
-    val_send_pipe = None;    
+    val_send_pipe = None;
     splice = false;
     scopes = [];
     set_index = false;
@@ -232,8 +232,8 @@ let init_st =
     call_name = `Nm_na;
     set_name = `Nm_na ;
     get_name = `Nm_na ;
-    mk_obj = false ; 
-    return_wrapper = Return_unset; 
+    mk_obj = false ;
+    return_wrapper = Return_unset;
 
   }
 
@@ -241,52 +241,52 @@ let init_st =
 
 
 
-let process_external_attributes 
-    no_arguments 
+let process_external_attributes
+    no_arguments
     (prim_name_or_pval_prim: [< bundle_source ] as 'a)
     pval_prim
     (prim_attributes : Ast_attributes.t) : _ * Ast_attributes.t =
 
-  (* shared by `[@@bs.val]`, `[@@bs.send]`, 
-     `[@@bs.set]`, `[@@bs.get]` , `[@@bs.new]` 
-     `[@@bs.send.pipe]` does not use it 
+  (* shared by `[@@bs.val]`, `[@@bs.send]`,
+     `[@@bs.set]`, `[@@bs.get]` , `[@@bs.new]`
+     `[@@bs.send.pipe]` does not use it
   *)
   let name_from_payload_or_prim ~loc (payload : Parsetree.payload) : name_source =
-    match payload with 
-    | PStr [] -> 
-      (prim_name_or_pval_prim :> name_source)  
+    match payload with
+    | PStr [] ->
+      (prim_name_or_pval_prim :> name_source)
     (* It is okay to have [@@bs.val] without payload *)
-    | _ -> 
+    | _ ->
       begin match Ast_payload.is_single_string payload with
         | Some  (val_name, _) ->  `Nm_payload val_name
-        | None ->  
+        | None ->
           Location.raise_errorf ~loc "Invalid payload"
       end
 
   in
-  List.fold_left 
+  List.fold_left
     (fun (st, attrs)
-      (({txt ; loc}, payload) as attr : Ast_attributes.attr) 
+      (({txt ; loc}, payload) as attr : Ast_attributes.attr)
       ->
         if Ext_string.starts_with txt "bs." then
-          begin match txt with 
-            | "bs.val" ->  
+          begin match txt with
+            | "bs.val" ->
               if no_arguments then
                 {st with val_name = name_from_payload_or_prim ~loc payload}
-              else 
+              else
                 {st with call_name = name_from_payload_or_prim ~loc  payload}
 
-            | "bs.module" -> 
-              begin match Ast_payload.assert_strings loc payload with 
+            | "bs.module" ->
+              begin match Ast_payload.assert_strings loc payload with
                 | [bundle] ->
                   {st with external_module_name =
                              Some {bundle; module_bind_name = Phint_nothing}}
-                | [bundle;bind_name] -> 
+                | [bundle;bind_name] ->
                   {st with external_module_name =
                              Some {bundle; module_bind_name = Phint_name bind_name}}
                 | [] ->
                   { st with
-                    module_as_val = 
+                    module_as_val =
                       Some
                         { bundle =
                             string_of_bundle_source
@@ -297,21 +297,21 @@ let process_external_attributes
                   Bs_syntaxerr.err loc Illegal_attribute
               end
             | "bs.scope" ->
-              begin match Ast_payload.assert_strings loc payload with 
-                | [] -> 
-                  Bs_syntaxerr.err loc Illegal_attribute 
-                (* We need err on empty scope, so we can tell the difference 
+              begin match Ast_payload.assert_strings loc payload with
+                | [] ->
+                  Bs_syntaxerr.err loc Illegal_attribute
+                (* We need err on empty scope, so we can tell the difference
                    between unset/set
                 *)
                 | scopes ->  { st with scopes = scopes }
               end
             | "bs.splice" -> {st with splice = true}
-            | "bs.send" -> 
+            | "bs.send" ->
               { st with val_send = name_from_payload_or_prim ~loc payload}
             | "bs.send.pipe"
               ->
-              { st with val_send_pipe = Some (Ast_payload.as_core_type loc payload)}                
-            | "bs.set" -> 
+              { st with val_send_pipe = Some (Ast_payload.as_core_type loc payload)}
+            | "bs.set" ->
               {st with set_name = name_from_payload_or_prim ~loc  payload}
             | "bs.get" -> {st with get_name = name_from_payload_or_prim ~loc payload}
 
@@ -320,21 +320,21 @@ let process_external_attributes
             | "bs.get_index"-> {st with get_index = true}
             | "bs.obj" -> {st with mk_obj = true}
             | "bs.return" ->
-              let aux loc txt : External_ffi_types.return_wrapper = 
-                begin match txt with 
+              let aux loc txt : External_ffi_types.return_wrapper =
+                begin match txt with
                   | "undefined_to_opt" -> Return_undefined_to_opt
                   | "null_to_opt" -> Return_null_to_opt
                   | "nullable"
                   | "null_undefined_to_opt" -> Return_null_undefined_to_opt
-                  | "identity" -> Return_identity 
+                  | "identity" -> Return_identity
                   | _ ->
                     Bs_syntaxerr.err loc Not_supported_directive_in_bs_return
                 end in
-              let actions = 
-                Ast_payload.ident_or_record_as_config loc payload 
+              let actions =
+                Ast_payload.ident_or_record_as_config loc payload
               in
-              begin match actions with 
-                | [ ({txt; _ },None) ] -> 
+              begin match actions with
+                | [ ({txt; _ },None) ] ->
                   { st with return_wrapper = aux loc txt}
                 | _ ->
                   Bs_syntaxerr.err loc Not_supported_directive_in_bs_return
@@ -343,212 +343,212 @@ let process_external_attributes
           end, attrs
         else (st , attr :: attrs)
     )
-    (init_st, []) prim_attributes 
+    (init_st, []) prim_attributes
 
 
-let rec has_bs_uncurry (attrs : Ast_attributes.t) = 
-  match attrs with 
-  | ({txt = "bs.uncurry"; _ }, _) :: attrs -> 
-    true 
-  | _ :: attrs -> has_bs_uncurry attrs 
-  | [] -> false 
+let rec has_bs_uncurry (attrs : Ast_attributes.t) =
+  match attrs with
+  | ({txt = "bs.uncurry"; _ }, _) :: attrs ->
+    true
+  | _ :: attrs -> has_bs_uncurry attrs
+  | [] -> false
 
 
-let check_return_wrapper 
-    loc (wrapper : External_ffi_types.return_wrapper) 
-    result_type = 
-  match wrapper with 
+let check_return_wrapper
+    loc (wrapper : External_ffi_types.return_wrapper)
+    result_type =
+  match wrapper with
   | Return_identity -> wrapper
-  | Return_unset  ->         
-    if Ast_core_type.is_unit result_type then 
-      Return_replaced_with_unit 
-    else if Ast_core_type.is_user_bool result_type then 
+  | Return_unset  ->
+    if Ast_core_type.is_unit result_type then
+      Return_replaced_with_unit
+    else if Ast_core_type.is_user_bool result_type then
       Return_to_ocaml_bool
-    else 
+    else
       wrapper
   | Return_undefined_to_opt
-  | Return_null_to_opt 
-  | Return_null_undefined_to_opt  
-    -> 
-    if Ast_core_type.is_user_option result_type then 
+  | Return_null_to_opt
+  | Return_null_undefined_to_opt
+    ->
+    if Ast_core_type.is_user_option result_type then
       wrapper
     else
       Bs_syntaxerr.err loc Expect_opt_in_bs_return_to_opt
-  | Return_replaced_with_unit 
-  | Return_to_ocaml_bool  -> 
+  | Return_replaced_with_unit
+  | Return_to_ocaml_bool  ->
     assert false (* Not going to happen from user input*)
 
 
 
 
-(** Note that the passed [type_annotation] is already processed by visitor pattern before 
+(** Note that the passed [type_annotation] is already processed by visitor pattern before
 *)
-let handle_attributes 
+let handle_attributes
     (loc : Bs_loc.t)
-    (pval_prim : string ) 
+    (pval_prim : string )
     (type_annotation : Parsetree.core_type)
     (prim_attributes : Ast_attributes.t) (prim_name : string)
   : Ast_core_type.t * string * External_ffi_types.t * Ast_attributes.t =
-  (** sanity check here 
+  (** sanity check here
       {[ int -> int -> (int -> int -> int [@bs.uncurry])]}
-      It does not make sense 
+      It does not make sense
   *)
-  if has_bs_uncurry type_annotation.Parsetree.ptyp_attributes then 
-    begin 
-      Location.raise_errorf 
+  if has_bs_uncurry type_annotation.Parsetree.ptyp_attributes then
+    begin
+      Location.raise_errorf
         ~loc "[@@bs.uncurry] can not be applied to the whole definition"
-    end; 
+    end;
 
   let prim_name_or_pval_prim =
     if String.length prim_name = 0 then  `Nm_val pval_prim
     else  `Nm_external prim_name  (* need check name *)
-  in    
+  in
   let result_type, arg_types_ty =
     Ast_core_type.list_of_arrow type_annotation in
-  if has_bs_uncurry result_type.ptyp_attributes then 
-    begin 
-      Location.raise_errorf 
+  if has_bs_uncurry result_type.ptyp_attributes then
+    begin
+      Location.raise_errorf
         ~loc:result_type.ptyp_loc
         "[@@bs.uncurry] can not be applied to tailed position"
     end ;
-  let (st, left_attrs) = 
-    process_external_attributes 
+  let (st, left_attrs) =
+    process_external_attributes
       (arg_types_ty = [])
-      prim_name_or_pval_prim pval_prim prim_attributes in 
+      prim_name_or_pval_prim pval_prim prim_attributes in
 
 
-  if st.mk_obj then 
-    begin match st with 
+  if st.mk_obj then
+    begin match st with
       | {
-        val_name = `Nm_na; 
+        val_name = `Nm_na;
         external_module_name = None ;
         module_as_val = None;
         val_send = `Nm_na;
-        val_send_pipe = None;    
+        val_send_pipe = None;
         splice = false;
         new_name = `Nm_na;
         call_name = `Nm_na;
         set_name = `Nm_na ;
         get_name = `Nm_na ;
         get_index = false ;
-        return_wrapper = Return_unset ;        
-        set_index = false ; 
-        mk_obj = _; 
+        return_wrapper = Return_unset ;
+        set_index = false ;
+        mk_obj = _;
         scopes = [];
         (* wrapper does not work with [bs.obj]
            TODO: better error message *)
-      } -> 
-        if String.length prim_name <> 0 then 
+      } ->
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.obj] expect external names to be empty string";
-        let arg_kinds, new_arg_types_ty, result_types = 
-          Ext_list.fold_right 
-            (fun (label,ty,attr,loc) ( arg_labels, arg_types, result_types) -> 
-               let arg_label = Ast_core_type.label_name label in 
-               let new_arg_label, new_arg_types,  output_tys = 
-                 match arg_label with 
-                 | Empty -> 
-                   let arg_type, new_ty = get_arg_type ~nolabel:true false ty in 
-                   begin match arg_type with 
-                     | Extern_unit ->  
+        let arg_kinds, new_arg_types_ty, result_types =
+          Ext_list.fold_right
+            (fun (label,ty,attr,loc) ( arg_labels, arg_types, result_types) ->
+               let arg_label = Ast_core_type.label_name label in
+               let new_arg_label, new_arg_types,  output_tys =
+                 match arg_label with
+                 | Empty ->
+                   let arg_type, new_ty = get_arg_type ~nolabel:true false ty in
+                   begin match arg_type with
+                     | Extern_unit ->
                        External_arg_spec.empty_kind arg_type, (label,new_ty,attr,loc)::arg_types, result_types
-                     | _ ->  
+                     | _ ->
                        Location.raise_errorf ~loc "expect label, optional, or unit here"
-                   end 
-                 | Label name -> 
-                   let arg_type, new_ty = get_arg_type ~nolabel:false false ty in 
-                   begin match arg_type with 
-                     | Ignore -> 
-                       External_arg_spec.empty_kind arg_type, 
+                   end
+                 | Label name ->
+                   let arg_type, new_ty = get_arg_type ~nolabel:false false ty in
+                   begin match arg_type with
+                     | Ignore ->
+                       External_arg_spec.empty_kind arg_type,
                        (label,new_ty,attr,loc)::arg_types, result_types
-                     | Arg_cst  i  -> 
+                     | Arg_cst  i  ->
                        let s = (Lam_methname.translate ~loc name) in
                        {arg_label = External_arg_spec.label s (Some i);
-                        arg_type }, 
+                        arg_type },
                        arg_types, (* ignored in [arg_types], reserved in [result_types] *)
                        ((name , [], new_ty) :: result_types)
-                     | Nothing | Array -> 
+                     | Nothing | Array ->
                        let s = (Lam_methname.translate ~loc name) in
                        {arg_label = External_arg_spec.label s None ; arg_type },
-                       (label,new_ty,attr,loc)::arg_types, 
+                       (label,new_ty,attr,loc)::arg_types,
                        ((name , [], new_ty) :: result_types)
-                     | Int _  -> 
+                     | Int _  ->
                        let s = Lam_methname.translate ~loc name in
                        {arg_label = External_arg_spec.label s None; arg_type},
-                       (label,new_ty,attr,loc)::arg_types, 
-                       ((name, [], Ast_literal.type_int ~loc ()) :: result_types)  
-                     | NullString _ -> 
+                       (label,new_ty,attr,loc)::arg_types,
+                       ((name, [], Ast_literal.type_int ~loc ()) :: result_types)
+                     | NullString _ ->
                        let s = Lam_methname.translate ~loc name in
-                       {arg_label = External_arg_spec.label s None; arg_type}, 
-                       (label,new_ty,attr,loc)::arg_types, 
-                       ((name, [], Ast_literal.type_string ~loc ()) :: result_types)  
-                     | Fn_uncurry_arity _ -> 
+                       {arg_label = External_arg_spec.label s None; arg_type},
+                       (label,new_ty,attr,loc)::arg_types,
+                       ((name, [], Ast_literal.type_string ~loc ()) :: result_types)
+                     | Fn_uncurry_arity _ ->
                        Location.raise_errorf ~loc
                          "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"
-                     | Extern_unit -> assert false 
-                     | NonNullString _ 
-                       ->  
-                       Location.raise_errorf ~loc 
+                     | Extern_unit -> assert false
+                     | NonNullString _
+                       ->
+                       Location.raise_errorf ~loc
                          "bs.obj label %s does not support such arg type" name
                      | Unwrap ->
                        Location.raise_errorf ~loc
                          "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
-                 | Optional name -> 
-                   let arg_type, new_ty_extract = get_arg_type ~nolabel:false true ty in 
-                   let new_ty = Ast_core_type.lift_option_type new_ty_extract in 
-                   begin match arg_type with 
-                     | Ignore -> 
-                       External_arg_spec.empty_kind arg_type, 
+                 | Optional name ->
+                   let arg_type, new_ty_extract = get_arg_type ~nolabel:false true ty in
+                   let new_ty = Ast_core_type.lift_option_type new_ty_extract in
+                   begin match arg_type with
+                     | Ignore ->
+                       External_arg_spec.empty_kind arg_type,
                        (label,new_ty,attr,loc)::arg_types, result_types
 
-                     | Nothing | Array -> 
-                       let s = (Lam_methname.translate ~loc name) in 
-                       {arg_label = External_arg_spec.optional s; arg_type}, 
-                       (label,new_ty,attr,loc)::arg_types, 
+                     | Nothing | Array ->
+                       let s = (Lam_methname.translate ~loc name) in
+                       {arg_label = External_arg_spec.optional s; arg_type},
+                       (label,new_ty,attr,loc)::arg_types,
                        ( (name, [], Ast_comb.to_undefined_type loc new_ty_extract) ::  result_types)
-                     | Int _  -> 
-                       let s = Lam_methname.translate ~loc name in 
+                     | Int _  ->
+                       let s = Lam_methname.translate ~loc name in
                        {arg_label = External_arg_spec.optional s ; arg_type },
                        (label,new_ty,attr,loc)::arg_types,
-                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_int ~loc ()) :: result_types)                      
-                     | NullString _  -> 
-                       let s = Lam_methname.translate ~loc name in 
-                       {arg_label = External_arg_spec.optional s ; arg_type }, 
+                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_int ~loc ()) :: result_types)
+                     | NullString _  ->
+                       let s = Lam_methname.translate ~loc name in
+                       {arg_label = External_arg_spec.optional s ; arg_type },
                        (label,new_ty,attr,loc)::arg_types,
-                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_string ~loc ()) :: result_types)                      
-                     | Arg_cst _   
-                       -> 
+                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_string ~loc ()) :: result_types)
+                     | Arg_cst _
+                       ->
                        Location.raise_errorf ~loc "bs.as is not supported with optional yet"
-                     | Fn_uncurry_arity _ -> 
+                     | Fn_uncurry_arity _ ->
                        Location.raise_errorf ~loc
-                         "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"                      
-                     | Extern_unit   -> assert false                      
-                     | NonNullString _ 
-                       ->  
+                         "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"
+                     | Extern_unit   -> assert false
+                     | NonNullString _
+                       ->
                        Location.raise_errorf ~loc
-                         "bs.obj label %s does not support such arg type" name                        
+                         "bs.obj label %s does not support such arg type" name
                      | Unwrap ->
                        Location.raise_errorf ~loc
                          "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
-               in     
+               in
                (
                  new_arg_label::arg_labels,
                  new_arg_types,
-                 output_tys)) arg_types_ty 
-            ( [], [], []) in 
+                 output_tys)) arg_types_ty
+            ( [], [], []) in
 
-        let result = 
-          if Ast_core_type.is_any  result_type then            
-            Ast_core_type.make_obj ~loc result_types 
-          else           
-            snd @@ get_arg_type ~nolabel:true false result_type (* result type can not be labeled *)            
+        let result =
+          if Ast_core_type.is_any  result_type then
+            Ast_core_type.make_obj ~loc result_types
+          else
+            snd @@ get_arg_type ~nolabel:true false result_type (* result type can not be labeled *)
 
         in
-        begin 
-          (             
-            Ext_list.fold_right (fun (label,ty,attrs,loc) acc -> 
-                Ast_helper.Typ.arrow ~loc  ~attrs label ty acc 
+        begin
+          (
+            Ext_list.fold_right (fun (label,ty,attrs,loc) acc ->
+                Ast_helper.Typ.arrow ~loc  ~attrs label ty acc
               ) new_arg_types_ty result
           ) ,
           prim_name,
@@ -556,64 +556,64 @@ let handle_attributes
           left_attrs
         end
 
-      | _ -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.obj]"  
+      | _ -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.obj]"
 
-    end  
+    end
 
-  else   
-    let splice = st.splice in 
-    let arg_type_specs, new_arg_types_ty, arg_type_specs_length   = 
-      Ext_list.fold_right 
-        (fun (label,ty,attr,loc) (arg_type_specs, arg_types, i) -> 
-           let arg_label = Ast_core_type.label_name label in 
-           let arg_label, arg_type, new_arg_types = 
-             match arg_label with 
-             | Optional s  -> 
+  else
+    let splice = st.splice in
+    let arg_type_specs, new_arg_types_ty, arg_type_specs_length   =
+      Ext_list.fold_right
+        (fun (label,ty,attr,loc) (arg_type_specs, arg_types, i) ->
+           let arg_label = Ast_core_type.label_name label in
+           let arg_label, arg_type, new_arg_types =
+             match arg_label with
+             | Optional s  ->
 
-               let arg_type , new_ty = get_arg_type ~nolabel:false true ty in 
-               begin match arg_type with 
-                 | NonNullString _ -> 
+               let arg_type , new_ty = get_arg_type ~nolabel:false true ty in
+               begin match arg_type with
+                 | NonNullString _ ->
                    (* ?x:([`x of int ] [@bs.string]) does not make sense *)
-                   Location.raise_errorf 
+                   Location.raise_errorf
                      ~loc
                      "[@@bs.string] does not work with optional when it has arities in label %s" label
-                 | _ -> 
-                   External_arg_spec.optional s, arg_type, 
+                 | _ ->
+                   External_arg_spec.optional s, arg_type,
                    ((label, Ast_core_type.lift_option_type new_ty , attr,loc) :: arg_types) end
-             | Label s  -> 
+             | Label s  ->
                begin match get_arg_type ~nolabel:false false  ty with
-                 | (Arg_cst ( i) as arg_type), new_ty -> 
+                 | (Arg_cst ( i) as arg_type), new_ty ->
                    External_arg_spec.label s (Some i), arg_type, arg_types
-                 | arg_type, new_ty -> 
+                 | arg_type, new_ty ->
                    External_arg_spec.label s None, arg_type, (label, new_ty,attr,loc) :: arg_types
                end
-             | Empty -> 
-               begin match get_arg_type ~nolabel:true false  ty with 
-                 | (Arg_cst ( i) as arg_type), new_ty -> 
+             | Empty ->
+               begin match get_arg_type ~nolabel:true false  ty with
+                 | (Arg_cst ( i) as arg_type), new_ty ->
                    External_arg_spec.empty_lit i , arg_type,  arg_types
-                 | arg_type, new_ty -> 
+                 | arg_type, new_ty ->
                    External_arg_spec.empty_label, arg_type, (label, new_ty,attr,loc) :: arg_types
                end
            in
            (if i = 0 && splice  then
-              match arg_type with 
+              match arg_type with
               | Array  -> ()
               | _ ->  Location.raise_errorf ~loc "[@@@@bs.splice] expect the last type to be an array");
-           ({ External_arg_spec.arg_label  ; 
-              arg_type 
+           ({ External_arg_spec.arg_label  ;
+              arg_type
             } :: arg_type_specs,
             new_arg_types,
-            if arg_type = Ignore then i 
+            if arg_type = Ignore then i
             else i + 1
            )
-        ) arg_types_ty 
+        ) arg_types_ty
         (match st with
-         | {val_send_pipe = Some obj; _ } ->      
-           let arg_type, new_ty = get_arg_type ~nolabel:true false obj in 
-           begin match arg_type with 
-             | Arg_cst _ -> 
+         | {val_send_pipe = Some obj; _ } ->
+           let arg_type, new_ty = get_arg_type ~nolabel:true false obj in
+           begin match arg_type with
+             | Arg_cst _ ->
                Location.raise_errorf ~loc:obj.ptyp_loc "[@bs.as] is not supported in bs.send type "
-             | _ -> 
+             | _ ->
                (* more error checking *)
                [External_arg_spec.empty_kind arg_type]
                ,
@@ -621,16 +621,16 @@ let handle_attributes
                ,0
            end
 
-         | {val_send_pipe = None ; _ } -> [],[], 0) in 
+         | {val_send_pipe = None ; _ } -> [],[], 0) in
 
-    let ffi : External_ffi_types.attr  = match st with           
+    let ffi : External_ffi_types.attr  = match st with
       | {set_index = true;
 
-         val_name = `Nm_na; 
+         val_name = `Nm_na;
          external_module_name = None ;
          module_as_val = None;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          splice = false;
          scopes ;
          get_index = false;
@@ -639,16 +639,16 @@ let handle_attributes
          set_name = `Nm_na ;
          get_name = `Nm_na ;
 
-         return_wrapper = _; 
-         mk_obj = _ ; 
+         return_wrapper = _;
+         mk_obj = _ ;
 
-        } 
+        }
         ->
-        if String.length prim_name <> 0 then 
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.set_index] expect external names to be empty string";
-        if arg_type_specs_length = 3 then 
+        if arg_type_specs_length = 3 then
           Js_set_index {js_set_index_scopes = scopes}
-        else 
+        else
           Location.raise_errorf ~loc "Ill defined attribute [@@bs.set_index](arity of 3)"
 
       | {set_index = true; _}
@@ -658,11 +658,11 @@ let handle_attributes
 
       | {get_index = true;
 
-         val_name = `Nm_na; 
+         val_name = `Nm_na;
          external_module_name = None ;
          module_as_val = None;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
 
          splice = false;
          scopes ;
@@ -670,20 +670,20 @@ let handle_attributes
          call_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         set_index = false; 
+         set_index = false;
          mk_obj;
-         return_wrapper ; 
+         return_wrapper ;
         } ->
-        if String.length prim_name <> 0 then 
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.get_index] expect external names to be empty string";
-        if arg_type_specs_length = 2 then 
+        if arg_type_specs_length = 2 then
           Js_get_index {js_get_index_scopes = scopes}
-        else Location.raise_errorf ~loc 
+        else Location.raise_errorf ~loc
             "Ill defined attribute [@@bs.get_index] (arity expected 2 : while %d)" arg_type_specs_length
 
       | {get_index = true; _}
 
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.get_index]")
 
 
@@ -697,17 +697,17 @@ let handle_attributes
 
          external_module_name = None ;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          scopes = []; (* module as var does not need scopes *)
          splice;
          call_name = `Nm_na;
          set_name = `Nm_na ;
-         get_name = `Nm_na ;         
-         set_index = false; 
-         return_wrapper = _; 
+         get_name = `Nm_na ;
+         set_index = false;
+         return_wrapper = _;
          mk_obj = _ ;
         } ->
-        begin match arg_types_ty, new_name, val_name  with         
+        begin match arg_types_ty, new_name, val_name  with
           | [], `Nm_na,  _ -> Js_module_as_var external_module_name
           | _, `Nm_na, _ -> Js_module_as_fn {splice; external_module_name }
           | _, #bundle_source, #bundle_source ->
@@ -721,29 +721,29 @@ let handle_attributes
               "Incorrect FFI attribute found: (bs.new should not carry a payload here)"
         end
       | {module_as_val = Some x; _}
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.module].")
 
       | {call_name = (`Nm_val name | `Nm_external name | `Nm_payload name) ;
-         splice; 
+         splice;
          scopes ;
          external_module_name;
 
          val_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;    
+         val_send_pipe = None;
 
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         mk_obj = _ ; 
-         return_wrapper = _ ; 
-        } -> 
+         mk_obj = _ ;
+         return_wrapper = _ ;
+        } ->
         Js_call {splice; name; external_module_name; scopes }
-      | {call_name = #bundle_source ; _ } 
+      | {call_name = #bundle_source ; _ }
         ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.val]")
 
@@ -754,18 +754,18 @@ let handle_attributes
          call_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na;
-         mk_obj = _; 
-         return_wrapper = _; 
+         mk_obj = _;
+         return_wrapper = _;
          splice = false ;
          scopes ;
-        } 
-        -> 
+        }
+        ->
         Js_global { name; external_module_name; scopes}
       | {val_name = #bundle_source ; _ }
         ->
@@ -775,27 +775,27 @@ let handle_attributes
          scopes ;
          external_module_name = (Some _ as external_module_name);
 
-         val_name = `Nm_na ;         
+         val_name = `Nm_na ;
          call_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         mk_obj = _ ; 
-         return_wrapper= _ ; 
+         mk_obj = _ ;
+         return_wrapper= _ ;
         }
         ->
         let name = string_of_bundle_source prim_name_or_pval_prim in
         if arg_type_specs_length  = 0 then
           Js_global { name; external_module_name; scopes}
-        else  Js_call {splice; name; external_module_name; scopes}                     
-      | {val_send = (`Nm_val name | `Nm_external name | `Nm_payload name); 
+        else  Js_call {splice; name; external_module_name; scopes}
+      | {val_send = (`Nm_val name | `Nm_external name | `Nm_payload name);
          splice;
-         scopes; 
+         scopes;
          val_send_pipe = None;
          val_name = `Nm_na  ;
          call_name = `Nm_na ;
@@ -807,28 +807,28 @@ let handle_attributes
          get_name = `Nm_na ;
          external_module_name = None ;
          mk_obj = _ ;
-         return_wrapper = _ ; 
-        } -> 
+         return_wrapper = _ ;
+        } ->
 
-        (* PR #2162 - since when we assemble arguments the first argument in 
+        (* PR #2162 - since when we assemble arguments the first argument in
            [@@bs.send] is ignored
         *)
-        begin match arg_type_specs with 
+        begin match arg_type_specs with
           | [] ->
-            Location.raise_errorf 
+            Location.raise_errorf
               ~loc "Ill defined attribute [@@bs.send] (at least one argument)"
           |  {arg_type = Arg_cst _ ; arg_label = _} :: _
-            -> 
-            Location.raise_errorf 
+            ->
+            Location.raise_errorf
               ~loc "Ill defined attribute [@@bs.send] (first argument can not be const)"
-          | _ :: _  -> 
+          | _ :: _  ->
             Js_send {splice ; name; js_send_scopes = scopes ;  pipe = false}
         end
 
-      | {val_send = #bundle_source; _ } 
+      | {val_send = #bundle_source; _ }
         -> Location.raise_errorf ~loc "You used an FFI attribute that can't be used with [@@bs.send]"
 
-      | {val_send_pipe = Some typ; 
+      | {val_send_pipe = Some typ;
          (* splice = (false as splice); *)
          val_send = `Nm_na;
          val_name = `Nm_na  ;
@@ -841,17 +841,17 @@ let handle_attributes
          get_name = `Nm_na ;
          external_module_name = None ;
          mk_obj = _;
-         return_wrapper = _; 
+         return_wrapper = _;
          scopes;
-         splice ; 
-        } -> 
+         splice ;
+        } ->
         (** can be one argument *)
         Js_send {splice  ;
                  name = string_of_bundle_source prim_name_or_pval_prim;
                  js_send_scopes = scopes;
                  pipe = true}
 
-      | {val_send_pipe = Some _ ; _} 
+      | {val_send_pipe = Some _ ; _}
         -> Location.raise_errorf ~loc "conflict attributes found with [@@bs.send.pipe]"
 
       | {new_name = (`Nm_val name | `Nm_external name | `Nm_payload name);
@@ -863,18 +863,18 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
          splice ;
-         scopes; 
-         mk_obj = _ ; 
-         return_wrapper = _ ; 
+         scopes;
+         mk_obj = _ ;
+         return_wrapper = _ ;
 
-        } 
+        }
         -> Js_new {name; external_module_name; splice; scopes}
       | {new_name = #bundle_source ; _ }
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.new]")
 
 
@@ -886,17 +886,17 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          get_name = `Nm_na ;
          external_module_name = None;
-         splice = false; 
+         splice = false;
          mk_obj = _ ;
-         return_wrapper = _; 
+         return_wrapper = _;
          scopes ;
-        } 
-        -> 
-        if arg_type_specs_length = 2 then 
+        }
+        ->
+        if arg_type_specs_length = 2 then
           Js_set { js_set_scopes = scopes ; js_set_name = name}
         else  Location.raise_errorf ~loc "Ill defined attribute [@@bs.set] (two args required)"
 
@@ -911,19 +911,19 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          set_name = `Nm_na ;
          external_module_name = None;
-         splice = false ; 
+         splice = false ;
          mk_obj = _;
          return_wrapper = _;
          scopes
         }
         ->
-        if arg_type_specs_length = 1 then  
+        if arg_type_specs_length = 1 then
           Js_get { js_get_name = name; js_get_scopes = scopes }
-        else 
+        else
           Location.raise_errorf ~loc "Ill defined attribute [@@bs.get] (only one argument)"
       | {get_name = #bundle_source; _}
         -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.get]"
@@ -935,30 +935,30 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          set_name = `Nm_na ;
          external_module_name = None;
-         splice = _ ; 
+         splice = _ ;
          scopes = _;
          mk_obj = _;
          return_wrapper = _;
 
-        }       
-        ->  Location.raise_errorf ~loc "Could not infer which FFI category it belongs to, maybe you forgot [%@%@bs.val]? "  in 
-    begin 
+        }
+        ->  Location.raise_errorf ~loc "Could not infer which FFI category it belongs to, maybe you forgot [%@%@bs.val]? "  in
+    begin
       External_ffi_types.check_ffi ~loc ffi;
       (* result type can not be labeled *)
-      (* currently we don't process attributes of 
+      (* currently we don't process attributes of
          return type, in the future we may  *)
       let  new_result_type  =  result_type in
       (* get_arg_type ~nolabel:true false result_type in *)
-      let return_wrapper : External_ffi_types.return_wrapper = 
+      let return_wrapper : External_ffi_types.return_wrapper =
         check_return_wrapper loc st.return_wrapper new_result_type
-      in 
+      in
       (
-        Ext_list.fold_right (fun (label,ty,attrs,loc) acc -> 
-            Ast_helper.Typ.arrow ~loc  ~attrs label ty acc 
+        Ext_list.fold_right (fun (label,ty,attrs,loc) acc ->
+            Ast_helper.Typ.arrow ~loc  ~attrs label ty acc
           ) new_arg_types_ty new_result_type
       ) ,
 
@@ -966,28 +966,30 @@ let handle_attributes
       (Ffi_bs (arg_type_specs,return_wrapper ,  ffi)), left_attrs
     end
 
-let handle_attributes_as_string 
+let handle_attributes_as_string
     pval_loc
-    pval_prim 
-    (typ : Ast_core_type.t) attrs v = 
-  let pval_type, prim_name, ffi, processed_attrs  = 
+    pval_prim
+    (typ : Ast_core_type.t) attrs v =
+  let pval_type, prim_name, ffi, processed_attrs  =
     handle_attributes pval_loc pval_prim typ attrs v  in
   pval_type, [prim_name; External_ffi_types.to_string ffi], processed_attrs
 
 
 
-let pval_prim_of_labels labels = 
-  let encoding = 
-    let arg_kinds = 
-      Ext_list.fold_right 
+let pval_prim_of_labels labels =
+  let encoding =
+    let arg_kinds =
+      Ext_list.fold_right
         (fun {Asttypes.loc ; txt } arg_kinds
           ->
-            let arg_label =  External_arg_spec.label (Lam_methname.translate ~loc txt) None in
-            {External_arg_spec.arg_type = Nothing ; 
+            let arg_label =
+                External_arg_spec.label
+                  (Lam_methname.translate ~loc txt) None in
+            {External_arg_spec.arg_type = Nothing ;
              arg_label  } :: arg_kinds
         )
-        labels [] in 
-    External_ffi_types.to_string 
-      (Ffi_obj_create arg_kinds)   in 
+        labels [] in
+    External_ffi_types.to_string
+      (Ffi_obj_create arg_kinds)   in
   [""; encoding]
 

--- a/jscomp/test/gpr_2614_test.js
+++ b/jscomp/test/gpr_2614_test.js
@@ -1,1 +1,27 @@
-/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */
+'use strict';
+
+
+var v = {
+  "Content-Type": 3,
+  l: 2,
+  open: 2
+};
+
+var a = v["Content-Type"];
+
+var b = v.l;
+
+var c = v.open;
+
+function ff() {
+  v["Content-Type"] = 3;
+  v.l = 2;
+  return /* () */0;
+}
+
+exports.v = v;
+exports.a = a;
+exports.b = b;
+exports.c = c;
+exports.ff = ff;
+/* a Not a pure module */

--- a/jscomp/test/gpr_2614_test.ml
+++ b/jscomp/test/gpr_2614_test.ml
@@ -3,8 +3,25 @@
 
 type t = {
 
-  hi : int ;
-    (* [@bs.as "hi"] *)
-  low : int
+  mutable hi : int
+    [@bs.as "Content-Type"];
+  mutable low : int
+    [@bs.as "l"];
+  mutable x : int;
+    [@bs.as "open"]
 } [@@bs.deriving abstract]
   (* [@@bs.x] *)
+
+
+let v = t ~hi:3 ~low:2 ~x:2
+
+
+let (a,b,c) = (v |. hi, v |. low, v |. x)
+
+(**
+
+  v |. (hi, lo)
+*)
+let ff () =
+  v |. hiSet 3;
+  v |. lowSet 2

--- a/lib/bsdep.ml
+++ b/lib/bsdep.ml
@@ -28298,7 +28298,7 @@ val bs_set : attr
 end = struct
 #1 "ast_attributes.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -28316,84 +28316,84 @@ end = struct
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 type attr =  Parsetree.attribute
-type t =  attr list 
+type t =  attr list
 
-type ('a,'b) st = 
-  { get : 'a option ; 
+type ('a,'b) st =
+  { get : 'a option ;
     set : 'b option }
 
 
-let process_method_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st,acc) (({txt ; loc}, payload) as attr : attr) -> 
+let process_method_attributes_rev (attrs : t) =
+  List.fold_left (fun (st,acc) (({txt ; loc}, payload) as attr : attr) ->
 
-      match txt  with 
+      match txt  with
       | "bs.get" (* [@@bs.get{null; undefined}]*)
-        -> 
-        let result = 
-          List.fold_left 
-            (fun 
+        ->
+        let result =
+          List.fold_left
+            (fun
               (null, undefined)
-              (({txt ; loc}, opt_expr) : Ast_payload.action) -> 
-              match txt with 
+              (({txt ; loc}, opt_expr) : Ast_payload.action) ->
+              match txt with
               | "null" ->
-                (match opt_expr with 
+                (match opt_expr with
                  | None -> true
-                 | Some e -> 
+                 | Some e ->
                    Ast_payload.assert_bool_lit e), undefined
 
               |  "undefined" ->
-                null, 
+                null,
                 (match opt_expr with
                  | None ->  true
-                 | Some e -> 
+                 | Some e ->
                    Ast_payload.assert_bool_lit e)
-              | "nullable" -> 
-                begin match opt_expr with 
-                  | None -> true, true 
+              | "nullable" ->
+                begin match opt_expr with
+                  | None -> true, true
                   | Some e ->
-                    let v = Ast_payload.assert_bool_lit e in 
+                    let v = Ast_payload.assert_bool_lit e in
                     v,v
                 end
               | _ -> Bs_syntaxerr.err loc Unsupported_predicates
-            ) (false, false) 
-            (Ast_payload.ident_or_record_as_config loc payload)  in 
+            ) (false, false)
+            (Ast_payload.ident_or_record_as_config loc payload)  in
 
         ({st with get = Some result}, acc  )
 
       | "bs.set"
-        -> 
-        let result = 
-          List.fold_left 
-            (fun st (({txt ; loc}, opt_expr) : Ast_payload.action) -> 
-               if txt =  "no_get" then 
-                 match opt_expr with 
-                 | None -> `No_get 
-                 | Some e -> 
-                   if Ast_payload.assert_bool_lit e then 
+        ->
+        let result =
+          List.fold_left
+            (fun st (({txt ; loc}, opt_expr) : Ast_payload.action) ->
+               if txt =  "no_get" then
+                 match opt_expr with
+                 | None -> `No_get
+                 | Some e ->
+                   if Ast_payload.assert_bool_lit e then
                      `No_get
                    else `Get
                else Bs_syntaxerr.err loc Unsupported_predicates
-            ) `Get (Ast_payload.ident_or_record_as_config loc payload)  in 
-        (* properties -- void 
+            ) `Get (Ast_payload.ident_or_record_as_config loc payload)  in
+        (* properties -- void
               [@@bs.set{only}]
         *)
         {st with set = Some result }, acc
-      | _ -> 
+      | _ ->
         (st, attr::acc  )
     ) ( {get = None ; set = None}, []) attrs
 
 
-let process_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
-      | "bs", (`Nothing | `Uncurry) 
-        -> 
+let process_attributes_rev (attrs : t) =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
+      | "bs", (`Nothing | `Uncurry)
+        ->
         `Uncurry, acc
       | "bs.this", (`Nothing | `Meth_callback)
         ->  `Meth_callback, acc
@@ -28402,34 +28402,34 @@ let process_attributes_rev (attrs : t) =
       | "bs", _
       | "bs.this", _
         -> Bs_syntaxerr.err loc Conflict_bs_bs_this_bs_meth
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_pexp_fun_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
-      | "bs.open", (`Nothing | `Exn) 
-        -> 
+let process_pexp_fun_attributes_rev (attrs : t) =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
+      | "bs.open", (`Nothing | `Exn)
+        ->
         `Exn, acc
 
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_bs attrs = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
+let process_bs attrs =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
       | "bs", _
-        -> 
+        ->
         `Has, acc
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_external attrs = 
-  List.exists (fun (({txt; }, _)  : attr) -> 
-      if Ext_string.starts_with txt "bs." then true 
+let process_external attrs =
+  List.exists (fun (({txt; }, _)  : attr) ->
+      if Ext_string.starts_with txt "bs." then true
       else false
     ) attrs
 
@@ -28440,57 +28440,57 @@ type derive_attr = {
 }
 
 let process_derive_type attrs : derive_attr * t =
-  List.fold_left 
-    (fun (st, acc) 
+  List.fold_left
+    (fun (st, acc)
       (({txt ; loc}, payload  as attr): attr)  ->
       match  st, txt  with
       |  {bs_deriving = None}, "bs.deriving"
         ->
         {st with
          bs_deriving = Some
-             (Ast_payload.ident_or_record_as_config loc payload)}, acc 
+             (Ast_payload.ident_or_record_as_config loc payload)}, acc
       | {bs_deriving = Some _}, "bs.deriving"
-        -> 
+        ->
         Bs_syntaxerr.err loc Duplicated_bs_deriving
 
       | _ , _ ->
-        let st = 
-          if txt = "nonrec" then 
+        let st =
+          if txt = "nonrec" then
             { st with explict_nonrec = true }
-          else st in 
+          else st in
         st, attr::acc
     ) ( {explict_nonrec = false; bs_deriving = None }, []) attrs
 
 let iter_process_derive_type attrs =
-  let st = ref {explict_nonrec = false; bs_deriving = None } in 
+  let st = ref {explict_nonrec = false; bs_deriving = None } in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload  as attr): attr)  ->
       match  txt  with
       |  "bs.deriving"
         ->
-        let ost = !st in 
-        (match ost with 
-         | {bs_deriving = None } -> 
-           Bs_ast_invariant.mark_used_bs_attribute attr ; 
-           st := 
+        let ost = !st in
+        (match ost with
+         | {bs_deriving = None } ->
+           Bs_ast_invariant.mark_used_bs_attribute attr ;
+           st :=
              {ost with
               bs_deriving = Some
                   (Ast_payload.ident_or_record_as_config loc payload)}
-         | {bs_deriving = Some _} ->       
+         | {bs_deriving = Some _} ->
            Bs_syntaxerr.err loc Duplicated_bs_deriving)
 
       | "nonrec" ->
-        st :=         
+        st :=
           { !st with explict_nonrec = true }
-      (* non bs attribute, no need to mark its use *)  
+      (* non bs attribute, no need to mark its use *)
       | _ -> ()
     )  attrs;
-  !st 
+  !st
 
 
 let process_bs_string_int_unwrap_uncurry attrs =
-  List.fold_left 
+  List.fold_left
     (fun (st,attrs)
       (({txt ; loc}, (payload : _ ) ) as attr : attr)  ->
       match  txt, st  with
@@ -28504,84 +28504,84 @@ let process_bs_string_int_unwrap_uncurry attrs =
         -> `Unwrap, attrs
       | "bs.uncurry", `Nothing
         ->
-        `Uncurry (Ast_payload.is_single_int payload), attrs 
+        `Uncurry (Ast_payload.is_single_int payload), attrs
       (* Don't allow duplicated [bs.uncurry] since
          it may introduce inconsistency in arity
-      *)  
+      *)
       | "bs.int", _
       | "bs.string", _
       | "bs.ignore", _
       | "bs.unwrap", _
-        -> 
+        ->
         Bs_syntaxerr.err loc Conflict_attributes
       | _ , _ -> st, (attr :: attrs )
     ) (`Nothing, []) attrs
 
 
-let iter_process_bs_string_as  attrs = 
-  let st = ref None in 
-  List.iter 
-    (fun 
-      (({txt ; loc}, payload ) as attr : attr)  ->
-      match  txt with
-      | "bs.as"
-        ->
-        if !st = None then 
-          match Ast_payload.is_single_string payload with 
-          | None -> 
-            Bs_syntaxerr.err loc Expect_string_literal
-          | Some  (v,_dec) -> 
-            Bs_ast_invariant.mark_used_bs_attribute attr ; 
-            st:= Some v 
-        else 
-          Bs_syntaxerr.err loc Duplicated_bs_as 
-      | _  -> ()
-    ) attrs;
-  !st 
-
-let iter_process_bs_int_as  attrs = 
-  let st = ref None in 
+let iter_process_bs_string_as  (attrs : t) : string option =
+  let st = ref None in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload ) as attr : attr)  ->
       match  txt with
       | "bs.as"
         ->
-        if !st =  None then 
-          match Ast_payload.is_single_int payload with 
-          | None -> 
-            Bs_syntaxerr.err loc Expect_int_literal
-          | Some  _ as v->  
-            Bs_ast_invariant.mark_used_bs_attribute attr ; 
-            st := v
-        else 
+        if !st = None then
+          match Ast_payload.is_single_string payload with
+          | None ->
+            Bs_syntaxerr.err loc Expect_string_literal
+          | Some  (v,_dec) ->
+            Bs_ast_invariant.mark_used_bs_attribute attr ;
+            st:= Some v
+        else
           Bs_syntaxerr.err loc Duplicated_bs_as
       | _  -> ()
-    ) attrs; !st 
+    ) attrs;
+  !st
 
-
-let iter_process_bs_string_or_int_as attrs = 
-  let st = ref None in 
+let iter_process_bs_int_as  attrs =
+  let st = ref None in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload ) as attr : attr)  ->
       match  txt with
       | "bs.as"
         ->
-        if !st = None then 
-          (Bs_ast_invariant.mark_used_bs_attribute attr ; 
-           match Ast_payload.is_single_int payload with 
-           | None -> 
-             begin match Ast_payload.is_single_string payload with 
-               | Some (s,None) -> 
-                 st := Some (`Str (s))                
-               | Some (s, Some "json") -> 
+        if !st =  None then
+          match Ast_payload.is_single_int payload with
+          | None ->
+            Bs_syntaxerr.err loc Expect_int_literal
+          | Some  _ as v->
+            Bs_ast_invariant.mark_used_bs_attribute attr ;
+            st := v
+        else
+          Bs_syntaxerr.err loc Duplicated_bs_as
+      | _  -> ()
+    ) attrs; !st
+
+
+let iter_process_bs_string_or_int_as attrs =
+  let st = ref None in
+  List.iter
+    (fun
+      (({txt ; loc}, payload ) as attr : attr)  ->
+      match  txt with
+      | "bs.as"
+        ->
+        if !st = None then
+          (Bs_ast_invariant.mark_used_bs_attribute attr ;
+           match Ast_payload.is_single_int payload with
+           | None ->
+             begin match Ast_payload.is_single_string payload with
+               | Some (s,None) ->
+                 st := Some (`Str (s))
+               | Some (s, Some "json") ->
                  st := Some (`Json_str s )
-               | None | Some (_, Some _) -> 
+               | None | Some (_, Some _) ->
                  Bs_syntaxerr.err loc Expect_int_or_string_or_json_literal
 
              end
-           | Some   v->  
+           | Some   v->
              st := (Some (`Int v))
           )
         else
@@ -28589,30 +28589,30 @@ let iter_process_bs_string_or_int_as attrs =
       | _ -> ()
 
     ) attrs;
-  !st 
+  !st
 
 let bs : attr
   =  {txt = "bs" ; loc = Location.none}, Ast_payload.empty
 
-let is_bs (attr : attr) =   
-  match attr with 
-  | {Location.txt = "bs"; _}, _ -> true 
+let is_bs (attr : attr) =
+  match attr with
+  | {Location.txt = "bs"; _}, _ -> true
   | _ -> false
 
 let bs_this : attr
   =  {txt = "bs.this" ; loc = Location.none}, Ast_payload.empty
 
-let bs_method : attr 
+let bs_method : attr
   =  {txt = "bs.meth"; loc = Location.none}, Ast_payload.empty
 
-let bs_obj : attr  
+let bs_obj : attr
   =  {txt = "bs.obj"; loc = Location.none}, Ast_payload.empty
 
-let bs_get : attr  
+let bs_get : attr
   =  {txt = "bs.get"; loc = Location.none}, Ast_payload.empty
 
 let bs_set : attr
-  =  {txt = "bs.set"; loc = Location.none}, Ast_payload.empty 
+  =  {txt = "bs.set"; loc = Location.none}, Ast_payload.empty
 
 
 end
@@ -31598,7 +31598,7 @@ end
 module External_ffi_types : sig 
 #1 "external_ffi_types.mli"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -31616,127 +31616,128 @@ module External_ffi_types : sig
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type module_bind_name = 
-  | Phint_name of string 
+type module_bind_name =
+  | Phint_name of string
   (* explicit hint name *)
   | Phint_nothing
 
-type external_module_name = 
-  { bundle : string ; 
+type external_module_name =
+  { bundle : string ;
     module_bind_name : module_bind_name
   }
 
-type pipe = bool 
-type js_call = { 
+type pipe = bool
+type js_call = {
   name : string;
   external_module_name : external_module_name option;
   splice : bool ;
-  scopes : string list 
+  scopes : string list
 }
 
-type js_send = { 
+type js_send = {
   name : string ;
-  splice : bool ; 
+  splice : bool ;
   pipe : pipe  ;
-  js_send_scopes : string list; 
+  js_send_scopes : string list;
 } (* we know it is a js send, but what will happen if you pass an ocaml objct *)
 
 type js_global_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   scopes : string list
 }
 
 type js_new_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   splice : bool ;
   scopes : string list;
 }
 
-type js_module_as_fn = 
+type js_module_as_fn =
   { external_module_name : external_module_name;
-    splice : bool 
+    splice : bool
   }
 
 type arg_type = External_arg_spec.attr
 
-type arg_label = External_arg_spec.label 
+type arg_label = External_arg_spec.label
 
 
 type obj_create = External_arg_spec.t list
 
-type js_get =  
+type js_get =
   { js_get_name : string   ;
     js_get_scopes :  string list;
   }
 
-type js_set = 
+type js_set =
   { js_set_name : string  ;
-    js_set_scopes : string list 
+    js_set_scopes : string list
   }
 
 
 type js_get_index =   {
-  js_get_index_scopes : string list 
+  js_get_index_scopes : string list
 }
 
 type js_set_index = {
-  js_set_index_scopes : string list 
-} 
+  js_set_index_scopes : string list
+}
 
 
 
-type attr  = 
-  | Js_global of js_global_val 
+type attr  =
+  | Js_global of js_global_val
   | Js_module_as_var of  external_module_name
   | Js_module_as_fn of js_module_as_fn
-  | Js_module_as_class of external_module_name             
-  | Js_call of js_call 
+  | Js_module_as_class of external_module_name
+  | Js_call of js_call
   | Js_send of js_send
   | Js_new of js_new_val
   | Js_set of js_set
   | Js_get of js_get
   | Js_get_index of js_get_index
-  | Js_set_index of js_set_index 
+  | Js_set_index of js_set_index
 
-type return_wrapper = 
-  | Return_unset 
+type return_wrapper =
+  | Return_unset
   | Return_identity
-  | Return_undefined_to_opt  
+  | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
   | Return_to_ocaml_bool
-  | Return_replaced_with_unit    
+  | Return_replaced_with_unit
 
-type t  = 
-  | Ffi_bs of 
+type t  =
+  | Ffi_bs of
       External_arg_spec.t list  *
-      return_wrapper * attr
+      return_wrapper *
+      attr
   | Ffi_obj_create of obj_create
-  | Ffi_normal 
+  | Ffi_normal
   (* When it's normal, it is handled as normal c functional ffi call *)
 
 
 val name_of_ffi : attr -> string
 
-val check_ffi : ?loc:Location.t ->  attr -> unit 
+val check_ffi : ?loc:Location.t ->  attr -> unit
 
-val to_string : t -> string 
+val to_string : t -> string
 
 (** Note *)
-val from_string : string -> t 
+val from_string : string -> t
 
 
 end = struct
 #1 "external_ffi_types.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -31754,76 +31755,76 @@ end = struct
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type module_bind_name = 
-  | Phint_name of string 
+type module_bind_name =
+  | Phint_name of string
     (* explicit hint name *)
 
   | Phint_nothing
-  
 
-type external_module_name = 
-  { bundle : string ; 
+
+type external_module_name =
+  { bundle : string ;
     module_bind_name : module_bind_name
   }
 
-type pipe = bool 
-type js_call = { 
+type pipe = bool
+type js_call = {
   name : string;
   external_module_name : external_module_name option;
   splice : bool ;
-  scopes : string list ; 
+  scopes : string list ;
 }
 
-type js_send = { 
+type js_send = {
   name : string ;
-  splice : bool ; 
+  splice : bool ;
   pipe : pipe   ;
-  js_send_scopes : string list; 
+  js_send_scopes : string list;
 } (* we know it is a js send, but what will happen if you pass an ocaml objct *)
 
 type js_global_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   scopes : string list ;
 }
 
 type js_new_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   splice : bool ;
   scopes : string list;
 }
 
-type js_module_as_fn = 
+type js_module_as_fn =
   { external_module_name : external_module_name;
     splice : bool ;
 
   }
-type js_get =  
+type js_get =
   { js_get_name : string   ;
     js_get_scopes :  string list;
   }
 
-type js_set = 
+type js_set =
   { js_set_name : string  ;
-    js_set_scopes : string list 
+    js_set_scopes : string list
   }
 
 type js_get_index =   {
-  js_get_index_scopes : string list 
+  js_get_index_scopes : string list
 }
 
 type js_set_index = {
-  js_set_index_scopes : string list 
-}  
-(** TODO: information between [arg_type] and [arg_label] are duplicated, 
+  js_set_index_scopes : string list
+}
+(** TODO: information between [arg_type] and [arg_label] are duplicated,
   design a more compact representation so that it is also easy to seralize by hand
-*)  
+*)
 type arg_type = External_arg_spec.attr
 
 type arg_label = External_arg_spec.label
@@ -31832,55 +31833,55 @@ type arg_label = External_arg_spec.label
 (**TODO: maybe we can merge [arg_label] and [arg_type] *)
 type obj_create = External_arg_spec.t list
 
-type attr = 
-  | Js_global of js_global_val 
+type attr =
+  | Js_global of js_global_val
   | Js_module_as_var of  external_module_name
   | Js_module_as_fn of js_module_as_fn
-  | Js_module_as_class of external_module_name             
-  | Js_call of js_call 
+  | Js_module_as_class of external_module_name
+  | Js_call of js_call
   | Js_send of js_send
   | Js_new of js_new_val
   | Js_set of js_set
   | Js_get of js_get
   | Js_get_index of js_get_index
-  | Js_set_index of js_set_index 
+  | Js_set_index of js_set_index
 
 let name_of_ffi ffi =
-  match ffi with 
+  match ffi with
   | Js_get_index _scope -> "[@@bs.get_index ..]"
   | Js_set_index _scope -> "[@@bs.set_index ..]"
-  | Js_get { js_get_name = s} -> Printf.sprintf "[@@bs.get %S]" s 
-  | Js_set { js_set_name = s} -> Printf.sprintf "[@@bs.set %S]" s 
+  | Js_get { js_get_name = s} -> Printf.sprintf "[@@bs.get %S]" s
+  | Js_set { js_set_name = s} -> Printf.sprintf "[@@bs.set %S]" s
   | Js_call v  -> Printf.sprintf "[@@bs.val %S]" v.name
   | Js_send v  -> Printf.sprintf "[@@bs.send %S]" v.name
   | Js_module_as_fn v  -> Printf.sprintf "[@@bs.val %S]" v.external_module_name.bundle
-  | Js_new v  -> Printf.sprintf "[@@bs.new %S]" v.name                    
+  | Js_new v  -> Printf.sprintf "[@@bs.new %S]" v.name
   | Js_module_as_class v
     -> Printf.sprintf "[@@bs.module] %S " v.bundle
   | Js_module_as_var v
-    -> 
+    ->
     Printf.sprintf "[@@bs.module] %S " v.bundle
-  | Js_global v 
-    -> 
-    Printf.sprintf "[@@bs.val] %S " v.name                    
+  | Js_global v
+    ->
+    Printf.sprintf "[@@bs.val] %S " v.name
 
-type return_wrapper = 
-  | Return_unset 
+type return_wrapper =
+  | Return_unset
   | Return_identity
-  | Return_undefined_to_opt  
+  | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
   | Return_to_ocaml_bool
-  | Return_replaced_with_unit    
-type t  = 
+  | Return_replaced_with_unit
+type t  =
   | Ffi_bs of External_arg_spec.t list  *
-     return_wrapper * attr 
+     return_wrapper * attr
   (**  [Ffi_bs(args,return,attr) ]
-       [return] means return value is unit or not, 
-        [true] means is [unit]  
+       [return] means return value is unit or not,
+        [true] means is [unit]
   *)
   | Ffi_obj_create of obj_create
-  | Ffi_normal 
+  | Ffi_normal
   (* When it's normal, it is handled as normal c functional ffi call *)
 
 
@@ -31892,7 +31893,7 @@ let valid_js_char =
     ) in
   (fun c -> Array.unsafe_get a (Char.code c))
 
-let valid_first_js_char = 
+let valid_first_js_char =
   let a = Array.init 256 (fun i ->
       let c = Char.chr i in
       (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c = '_' || c = '$'
@@ -31907,10 +31908,10 @@ let valid_ident (s : string) =
    try
      for i = 1 to len - 1 do
        if not (valid_js_char (String.unsafe_get s i)) then
-         raise E.E         
+         raise E.E
      done ;
-     true     
-   with E.E -> false )  
+     true
+   with E.E -> false )
 
 let valid_global_name ?loc txt =
   if not (valid_ident txt) then
@@ -31919,30 +31920,36 @@ let valid_global_name ?loc txt =
       (fun s ->
          if not (valid_ident s) then
            Location.raise_errorf ?loc "Not a valid global name %s"  txt
-      ) v      
+      ) v
 
-let valid_method_name ?loc txt =         
-  if not (valid_ident txt) then
-    Location.raise_errorf ?loc "Not a valid method name %s"  txt
+(*
+  We loose such check (see #2583),
+  it 
+*)
+
+let valid_method_name ?loc txt =
+    ()
+  (* if not (valid_ident txt) then
+    Location.raise_errorf ?loc "Not a valid method name %s"  txt *)
 
 
 
-let check_external_module_name ?loc x = 
-  match x with 
-  | {bundle = ""; _ } 
-  | { module_bind_name = Phint_name "" } -> 
+let check_external_module_name ?loc x =
+  match x with
+  | {bundle = ""; _ }
+  | { module_bind_name = Phint_name "" } ->
     Location.raise_errorf ?loc "empty name encountered"
   | _ -> ()
-let check_external_module_name_opt ?loc x = 
-  match x with 
+let check_external_module_name_opt ?loc x =
+  match x with
   | None -> ()
-  | Some v -> check_external_module_name ?loc v 
+  | Some v -> check_external_module_name ?loc v
 
 
-let check_ffi ?loc ffi = 
-  match ffi with 
+let check_ffi ?loc ffi =
+  match ffi with
   | Js_global {name} -> valid_global_name ?loc  name
-  | Js_send {name } 
+  | Js_send {name }
   | Js_set  {js_set_name = name}
   | Js_get { js_get_name = name}
     ->  valid_method_name ?loc name
@@ -31952,47 +31959,47 @@ let check_ffi ?loc ffi =
 
   | Js_module_as_var external_module_name
   | Js_module_as_fn {external_module_name; _}
-  | Js_module_as_class external_module_name             
+  | Js_module_as_class external_module_name
     -> check_external_module_name external_module_name
   | Js_new {external_module_name ;  name}
   | Js_call {external_module_name ;  name ; _}
-    -> 
+    ->
     check_external_module_name_opt ?loc external_module_name ;
-    valid_global_name ?loc name     
+    valid_global_name ?loc name
 
 let bs_prefix = "BS:"
-let bs_prefix_length = String.length bs_prefix 
+let bs_prefix_length = String.length bs_prefix
 
 
 (** TODO: Make sure each version is not prefix of each other
     Solution:
-    1. fixed length 
+    1. fixed length
     2. non-prefix approach
 *)
-let bs_external = bs_prefix ^ Bs_version.version 
+let bs_external = bs_prefix ^ Bs_version.version
 
 
 let bs_external_length = String.length bs_external
 
 
-let to_string  t = 
+let to_string  t =
   bs_external ^ Marshal.to_string t []
 
 
 (* TODO:  better error message when version mismatch *)
-let from_string s : t = 
-  let s_len = String.length s in 
+let from_string s : t =
+  let s_len = String.length s in
   if s_len >= bs_prefix_length &&
      String.unsafe_get s 0 = 'B' &&
      String.unsafe_get s 1 = 'S' &&
-     String.unsafe_get s 2 = ':' then 
-    if Ext_string.starts_with s bs_external then 
-      Marshal.from_string s bs_external_length 
-    else 
-      Ext_pervasives.failwithf 
+     String.unsafe_get s 2 = ':' then
+    if Ext_string.starts_with s bs_external then
+      Marshal.from_string s bs_external_length
+    else
+      Ext_pervasives.failwithf
         ~loc:__LOC__
         "Compiler version mismatch. The project might have been built with one version of BuckleScript, and then with another. Please wipe the artifacts and do a clean build."
-  else Ffi_normal    
+  else Ffi_normal
 
 end
 module Bs_hash_stubs
@@ -32393,7 +32400,7 @@ val pval_prim_of_labels : string Asttypes.loc list -> string list
 end = struct
 #1 "external_process.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -32411,7 +32418,7 @@ end = struct
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -32422,7 +32429,7 @@ end = struct
 
 
 let variant_can_bs_unwrap_fields row_fields =
-  let validity = 
+  let validity =
     List.fold_left
       begin fun st row ->
         match st, row with
@@ -32446,7 +32453,7 @@ let variant_can_bs_unwrap_fields row_fields =
 
 
 (** Given the type of argument, process its [bs.] attribute and new type,
-    The new type is currently used to reconstruct the external type 
+    The new type is currently used to reconstruct the external type
     and result type in [@@bs.obj]
     They are not the same though, for example
     {[
@@ -32454,96 +32461,96 @@ let variant_can_bs_unwrap_fields row_fields =
     ]}
     The result type would be [ hi:string ]
 *)
-let get_arg_type ~nolabel optional 
-    (ptyp : Ast_core_type.t) : 
-  External_arg_spec.attr * Ast_core_type.t  = 
-  let ptyp = if optional then Ast_core_type.extract_option_type_exn ptyp else ptyp in 
+let get_arg_type ~nolabel optional
+    (ptyp : Ast_core_type.t) :
+  External_arg_spec.attr * Ast_core_type.t  =
+  let ptyp = if optional then Ast_core_type.extract_option_type_exn ptyp else ptyp in
   if Ast_core_type.is_any ptyp then (* (_[@bs.as ])*)
-    if optional then 
+    if optional then
       Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
     else begin
-      let ptyp_attrs = 
-        ptyp.Parsetree.ptyp_attributes 
-      in   
-      let result = 
+      let ptyp_attrs =
+        ptyp.Parsetree.ptyp_attributes
+      in
+      let result =
         Ast_attributes.iter_process_bs_string_or_int_as ptyp_attrs
-      in   
+      in
       (* when ppx start dropping attributes
         we should warn, there is a trade off whether
         we should warn dropped non bs attribute or not
-      *) 
-      Bs_ast_invariant.warn_unused_attributes ptyp_attrs; 
-      match result with 
-      |  None -> 
+      *)
+      Bs_ast_invariant.warn_unused_attributes ptyp_attrs;
+      match result with
+      |  None ->
         Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
 
-      | Some (`Int i) -> 
-        Arg_cst(External_arg_spec.cst_int i), Ast_literal.type_int ~loc:ptyp.ptyp_loc ()  
-      | Some (`Str i)-> 
-        Arg_cst (External_arg_spec.cst_string i), Ast_literal.type_string ~loc:ptyp.ptyp_loc () 
+      | Some (`Int i) ->
+        Arg_cst(External_arg_spec.cst_int i), Ast_literal.type_int ~loc:ptyp.ptyp_loc ()
+      | Some (`Str i)->
+        Arg_cst (External_arg_spec.cst_string i), Ast_literal.type_string ~loc:ptyp.ptyp_loc ()
       | Some (`Json_str s) ->
         Arg_cst (External_arg_spec.cst_json ptyp.ptyp_loc s),
-        Ast_literal.type_string ~loc:ptyp.ptyp_loc () 
+        Ast_literal.type_string ~loc:ptyp.ptyp_loc ()
 
-    end 
+    end
   else (* ([`a|`b] [@bs.string]) *)
-    let ptyp_desc = ptyp.ptyp_desc in 
+    let ptyp_desc = ptyp.ptyp_desc in
     match Ast_attributes.process_bs_string_int_unwrap_uncurry ptyp.ptyp_attributes with
     | (`String, ptyp_attributes)
-      -> 
-      begin match ptyp_desc with 
+      ->
+      begin match ptyp_desc with
         | Ptyp_variant ( row_fields, Closed, None)
           ->
-          let attr = 
-            Ast_polyvar.map_row_fields_into_strings ptyp.ptyp_loc row_fields in 
-          attr, 
+          let attr =
+            Ast_polyvar.map_row_fields_into_strings ptyp.ptyp_loc row_fields in
+          attr,
           {ptyp with
-           ptyp_attributes 
+           ptyp_attributes
           }
         | _ ->
           Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
-      end 
-    | (`Ignore, ptyp_attributes)  -> 
+      end
+    | (`Ignore, ptyp_attributes)  ->
       (Ignore, {ptyp with ptyp_attributes})
-    | (`Int , ptyp_attributes) -> 
-      begin match ptyp_desc with 
-        | Ptyp_variant ( row_fields, Closed, None) -> 
-          let int_lists = 
-            Ast_polyvar.map_row_fields_into_ints ptyp.ptyp_loc row_fields in 
+    | (`Int , ptyp_attributes) ->
+      begin match ptyp_desc with
+        | Ptyp_variant ( row_fields, Closed, None) ->
+          let int_lists =
+            Ast_polyvar.map_row_fields_into_ints ptyp.ptyp_loc row_fields in
           Int int_lists ,
-          {ptyp with            
+          {ptyp with
            ptyp_attributes
           }
-        | _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type   
+        | _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
       end
-    | (`Unwrap, ptyp_attributes) -> 
+    | (`Unwrap, ptyp_attributes) ->
 
-      begin match ptyp_desc with 
+      begin match ptyp_desc with
         | (Ptyp_variant (row_fields, Closed, _) as ptyp_desc)
           when variant_can_bs_unwrap_fields row_fields ->
           Unwrap, {ptyp with ptyp_desc; ptyp_attributes}
         | _ ->
           Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_unwrap_type
-      end 
-    | (`Uncurry opt_arity, ptyp_attributes) -> 
-      let real_arity =  Ast_core_type.get_uncurry_arity ptyp in 
-      (begin match opt_arity, real_arity with 
-         | Some arity, `Not_function -> 
-           Fn_uncurry_arity arity 
+      end
+    | (`Uncurry opt_arity, ptyp_attributes) ->
+      let real_arity =  Ast_core_type.get_uncurry_arity ptyp in
+      (begin match opt_arity, real_arity with
+         | Some arity, `Not_function ->
+           Fn_uncurry_arity arity
          | None, `Not_function  ->
            Bs_syntaxerr.err ptyp.ptyp_loc Canot_infer_arity_by_syntax
-         | None, `Arity arity  ->         
+         | None, `Arity arity  ->
            Fn_uncurry_arity arity
-         | Some arity, `Arity n -> 
+         | Some arity, `Arity n ->
            if n <> arity then
              Bs_syntaxerr.err ptyp.ptyp_loc (Inconsistent_arity (arity,n))
-           else Fn_uncurry_arity arity 
+           else Fn_uncurry_arity arity
 
        end, {ptyp with ptyp_attributes})
     | (`Nothing, ptyp_attributes) ->
       begin match ptyp_desc with
         | Ptyp_constr ({txt = Lident "bool"; _}, [])
-          -> 
+          ->
           Bs_warnings.prerr_bs_ffi_warning ptyp.ptyp_loc Unsafe_ffi_bool_type;
           Nothing
         | Ptyp_constr ({txt = Lident "unit"; _}, [])
@@ -32552,38 +32559,38 @@ let get_arg_type ~nolabel optional
           -> Array
         | Ptyp_variant _ ->
           Bs_warnings.prerr_bs_ffi_warning ptyp.ptyp_loc Unsafe_poly_variant_type;
-          Nothing           
+          Nothing
         | _ ->
-          Nothing           
+          Nothing
       end, ptyp
 
 
 
-(** 
+(**
    [@@bs.module "react"]
    [@@bs.module "react"]
    ---
    [@@bs.module "@" "react"]
    [@@bs.module "@" "react"]
 
-   They should have the same module name 
+   They should have the same module name
 
-   TODO: we should emit an warning if we bind 
+   TODO: we should emit an warning if we bind
    two external files to the same module name
 *)
 type bundle_source =
   [`Nm_payload of string (* from payload [@@bs.val "xx" ]*)
   |`Nm_external of string (* from "" in external *)
-  | `Nm_val of string   (* from function name *)   
-  ]  
+  | `Nm_val of string   (* from function name *)
+  ]
 
 let string_of_bundle_source (x : bundle_source) =
   match x with
   | `Nm_payload x
   | `Nm_external x
-  | `Nm_val x -> x   
+  | `Nm_val x -> x
 type name_source =
-  [ bundle_source  
+  [ bundle_source
   | `Nm_na
 
   ]
@@ -32591,14 +32598,14 @@ type name_source =
 
 
 
-type st = 
+type st =
   { val_name : name_source;
     external_module_name : External_ffi_types.external_module_name option;
     module_as_val : External_ffi_types.external_module_name option;
     val_send : name_source ;
-    val_send_pipe : Ast_core_type.t option;    
+    val_send_pipe : Ast_core_type.t option;
     splice : bool ; (* mutable *)
-    scopes : string list ; 
+    scopes : string list ;
     set_index : bool; (* mutable *)
     get_index : bool;
     new_name : name_source ;
@@ -32611,13 +32618,13 @@ type st =
 
   }
 
-let init_st = 
+let init_st =
   {
-    val_name = `Nm_na; 
+    val_name = `Nm_na;
     external_module_name = None ;
     module_as_val = None;
     val_send = `Nm_na;
-    val_send_pipe = None;    
+    val_send_pipe = None;
     splice = false;
     scopes = [];
     set_index = false;
@@ -32626,8 +32633,8 @@ let init_st =
     call_name = `Nm_na;
     set_name = `Nm_na ;
     get_name = `Nm_na ;
-    mk_obj = false ; 
-    return_wrapper = Return_unset; 
+    mk_obj = false ;
+    return_wrapper = Return_unset;
 
   }
 
@@ -32635,52 +32642,52 @@ let init_st =
 
 
 
-let process_external_attributes 
-    no_arguments 
+let process_external_attributes
+    no_arguments
     (prim_name_or_pval_prim: [< bundle_source ] as 'a)
     pval_prim
     (prim_attributes : Ast_attributes.t) : _ * Ast_attributes.t =
 
-  (* shared by `[@@bs.val]`, `[@@bs.send]`, 
-     `[@@bs.set]`, `[@@bs.get]` , `[@@bs.new]` 
-     `[@@bs.send.pipe]` does not use it 
+  (* shared by `[@@bs.val]`, `[@@bs.send]`,
+     `[@@bs.set]`, `[@@bs.get]` , `[@@bs.new]`
+     `[@@bs.send.pipe]` does not use it
   *)
   let name_from_payload_or_prim ~loc (payload : Parsetree.payload) : name_source =
-    match payload with 
-    | PStr [] -> 
-      (prim_name_or_pval_prim :> name_source)  
+    match payload with
+    | PStr [] ->
+      (prim_name_or_pval_prim :> name_source)
     (* It is okay to have [@@bs.val] without payload *)
-    | _ -> 
+    | _ ->
       begin match Ast_payload.is_single_string payload with
         | Some  (val_name, _) ->  `Nm_payload val_name
-        | None ->  
+        | None ->
           Location.raise_errorf ~loc "Invalid payload"
       end
 
   in
-  List.fold_left 
+  List.fold_left
     (fun (st, attrs)
-      (({txt ; loc}, payload) as attr : Ast_attributes.attr) 
+      (({txt ; loc}, payload) as attr : Ast_attributes.attr)
       ->
         if Ext_string.starts_with txt "bs." then
-          begin match txt with 
-            | "bs.val" ->  
+          begin match txt with
+            | "bs.val" ->
               if no_arguments then
                 {st with val_name = name_from_payload_or_prim ~loc payload}
-              else 
+              else
                 {st with call_name = name_from_payload_or_prim ~loc  payload}
 
-            | "bs.module" -> 
-              begin match Ast_payload.assert_strings loc payload with 
+            | "bs.module" ->
+              begin match Ast_payload.assert_strings loc payload with
                 | [bundle] ->
                   {st with external_module_name =
                              Some {bundle; module_bind_name = Phint_nothing}}
-                | [bundle;bind_name] -> 
+                | [bundle;bind_name] ->
                   {st with external_module_name =
                              Some {bundle; module_bind_name = Phint_name bind_name}}
                 | [] ->
                   { st with
-                    module_as_val = 
+                    module_as_val =
                       Some
                         { bundle =
                             string_of_bundle_source
@@ -32691,21 +32698,21 @@ let process_external_attributes
                   Bs_syntaxerr.err loc Illegal_attribute
               end
             | "bs.scope" ->
-              begin match Ast_payload.assert_strings loc payload with 
-                | [] -> 
-                  Bs_syntaxerr.err loc Illegal_attribute 
-                (* We need err on empty scope, so we can tell the difference 
+              begin match Ast_payload.assert_strings loc payload with
+                | [] ->
+                  Bs_syntaxerr.err loc Illegal_attribute
+                (* We need err on empty scope, so we can tell the difference
                    between unset/set
                 *)
                 | scopes ->  { st with scopes = scopes }
               end
             | "bs.splice" -> {st with splice = true}
-            | "bs.send" -> 
+            | "bs.send" ->
               { st with val_send = name_from_payload_or_prim ~loc payload}
             | "bs.send.pipe"
               ->
-              { st with val_send_pipe = Some (Ast_payload.as_core_type loc payload)}                
-            | "bs.set" -> 
+              { st with val_send_pipe = Some (Ast_payload.as_core_type loc payload)}
+            | "bs.set" ->
               {st with set_name = name_from_payload_or_prim ~loc  payload}
             | "bs.get" -> {st with get_name = name_from_payload_or_prim ~loc payload}
 
@@ -32714,21 +32721,21 @@ let process_external_attributes
             | "bs.get_index"-> {st with get_index = true}
             | "bs.obj" -> {st with mk_obj = true}
             | "bs.return" ->
-              let aux loc txt : External_ffi_types.return_wrapper = 
-                begin match txt with 
+              let aux loc txt : External_ffi_types.return_wrapper =
+                begin match txt with
                   | "undefined_to_opt" -> Return_undefined_to_opt
                   | "null_to_opt" -> Return_null_to_opt
                   | "nullable"
                   | "null_undefined_to_opt" -> Return_null_undefined_to_opt
-                  | "identity" -> Return_identity 
+                  | "identity" -> Return_identity
                   | _ ->
                     Bs_syntaxerr.err loc Not_supported_directive_in_bs_return
                 end in
-              let actions = 
-                Ast_payload.ident_or_record_as_config loc payload 
+              let actions =
+                Ast_payload.ident_or_record_as_config loc payload
               in
-              begin match actions with 
-                | [ ({txt; _ },None) ] -> 
+              begin match actions with
+                | [ ({txt; _ },None) ] ->
                   { st with return_wrapper = aux loc txt}
                 | _ ->
                   Bs_syntaxerr.err loc Not_supported_directive_in_bs_return
@@ -32737,212 +32744,212 @@ let process_external_attributes
           end, attrs
         else (st , attr :: attrs)
     )
-    (init_st, []) prim_attributes 
+    (init_st, []) prim_attributes
 
 
-let rec has_bs_uncurry (attrs : Ast_attributes.t) = 
-  match attrs with 
-  | ({txt = "bs.uncurry"; _ }, _) :: attrs -> 
-    true 
-  | _ :: attrs -> has_bs_uncurry attrs 
-  | [] -> false 
+let rec has_bs_uncurry (attrs : Ast_attributes.t) =
+  match attrs with
+  | ({txt = "bs.uncurry"; _ }, _) :: attrs ->
+    true
+  | _ :: attrs -> has_bs_uncurry attrs
+  | [] -> false
 
 
-let check_return_wrapper 
-    loc (wrapper : External_ffi_types.return_wrapper) 
-    result_type = 
-  match wrapper with 
+let check_return_wrapper
+    loc (wrapper : External_ffi_types.return_wrapper)
+    result_type =
+  match wrapper with
   | Return_identity -> wrapper
-  | Return_unset  ->         
-    if Ast_core_type.is_unit result_type then 
-      Return_replaced_with_unit 
-    else if Ast_core_type.is_user_bool result_type then 
+  | Return_unset  ->
+    if Ast_core_type.is_unit result_type then
+      Return_replaced_with_unit
+    else if Ast_core_type.is_user_bool result_type then
       Return_to_ocaml_bool
-    else 
+    else
       wrapper
   | Return_undefined_to_opt
-  | Return_null_to_opt 
-  | Return_null_undefined_to_opt  
-    -> 
-    if Ast_core_type.is_user_option result_type then 
+  | Return_null_to_opt
+  | Return_null_undefined_to_opt
+    ->
+    if Ast_core_type.is_user_option result_type then
       wrapper
     else
       Bs_syntaxerr.err loc Expect_opt_in_bs_return_to_opt
-  | Return_replaced_with_unit 
-  | Return_to_ocaml_bool  -> 
+  | Return_replaced_with_unit
+  | Return_to_ocaml_bool  ->
     assert false (* Not going to happen from user input*)
 
 
 
 
-(** Note that the passed [type_annotation] is already processed by visitor pattern before 
+(** Note that the passed [type_annotation] is already processed by visitor pattern before
 *)
-let handle_attributes 
+let handle_attributes
     (loc : Bs_loc.t)
-    (pval_prim : string ) 
+    (pval_prim : string )
     (type_annotation : Parsetree.core_type)
     (prim_attributes : Ast_attributes.t) (prim_name : string)
   : Ast_core_type.t * string * External_ffi_types.t * Ast_attributes.t =
-  (** sanity check here 
+  (** sanity check here
       {[ int -> int -> (int -> int -> int [@bs.uncurry])]}
-      It does not make sense 
+      It does not make sense
   *)
-  if has_bs_uncurry type_annotation.Parsetree.ptyp_attributes then 
-    begin 
-      Location.raise_errorf 
+  if has_bs_uncurry type_annotation.Parsetree.ptyp_attributes then
+    begin
+      Location.raise_errorf
         ~loc "[@@bs.uncurry] can not be applied to the whole definition"
-    end; 
+    end;
 
   let prim_name_or_pval_prim =
     if String.length prim_name = 0 then  `Nm_val pval_prim
     else  `Nm_external prim_name  (* need check name *)
-  in    
+  in
   let result_type, arg_types_ty =
     Ast_core_type.list_of_arrow type_annotation in
-  if has_bs_uncurry result_type.ptyp_attributes then 
-    begin 
-      Location.raise_errorf 
+  if has_bs_uncurry result_type.ptyp_attributes then
+    begin
+      Location.raise_errorf
         ~loc:result_type.ptyp_loc
         "[@@bs.uncurry] can not be applied to tailed position"
     end ;
-  let (st, left_attrs) = 
-    process_external_attributes 
+  let (st, left_attrs) =
+    process_external_attributes
       (arg_types_ty = [])
-      prim_name_or_pval_prim pval_prim prim_attributes in 
+      prim_name_or_pval_prim pval_prim prim_attributes in
 
 
-  if st.mk_obj then 
-    begin match st with 
+  if st.mk_obj then
+    begin match st with
       | {
-        val_name = `Nm_na; 
+        val_name = `Nm_na;
         external_module_name = None ;
         module_as_val = None;
         val_send = `Nm_na;
-        val_send_pipe = None;    
+        val_send_pipe = None;
         splice = false;
         new_name = `Nm_na;
         call_name = `Nm_na;
         set_name = `Nm_na ;
         get_name = `Nm_na ;
         get_index = false ;
-        return_wrapper = Return_unset ;        
-        set_index = false ; 
-        mk_obj = _; 
+        return_wrapper = Return_unset ;
+        set_index = false ;
+        mk_obj = _;
         scopes = [];
         (* wrapper does not work with [bs.obj]
            TODO: better error message *)
-      } -> 
-        if String.length prim_name <> 0 then 
+      } ->
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.obj] expect external names to be empty string";
-        let arg_kinds, new_arg_types_ty, result_types = 
-          Ext_list.fold_right 
-            (fun (label,ty,attr,loc) ( arg_labels, arg_types, result_types) -> 
-               let arg_label = Ast_core_type.label_name label in 
-               let new_arg_label, new_arg_types,  output_tys = 
-                 match arg_label with 
-                 | Empty -> 
-                   let arg_type, new_ty = get_arg_type ~nolabel:true false ty in 
-                   begin match arg_type with 
-                     | Extern_unit ->  
+        let arg_kinds, new_arg_types_ty, result_types =
+          Ext_list.fold_right
+            (fun (label,ty,attr,loc) ( arg_labels, arg_types, result_types) ->
+               let arg_label = Ast_core_type.label_name label in
+               let new_arg_label, new_arg_types,  output_tys =
+                 match arg_label with
+                 | Empty ->
+                   let arg_type, new_ty = get_arg_type ~nolabel:true false ty in
+                   begin match arg_type with
+                     | Extern_unit ->
                        External_arg_spec.empty_kind arg_type, (label,new_ty,attr,loc)::arg_types, result_types
-                     | _ ->  
+                     | _ ->
                        Location.raise_errorf ~loc "expect label, optional, or unit here"
-                   end 
-                 | Label name -> 
-                   let arg_type, new_ty = get_arg_type ~nolabel:false false ty in 
-                   begin match arg_type with 
-                     | Ignore -> 
-                       External_arg_spec.empty_kind arg_type, 
+                   end
+                 | Label name ->
+                   let arg_type, new_ty = get_arg_type ~nolabel:false false ty in
+                   begin match arg_type with
+                     | Ignore ->
+                       External_arg_spec.empty_kind arg_type,
                        (label,new_ty,attr,loc)::arg_types, result_types
-                     | Arg_cst  i  -> 
+                     | Arg_cst  i  ->
                        let s = (Lam_methname.translate ~loc name) in
                        {arg_label = External_arg_spec.label s (Some i);
-                        arg_type }, 
+                        arg_type },
                        arg_types, (* ignored in [arg_types], reserved in [result_types] *)
                        ((name , [], new_ty) :: result_types)
-                     | Nothing | Array -> 
+                     | Nothing | Array ->
                        let s = (Lam_methname.translate ~loc name) in
                        {arg_label = External_arg_spec.label s None ; arg_type },
-                       (label,new_ty,attr,loc)::arg_types, 
+                       (label,new_ty,attr,loc)::arg_types,
                        ((name , [], new_ty) :: result_types)
-                     | Int _  -> 
+                     | Int _  ->
                        let s = Lam_methname.translate ~loc name in
                        {arg_label = External_arg_spec.label s None; arg_type},
-                       (label,new_ty,attr,loc)::arg_types, 
-                       ((name, [], Ast_literal.type_int ~loc ()) :: result_types)  
-                     | NullString _ -> 
+                       (label,new_ty,attr,loc)::arg_types,
+                       ((name, [], Ast_literal.type_int ~loc ()) :: result_types)
+                     | NullString _ ->
                        let s = Lam_methname.translate ~loc name in
-                       {arg_label = External_arg_spec.label s None; arg_type}, 
-                       (label,new_ty,attr,loc)::arg_types, 
-                       ((name, [], Ast_literal.type_string ~loc ()) :: result_types)  
-                     | Fn_uncurry_arity _ -> 
+                       {arg_label = External_arg_spec.label s None; arg_type},
+                       (label,new_ty,attr,loc)::arg_types,
+                       ((name, [], Ast_literal.type_string ~loc ()) :: result_types)
+                     | Fn_uncurry_arity _ ->
                        Location.raise_errorf ~loc
                          "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"
-                     | Extern_unit -> assert false 
-                     | NonNullString _ 
-                       ->  
-                       Location.raise_errorf ~loc 
+                     | Extern_unit -> assert false
+                     | NonNullString _
+                       ->
+                       Location.raise_errorf ~loc
                          "bs.obj label %s does not support such arg type" name
                      | Unwrap ->
                        Location.raise_errorf ~loc
                          "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
-                 | Optional name -> 
-                   let arg_type, new_ty_extract = get_arg_type ~nolabel:false true ty in 
-                   let new_ty = Ast_core_type.lift_option_type new_ty_extract in 
-                   begin match arg_type with 
-                     | Ignore -> 
-                       External_arg_spec.empty_kind arg_type, 
+                 | Optional name ->
+                   let arg_type, new_ty_extract = get_arg_type ~nolabel:false true ty in
+                   let new_ty = Ast_core_type.lift_option_type new_ty_extract in
+                   begin match arg_type with
+                     | Ignore ->
+                       External_arg_spec.empty_kind arg_type,
                        (label,new_ty,attr,loc)::arg_types, result_types
 
-                     | Nothing | Array -> 
-                       let s = (Lam_methname.translate ~loc name) in 
-                       {arg_label = External_arg_spec.optional s; arg_type}, 
-                       (label,new_ty,attr,loc)::arg_types, 
+                     | Nothing | Array ->
+                       let s = (Lam_methname.translate ~loc name) in
+                       {arg_label = External_arg_spec.optional s; arg_type},
+                       (label,new_ty,attr,loc)::arg_types,
                        ( (name, [], Ast_comb.to_undefined_type loc new_ty_extract) ::  result_types)
-                     | Int _  -> 
-                       let s = Lam_methname.translate ~loc name in 
+                     | Int _  ->
+                       let s = Lam_methname.translate ~loc name in
                        {arg_label = External_arg_spec.optional s ; arg_type },
                        (label,new_ty,attr,loc)::arg_types,
-                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_int ~loc ()) :: result_types)                      
-                     | NullString _  -> 
-                       let s = Lam_methname.translate ~loc name in 
-                       {arg_label = External_arg_spec.optional s ; arg_type }, 
+                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_int ~loc ()) :: result_types)
+                     | NullString _  ->
+                       let s = Lam_methname.translate ~loc name in
+                       {arg_label = External_arg_spec.optional s ; arg_type },
                        (label,new_ty,attr,loc)::arg_types,
-                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_string ~loc ()) :: result_types)                      
-                     | Arg_cst _   
-                       -> 
+                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_string ~loc ()) :: result_types)
+                     | Arg_cst _
+                       ->
                        Location.raise_errorf ~loc "bs.as is not supported with optional yet"
-                     | Fn_uncurry_arity _ -> 
+                     | Fn_uncurry_arity _ ->
                        Location.raise_errorf ~loc
-                         "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"                      
-                     | Extern_unit   -> assert false                      
-                     | NonNullString _ 
-                       ->  
+                         "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"
+                     | Extern_unit   -> assert false
+                     | NonNullString _
+                       ->
                        Location.raise_errorf ~loc
-                         "bs.obj label %s does not support such arg type" name                        
+                         "bs.obj label %s does not support such arg type" name
                      | Unwrap ->
                        Location.raise_errorf ~loc
                          "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
-               in     
+               in
                (
                  new_arg_label::arg_labels,
                  new_arg_types,
-                 output_tys)) arg_types_ty 
-            ( [], [], []) in 
+                 output_tys)) arg_types_ty
+            ( [], [], []) in
 
-        let result = 
-          if Ast_core_type.is_any  result_type then            
-            Ast_core_type.make_obj ~loc result_types 
-          else           
-            snd @@ get_arg_type ~nolabel:true false result_type (* result type can not be labeled *)            
+        let result =
+          if Ast_core_type.is_any  result_type then
+            Ast_core_type.make_obj ~loc result_types
+          else
+            snd @@ get_arg_type ~nolabel:true false result_type (* result type can not be labeled *)
 
         in
-        begin 
-          (             
-            Ext_list.fold_right (fun (label,ty,attrs,loc) acc -> 
-                Ast_helper.Typ.arrow ~loc  ~attrs label ty acc 
+        begin
+          (
+            Ext_list.fold_right (fun (label,ty,attrs,loc) acc ->
+                Ast_helper.Typ.arrow ~loc  ~attrs label ty acc
               ) new_arg_types_ty result
           ) ,
           prim_name,
@@ -32950,64 +32957,64 @@ let handle_attributes
           left_attrs
         end
 
-      | _ -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.obj]"  
+      | _ -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.obj]"
 
-    end  
+    end
 
-  else   
-    let splice = st.splice in 
-    let arg_type_specs, new_arg_types_ty, arg_type_specs_length   = 
-      Ext_list.fold_right 
-        (fun (label,ty,attr,loc) (arg_type_specs, arg_types, i) -> 
-           let arg_label = Ast_core_type.label_name label in 
-           let arg_label, arg_type, new_arg_types = 
-             match arg_label with 
-             | Optional s  -> 
+  else
+    let splice = st.splice in
+    let arg_type_specs, new_arg_types_ty, arg_type_specs_length   =
+      Ext_list.fold_right
+        (fun (label,ty,attr,loc) (arg_type_specs, arg_types, i) ->
+           let arg_label = Ast_core_type.label_name label in
+           let arg_label, arg_type, new_arg_types =
+             match arg_label with
+             | Optional s  ->
 
-               let arg_type , new_ty = get_arg_type ~nolabel:false true ty in 
-               begin match arg_type with 
-                 | NonNullString _ -> 
+               let arg_type , new_ty = get_arg_type ~nolabel:false true ty in
+               begin match arg_type with
+                 | NonNullString _ ->
                    (* ?x:([`x of int ] [@bs.string]) does not make sense *)
-                   Location.raise_errorf 
+                   Location.raise_errorf
                      ~loc
                      "[@@bs.string] does not work with optional when it has arities in label %s" label
-                 | _ -> 
-                   External_arg_spec.optional s, arg_type, 
+                 | _ ->
+                   External_arg_spec.optional s, arg_type,
                    ((label, Ast_core_type.lift_option_type new_ty , attr,loc) :: arg_types) end
-             | Label s  -> 
+             | Label s  ->
                begin match get_arg_type ~nolabel:false false  ty with
-                 | (Arg_cst ( i) as arg_type), new_ty -> 
+                 | (Arg_cst ( i) as arg_type), new_ty ->
                    External_arg_spec.label s (Some i), arg_type, arg_types
-                 | arg_type, new_ty -> 
+                 | arg_type, new_ty ->
                    External_arg_spec.label s None, arg_type, (label, new_ty,attr,loc) :: arg_types
                end
-             | Empty -> 
-               begin match get_arg_type ~nolabel:true false  ty with 
-                 | (Arg_cst ( i) as arg_type), new_ty -> 
+             | Empty ->
+               begin match get_arg_type ~nolabel:true false  ty with
+                 | (Arg_cst ( i) as arg_type), new_ty ->
                    External_arg_spec.empty_lit i , arg_type,  arg_types
-                 | arg_type, new_ty -> 
+                 | arg_type, new_ty ->
                    External_arg_spec.empty_label, arg_type, (label, new_ty,attr,loc) :: arg_types
                end
            in
            (if i = 0 && splice  then
-              match arg_type with 
+              match arg_type with
               | Array  -> ()
               | _ ->  Location.raise_errorf ~loc "[@@@@bs.splice] expect the last type to be an array");
-           ({ External_arg_spec.arg_label  ; 
-              arg_type 
+           ({ External_arg_spec.arg_label  ;
+              arg_type
             } :: arg_type_specs,
             new_arg_types,
-            if arg_type = Ignore then i 
+            if arg_type = Ignore then i
             else i + 1
            )
-        ) arg_types_ty 
+        ) arg_types_ty
         (match st with
-         | {val_send_pipe = Some obj; _ } ->      
-           let arg_type, new_ty = get_arg_type ~nolabel:true false obj in 
-           begin match arg_type with 
-             | Arg_cst _ -> 
+         | {val_send_pipe = Some obj; _ } ->
+           let arg_type, new_ty = get_arg_type ~nolabel:true false obj in
+           begin match arg_type with
+             | Arg_cst _ ->
                Location.raise_errorf ~loc:obj.ptyp_loc "[@bs.as] is not supported in bs.send type "
-             | _ -> 
+             | _ ->
                (* more error checking *)
                [External_arg_spec.empty_kind arg_type]
                ,
@@ -33015,16 +33022,16 @@ let handle_attributes
                ,0
            end
 
-         | {val_send_pipe = None ; _ } -> [],[], 0) in 
+         | {val_send_pipe = None ; _ } -> [],[], 0) in
 
-    let ffi : External_ffi_types.attr  = match st with           
+    let ffi : External_ffi_types.attr  = match st with
       | {set_index = true;
 
-         val_name = `Nm_na; 
+         val_name = `Nm_na;
          external_module_name = None ;
          module_as_val = None;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          splice = false;
          scopes ;
          get_index = false;
@@ -33033,16 +33040,16 @@ let handle_attributes
          set_name = `Nm_na ;
          get_name = `Nm_na ;
 
-         return_wrapper = _; 
-         mk_obj = _ ; 
+         return_wrapper = _;
+         mk_obj = _ ;
 
-        } 
+        }
         ->
-        if String.length prim_name <> 0 then 
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.set_index] expect external names to be empty string";
-        if arg_type_specs_length = 3 then 
+        if arg_type_specs_length = 3 then
           Js_set_index {js_set_index_scopes = scopes}
-        else 
+        else
           Location.raise_errorf ~loc "Ill defined attribute [@@bs.set_index](arity of 3)"
 
       | {set_index = true; _}
@@ -33052,11 +33059,11 @@ let handle_attributes
 
       | {get_index = true;
 
-         val_name = `Nm_na; 
+         val_name = `Nm_na;
          external_module_name = None ;
          module_as_val = None;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
 
          splice = false;
          scopes ;
@@ -33064,20 +33071,20 @@ let handle_attributes
          call_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         set_index = false; 
+         set_index = false;
          mk_obj;
-         return_wrapper ; 
+         return_wrapper ;
         } ->
-        if String.length prim_name <> 0 then 
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.get_index] expect external names to be empty string";
-        if arg_type_specs_length = 2 then 
+        if arg_type_specs_length = 2 then
           Js_get_index {js_get_index_scopes = scopes}
-        else Location.raise_errorf ~loc 
+        else Location.raise_errorf ~loc
             "Ill defined attribute [@@bs.get_index] (arity expected 2 : while %d)" arg_type_specs_length
 
       | {get_index = true; _}
 
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.get_index]")
 
 
@@ -33091,17 +33098,17 @@ let handle_attributes
 
          external_module_name = None ;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          scopes = []; (* module as var does not need scopes *)
          splice;
          call_name = `Nm_na;
          set_name = `Nm_na ;
-         get_name = `Nm_na ;         
-         set_index = false; 
-         return_wrapper = _; 
+         get_name = `Nm_na ;
+         set_index = false;
+         return_wrapper = _;
          mk_obj = _ ;
         } ->
-        begin match arg_types_ty, new_name, val_name  with         
+        begin match arg_types_ty, new_name, val_name  with
           | [], `Nm_na,  _ -> Js_module_as_var external_module_name
           | _, `Nm_na, _ -> Js_module_as_fn {splice; external_module_name }
           | _, #bundle_source, #bundle_source ->
@@ -33115,29 +33122,29 @@ let handle_attributes
               "Incorrect FFI attribute found: (bs.new should not carry a payload here)"
         end
       | {module_as_val = Some x; _}
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.module].")
 
       | {call_name = (`Nm_val name | `Nm_external name | `Nm_payload name) ;
-         splice; 
+         splice;
          scopes ;
          external_module_name;
 
          val_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;    
+         val_send_pipe = None;
 
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         mk_obj = _ ; 
-         return_wrapper = _ ; 
-        } -> 
+         mk_obj = _ ;
+         return_wrapper = _ ;
+        } ->
         Js_call {splice; name; external_module_name; scopes }
-      | {call_name = #bundle_source ; _ } 
+      | {call_name = #bundle_source ; _ }
         ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.val]")
 
@@ -33148,18 +33155,18 @@ let handle_attributes
          call_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na;
-         mk_obj = _; 
-         return_wrapper = _; 
+         mk_obj = _;
+         return_wrapper = _;
          splice = false ;
          scopes ;
-        } 
-        -> 
+        }
+        ->
         Js_global { name; external_module_name; scopes}
       | {val_name = #bundle_source ; _ }
         ->
@@ -33169,27 +33176,27 @@ let handle_attributes
          scopes ;
          external_module_name = (Some _ as external_module_name);
 
-         val_name = `Nm_na ;         
+         val_name = `Nm_na ;
          call_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         mk_obj = _ ; 
-         return_wrapper= _ ; 
+         mk_obj = _ ;
+         return_wrapper= _ ;
         }
         ->
         let name = string_of_bundle_source prim_name_or_pval_prim in
         if arg_type_specs_length  = 0 then
           Js_global { name; external_module_name; scopes}
-        else  Js_call {splice; name; external_module_name; scopes}                     
-      | {val_send = (`Nm_val name | `Nm_external name | `Nm_payload name); 
+        else  Js_call {splice; name; external_module_name; scopes}
+      | {val_send = (`Nm_val name | `Nm_external name | `Nm_payload name);
          splice;
-         scopes; 
+         scopes;
          val_send_pipe = None;
          val_name = `Nm_na  ;
          call_name = `Nm_na ;
@@ -33201,28 +33208,28 @@ let handle_attributes
          get_name = `Nm_na ;
          external_module_name = None ;
          mk_obj = _ ;
-         return_wrapper = _ ; 
-        } -> 
+         return_wrapper = _ ;
+        } ->
 
-        (* PR #2162 - since when we assemble arguments the first argument in 
+        (* PR #2162 - since when we assemble arguments the first argument in
            [@@bs.send] is ignored
         *)
-        begin match arg_type_specs with 
+        begin match arg_type_specs with
           | [] ->
-            Location.raise_errorf 
+            Location.raise_errorf
               ~loc "Ill defined attribute [@@bs.send] (at least one argument)"
           |  {arg_type = Arg_cst _ ; arg_label = _} :: _
-            -> 
-            Location.raise_errorf 
+            ->
+            Location.raise_errorf
               ~loc "Ill defined attribute [@@bs.send] (first argument can not be const)"
-          | _ :: _  -> 
+          | _ :: _  ->
             Js_send {splice ; name; js_send_scopes = scopes ;  pipe = false}
         end
 
-      | {val_send = #bundle_source; _ } 
+      | {val_send = #bundle_source; _ }
         -> Location.raise_errorf ~loc "You used an FFI attribute that can't be used with [@@bs.send]"
 
-      | {val_send_pipe = Some typ; 
+      | {val_send_pipe = Some typ;
          (* splice = (false as splice); *)
          val_send = `Nm_na;
          val_name = `Nm_na  ;
@@ -33235,17 +33242,17 @@ let handle_attributes
          get_name = `Nm_na ;
          external_module_name = None ;
          mk_obj = _;
-         return_wrapper = _; 
+         return_wrapper = _;
          scopes;
-         splice ; 
-        } -> 
+         splice ;
+        } ->
         (** can be one argument *)
         Js_send {splice  ;
                  name = string_of_bundle_source prim_name_or_pval_prim;
                  js_send_scopes = scopes;
                  pipe = true}
 
-      | {val_send_pipe = Some _ ; _} 
+      | {val_send_pipe = Some _ ; _}
         -> Location.raise_errorf ~loc "conflict attributes found with [@@bs.send.pipe]"
 
       | {new_name = (`Nm_val name | `Nm_external name | `Nm_payload name);
@@ -33257,18 +33264,18 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
          splice ;
-         scopes; 
-         mk_obj = _ ; 
-         return_wrapper = _ ; 
+         scopes;
+         mk_obj = _ ;
+         return_wrapper = _ ;
 
-        } 
+        }
         -> Js_new {name; external_module_name; splice; scopes}
       | {new_name = #bundle_source ; _ }
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.new]")
 
 
@@ -33280,17 +33287,17 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          get_name = `Nm_na ;
          external_module_name = None;
-         splice = false; 
+         splice = false;
          mk_obj = _ ;
-         return_wrapper = _; 
+         return_wrapper = _;
          scopes ;
-        } 
-        -> 
-        if arg_type_specs_length = 2 then 
+        }
+        ->
+        if arg_type_specs_length = 2 then
           Js_set { js_set_scopes = scopes ; js_set_name = name}
         else  Location.raise_errorf ~loc "Ill defined attribute [@@bs.set] (two args required)"
 
@@ -33305,19 +33312,19 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          set_name = `Nm_na ;
          external_module_name = None;
-         splice = false ; 
+         splice = false ;
          mk_obj = _;
          return_wrapper = _;
          scopes
         }
         ->
-        if arg_type_specs_length = 1 then  
+        if arg_type_specs_length = 1 then
           Js_get { js_get_name = name; js_get_scopes = scopes }
-        else 
+        else
           Location.raise_errorf ~loc "Ill defined attribute [@@bs.get] (only one argument)"
       | {get_name = #bundle_source; _}
         -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.get]"
@@ -33329,30 +33336,30 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          set_name = `Nm_na ;
          external_module_name = None;
-         splice = _ ; 
+         splice = _ ;
          scopes = _;
          mk_obj = _;
          return_wrapper = _;
 
-        }       
-        ->  Location.raise_errorf ~loc "Could not infer which FFI category it belongs to, maybe you forgot [%@%@bs.val]? "  in 
-    begin 
+        }
+        ->  Location.raise_errorf ~loc "Could not infer which FFI category it belongs to, maybe you forgot [%@%@bs.val]? "  in
+    begin
       External_ffi_types.check_ffi ~loc ffi;
       (* result type can not be labeled *)
-      (* currently we don't process attributes of 
+      (* currently we don't process attributes of
          return type, in the future we may  *)
       let  new_result_type  =  result_type in
       (* get_arg_type ~nolabel:true false result_type in *)
-      let return_wrapper : External_ffi_types.return_wrapper = 
+      let return_wrapper : External_ffi_types.return_wrapper =
         check_return_wrapper loc st.return_wrapper new_result_type
-      in 
+      in
       (
-        Ext_list.fold_right (fun (label,ty,attrs,loc) acc -> 
-            Ast_helper.Typ.arrow ~loc  ~attrs label ty acc 
+        Ext_list.fold_right (fun (label,ty,attrs,loc) acc ->
+            Ast_helper.Typ.arrow ~loc  ~attrs label ty acc
           ) new_arg_types_ty new_result_type
       ) ,
 
@@ -33360,29 +33367,31 @@ let handle_attributes
       (Ffi_bs (arg_type_specs,return_wrapper ,  ffi)), left_attrs
     end
 
-let handle_attributes_as_string 
+let handle_attributes_as_string
     pval_loc
-    pval_prim 
-    (typ : Ast_core_type.t) attrs v = 
-  let pval_type, prim_name, ffi, processed_attrs  = 
+    pval_prim
+    (typ : Ast_core_type.t) attrs v =
+  let pval_type, prim_name, ffi, processed_attrs  =
     handle_attributes pval_loc pval_prim typ attrs v  in
   pval_type, [prim_name; External_ffi_types.to_string ffi], processed_attrs
 
 
 
-let pval_prim_of_labels labels = 
-  let encoding = 
-    let arg_kinds = 
-      Ext_list.fold_right 
+let pval_prim_of_labels labels =
+  let encoding =
+    let arg_kinds =
+      Ext_list.fold_right
         (fun {Asttypes.loc ; txt } arg_kinds
           ->
-            let arg_label =  External_arg_spec.label (Lam_methname.translate ~loc txt) None in
-            {External_arg_spec.arg_type = Nothing ; 
+            let arg_label =
+                External_arg_spec.label
+                  (Lam_methname.translate ~loc txt) None in
+            {External_arg_spec.arg_type = Nothing ;
              arg_label  } :: arg_kinds
         )
-        labels [] in 
-    External_ffi_types.to_string 
-      (Ffi_obj_create arg_kinds)   in 
+        labels [] in
+    External_ffi_types.to_string
+      (Ffi_obj_create arg_kinds)   in
   [""; encoding]
 
 
@@ -36441,42 +36450,59 @@ let handleTdcl (tdcl : Parsetree.type_declaration) =
   match tdcl.ptype_kind with
   | Ptype_record label_declarations ->
     let setter_accessor =
-      Ext_list.fold_right (fun (x: Parsetree.label_declaration) acc ->
-          let pld_name = x.pld_name.txt in
-          let pld_loc = x.pld_name.loc in
-          let pld_type = x.pld_type in
+      Ext_list.fold_right (fun
+          ({pld_name = {txt = label_name; loc = label_loc} as pld_name;
+            pld_type;
+            pld_mutable;
+            pld_attributes
+            }:
+          Parsetree.label_declaration) acc ->
           let () = checkNotFunciton pld_type in
-          let setter =
+          let prim =
+            match Ast_attributes.iter_process_bs_string_as pld_attributes with
+            | None -> [label_name]
+            | Some new_name -> [new_name]
+          in
+          let getter =
             Val.mk
-              {loc = pld_loc; txt = pld_name}
+              pld_name (* we always use this: it is fixed in ocaml API*)
               ~attrs:[Ast_attributes.bs_get]
-              ~prim:[pld_name]
+              ~prim
               (Typ.arrow "" core_type pld_type) :: acc in
-          match x.pld_mutable with
+          match pld_mutable with
           | Mutable ->
             Val.mk
-              {loc = pld_loc; txt = pld_name ^ "Set"}
+              {loc = label_loc; txt = label_name ^ "Set"}
+              (* setter *)
               ~attrs:[Ast_attributes.bs_set]
-              ~prim:[pld_name]
-              (Typ.arrow "" core_type (Typ.arrow "" pld_type (Ast_literal.type_unit ()))) :: setter
-          | Immutable -> setter
+              ~prim
+              (Typ.arrow "" core_type (Typ.arrow "" pld_type (Ast_literal.type_unit ()))) :: getter
+          | Immutable -> getter
         ) label_declarations []
     in
-
     newTdcl,
     (match tdcl.ptype_private with
      | Private -> setter_accessor
      | Public ->
        let ty =
-         Ext_list.fold_right (fun (label_declaration : Parsetree.label_declaration) acc ->
-             Typ.arrow
-               label_declaration.pld_name.txt label_declaration.pld_type acc
+         Ext_list.fold_right (fun ({pld_name = {txt}; pld_type}: Parsetree.label_declaration) acc ->
+             Typ.arrow txt pld_type acc
            ) label_declarations  core_type in
-       let maker =
-         Val.mk  {loc; txt = type_name}
-           ~attrs:[Ast_attributes.bs_obj]
-           ~prim:[""] ty in
-       (maker :: setter_accessor))
+       let myPrims =
+         External_process.pval_prim_of_labels
+           (List.map
+              (fun ({pld_name; pld_attributes} : Parsetree.label_declaration) ->
+                match Ast_attributes.iter_process_bs_string_as pld_attributes with
+                | None -> pld_name
+                | Some new_name -> {pld_name with txt = new_name}
+              )
+              label_declarations)
+       in
+       let myMaker =
+        Val.mk  ~loc
+        {loc; txt = type_name}
+        ~prim:myPrims ty in
+       (myMaker :: setter_accessor))
 
   | Ptype_abstract
   | Ptype_variant _

--- a/lib/bsdep.ml
+++ b/lib/bsdep.ml
@@ -36371,7 +36371,7 @@ val handleTdclsInSig:
 end = struct
 #1 "ast_derive_abstract.ml"
 (* Copyright (C) 2017 Authors of BuckleScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -36389,7 +36389,7 @@ end = struct
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -36398,113 +36398,116 @@ end = struct
 let derivingName = "abstract"
 module U = Ast_derive_util
 open Ast_helper
-type tdcls = Parsetree.type_declaration list 
+type tdcls = Parsetree.type_declaration list
 
-let handle_config (config : Parsetree.expression option) = 
-  match config with 
-  | Some config -> 
+let handle_config (config : Parsetree.expression option) =
+  match config with
+  | Some config ->
     U.invalid_config config
   | None -> ()
 
-(* see #2337 
+(* see #2337
    TODO: relax it to allow (int -> int [@bs])
-*)  
-let rec checkNotFunciton (ty : Parsetree.core_type) = 
-  match ty.ptyp_desc with 
-  | Ptyp_poly (_,ty) -> checkNotFunciton ty 
-  | Ptyp_alias (ty,_) -> checkNotFunciton ty 
-  | Ptyp_arrow _ -> 
-    Location.raise_errorf 
-      ~loc:ty.ptyp_loc 
+*)
+let rec checkNotFunciton (ty : Parsetree.core_type) =
+  match ty.ptyp_desc with
+  | Ptyp_poly (_,ty) -> checkNotFunciton ty
+  | Ptyp_alias (ty,_) -> checkNotFunciton ty
+  | Ptyp_arrow _ ->
+    Location.raise_errorf
+      ~loc:ty.ptyp_loc
       "syntactic function type is not allowed when working with abstract bs.deriving, create a named type as work around"
-  | Ptyp_any 
+  | Ptyp_any
   | Ptyp_var _
-  | Ptyp_tuple _ 
+  | Ptyp_tuple _
   | Ptyp_constr _
-  | Ptyp_object _  
-  | Ptyp_class _ 
+  | Ptyp_object _
+  | Ptyp_class _
   | Ptyp_variant _
   | Ptyp_package _
-  | Ptyp_extension _ -> () 
-let handleTdcl (tdcl : Parsetree.type_declaration) =   
-  let core_type = U.core_type_of_type_declaration tdcl in 
-  let loc = tdcl.ptype_loc in 
-  let name = tdcl.ptype_name.txt in 
+  | Ptyp_extension _ -> ()
+
+
+let handleTdcl (tdcl : Parsetree.type_declaration) =
+  let core_type = U.core_type_of_type_declaration tdcl in
+  let loc = tdcl.ptype_loc in
+  let type_name = tdcl.ptype_name.txt in
   let newTdcl = {
-    tdcl with 
+    tdcl with
     ptype_kind = Ptype_abstract;
     ptype_attributes = [];
     (* avoid non-terminating*)
-  } in 
-  match tdcl.ptype_kind with 
-  | Ptype_record label_declarations -> 
-    let ty =   
-      Ext_list.fold_right (fun (label_declaration : Parsetree.label_declaration) acc -> 
-          Typ.arrow
-            label_declaration.pld_name.txt label_declaration.pld_type acc 
-        ) label_declarations  core_type in 
-    let setter_accessor =     
-      Ext_list.fold_right (fun (x: Parsetree.label_declaration) acc -> 
-          let pld_name = x.pld_name.txt in 
-          let pld_loc = x.pld_name.loc in 
+  } in
+  match tdcl.ptype_kind with
+  | Ptype_record label_declarations ->
+    let setter_accessor =
+      Ext_list.fold_right (fun (x: Parsetree.label_declaration) acc ->
+          let pld_name = x.pld_name.txt in
+          let pld_loc = x.pld_name.loc in
           let pld_type = x.pld_type in
-          let () = checkNotFunciton pld_type in 
-          let setter = 
-            Val.mk 
+          let () = checkNotFunciton pld_type in
+          let setter =
+            Val.mk
               {loc = pld_loc; txt = pld_name}
               ~attrs:[Ast_attributes.bs_get]
               ~prim:[pld_name]
-              (Typ.arrow "" core_type pld_type) :: acc in 
-          match x.pld_mutable with 
-          | Mutable -> 
-            Val.mk 
+              (Typ.arrow "" core_type pld_type) :: acc in
+          match x.pld_mutable with
+          | Mutable ->
+            Val.mk
               {loc = pld_loc; txt = pld_name ^ "Set"}
               ~attrs:[Ast_attributes.bs_set]
               ~prim:[pld_name]
               (Typ.arrow "" core_type (Typ.arrow "" pld_type (Ast_literal.type_unit ()))) :: setter
-          | Immutable -> setter 
+          | Immutable -> setter
         ) label_declarations []
-    in 
+    in
 
-    newTdcl, 
-    (match tdcl.ptype_private with 
+    newTdcl,
+    (match tdcl.ptype_private with
      | Private -> setter_accessor
-     | Public -> 
-       let maker =   
-         Val.mk  {loc; txt = name}
+     | Public ->
+       let ty =
+         Ext_list.fold_right (fun (label_declaration : Parsetree.label_declaration) acc ->
+             Typ.arrow
+               label_declaration.pld_name.txt label_declaration.pld_type acc
+           ) label_declarations  core_type in
+       let maker =
+         Val.mk  {loc; txt = type_name}
            ~attrs:[Ast_attributes.bs_obj]
-           ~prim:[""] ty in 
+           ~prim:[""] ty in
        (maker :: setter_accessor))
 
-  | Ptype_abstract 
-  | Ptype_variant _ 
-  | Ptype_open -> 
+  | Ptype_abstract
+  | Ptype_variant _
+  | Ptype_open ->
     (* Looks obvious that it does not make sense to warn *)
     (* U.notApplicable tdcl.ptype_loc derivingName;  *)
     tdcl, []
 
-let handleTdclsInStr tdcls =     
-  let tdcls, code = 
-    List.fold_right (fun tdcl (tdcls, sts)  -> 
-        match handleTdcl tdcl with 
-          ntdcl, value_descriptions -> 
-          ntdcl::tdcls, 
+let handleTdclsInStr tdcls =
+  let tdcls, code =
+    List.fold_right (fun tdcl (tdcls, sts)  ->
+        match handleTdcl tdcl with
+          ntdcl, value_descriptions ->
+          ntdcl::tdcls,
           Ext_list.map_append (fun x -> Str.primitive x) value_descriptions sts
 
-      ) tdcls ([],[])  in 
-  Str.type_ tdcls :: code    
+      ) tdcls ([],[])  in
+  Str.type_ tdcls :: code
 (* still need perform transformation for non-abstract type*)
 
-let handleTdclsInSig tdcls =     
-  let tdcls, code = 
-    List.fold_right (fun tdcl (tdcls, sts)  -> 
-        match handleTdcl tdcl with 
-          ntdcl, value_descriptions -> 
-          ntdcl::tdcls, 
+let handleTdclsInSig tdcls =
+  let tdcls, code =
+    List.fold_right (fun tdcl (tdcls, sts)  ->
+        match handleTdcl tdcl with
+          ntdcl, value_descriptions ->
+          ntdcl::tdcls,
           Ext_list.map_append (fun x -> Sig.value x) value_descriptions sts
 
-      ) tdcls ([],[])  in 
-  Sig.type_ tdcls :: code  
+      ) tdcls ([],[])  in
+  Sig.type_ tdcls :: code
+
 end
 module Ast_tdcls : sig 
 #1 "ast_tdcls.mli"

--- a/lib/bsppx.ml
+++ b/lib/bsppx.ml
@@ -18377,7 +18377,7 @@ val handleTdclsInSig:
 end = struct
 #1 "ast_derive_abstract.ml"
 (* Copyright (C) 2017 Authors of BuckleScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -18395,7 +18395,7 @@ end = struct
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -18404,113 +18404,116 @@ end = struct
 let derivingName = "abstract"
 module U = Ast_derive_util
 open Ast_helper
-type tdcls = Parsetree.type_declaration list 
+type tdcls = Parsetree.type_declaration list
 
-let handle_config (config : Parsetree.expression option) = 
-  match config with 
-  | Some config -> 
+let handle_config (config : Parsetree.expression option) =
+  match config with
+  | Some config ->
     U.invalid_config config
   | None -> ()
 
-(* see #2337 
+(* see #2337
    TODO: relax it to allow (int -> int [@bs])
-*)  
-let rec checkNotFunciton (ty : Parsetree.core_type) = 
-  match ty.ptyp_desc with 
-  | Ptyp_poly (_,ty) -> checkNotFunciton ty 
-  | Ptyp_alias (ty,_) -> checkNotFunciton ty 
-  | Ptyp_arrow _ -> 
-    Location.raise_errorf 
-      ~loc:ty.ptyp_loc 
+*)
+let rec checkNotFunciton (ty : Parsetree.core_type) =
+  match ty.ptyp_desc with
+  | Ptyp_poly (_,ty) -> checkNotFunciton ty
+  | Ptyp_alias (ty,_) -> checkNotFunciton ty
+  | Ptyp_arrow _ ->
+    Location.raise_errorf
+      ~loc:ty.ptyp_loc
       "syntactic function type is not allowed when working with abstract bs.deriving, create a named type as work around"
-  | Ptyp_any 
+  | Ptyp_any
   | Ptyp_var _
-  | Ptyp_tuple _ 
+  | Ptyp_tuple _
   | Ptyp_constr _
-  | Ptyp_object _  
-  | Ptyp_class _ 
+  | Ptyp_object _
+  | Ptyp_class _
   | Ptyp_variant _
   | Ptyp_package _
-  | Ptyp_extension _ -> () 
-let handleTdcl (tdcl : Parsetree.type_declaration) =   
-  let core_type = U.core_type_of_type_declaration tdcl in 
-  let loc = tdcl.ptype_loc in 
-  let name = tdcl.ptype_name.txt in 
+  | Ptyp_extension _ -> ()
+
+
+let handleTdcl (tdcl : Parsetree.type_declaration) =
+  let core_type = U.core_type_of_type_declaration tdcl in
+  let loc = tdcl.ptype_loc in
+  let type_name = tdcl.ptype_name.txt in
   let newTdcl = {
-    tdcl with 
+    tdcl with
     ptype_kind = Ptype_abstract;
     ptype_attributes = [];
     (* avoid non-terminating*)
-  } in 
-  match tdcl.ptype_kind with 
-  | Ptype_record label_declarations -> 
-    let ty =   
-      Ext_list.fold_right (fun (label_declaration : Parsetree.label_declaration) acc -> 
-          Typ.arrow
-            label_declaration.pld_name.txt label_declaration.pld_type acc 
-        ) label_declarations  core_type in 
-    let setter_accessor =     
-      Ext_list.fold_right (fun (x: Parsetree.label_declaration) acc -> 
-          let pld_name = x.pld_name.txt in 
-          let pld_loc = x.pld_name.loc in 
+  } in
+  match tdcl.ptype_kind with
+  | Ptype_record label_declarations ->
+    let setter_accessor =
+      Ext_list.fold_right (fun (x: Parsetree.label_declaration) acc ->
+          let pld_name = x.pld_name.txt in
+          let pld_loc = x.pld_name.loc in
           let pld_type = x.pld_type in
-          let () = checkNotFunciton pld_type in 
-          let setter = 
-            Val.mk 
+          let () = checkNotFunciton pld_type in
+          let setter =
+            Val.mk
               {loc = pld_loc; txt = pld_name}
               ~attrs:[Ast_attributes.bs_get]
               ~prim:[pld_name]
-              (Typ.arrow "" core_type pld_type) :: acc in 
-          match x.pld_mutable with 
-          | Mutable -> 
-            Val.mk 
+              (Typ.arrow "" core_type pld_type) :: acc in
+          match x.pld_mutable with
+          | Mutable ->
+            Val.mk
               {loc = pld_loc; txt = pld_name ^ "Set"}
               ~attrs:[Ast_attributes.bs_set]
               ~prim:[pld_name]
               (Typ.arrow "" core_type (Typ.arrow "" pld_type (Ast_literal.type_unit ()))) :: setter
-          | Immutable -> setter 
+          | Immutable -> setter
         ) label_declarations []
-    in 
+    in
 
-    newTdcl, 
-    (match tdcl.ptype_private with 
+    newTdcl,
+    (match tdcl.ptype_private with
      | Private -> setter_accessor
-     | Public -> 
-       let maker =   
-         Val.mk  {loc; txt = name}
+     | Public ->
+       let ty =
+         Ext_list.fold_right (fun (label_declaration : Parsetree.label_declaration) acc ->
+             Typ.arrow
+               label_declaration.pld_name.txt label_declaration.pld_type acc
+           ) label_declarations  core_type in
+       let maker =
+         Val.mk  {loc; txt = type_name}
            ~attrs:[Ast_attributes.bs_obj]
-           ~prim:[""] ty in 
+           ~prim:[""] ty in
        (maker :: setter_accessor))
 
-  | Ptype_abstract 
-  | Ptype_variant _ 
-  | Ptype_open -> 
+  | Ptype_abstract
+  | Ptype_variant _
+  | Ptype_open ->
     (* Looks obvious that it does not make sense to warn *)
     (* U.notApplicable tdcl.ptype_loc derivingName;  *)
     tdcl, []
 
-let handleTdclsInStr tdcls =     
-  let tdcls, code = 
-    List.fold_right (fun tdcl (tdcls, sts)  -> 
-        match handleTdcl tdcl with 
-          ntdcl, value_descriptions -> 
-          ntdcl::tdcls, 
+let handleTdclsInStr tdcls =
+  let tdcls, code =
+    List.fold_right (fun tdcl (tdcls, sts)  ->
+        match handleTdcl tdcl with
+          ntdcl, value_descriptions ->
+          ntdcl::tdcls,
           Ext_list.map_append (fun x -> Str.primitive x) value_descriptions sts
 
-      ) tdcls ([],[])  in 
-  Str.type_ tdcls :: code    
+      ) tdcls ([],[])  in
+  Str.type_ tdcls :: code
 (* still need perform transformation for non-abstract type*)
 
-let handleTdclsInSig tdcls =     
-  let tdcls, code = 
-    List.fold_right (fun tdcl (tdcls, sts)  -> 
-        match handleTdcl tdcl with 
-          ntdcl, value_descriptions -> 
-          ntdcl::tdcls, 
+let handleTdclsInSig tdcls =
+  let tdcls, code =
+    List.fold_right (fun tdcl (tdcls, sts)  ->
+        match handleTdcl tdcl with
+          ntdcl, value_descriptions ->
+          ntdcl::tdcls,
           Ext_list.map_append (fun x -> Sig.value x) value_descriptions sts
 
-      ) tdcls ([],[])  in 
-  Sig.type_ tdcls :: code  
+      ) tdcls ([],[])  in
+  Sig.type_ tdcls :: code
+
 end
 module Ast_tdcls : sig 
 #1 "ast_tdcls.mli"

--- a/lib/bsppx.ml
+++ b/lib/bsppx.ml
@@ -10241,7 +10241,7 @@ val bs_set : attr
 end = struct
 #1 "ast_attributes.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -10259,84 +10259,84 @@ end = struct
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 type attr =  Parsetree.attribute
-type t =  attr list 
+type t =  attr list
 
-type ('a,'b) st = 
-  { get : 'a option ; 
+type ('a,'b) st =
+  { get : 'a option ;
     set : 'b option }
 
 
-let process_method_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st,acc) (({txt ; loc}, payload) as attr : attr) -> 
+let process_method_attributes_rev (attrs : t) =
+  List.fold_left (fun (st,acc) (({txt ; loc}, payload) as attr : attr) ->
 
-      match txt  with 
+      match txt  with
       | "bs.get" (* [@@bs.get{null; undefined}]*)
-        -> 
-        let result = 
-          List.fold_left 
-            (fun 
+        ->
+        let result =
+          List.fold_left
+            (fun
               (null, undefined)
-              (({txt ; loc}, opt_expr) : Ast_payload.action) -> 
-              match txt with 
+              (({txt ; loc}, opt_expr) : Ast_payload.action) ->
+              match txt with
               | "null" ->
-                (match opt_expr with 
+                (match opt_expr with
                  | None -> true
-                 | Some e -> 
+                 | Some e ->
                    Ast_payload.assert_bool_lit e), undefined
 
               |  "undefined" ->
-                null, 
+                null,
                 (match opt_expr with
                  | None ->  true
-                 | Some e -> 
+                 | Some e ->
                    Ast_payload.assert_bool_lit e)
-              | "nullable" -> 
-                begin match opt_expr with 
-                  | None -> true, true 
+              | "nullable" ->
+                begin match opt_expr with
+                  | None -> true, true
                   | Some e ->
-                    let v = Ast_payload.assert_bool_lit e in 
+                    let v = Ast_payload.assert_bool_lit e in
                     v,v
                 end
               | _ -> Bs_syntaxerr.err loc Unsupported_predicates
-            ) (false, false) 
-            (Ast_payload.ident_or_record_as_config loc payload)  in 
+            ) (false, false)
+            (Ast_payload.ident_or_record_as_config loc payload)  in
 
         ({st with get = Some result}, acc  )
 
       | "bs.set"
-        -> 
-        let result = 
-          List.fold_left 
-            (fun st (({txt ; loc}, opt_expr) : Ast_payload.action) -> 
-               if txt =  "no_get" then 
-                 match opt_expr with 
-                 | None -> `No_get 
-                 | Some e -> 
-                   if Ast_payload.assert_bool_lit e then 
+        ->
+        let result =
+          List.fold_left
+            (fun st (({txt ; loc}, opt_expr) : Ast_payload.action) ->
+               if txt =  "no_get" then
+                 match opt_expr with
+                 | None -> `No_get
+                 | Some e ->
+                   if Ast_payload.assert_bool_lit e then
                      `No_get
                    else `Get
                else Bs_syntaxerr.err loc Unsupported_predicates
-            ) `Get (Ast_payload.ident_or_record_as_config loc payload)  in 
-        (* properties -- void 
+            ) `Get (Ast_payload.ident_or_record_as_config loc payload)  in
+        (* properties -- void
               [@@bs.set{only}]
         *)
         {st with set = Some result }, acc
-      | _ -> 
+      | _ ->
         (st, attr::acc  )
     ) ( {get = None ; set = None}, []) attrs
 
 
-let process_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
-      | "bs", (`Nothing | `Uncurry) 
-        -> 
+let process_attributes_rev (attrs : t) =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
+      | "bs", (`Nothing | `Uncurry)
+        ->
         `Uncurry, acc
       | "bs.this", (`Nothing | `Meth_callback)
         ->  `Meth_callback, acc
@@ -10345,34 +10345,34 @@ let process_attributes_rev (attrs : t) =
       | "bs", _
       | "bs.this", _
         -> Bs_syntaxerr.err loc Conflict_bs_bs_this_bs_meth
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_pexp_fun_attributes_rev (attrs : t) = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
-      | "bs.open", (`Nothing | `Exn) 
-        -> 
+let process_pexp_fun_attributes_rev (attrs : t) =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
+      | "bs.open", (`Nothing | `Exn)
+        ->
         `Exn, acc
 
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_bs attrs = 
-  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) -> 
-      match txt, st  with 
+let process_bs attrs =
+  List.fold_left (fun (st, acc) (({txt; loc}, _) as attr : attr) ->
+      match txt, st  with
       | "bs", _
-        -> 
+        ->
         `Has, acc
-      | _ , _ -> 
-        st, attr::acc 
+      | _ , _ ->
+        st, attr::acc
     ) ( `Nothing, []) attrs
 
-let process_external attrs = 
-  List.exists (fun (({txt; }, _)  : attr) -> 
-      if Ext_string.starts_with txt "bs." then true 
+let process_external attrs =
+  List.exists (fun (({txt; }, _)  : attr) ->
+      if Ext_string.starts_with txt "bs." then true
       else false
     ) attrs
 
@@ -10383,57 +10383,57 @@ type derive_attr = {
 }
 
 let process_derive_type attrs : derive_attr * t =
-  List.fold_left 
-    (fun (st, acc) 
+  List.fold_left
+    (fun (st, acc)
       (({txt ; loc}, payload  as attr): attr)  ->
       match  st, txt  with
       |  {bs_deriving = None}, "bs.deriving"
         ->
         {st with
          bs_deriving = Some
-             (Ast_payload.ident_or_record_as_config loc payload)}, acc 
+             (Ast_payload.ident_or_record_as_config loc payload)}, acc
       | {bs_deriving = Some _}, "bs.deriving"
-        -> 
+        ->
         Bs_syntaxerr.err loc Duplicated_bs_deriving
 
       | _ , _ ->
-        let st = 
-          if txt = "nonrec" then 
+        let st =
+          if txt = "nonrec" then
             { st with explict_nonrec = true }
-          else st in 
+          else st in
         st, attr::acc
     ) ( {explict_nonrec = false; bs_deriving = None }, []) attrs
 
 let iter_process_derive_type attrs =
-  let st = ref {explict_nonrec = false; bs_deriving = None } in 
+  let st = ref {explict_nonrec = false; bs_deriving = None } in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload  as attr): attr)  ->
       match  txt  with
       |  "bs.deriving"
         ->
-        let ost = !st in 
-        (match ost with 
-         | {bs_deriving = None } -> 
-           Bs_ast_invariant.mark_used_bs_attribute attr ; 
-           st := 
+        let ost = !st in
+        (match ost with
+         | {bs_deriving = None } ->
+           Bs_ast_invariant.mark_used_bs_attribute attr ;
+           st :=
              {ost with
               bs_deriving = Some
                   (Ast_payload.ident_or_record_as_config loc payload)}
-         | {bs_deriving = Some _} ->       
+         | {bs_deriving = Some _} ->
            Bs_syntaxerr.err loc Duplicated_bs_deriving)
 
       | "nonrec" ->
-        st :=         
+        st :=
           { !st with explict_nonrec = true }
-      (* non bs attribute, no need to mark its use *)  
+      (* non bs attribute, no need to mark its use *)
       | _ -> ()
     )  attrs;
-  !st 
+  !st
 
 
 let process_bs_string_int_unwrap_uncurry attrs =
-  List.fold_left 
+  List.fold_left
     (fun (st,attrs)
       (({txt ; loc}, (payload : _ ) ) as attr : attr)  ->
       match  txt, st  with
@@ -10447,84 +10447,84 @@ let process_bs_string_int_unwrap_uncurry attrs =
         -> `Unwrap, attrs
       | "bs.uncurry", `Nothing
         ->
-        `Uncurry (Ast_payload.is_single_int payload), attrs 
+        `Uncurry (Ast_payload.is_single_int payload), attrs
       (* Don't allow duplicated [bs.uncurry] since
          it may introduce inconsistency in arity
-      *)  
+      *)
       | "bs.int", _
       | "bs.string", _
       | "bs.ignore", _
       | "bs.unwrap", _
-        -> 
+        ->
         Bs_syntaxerr.err loc Conflict_attributes
       | _ , _ -> st, (attr :: attrs )
     ) (`Nothing, []) attrs
 
 
-let iter_process_bs_string_as  attrs = 
-  let st = ref None in 
-  List.iter 
-    (fun 
-      (({txt ; loc}, payload ) as attr : attr)  ->
-      match  txt with
-      | "bs.as"
-        ->
-        if !st = None then 
-          match Ast_payload.is_single_string payload with 
-          | None -> 
-            Bs_syntaxerr.err loc Expect_string_literal
-          | Some  (v,_dec) -> 
-            Bs_ast_invariant.mark_used_bs_attribute attr ; 
-            st:= Some v 
-        else 
-          Bs_syntaxerr.err loc Duplicated_bs_as 
-      | _  -> ()
-    ) attrs;
-  !st 
-
-let iter_process_bs_int_as  attrs = 
-  let st = ref None in 
+let iter_process_bs_string_as  (attrs : t) : string option =
+  let st = ref None in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload ) as attr : attr)  ->
       match  txt with
       | "bs.as"
         ->
-        if !st =  None then 
-          match Ast_payload.is_single_int payload with 
-          | None -> 
-            Bs_syntaxerr.err loc Expect_int_literal
-          | Some  _ as v->  
-            Bs_ast_invariant.mark_used_bs_attribute attr ; 
-            st := v
-        else 
+        if !st = None then
+          match Ast_payload.is_single_string payload with
+          | None ->
+            Bs_syntaxerr.err loc Expect_string_literal
+          | Some  (v,_dec) ->
+            Bs_ast_invariant.mark_used_bs_attribute attr ;
+            st:= Some v
+        else
           Bs_syntaxerr.err loc Duplicated_bs_as
       | _  -> ()
-    ) attrs; !st 
+    ) attrs;
+  !st
 
-
-let iter_process_bs_string_or_int_as attrs = 
-  let st = ref None in 
+let iter_process_bs_int_as  attrs =
+  let st = ref None in
   List.iter
-    (fun 
+    (fun
       (({txt ; loc}, payload ) as attr : attr)  ->
       match  txt with
       | "bs.as"
         ->
-        if !st = None then 
-          (Bs_ast_invariant.mark_used_bs_attribute attr ; 
-           match Ast_payload.is_single_int payload with 
-           | None -> 
-             begin match Ast_payload.is_single_string payload with 
-               | Some (s,None) -> 
-                 st := Some (`Str (s))                
-               | Some (s, Some "json") -> 
+        if !st =  None then
+          match Ast_payload.is_single_int payload with
+          | None ->
+            Bs_syntaxerr.err loc Expect_int_literal
+          | Some  _ as v->
+            Bs_ast_invariant.mark_used_bs_attribute attr ;
+            st := v
+        else
+          Bs_syntaxerr.err loc Duplicated_bs_as
+      | _  -> ()
+    ) attrs; !st
+
+
+let iter_process_bs_string_or_int_as attrs =
+  let st = ref None in
+  List.iter
+    (fun
+      (({txt ; loc}, payload ) as attr : attr)  ->
+      match  txt with
+      | "bs.as"
+        ->
+        if !st = None then
+          (Bs_ast_invariant.mark_used_bs_attribute attr ;
+           match Ast_payload.is_single_int payload with
+           | None ->
+             begin match Ast_payload.is_single_string payload with
+               | Some (s,None) ->
+                 st := Some (`Str (s))
+               | Some (s, Some "json") ->
                  st := Some (`Json_str s )
-               | None | Some (_, Some _) -> 
+               | None | Some (_, Some _) ->
                  Bs_syntaxerr.err loc Expect_int_or_string_or_json_literal
 
              end
-           | Some   v->  
+           | Some   v->
              st := (Some (`Int v))
           )
         else
@@ -10532,30 +10532,30 @@ let iter_process_bs_string_or_int_as attrs =
       | _ -> ()
 
     ) attrs;
-  !st 
+  !st
 
 let bs : attr
   =  {txt = "bs" ; loc = Location.none}, Ast_payload.empty
 
-let is_bs (attr : attr) =   
-  match attr with 
-  | {Location.txt = "bs"; _}, _ -> true 
+let is_bs (attr : attr) =
+  match attr with
+  | {Location.txt = "bs"; _}, _ -> true
   | _ -> false
 
 let bs_this : attr
   =  {txt = "bs.this" ; loc = Location.none}, Ast_payload.empty
 
-let bs_method : attr 
+let bs_method : attr
   =  {txt = "bs.meth"; loc = Location.none}, Ast_payload.empty
 
-let bs_obj : attr  
+let bs_obj : attr
   =  {txt = "bs.obj"; loc = Location.none}, Ast_payload.empty
 
-let bs_get : attr  
+let bs_get : attr
   =  {txt = "bs.get"; loc = Location.none}, Ast_payload.empty
 
 let bs_set : attr
-  =  {txt = "bs.set"; loc = Location.none}, Ast_payload.empty 
+  =  {txt = "bs.set"; loc = Location.none}, Ast_payload.empty
 
 
 end
@@ -13604,7 +13604,7 @@ end
 module External_ffi_types : sig 
 #1 "external_ffi_types.mli"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -13622,127 +13622,128 @@ module External_ffi_types : sig
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type module_bind_name = 
-  | Phint_name of string 
+type module_bind_name =
+  | Phint_name of string
   (* explicit hint name *)
   | Phint_nothing
 
-type external_module_name = 
-  { bundle : string ; 
+type external_module_name =
+  { bundle : string ;
     module_bind_name : module_bind_name
   }
 
-type pipe = bool 
-type js_call = { 
+type pipe = bool
+type js_call = {
   name : string;
   external_module_name : external_module_name option;
   splice : bool ;
-  scopes : string list 
+  scopes : string list
 }
 
-type js_send = { 
+type js_send = {
   name : string ;
-  splice : bool ; 
+  splice : bool ;
   pipe : pipe  ;
-  js_send_scopes : string list; 
+  js_send_scopes : string list;
 } (* we know it is a js send, but what will happen if you pass an ocaml objct *)
 
 type js_global_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   scopes : string list
 }
 
 type js_new_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   splice : bool ;
   scopes : string list;
 }
 
-type js_module_as_fn = 
+type js_module_as_fn =
   { external_module_name : external_module_name;
-    splice : bool 
+    splice : bool
   }
 
 type arg_type = External_arg_spec.attr
 
-type arg_label = External_arg_spec.label 
+type arg_label = External_arg_spec.label
 
 
 type obj_create = External_arg_spec.t list
 
-type js_get =  
+type js_get =
   { js_get_name : string   ;
     js_get_scopes :  string list;
   }
 
-type js_set = 
+type js_set =
   { js_set_name : string  ;
-    js_set_scopes : string list 
+    js_set_scopes : string list
   }
 
 
 type js_get_index =   {
-  js_get_index_scopes : string list 
+  js_get_index_scopes : string list
 }
 
 type js_set_index = {
-  js_set_index_scopes : string list 
-} 
+  js_set_index_scopes : string list
+}
 
 
 
-type attr  = 
-  | Js_global of js_global_val 
+type attr  =
+  | Js_global of js_global_val
   | Js_module_as_var of  external_module_name
   | Js_module_as_fn of js_module_as_fn
-  | Js_module_as_class of external_module_name             
-  | Js_call of js_call 
+  | Js_module_as_class of external_module_name
+  | Js_call of js_call
   | Js_send of js_send
   | Js_new of js_new_val
   | Js_set of js_set
   | Js_get of js_get
   | Js_get_index of js_get_index
-  | Js_set_index of js_set_index 
+  | Js_set_index of js_set_index
 
-type return_wrapper = 
-  | Return_unset 
+type return_wrapper =
+  | Return_unset
   | Return_identity
-  | Return_undefined_to_opt  
+  | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
   | Return_to_ocaml_bool
-  | Return_replaced_with_unit    
+  | Return_replaced_with_unit
 
-type t  = 
-  | Ffi_bs of 
+type t  =
+  | Ffi_bs of
       External_arg_spec.t list  *
-      return_wrapper * attr
+      return_wrapper *
+      attr
   | Ffi_obj_create of obj_create
-  | Ffi_normal 
+  | Ffi_normal
   (* When it's normal, it is handled as normal c functional ffi call *)
 
 
 val name_of_ffi : attr -> string
 
-val check_ffi : ?loc:Location.t ->  attr -> unit 
+val check_ffi : ?loc:Location.t ->  attr -> unit
 
-val to_string : t -> string 
+val to_string : t -> string
 
 (** Note *)
-val from_string : string -> t 
+val from_string : string -> t
 
 
 end = struct
 #1 "external_ffi_types.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -13760,76 +13761,76 @@ end = struct
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type module_bind_name = 
-  | Phint_name of string 
+type module_bind_name =
+  | Phint_name of string
     (* explicit hint name *)
 
   | Phint_nothing
-  
 
-type external_module_name = 
-  { bundle : string ; 
+
+type external_module_name =
+  { bundle : string ;
     module_bind_name : module_bind_name
   }
 
-type pipe = bool 
-type js_call = { 
+type pipe = bool
+type js_call = {
   name : string;
   external_module_name : external_module_name option;
   splice : bool ;
-  scopes : string list ; 
+  scopes : string list ;
 }
 
-type js_send = { 
+type js_send = {
   name : string ;
-  splice : bool ; 
+  splice : bool ;
   pipe : pipe   ;
-  js_send_scopes : string list; 
+  js_send_scopes : string list;
 } (* we know it is a js send, but what will happen if you pass an ocaml objct *)
 
 type js_global_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   scopes : string list ;
 }
 
 type js_new_val = {
-  name : string ; 
+  name : string ;
   external_module_name : external_module_name option;
   splice : bool ;
   scopes : string list;
 }
 
-type js_module_as_fn = 
+type js_module_as_fn =
   { external_module_name : external_module_name;
     splice : bool ;
 
   }
-type js_get =  
+type js_get =
   { js_get_name : string   ;
     js_get_scopes :  string list;
   }
 
-type js_set = 
+type js_set =
   { js_set_name : string  ;
-    js_set_scopes : string list 
+    js_set_scopes : string list
   }
 
 type js_get_index =   {
-  js_get_index_scopes : string list 
+  js_get_index_scopes : string list
 }
 
 type js_set_index = {
-  js_set_index_scopes : string list 
-}  
-(** TODO: information between [arg_type] and [arg_label] are duplicated, 
+  js_set_index_scopes : string list
+}
+(** TODO: information between [arg_type] and [arg_label] are duplicated,
   design a more compact representation so that it is also easy to seralize by hand
-*)  
+*)
 type arg_type = External_arg_spec.attr
 
 type arg_label = External_arg_spec.label
@@ -13838,55 +13839,55 @@ type arg_label = External_arg_spec.label
 (**TODO: maybe we can merge [arg_label] and [arg_type] *)
 type obj_create = External_arg_spec.t list
 
-type attr = 
-  | Js_global of js_global_val 
+type attr =
+  | Js_global of js_global_val
   | Js_module_as_var of  external_module_name
   | Js_module_as_fn of js_module_as_fn
-  | Js_module_as_class of external_module_name             
-  | Js_call of js_call 
+  | Js_module_as_class of external_module_name
+  | Js_call of js_call
   | Js_send of js_send
   | Js_new of js_new_val
   | Js_set of js_set
   | Js_get of js_get
   | Js_get_index of js_get_index
-  | Js_set_index of js_set_index 
+  | Js_set_index of js_set_index
 
 let name_of_ffi ffi =
-  match ffi with 
+  match ffi with
   | Js_get_index _scope -> "[@@bs.get_index ..]"
   | Js_set_index _scope -> "[@@bs.set_index ..]"
-  | Js_get { js_get_name = s} -> Printf.sprintf "[@@bs.get %S]" s 
-  | Js_set { js_set_name = s} -> Printf.sprintf "[@@bs.set %S]" s 
+  | Js_get { js_get_name = s} -> Printf.sprintf "[@@bs.get %S]" s
+  | Js_set { js_set_name = s} -> Printf.sprintf "[@@bs.set %S]" s
   | Js_call v  -> Printf.sprintf "[@@bs.val %S]" v.name
   | Js_send v  -> Printf.sprintf "[@@bs.send %S]" v.name
   | Js_module_as_fn v  -> Printf.sprintf "[@@bs.val %S]" v.external_module_name.bundle
-  | Js_new v  -> Printf.sprintf "[@@bs.new %S]" v.name                    
+  | Js_new v  -> Printf.sprintf "[@@bs.new %S]" v.name
   | Js_module_as_class v
     -> Printf.sprintf "[@@bs.module] %S " v.bundle
   | Js_module_as_var v
-    -> 
+    ->
     Printf.sprintf "[@@bs.module] %S " v.bundle
-  | Js_global v 
-    -> 
-    Printf.sprintf "[@@bs.val] %S " v.name                    
+  | Js_global v
+    ->
+    Printf.sprintf "[@@bs.val] %S " v.name
 
-type return_wrapper = 
-  | Return_unset 
+type return_wrapper =
+  | Return_unset
   | Return_identity
-  | Return_undefined_to_opt  
+  | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
   | Return_to_ocaml_bool
-  | Return_replaced_with_unit    
-type t  = 
+  | Return_replaced_with_unit
+type t  =
   | Ffi_bs of External_arg_spec.t list  *
-     return_wrapper * attr 
+     return_wrapper * attr
   (**  [Ffi_bs(args,return,attr) ]
-       [return] means return value is unit or not, 
-        [true] means is [unit]  
+       [return] means return value is unit or not,
+        [true] means is [unit]
   *)
   | Ffi_obj_create of obj_create
-  | Ffi_normal 
+  | Ffi_normal
   (* When it's normal, it is handled as normal c functional ffi call *)
 
 
@@ -13898,7 +13899,7 @@ let valid_js_char =
     ) in
   (fun c -> Array.unsafe_get a (Char.code c))
 
-let valid_first_js_char = 
+let valid_first_js_char =
   let a = Array.init 256 (fun i ->
       let c = Char.chr i in
       (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c = '_' || c = '$'
@@ -13913,10 +13914,10 @@ let valid_ident (s : string) =
    try
      for i = 1 to len - 1 do
        if not (valid_js_char (String.unsafe_get s i)) then
-         raise E.E         
+         raise E.E
      done ;
-     true     
-   with E.E -> false )  
+     true
+   with E.E -> false )
 
 let valid_global_name ?loc txt =
   if not (valid_ident txt) then
@@ -13925,30 +13926,36 @@ let valid_global_name ?loc txt =
       (fun s ->
          if not (valid_ident s) then
            Location.raise_errorf ?loc "Not a valid global name %s"  txt
-      ) v      
+      ) v
 
-let valid_method_name ?loc txt =         
-  if not (valid_ident txt) then
-    Location.raise_errorf ?loc "Not a valid method name %s"  txt
+(*
+  We loose such check (see #2583),
+  it 
+*)
+
+let valid_method_name ?loc txt =
+    ()
+  (* if not (valid_ident txt) then
+    Location.raise_errorf ?loc "Not a valid method name %s"  txt *)
 
 
 
-let check_external_module_name ?loc x = 
-  match x with 
-  | {bundle = ""; _ } 
-  | { module_bind_name = Phint_name "" } -> 
+let check_external_module_name ?loc x =
+  match x with
+  | {bundle = ""; _ }
+  | { module_bind_name = Phint_name "" } ->
     Location.raise_errorf ?loc "empty name encountered"
   | _ -> ()
-let check_external_module_name_opt ?loc x = 
-  match x with 
+let check_external_module_name_opt ?loc x =
+  match x with
   | None -> ()
-  | Some v -> check_external_module_name ?loc v 
+  | Some v -> check_external_module_name ?loc v
 
 
-let check_ffi ?loc ffi = 
-  match ffi with 
+let check_ffi ?loc ffi =
+  match ffi with
   | Js_global {name} -> valid_global_name ?loc  name
-  | Js_send {name } 
+  | Js_send {name }
   | Js_set  {js_set_name = name}
   | Js_get { js_get_name = name}
     ->  valid_method_name ?loc name
@@ -13958,47 +13965,47 @@ let check_ffi ?loc ffi =
 
   | Js_module_as_var external_module_name
   | Js_module_as_fn {external_module_name; _}
-  | Js_module_as_class external_module_name             
+  | Js_module_as_class external_module_name
     -> check_external_module_name external_module_name
   | Js_new {external_module_name ;  name}
   | Js_call {external_module_name ;  name ; _}
-    -> 
+    ->
     check_external_module_name_opt ?loc external_module_name ;
-    valid_global_name ?loc name     
+    valid_global_name ?loc name
 
 let bs_prefix = "BS:"
-let bs_prefix_length = String.length bs_prefix 
+let bs_prefix_length = String.length bs_prefix
 
 
 (** TODO: Make sure each version is not prefix of each other
     Solution:
-    1. fixed length 
+    1. fixed length
     2. non-prefix approach
 *)
-let bs_external = bs_prefix ^ Bs_version.version 
+let bs_external = bs_prefix ^ Bs_version.version
 
 
 let bs_external_length = String.length bs_external
 
 
-let to_string  t = 
+let to_string  t =
   bs_external ^ Marshal.to_string t []
 
 
 (* TODO:  better error message when version mismatch *)
-let from_string s : t = 
-  let s_len = String.length s in 
+let from_string s : t =
+  let s_len = String.length s in
   if s_len >= bs_prefix_length &&
      String.unsafe_get s 0 = 'B' &&
      String.unsafe_get s 1 = 'S' &&
-     String.unsafe_get s 2 = ':' then 
-    if Ext_string.starts_with s bs_external then 
-      Marshal.from_string s bs_external_length 
-    else 
-      Ext_pervasives.failwithf 
+     String.unsafe_get s 2 = ':' then
+    if Ext_string.starts_with s bs_external then
+      Marshal.from_string s bs_external_length
+    else
+      Ext_pervasives.failwithf
         ~loc:__LOC__
         "Compiler version mismatch. The project might have been built with one version of BuckleScript, and then with another. Please wipe the artifacts and do a clean build."
-  else Ffi_normal    
+  else Ffi_normal
 
 end
 module Bs_hash_stubs
@@ -14399,7 +14406,7 @@ val pval_prim_of_labels : string Asttypes.loc list -> string list
 end = struct
 #1 "external_process.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -14417,7 +14424,7 @@ end = struct
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -14428,7 +14435,7 @@ end = struct
 
 
 let variant_can_bs_unwrap_fields row_fields =
-  let validity = 
+  let validity =
     List.fold_left
       begin fun st row ->
         match st, row with
@@ -14452,7 +14459,7 @@ let variant_can_bs_unwrap_fields row_fields =
 
 
 (** Given the type of argument, process its [bs.] attribute and new type,
-    The new type is currently used to reconstruct the external type 
+    The new type is currently used to reconstruct the external type
     and result type in [@@bs.obj]
     They are not the same though, for example
     {[
@@ -14460,96 +14467,96 @@ let variant_can_bs_unwrap_fields row_fields =
     ]}
     The result type would be [ hi:string ]
 *)
-let get_arg_type ~nolabel optional 
-    (ptyp : Ast_core_type.t) : 
-  External_arg_spec.attr * Ast_core_type.t  = 
-  let ptyp = if optional then Ast_core_type.extract_option_type_exn ptyp else ptyp in 
+let get_arg_type ~nolabel optional
+    (ptyp : Ast_core_type.t) :
+  External_arg_spec.attr * Ast_core_type.t  =
+  let ptyp = if optional then Ast_core_type.extract_option_type_exn ptyp else ptyp in
   if Ast_core_type.is_any ptyp then (* (_[@bs.as ])*)
-    if optional then 
+    if optional then
       Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
     else begin
-      let ptyp_attrs = 
-        ptyp.Parsetree.ptyp_attributes 
-      in   
-      let result = 
+      let ptyp_attrs =
+        ptyp.Parsetree.ptyp_attributes
+      in
+      let result =
         Ast_attributes.iter_process_bs_string_or_int_as ptyp_attrs
-      in   
+      in
       (* when ppx start dropping attributes
         we should warn, there is a trade off whether
         we should warn dropped non bs attribute or not
-      *) 
-      Bs_ast_invariant.warn_unused_attributes ptyp_attrs; 
-      match result with 
-      |  None -> 
+      *)
+      Bs_ast_invariant.warn_unused_attributes ptyp_attrs;
+      match result with
+      |  None ->
         Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
 
-      | Some (`Int i) -> 
-        Arg_cst(External_arg_spec.cst_int i), Ast_literal.type_int ~loc:ptyp.ptyp_loc ()  
-      | Some (`Str i)-> 
-        Arg_cst (External_arg_spec.cst_string i), Ast_literal.type_string ~loc:ptyp.ptyp_loc () 
+      | Some (`Int i) ->
+        Arg_cst(External_arg_spec.cst_int i), Ast_literal.type_int ~loc:ptyp.ptyp_loc ()
+      | Some (`Str i)->
+        Arg_cst (External_arg_spec.cst_string i), Ast_literal.type_string ~loc:ptyp.ptyp_loc ()
       | Some (`Json_str s) ->
         Arg_cst (External_arg_spec.cst_json ptyp.ptyp_loc s),
-        Ast_literal.type_string ~loc:ptyp.ptyp_loc () 
+        Ast_literal.type_string ~loc:ptyp.ptyp_loc ()
 
-    end 
+    end
   else (* ([`a|`b] [@bs.string]) *)
-    let ptyp_desc = ptyp.ptyp_desc in 
+    let ptyp_desc = ptyp.ptyp_desc in
     match Ast_attributes.process_bs_string_int_unwrap_uncurry ptyp.ptyp_attributes with
     | (`String, ptyp_attributes)
-      -> 
-      begin match ptyp_desc with 
+      ->
+      begin match ptyp_desc with
         | Ptyp_variant ( row_fields, Closed, None)
           ->
-          let attr = 
-            Ast_polyvar.map_row_fields_into_strings ptyp.ptyp_loc row_fields in 
-          attr, 
+          let attr =
+            Ast_polyvar.map_row_fields_into_strings ptyp.ptyp_loc row_fields in
+          attr,
           {ptyp with
-           ptyp_attributes 
+           ptyp_attributes
           }
         | _ ->
           Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
-      end 
-    | (`Ignore, ptyp_attributes)  -> 
+      end
+    | (`Ignore, ptyp_attributes)  ->
       (Ignore, {ptyp with ptyp_attributes})
-    | (`Int , ptyp_attributes) -> 
-      begin match ptyp_desc with 
-        | Ptyp_variant ( row_fields, Closed, None) -> 
-          let int_lists = 
-            Ast_polyvar.map_row_fields_into_ints ptyp.ptyp_loc row_fields in 
+    | (`Int , ptyp_attributes) ->
+      begin match ptyp_desc with
+        | Ptyp_variant ( row_fields, Closed, None) ->
+          let int_lists =
+            Ast_polyvar.map_row_fields_into_ints ptyp.ptyp_loc row_fields in
           Int int_lists ,
-          {ptyp with            
+          {ptyp with
            ptyp_attributes
           }
-        | _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type   
+        | _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
       end
-    | (`Unwrap, ptyp_attributes) -> 
+    | (`Unwrap, ptyp_attributes) ->
 
-      begin match ptyp_desc with 
+      begin match ptyp_desc with
         | (Ptyp_variant (row_fields, Closed, _) as ptyp_desc)
           when variant_can_bs_unwrap_fields row_fields ->
           Unwrap, {ptyp with ptyp_desc; ptyp_attributes}
         | _ ->
           Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_unwrap_type
-      end 
-    | (`Uncurry opt_arity, ptyp_attributes) -> 
-      let real_arity =  Ast_core_type.get_uncurry_arity ptyp in 
-      (begin match opt_arity, real_arity with 
-         | Some arity, `Not_function -> 
-           Fn_uncurry_arity arity 
+      end
+    | (`Uncurry opt_arity, ptyp_attributes) ->
+      let real_arity =  Ast_core_type.get_uncurry_arity ptyp in
+      (begin match opt_arity, real_arity with
+         | Some arity, `Not_function ->
+           Fn_uncurry_arity arity
          | None, `Not_function  ->
            Bs_syntaxerr.err ptyp.ptyp_loc Canot_infer_arity_by_syntax
-         | None, `Arity arity  ->         
+         | None, `Arity arity  ->
            Fn_uncurry_arity arity
-         | Some arity, `Arity n -> 
+         | Some arity, `Arity n ->
            if n <> arity then
              Bs_syntaxerr.err ptyp.ptyp_loc (Inconsistent_arity (arity,n))
-           else Fn_uncurry_arity arity 
+           else Fn_uncurry_arity arity
 
        end, {ptyp with ptyp_attributes})
     | (`Nothing, ptyp_attributes) ->
       begin match ptyp_desc with
         | Ptyp_constr ({txt = Lident "bool"; _}, [])
-          -> 
+          ->
           Bs_warnings.prerr_bs_ffi_warning ptyp.ptyp_loc Unsafe_ffi_bool_type;
           Nothing
         | Ptyp_constr ({txt = Lident "unit"; _}, [])
@@ -14558,38 +14565,38 @@ let get_arg_type ~nolabel optional
           -> Array
         | Ptyp_variant _ ->
           Bs_warnings.prerr_bs_ffi_warning ptyp.ptyp_loc Unsafe_poly_variant_type;
-          Nothing           
+          Nothing
         | _ ->
-          Nothing           
+          Nothing
       end, ptyp
 
 
 
-(** 
+(**
    [@@bs.module "react"]
    [@@bs.module "react"]
    ---
    [@@bs.module "@" "react"]
    [@@bs.module "@" "react"]
 
-   They should have the same module name 
+   They should have the same module name
 
-   TODO: we should emit an warning if we bind 
+   TODO: we should emit an warning if we bind
    two external files to the same module name
 *)
 type bundle_source =
   [`Nm_payload of string (* from payload [@@bs.val "xx" ]*)
   |`Nm_external of string (* from "" in external *)
-  | `Nm_val of string   (* from function name *)   
-  ]  
+  | `Nm_val of string   (* from function name *)
+  ]
 
 let string_of_bundle_source (x : bundle_source) =
   match x with
   | `Nm_payload x
   | `Nm_external x
-  | `Nm_val x -> x   
+  | `Nm_val x -> x
 type name_source =
-  [ bundle_source  
+  [ bundle_source
   | `Nm_na
 
   ]
@@ -14597,14 +14604,14 @@ type name_source =
 
 
 
-type st = 
+type st =
   { val_name : name_source;
     external_module_name : External_ffi_types.external_module_name option;
     module_as_val : External_ffi_types.external_module_name option;
     val_send : name_source ;
-    val_send_pipe : Ast_core_type.t option;    
+    val_send_pipe : Ast_core_type.t option;
     splice : bool ; (* mutable *)
-    scopes : string list ; 
+    scopes : string list ;
     set_index : bool; (* mutable *)
     get_index : bool;
     new_name : name_source ;
@@ -14617,13 +14624,13 @@ type st =
 
   }
 
-let init_st = 
+let init_st =
   {
-    val_name = `Nm_na; 
+    val_name = `Nm_na;
     external_module_name = None ;
     module_as_val = None;
     val_send = `Nm_na;
-    val_send_pipe = None;    
+    val_send_pipe = None;
     splice = false;
     scopes = [];
     set_index = false;
@@ -14632,8 +14639,8 @@ let init_st =
     call_name = `Nm_na;
     set_name = `Nm_na ;
     get_name = `Nm_na ;
-    mk_obj = false ; 
-    return_wrapper = Return_unset; 
+    mk_obj = false ;
+    return_wrapper = Return_unset;
 
   }
 
@@ -14641,52 +14648,52 @@ let init_st =
 
 
 
-let process_external_attributes 
-    no_arguments 
+let process_external_attributes
+    no_arguments
     (prim_name_or_pval_prim: [< bundle_source ] as 'a)
     pval_prim
     (prim_attributes : Ast_attributes.t) : _ * Ast_attributes.t =
 
-  (* shared by `[@@bs.val]`, `[@@bs.send]`, 
-     `[@@bs.set]`, `[@@bs.get]` , `[@@bs.new]` 
-     `[@@bs.send.pipe]` does not use it 
+  (* shared by `[@@bs.val]`, `[@@bs.send]`,
+     `[@@bs.set]`, `[@@bs.get]` , `[@@bs.new]`
+     `[@@bs.send.pipe]` does not use it
   *)
   let name_from_payload_or_prim ~loc (payload : Parsetree.payload) : name_source =
-    match payload with 
-    | PStr [] -> 
-      (prim_name_or_pval_prim :> name_source)  
+    match payload with
+    | PStr [] ->
+      (prim_name_or_pval_prim :> name_source)
     (* It is okay to have [@@bs.val] without payload *)
-    | _ -> 
+    | _ ->
       begin match Ast_payload.is_single_string payload with
         | Some  (val_name, _) ->  `Nm_payload val_name
-        | None ->  
+        | None ->
           Location.raise_errorf ~loc "Invalid payload"
       end
 
   in
-  List.fold_left 
+  List.fold_left
     (fun (st, attrs)
-      (({txt ; loc}, payload) as attr : Ast_attributes.attr) 
+      (({txt ; loc}, payload) as attr : Ast_attributes.attr)
       ->
         if Ext_string.starts_with txt "bs." then
-          begin match txt with 
-            | "bs.val" ->  
+          begin match txt with
+            | "bs.val" ->
               if no_arguments then
                 {st with val_name = name_from_payload_or_prim ~loc payload}
-              else 
+              else
                 {st with call_name = name_from_payload_or_prim ~loc  payload}
 
-            | "bs.module" -> 
-              begin match Ast_payload.assert_strings loc payload with 
+            | "bs.module" ->
+              begin match Ast_payload.assert_strings loc payload with
                 | [bundle] ->
                   {st with external_module_name =
                              Some {bundle; module_bind_name = Phint_nothing}}
-                | [bundle;bind_name] -> 
+                | [bundle;bind_name] ->
                   {st with external_module_name =
                              Some {bundle; module_bind_name = Phint_name bind_name}}
                 | [] ->
                   { st with
-                    module_as_val = 
+                    module_as_val =
                       Some
                         { bundle =
                             string_of_bundle_source
@@ -14697,21 +14704,21 @@ let process_external_attributes
                   Bs_syntaxerr.err loc Illegal_attribute
               end
             | "bs.scope" ->
-              begin match Ast_payload.assert_strings loc payload with 
-                | [] -> 
-                  Bs_syntaxerr.err loc Illegal_attribute 
-                (* We need err on empty scope, so we can tell the difference 
+              begin match Ast_payload.assert_strings loc payload with
+                | [] ->
+                  Bs_syntaxerr.err loc Illegal_attribute
+                (* We need err on empty scope, so we can tell the difference
                    between unset/set
                 *)
                 | scopes ->  { st with scopes = scopes }
               end
             | "bs.splice" -> {st with splice = true}
-            | "bs.send" -> 
+            | "bs.send" ->
               { st with val_send = name_from_payload_or_prim ~loc payload}
             | "bs.send.pipe"
               ->
-              { st with val_send_pipe = Some (Ast_payload.as_core_type loc payload)}                
-            | "bs.set" -> 
+              { st with val_send_pipe = Some (Ast_payload.as_core_type loc payload)}
+            | "bs.set" ->
               {st with set_name = name_from_payload_or_prim ~loc  payload}
             | "bs.get" -> {st with get_name = name_from_payload_or_prim ~loc payload}
 
@@ -14720,21 +14727,21 @@ let process_external_attributes
             | "bs.get_index"-> {st with get_index = true}
             | "bs.obj" -> {st with mk_obj = true}
             | "bs.return" ->
-              let aux loc txt : External_ffi_types.return_wrapper = 
-                begin match txt with 
+              let aux loc txt : External_ffi_types.return_wrapper =
+                begin match txt with
                   | "undefined_to_opt" -> Return_undefined_to_opt
                   | "null_to_opt" -> Return_null_to_opt
                   | "nullable"
                   | "null_undefined_to_opt" -> Return_null_undefined_to_opt
-                  | "identity" -> Return_identity 
+                  | "identity" -> Return_identity
                   | _ ->
                     Bs_syntaxerr.err loc Not_supported_directive_in_bs_return
                 end in
-              let actions = 
-                Ast_payload.ident_or_record_as_config loc payload 
+              let actions =
+                Ast_payload.ident_or_record_as_config loc payload
               in
-              begin match actions with 
-                | [ ({txt; _ },None) ] -> 
+              begin match actions with
+                | [ ({txt; _ },None) ] ->
                   { st with return_wrapper = aux loc txt}
                 | _ ->
                   Bs_syntaxerr.err loc Not_supported_directive_in_bs_return
@@ -14743,212 +14750,212 @@ let process_external_attributes
           end, attrs
         else (st , attr :: attrs)
     )
-    (init_st, []) prim_attributes 
+    (init_st, []) prim_attributes
 
 
-let rec has_bs_uncurry (attrs : Ast_attributes.t) = 
-  match attrs with 
-  | ({txt = "bs.uncurry"; _ }, _) :: attrs -> 
-    true 
-  | _ :: attrs -> has_bs_uncurry attrs 
-  | [] -> false 
+let rec has_bs_uncurry (attrs : Ast_attributes.t) =
+  match attrs with
+  | ({txt = "bs.uncurry"; _ }, _) :: attrs ->
+    true
+  | _ :: attrs -> has_bs_uncurry attrs
+  | [] -> false
 
 
-let check_return_wrapper 
-    loc (wrapper : External_ffi_types.return_wrapper) 
-    result_type = 
-  match wrapper with 
+let check_return_wrapper
+    loc (wrapper : External_ffi_types.return_wrapper)
+    result_type =
+  match wrapper with
   | Return_identity -> wrapper
-  | Return_unset  ->         
-    if Ast_core_type.is_unit result_type then 
-      Return_replaced_with_unit 
-    else if Ast_core_type.is_user_bool result_type then 
+  | Return_unset  ->
+    if Ast_core_type.is_unit result_type then
+      Return_replaced_with_unit
+    else if Ast_core_type.is_user_bool result_type then
       Return_to_ocaml_bool
-    else 
+    else
       wrapper
   | Return_undefined_to_opt
-  | Return_null_to_opt 
-  | Return_null_undefined_to_opt  
-    -> 
-    if Ast_core_type.is_user_option result_type then 
+  | Return_null_to_opt
+  | Return_null_undefined_to_opt
+    ->
+    if Ast_core_type.is_user_option result_type then
       wrapper
     else
       Bs_syntaxerr.err loc Expect_opt_in_bs_return_to_opt
-  | Return_replaced_with_unit 
-  | Return_to_ocaml_bool  -> 
+  | Return_replaced_with_unit
+  | Return_to_ocaml_bool  ->
     assert false (* Not going to happen from user input*)
 
 
 
 
-(** Note that the passed [type_annotation] is already processed by visitor pattern before 
+(** Note that the passed [type_annotation] is already processed by visitor pattern before
 *)
-let handle_attributes 
+let handle_attributes
     (loc : Bs_loc.t)
-    (pval_prim : string ) 
+    (pval_prim : string )
     (type_annotation : Parsetree.core_type)
     (prim_attributes : Ast_attributes.t) (prim_name : string)
   : Ast_core_type.t * string * External_ffi_types.t * Ast_attributes.t =
-  (** sanity check here 
+  (** sanity check here
       {[ int -> int -> (int -> int -> int [@bs.uncurry])]}
-      It does not make sense 
+      It does not make sense
   *)
-  if has_bs_uncurry type_annotation.Parsetree.ptyp_attributes then 
-    begin 
-      Location.raise_errorf 
+  if has_bs_uncurry type_annotation.Parsetree.ptyp_attributes then
+    begin
+      Location.raise_errorf
         ~loc "[@@bs.uncurry] can not be applied to the whole definition"
-    end; 
+    end;
 
   let prim_name_or_pval_prim =
     if String.length prim_name = 0 then  `Nm_val pval_prim
     else  `Nm_external prim_name  (* need check name *)
-  in    
+  in
   let result_type, arg_types_ty =
     Ast_core_type.list_of_arrow type_annotation in
-  if has_bs_uncurry result_type.ptyp_attributes then 
-    begin 
-      Location.raise_errorf 
+  if has_bs_uncurry result_type.ptyp_attributes then
+    begin
+      Location.raise_errorf
         ~loc:result_type.ptyp_loc
         "[@@bs.uncurry] can not be applied to tailed position"
     end ;
-  let (st, left_attrs) = 
-    process_external_attributes 
+  let (st, left_attrs) =
+    process_external_attributes
       (arg_types_ty = [])
-      prim_name_or_pval_prim pval_prim prim_attributes in 
+      prim_name_or_pval_prim pval_prim prim_attributes in
 
 
-  if st.mk_obj then 
-    begin match st with 
+  if st.mk_obj then
+    begin match st with
       | {
-        val_name = `Nm_na; 
+        val_name = `Nm_na;
         external_module_name = None ;
         module_as_val = None;
         val_send = `Nm_na;
-        val_send_pipe = None;    
+        val_send_pipe = None;
         splice = false;
         new_name = `Nm_na;
         call_name = `Nm_na;
         set_name = `Nm_na ;
         get_name = `Nm_na ;
         get_index = false ;
-        return_wrapper = Return_unset ;        
-        set_index = false ; 
-        mk_obj = _; 
+        return_wrapper = Return_unset ;
+        set_index = false ;
+        mk_obj = _;
         scopes = [];
         (* wrapper does not work with [bs.obj]
            TODO: better error message *)
-      } -> 
-        if String.length prim_name <> 0 then 
+      } ->
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.obj] expect external names to be empty string";
-        let arg_kinds, new_arg_types_ty, result_types = 
-          Ext_list.fold_right 
-            (fun (label,ty,attr,loc) ( arg_labels, arg_types, result_types) -> 
-               let arg_label = Ast_core_type.label_name label in 
-               let new_arg_label, new_arg_types,  output_tys = 
-                 match arg_label with 
-                 | Empty -> 
-                   let arg_type, new_ty = get_arg_type ~nolabel:true false ty in 
-                   begin match arg_type with 
-                     | Extern_unit ->  
+        let arg_kinds, new_arg_types_ty, result_types =
+          Ext_list.fold_right
+            (fun (label,ty,attr,loc) ( arg_labels, arg_types, result_types) ->
+               let arg_label = Ast_core_type.label_name label in
+               let new_arg_label, new_arg_types,  output_tys =
+                 match arg_label with
+                 | Empty ->
+                   let arg_type, new_ty = get_arg_type ~nolabel:true false ty in
+                   begin match arg_type with
+                     | Extern_unit ->
                        External_arg_spec.empty_kind arg_type, (label,new_ty,attr,loc)::arg_types, result_types
-                     | _ ->  
+                     | _ ->
                        Location.raise_errorf ~loc "expect label, optional, or unit here"
-                   end 
-                 | Label name -> 
-                   let arg_type, new_ty = get_arg_type ~nolabel:false false ty in 
-                   begin match arg_type with 
-                     | Ignore -> 
-                       External_arg_spec.empty_kind arg_type, 
+                   end
+                 | Label name ->
+                   let arg_type, new_ty = get_arg_type ~nolabel:false false ty in
+                   begin match arg_type with
+                     | Ignore ->
+                       External_arg_spec.empty_kind arg_type,
                        (label,new_ty,attr,loc)::arg_types, result_types
-                     | Arg_cst  i  -> 
+                     | Arg_cst  i  ->
                        let s = (Lam_methname.translate ~loc name) in
                        {arg_label = External_arg_spec.label s (Some i);
-                        arg_type }, 
+                        arg_type },
                        arg_types, (* ignored in [arg_types], reserved in [result_types] *)
                        ((name , [], new_ty) :: result_types)
-                     | Nothing | Array -> 
+                     | Nothing | Array ->
                        let s = (Lam_methname.translate ~loc name) in
                        {arg_label = External_arg_spec.label s None ; arg_type },
-                       (label,new_ty,attr,loc)::arg_types, 
+                       (label,new_ty,attr,loc)::arg_types,
                        ((name , [], new_ty) :: result_types)
-                     | Int _  -> 
+                     | Int _  ->
                        let s = Lam_methname.translate ~loc name in
                        {arg_label = External_arg_spec.label s None; arg_type},
-                       (label,new_ty,attr,loc)::arg_types, 
-                       ((name, [], Ast_literal.type_int ~loc ()) :: result_types)  
-                     | NullString _ -> 
+                       (label,new_ty,attr,loc)::arg_types,
+                       ((name, [], Ast_literal.type_int ~loc ()) :: result_types)
+                     | NullString _ ->
                        let s = Lam_methname.translate ~loc name in
-                       {arg_label = External_arg_spec.label s None; arg_type}, 
-                       (label,new_ty,attr,loc)::arg_types, 
-                       ((name, [], Ast_literal.type_string ~loc ()) :: result_types)  
-                     | Fn_uncurry_arity _ -> 
+                       {arg_label = External_arg_spec.label s None; arg_type},
+                       (label,new_ty,attr,loc)::arg_types,
+                       ((name, [], Ast_literal.type_string ~loc ()) :: result_types)
+                     | Fn_uncurry_arity _ ->
                        Location.raise_errorf ~loc
                          "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"
-                     | Extern_unit -> assert false 
-                     | NonNullString _ 
-                       ->  
-                       Location.raise_errorf ~loc 
+                     | Extern_unit -> assert false
+                     | NonNullString _
+                       ->
+                       Location.raise_errorf ~loc
                          "bs.obj label %s does not support such arg type" name
                      | Unwrap ->
                        Location.raise_errorf ~loc
                          "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
-                 | Optional name -> 
-                   let arg_type, new_ty_extract = get_arg_type ~nolabel:false true ty in 
-                   let new_ty = Ast_core_type.lift_option_type new_ty_extract in 
-                   begin match arg_type with 
-                     | Ignore -> 
-                       External_arg_spec.empty_kind arg_type, 
+                 | Optional name ->
+                   let arg_type, new_ty_extract = get_arg_type ~nolabel:false true ty in
+                   let new_ty = Ast_core_type.lift_option_type new_ty_extract in
+                   begin match arg_type with
+                     | Ignore ->
+                       External_arg_spec.empty_kind arg_type,
                        (label,new_ty,attr,loc)::arg_types, result_types
 
-                     | Nothing | Array -> 
-                       let s = (Lam_methname.translate ~loc name) in 
-                       {arg_label = External_arg_spec.optional s; arg_type}, 
-                       (label,new_ty,attr,loc)::arg_types, 
+                     | Nothing | Array ->
+                       let s = (Lam_methname.translate ~loc name) in
+                       {arg_label = External_arg_spec.optional s; arg_type},
+                       (label,new_ty,attr,loc)::arg_types,
                        ( (name, [], Ast_comb.to_undefined_type loc new_ty_extract) ::  result_types)
-                     | Int _  -> 
-                       let s = Lam_methname.translate ~loc name in 
+                     | Int _  ->
+                       let s = Lam_methname.translate ~loc name in
                        {arg_label = External_arg_spec.optional s ; arg_type },
                        (label,new_ty,attr,loc)::arg_types,
-                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_int ~loc ()) :: result_types)                      
-                     | NullString _  -> 
-                       let s = Lam_methname.translate ~loc name in 
-                       {arg_label = External_arg_spec.optional s ; arg_type }, 
+                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_int ~loc ()) :: result_types)
+                     | NullString _  ->
+                       let s = Lam_methname.translate ~loc name in
+                       {arg_label = External_arg_spec.optional s ; arg_type },
                        (label,new_ty,attr,loc)::arg_types,
-                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_string ~loc ()) :: result_types)                      
-                     | Arg_cst _   
-                       -> 
+                       ((name, [], Ast_comb.to_undefined_type loc @@ Ast_literal.type_string ~loc ()) :: result_types)
+                     | Arg_cst _
+                       ->
                        Location.raise_errorf ~loc "bs.as is not supported with optional yet"
-                     | Fn_uncurry_arity _ -> 
+                     | Fn_uncurry_arity _ ->
                        Location.raise_errorf ~loc
-                         "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"                      
-                     | Extern_unit   -> assert false                      
-                     | NonNullString _ 
-                       ->  
+                         "The combination of [@@bs.obj], [@@bs.uncurry] is not supported yet"
+                     | Extern_unit   -> assert false
+                     | NonNullString _
+                       ->
                        Location.raise_errorf ~loc
-                         "bs.obj label %s does not support such arg type" name                        
+                         "bs.obj label %s does not support such arg type" name
                      | Unwrap ->
                        Location.raise_errorf ~loc
                          "bs.obj label %s does not support [@bs.unwrap] arguments" name
                    end
-               in     
+               in
                (
                  new_arg_label::arg_labels,
                  new_arg_types,
-                 output_tys)) arg_types_ty 
-            ( [], [], []) in 
+                 output_tys)) arg_types_ty
+            ( [], [], []) in
 
-        let result = 
-          if Ast_core_type.is_any  result_type then            
-            Ast_core_type.make_obj ~loc result_types 
-          else           
-            snd @@ get_arg_type ~nolabel:true false result_type (* result type can not be labeled *)            
+        let result =
+          if Ast_core_type.is_any  result_type then
+            Ast_core_type.make_obj ~loc result_types
+          else
+            snd @@ get_arg_type ~nolabel:true false result_type (* result type can not be labeled *)
 
         in
-        begin 
-          (             
-            Ext_list.fold_right (fun (label,ty,attrs,loc) acc -> 
-                Ast_helper.Typ.arrow ~loc  ~attrs label ty acc 
+        begin
+          (
+            Ext_list.fold_right (fun (label,ty,attrs,loc) acc ->
+                Ast_helper.Typ.arrow ~loc  ~attrs label ty acc
               ) new_arg_types_ty result
           ) ,
           prim_name,
@@ -14956,64 +14963,64 @@ let handle_attributes
           left_attrs
         end
 
-      | _ -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.obj]"  
+      | _ -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.obj]"
 
-    end  
+    end
 
-  else   
-    let splice = st.splice in 
-    let arg_type_specs, new_arg_types_ty, arg_type_specs_length   = 
-      Ext_list.fold_right 
-        (fun (label,ty,attr,loc) (arg_type_specs, arg_types, i) -> 
-           let arg_label = Ast_core_type.label_name label in 
-           let arg_label, arg_type, new_arg_types = 
-             match arg_label with 
-             | Optional s  -> 
+  else
+    let splice = st.splice in
+    let arg_type_specs, new_arg_types_ty, arg_type_specs_length   =
+      Ext_list.fold_right
+        (fun (label,ty,attr,loc) (arg_type_specs, arg_types, i) ->
+           let arg_label = Ast_core_type.label_name label in
+           let arg_label, arg_type, new_arg_types =
+             match arg_label with
+             | Optional s  ->
 
-               let arg_type , new_ty = get_arg_type ~nolabel:false true ty in 
-               begin match arg_type with 
-                 | NonNullString _ -> 
+               let arg_type , new_ty = get_arg_type ~nolabel:false true ty in
+               begin match arg_type with
+                 | NonNullString _ ->
                    (* ?x:([`x of int ] [@bs.string]) does not make sense *)
-                   Location.raise_errorf 
+                   Location.raise_errorf
                      ~loc
                      "[@@bs.string] does not work with optional when it has arities in label %s" label
-                 | _ -> 
-                   External_arg_spec.optional s, arg_type, 
+                 | _ ->
+                   External_arg_spec.optional s, arg_type,
                    ((label, Ast_core_type.lift_option_type new_ty , attr,loc) :: arg_types) end
-             | Label s  -> 
+             | Label s  ->
                begin match get_arg_type ~nolabel:false false  ty with
-                 | (Arg_cst ( i) as arg_type), new_ty -> 
+                 | (Arg_cst ( i) as arg_type), new_ty ->
                    External_arg_spec.label s (Some i), arg_type, arg_types
-                 | arg_type, new_ty -> 
+                 | arg_type, new_ty ->
                    External_arg_spec.label s None, arg_type, (label, new_ty,attr,loc) :: arg_types
                end
-             | Empty -> 
-               begin match get_arg_type ~nolabel:true false  ty with 
-                 | (Arg_cst ( i) as arg_type), new_ty -> 
+             | Empty ->
+               begin match get_arg_type ~nolabel:true false  ty with
+                 | (Arg_cst ( i) as arg_type), new_ty ->
                    External_arg_spec.empty_lit i , arg_type,  arg_types
-                 | arg_type, new_ty -> 
+                 | arg_type, new_ty ->
                    External_arg_spec.empty_label, arg_type, (label, new_ty,attr,loc) :: arg_types
                end
            in
            (if i = 0 && splice  then
-              match arg_type with 
+              match arg_type with
               | Array  -> ()
               | _ ->  Location.raise_errorf ~loc "[@@@@bs.splice] expect the last type to be an array");
-           ({ External_arg_spec.arg_label  ; 
-              arg_type 
+           ({ External_arg_spec.arg_label  ;
+              arg_type
             } :: arg_type_specs,
             new_arg_types,
-            if arg_type = Ignore then i 
+            if arg_type = Ignore then i
             else i + 1
            )
-        ) arg_types_ty 
+        ) arg_types_ty
         (match st with
-         | {val_send_pipe = Some obj; _ } ->      
-           let arg_type, new_ty = get_arg_type ~nolabel:true false obj in 
-           begin match arg_type with 
-             | Arg_cst _ -> 
+         | {val_send_pipe = Some obj; _ } ->
+           let arg_type, new_ty = get_arg_type ~nolabel:true false obj in
+           begin match arg_type with
+             | Arg_cst _ ->
                Location.raise_errorf ~loc:obj.ptyp_loc "[@bs.as] is not supported in bs.send type "
-             | _ -> 
+             | _ ->
                (* more error checking *)
                [External_arg_spec.empty_kind arg_type]
                ,
@@ -15021,16 +15028,16 @@ let handle_attributes
                ,0
            end
 
-         | {val_send_pipe = None ; _ } -> [],[], 0) in 
+         | {val_send_pipe = None ; _ } -> [],[], 0) in
 
-    let ffi : External_ffi_types.attr  = match st with           
+    let ffi : External_ffi_types.attr  = match st with
       | {set_index = true;
 
-         val_name = `Nm_na; 
+         val_name = `Nm_na;
          external_module_name = None ;
          module_as_val = None;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          splice = false;
          scopes ;
          get_index = false;
@@ -15039,16 +15046,16 @@ let handle_attributes
          set_name = `Nm_na ;
          get_name = `Nm_na ;
 
-         return_wrapper = _; 
-         mk_obj = _ ; 
+         return_wrapper = _;
+         mk_obj = _ ;
 
-        } 
+        }
         ->
-        if String.length prim_name <> 0 then 
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.set_index] expect external names to be empty string";
-        if arg_type_specs_length = 3 then 
+        if arg_type_specs_length = 3 then
           Js_set_index {js_set_index_scopes = scopes}
-        else 
+        else
           Location.raise_errorf ~loc "Ill defined attribute [@@bs.set_index](arity of 3)"
 
       | {set_index = true; _}
@@ -15058,11 +15065,11 @@ let handle_attributes
 
       | {get_index = true;
 
-         val_name = `Nm_na; 
+         val_name = `Nm_na;
          external_module_name = None ;
          module_as_val = None;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
 
          splice = false;
          scopes ;
@@ -15070,20 +15077,20 @@ let handle_attributes
          call_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         set_index = false; 
+         set_index = false;
          mk_obj;
-         return_wrapper ; 
+         return_wrapper ;
         } ->
-        if String.length prim_name <> 0 then 
+        if String.length prim_name <> 0 then
           Location.raise_errorf ~loc "[@@bs.get_index] expect external names to be empty string";
-        if arg_type_specs_length = 2 then 
+        if arg_type_specs_length = 2 then
           Js_get_index {js_get_index_scopes = scopes}
-        else Location.raise_errorf ~loc 
+        else Location.raise_errorf ~loc
             "Ill defined attribute [@@bs.get_index] (arity expected 2 : while %d)" arg_type_specs_length
 
       | {get_index = true; _}
 
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.get_index]")
 
 
@@ -15097,17 +15104,17 @@ let handle_attributes
 
          external_module_name = None ;
          val_send = `Nm_na;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          scopes = []; (* module as var does not need scopes *)
          splice;
          call_name = `Nm_na;
          set_name = `Nm_na ;
-         get_name = `Nm_na ;         
-         set_index = false; 
-         return_wrapper = _; 
+         get_name = `Nm_na ;
+         set_index = false;
+         return_wrapper = _;
          mk_obj = _ ;
         } ->
-        begin match arg_types_ty, new_name, val_name  with         
+        begin match arg_types_ty, new_name, val_name  with
           | [], `Nm_na,  _ -> Js_module_as_var external_module_name
           | _, `Nm_na, _ -> Js_module_as_fn {splice; external_module_name }
           | _, #bundle_source, #bundle_source ->
@@ -15121,29 +15128,29 @@ let handle_attributes
               "Incorrect FFI attribute found: (bs.new should not carry a payload here)"
         end
       | {module_as_val = Some x; _}
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.module].")
 
       | {call_name = (`Nm_val name | `Nm_external name | `Nm_payload name) ;
-         splice; 
+         splice;
          scopes ;
          external_module_name;
 
          val_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;    
+         val_send_pipe = None;
 
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         mk_obj = _ ; 
-         return_wrapper = _ ; 
-        } -> 
+         mk_obj = _ ;
+         return_wrapper = _ ;
+        } ->
         Js_call {splice; name; external_module_name; scopes }
-      | {call_name = #bundle_source ; _ } 
+      | {call_name = #bundle_source ; _ }
         ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.val]")
 
@@ -15154,18 +15161,18 @@ let handle_attributes
          call_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;    
+         val_send_pipe = None;
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na;
-         mk_obj = _; 
-         return_wrapper = _; 
+         mk_obj = _;
+         return_wrapper = _;
          splice = false ;
          scopes ;
-        } 
-        -> 
+        }
+        ->
         Js_global { name; external_module_name; scopes}
       | {val_name = #bundle_source ; _ }
         ->
@@ -15175,27 +15182,27 @@ let handle_attributes
          scopes ;
          external_module_name = (Some _ as external_module_name);
 
-         val_name = `Nm_na ;         
+         val_name = `Nm_na ;
          call_name = `Nm_na ;
          module_as_val = None;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          set_index = false;
          get_index = false;
          new_name = `Nm_na;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
-         mk_obj = _ ; 
-         return_wrapper= _ ; 
+         mk_obj = _ ;
+         return_wrapper= _ ;
         }
         ->
         let name = string_of_bundle_source prim_name_or_pval_prim in
         if arg_type_specs_length  = 0 then
           Js_global { name; external_module_name; scopes}
-        else  Js_call {splice; name; external_module_name; scopes}                     
-      | {val_send = (`Nm_val name | `Nm_external name | `Nm_payload name); 
+        else  Js_call {splice; name; external_module_name; scopes}
+      | {val_send = (`Nm_val name | `Nm_external name | `Nm_payload name);
          splice;
-         scopes; 
+         scopes;
          val_send_pipe = None;
          val_name = `Nm_na  ;
          call_name = `Nm_na ;
@@ -15207,28 +15214,28 @@ let handle_attributes
          get_name = `Nm_na ;
          external_module_name = None ;
          mk_obj = _ ;
-         return_wrapper = _ ; 
-        } -> 
+         return_wrapper = _ ;
+        } ->
 
-        (* PR #2162 - since when we assemble arguments the first argument in 
+        (* PR #2162 - since when we assemble arguments the first argument in
            [@@bs.send] is ignored
         *)
-        begin match arg_type_specs with 
+        begin match arg_type_specs with
           | [] ->
-            Location.raise_errorf 
+            Location.raise_errorf
               ~loc "Ill defined attribute [@@bs.send] (at least one argument)"
           |  {arg_type = Arg_cst _ ; arg_label = _} :: _
-            -> 
-            Location.raise_errorf 
+            ->
+            Location.raise_errorf
               ~loc "Ill defined attribute [@@bs.send] (first argument can not be const)"
-          | _ :: _  -> 
+          | _ :: _  ->
             Js_send {splice ; name; js_send_scopes = scopes ;  pipe = false}
         end
 
-      | {val_send = #bundle_source; _ } 
+      | {val_send = #bundle_source; _ }
         -> Location.raise_errorf ~loc "You used an FFI attribute that can't be used with [@@bs.send]"
 
-      | {val_send_pipe = Some typ; 
+      | {val_send_pipe = Some typ;
          (* splice = (false as splice); *)
          val_send = `Nm_na;
          val_name = `Nm_na  ;
@@ -15241,17 +15248,17 @@ let handle_attributes
          get_name = `Nm_na ;
          external_module_name = None ;
          mk_obj = _;
-         return_wrapper = _; 
+         return_wrapper = _;
          scopes;
-         splice ; 
-        } -> 
+         splice ;
+        } ->
         (** can be one argument *)
         Js_send {splice  ;
                  name = string_of_bundle_source prim_name_or_pval_prim;
                  js_send_scopes = scopes;
                  pipe = true}
 
-      | {val_send_pipe = Some _ ; _} 
+      | {val_send_pipe = Some _ ; _}
         -> Location.raise_errorf ~loc "conflict attributes found with [@@bs.send.pipe]"
 
       | {new_name = (`Nm_val name | `Nm_external name | `Nm_payload name);
@@ -15263,18 +15270,18 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          set_name = `Nm_na ;
          get_name = `Nm_na ;
          splice ;
-         scopes; 
-         mk_obj = _ ; 
-         return_wrapper = _ ; 
+         scopes;
+         mk_obj = _ ;
+         return_wrapper = _ ;
 
-        } 
+        }
         -> Js_new {name; external_module_name; splice; scopes}
       | {new_name = #bundle_source ; _ }
-        -> 
+        ->
         Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with [@@bs.new]")
 
 
@@ -15286,17 +15293,17 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          get_name = `Nm_na ;
          external_module_name = None;
-         splice = false; 
+         splice = false;
          mk_obj = _ ;
-         return_wrapper = _; 
+         return_wrapper = _;
          scopes ;
-        } 
-        -> 
-        if arg_type_specs_length = 2 then 
+        }
+        ->
+        if arg_type_specs_length = 2 then
           Js_set { js_set_scopes = scopes ; js_set_name = name}
         else  Location.raise_errorf ~loc "Ill defined attribute [@@bs.set] (two args required)"
 
@@ -15311,19 +15318,19 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          set_name = `Nm_na ;
          external_module_name = None;
-         splice = false ; 
+         splice = false ;
          mk_obj = _;
          return_wrapper = _;
          scopes
         }
         ->
-        if arg_type_specs_length = 1 then  
+        if arg_type_specs_length = 1 then
           Js_get { js_get_name = name; js_get_scopes = scopes }
-        else 
+        else
           Location.raise_errorf ~loc "Ill defined attribute [@@bs.get] (only one argument)"
       | {get_name = #bundle_source; _}
         -> Location.raise_errorf ~loc "Attribute found that conflicts with [@@bs.get]"
@@ -15335,30 +15342,30 @@ let handle_attributes
          set_index = false;
          get_index = false;
          val_send = `Nm_na ;
-         val_send_pipe = None;             
+         val_send_pipe = None;
          new_name = `Nm_na ;
          set_name = `Nm_na ;
          external_module_name = None;
-         splice = _ ; 
+         splice = _ ;
          scopes = _;
          mk_obj = _;
          return_wrapper = _;
 
-        }       
-        ->  Location.raise_errorf ~loc "Could not infer which FFI category it belongs to, maybe you forgot [%@%@bs.val]? "  in 
-    begin 
+        }
+        ->  Location.raise_errorf ~loc "Could not infer which FFI category it belongs to, maybe you forgot [%@%@bs.val]? "  in
+    begin
       External_ffi_types.check_ffi ~loc ffi;
       (* result type can not be labeled *)
-      (* currently we don't process attributes of 
+      (* currently we don't process attributes of
          return type, in the future we may  *)
       let  new_result_type  =  result_type in
       (* get_arg_type ~nolabel:true false result_type in *)
-      let return_wrapper : External_ffi_types.return_wrapper = 
+      let return_wrapper : External_ffi_types.return_wrapper =
         check_return_wrapper loc st.return_wrapper new_result_type
-      in 
+      in
       (
-        Ext_list.fold_right (fun (label,ty,attrs,loc) acc -> 
-            Ast_helper.Typ.arrow ~loc  ~attrs label ty acc 
+        Ext_list.fold_right (fun (label,ty,attrs,loc) acc ->
+            Ast_helper.Typ.arrow ~loc  ~attrs label ty acc
           ) new_arg_types_ty new_result_type
       ) ,
 
@@ -15366,29 +15373,31 @@ let handle_attributes
       (Ffi_bs (arg_type_specs,return_wrapper ,  ffi)), left_attrs
     end
 
-let handle_attributes_as_string 
+let handle_attributes_as_string
     pval_loc
-    pval_prim 
-    (typ : Ast_core_type.t) attrs v = 
-  let pval_type, prim_name, ffi, processed_attrs  = 
+    pval_prim
+    (typ : Ast_core_type.t) attrs v =
+  let pval_type, prim_name, ffi, processed_attrs  =
     handle_attributes pval_loc pval_prim typ attrs v  in
   pval_type, [prim_name; External_ffi_types.to_string ffi], processed_attrs
 
 
 
-let pval_prim_of_labels labels = 
-  let encoding = 
-    let arg_kinds = 
-      Ext_list.fold_right 
+let pval_prim_of_labels labels =
+  let encoding =
+    let arg_kinds =
+      Ext_list.fold_right
         (fun {Asttypes.loc ; txt } arg_kinds
           ->
-            let arg_label =  External_arg_spec.label (Lam_methname.translate ~loc txt) None in
-            {External_arg_spec.arg_type = Nothing ; 
+            let arg_label =
+                External_arg_spec.label
+                  (Lam_methname.translate ~loc txt) None in
+            {External_arg_spec.arg_type = Nothing ;
              arg_label  } :: arg_kinds
         )
-        labels [] in 
-    External_ffi_types.to_string 
-      (Ffi_obj_create arg_kinds)   in 
+        labels [] in
+    External_ffi_types.to_string
+      (Ffi_obj_create arg_kinds)   in
   [""; encoding]
 
 
@@ -18447,42 +18456,59 @@ let handleTdcl (tdcl : Parsetree.type_declaration) =
   match tdcl.ptype_kind with
   | Ptype_record label_declarations ->
     let setter_accessor =
-      Ext_list.fold_right (fun (x: Parsetree.label_declaration) acc ->
-          let pld_name = x.pld_name.txt in
-          let pld_loc = x.pld_name.loc in
-          let pld_type = x.pld_type in
+      Ext_list.fold_right (fun
+          ({pld_name = {txt = label_name; loc = label_loc} as pld_name;
+            pld_type;
+            pld_mutable;
+            pld_attributes
+            }:
+          Parsetree.label_declaration) acc ->
           let () = checkNotFunciton pld_type in
-          let setter =
+          let prim =
+            match Ast_attributes.iter_process_bs_string_as pld_attributes with
+            | None -> [label_name]
+            | Some new_name -> [new_name]
+          in
+          let getter =
             Val.mk
-              {loc = pld_loc; txt = pld_name}
+              pld_name (* we always use this: it is fixed in ocaml API*)
               ~attrs:[Ast_attributes.bs_get]
-              ~prim:[pld_name]
+              ~prim
               (Typ.arrow "" core_type pld_type) :: acc in
-          match x.pld_mutable with
+          match pld_mutable with
           | Mutable ->
             Val.mk
-              {loc = pld_loc; txt = pld_name ^ "Set"}
+              {loc = label_loc; txt = label_name ^ "Set"}
+              (* setter *)
               ~attrs:[Ast_attributes.bs_set]
-              ~prim:[pld_name]
-              (Typ.arrow "" core_type (Typ.arrow "" pld_type (Ast_literal.type_unit ()))) :: setter
-          | Immutable -> setter
+              ~prim
+              (Typ.arrow "" core_type (Typ.arrow "" pld_type (Ast_literal.type_unit ()))) :: getter
+          | Immutable -> getter
         ) label_declarations []
     in
-
     newTdcl,
     (match tdcl.ptype_private with
      | Private -> setter_accessor
      | Public ->
        let ty =
-         Ext_list.fold_right (fun (label_declaration : Parsetree.label_declaration) acc ->
-             Typ.arrow
-               label_declaration.pld_name.txt label_declaration.pld_type acc
+         Ext_list.fold_right (fun ({pld_name = {txt}; pld_type}: Parsetree.label_declaration) acc ->
+             Typ.arrow txt pld_type acc
            ) label_declarations  core_type in
-       let maker =
-         Val.mk  {loc; txt = type_name}
-           ~attrs:[Ast_attributes.bs_obj]
-           ~prim:[""] ty in
-       (maker :: setter_accessor))
+       let myPrims =
+         External_process.pval_prim_of_labels
+           (List.map
+              (fun ({pld_name; pld_attributes} : Parsetree.label_declaration) ->
+                match Ast_attributes.iter_process_bs_string_as pld_attributes with
+                | None -> pld_name
+                | Some new_name -> {pld_name with txt = new_name}
+              )
+              label_declarations)
+       in
+       let myMaker =
+        Val.mk  ~loc
+        {loc; txt = type_name}
+        ~prim:myPrims ty in
+       (myMaker :: setter_accessor))
 
   | Ptype_abstract
   | Ptype_variant _


### PR DESCRIPTION
fix #2583,
part One of #2614

```
type t = {

  mutable hi : int
    [@bs.as "Content-Type"];
  mutable low : int
    [@bs.as "l"];
  mutable x : int;
    [@bs.as "open"]
} [@@bs.deriving abstract]
let v = t ~hi:3 ~low:2 ~x:2
let (a,b,c) = (v |. hi, v |. low, v |. x)
let ff () =
  v |. hiSet 3;
  v |. lowSet 2
```

generated code:

```js
var v = {
  "Content-Type": 3,
  l: 2,
  open: 2
};

var a = v["Content-Type"];

var b = v.l;

var c = v.open;

function ff() {
  v["Content-Type"] = 3;
  v.l = 2;
  return /* () */0;
}
```