### PR TITLE
[Belt] Add List.sort

### DIFF
--- a/jscomp/others/.depend
+++ b/jscomp/others/.depend
@@ -21,7 +21,7 @@ belt_internalAVLset.cmj : belt_SortArray.cmj belt_Id.cmj belt_Array.cmj \
     belt_internalAVLset.cmi
 belt_internalAVLtree.cmj : belt_SortArray.cmj belt_Id.cmj belt_Array.cmj \
     belt_internalAVLtree.cmi
-belt_List.cmj : belt_Array.cmj belt_List.cmi
+belt_List.cmj : belt_Array.cmj belt_SortArray.cmj belt_List.cmi
 belt_SortArray.cmj : belt_SortArrayString.cmj belt_SortArrayInt.cmj \
     belt_Array.cmj belt_SortArray.cmi
 belt_SortArrayInt.cmj : belt_Array.cmj belt_SortArrayInt.cmi

--- a/jscomp/others/belt_List.ml
+++ b/jscomp/others/belt_List.ml
@@ -692,6 +692,13 @@ let setAssocU xs x k eq =
 
 let setAssoc xs x k eq = setAssocU xs x k (fun [@bs] a b -> eq a b)
 
+let sort xs cmp =
+  let arr = toArray xs in
+  begin
+    Belt_SortArray.stableSortInPlaceBy arr cmp;
+    fromArray arr;
+  end
+
 let rec getByU xs p = 
   match xs with 
   | [] -> None

--- a/jscomp/others/belt_List.ml
+++ b/jscomp/others/belt_List.ml
@@ -699,6 +699,13 @@ let sort xs cmp =
     fromArray arr;
   end
 
+let sortU xs cmp =
+  let arr = toArray xs in
+  begin
+    Belt_SortArray.stableSortInPlaceByU arr cmp;
+    fromArray arr;
+  end
+
 let rec getByU xs p = 
   match xs with 
   | [] -> None

--- a/jscomp/others/belt_List.ml
+++ b/jscomp/others/belt_List.ml
@@ -694,17 +694,13 @@ let setAssoc xs x k eq = setAssocU xs x k (fun [@bs] a b -> eq a b)
 
 let sort xs cmp =
   let arr = toArray xs in
-  begin
-    Belt_SortArray.stableSortInPlaceBy arr cmp;
-    fromArray arr;
-  end
+  Belt_SortArray.stableSortInPlaceBy arr cmp;
+  fromArray arr
 
 let sortU xs cmp =
   let arr = toArray xs in
-  begin
-    Belt_SortArray.stableSortInPlaceByU arr cmp;
-    fromArray arr;
-  end
+  Belt_SortArray.stableSortInPlaceByU arr cmp;
+  fromArray arr
 
 let rec getByU xs p = 
   match xs with 

--- a/jscomp/others/belt_List.ml
+++ b/jscomp/others/belt_List.ml
@@ -692,15 +692,12 @@ let setAssocU xs x k eq =
 
 let setAssoc xs x k eq = setAssocU xs x k (fun [@bs] a b -> eq a b)
 
-let sort xs cmp =
-  let arr = toArray xs in
-  Belt_SortArray.stableSortInPlaceBy arr cmp;
-  fromArray arr
-
 let sortU xs cmp =
   let arr = toArray xs in
   Belt_SortArray.stableSortInPlaceByU arr cmp;
   fromArray arr
+
+let sort xs cmp = sortU xs (fun [@bs] x y -> cmp x y)
 
 let rec getByU xs p = 
   match xs with 

--- a/jscomp/others/belt_List.mli
+++ b/jscomp/others/belt_List.mli
@@ -530,6 +530,8 @@ val setAssoc: ('a * 'c) t -> 'a -> 'c -> ('a -> 'a -> bool) -> ('a * 'c) t
     ]}
 *)
 
+
+val sortU: 'a t -> ('a -> 'a -> int [@bs]) -> 'a t
 val sort: 'a t -> ('a -> 'a -> int) -> 'a t
 (** [sort xs]
     Returns a sorted list.

--- a/jscomp/others/belt_List.mli
+++ b/jscomp/others/belt_List.mli
@@ -528,8 +528,12 @@ val setAssoc: ('a * 'c) t -> 'a -> 'c -> ('a -> 'a -> bool) -> ('a * 'c) t
       setAssoc [1,"a"; 3, "c"] 2 "2" (=) = 
       [2,"2"; 1,"a"; 3, "c"] 
     ]}
-*)    
+*)
 
-
-
-
+val sort: 'a t -> ('a -> 'a -> int) -> 'a t
+(** [sort xs]
+    Returns a sorted list.
+    @example {[
+      sort (fun a b -> a - b) [5; 4; 9; 3; 7] = [3; 4; 5; 7; 9]
+    ]}
+*)

--- a/jscomp/test/bs_list_test.js
+++ b/jscomp/test/bs_list_test.js
@@ -2181,7 +2181,69 @@ makeTest(2);
 
 makeTest(3);
 
-b("File \"bs_list_test.ml\", line 320, characters 4-11", 1 - Belt_List.eq(/* :: */[
+function cmp(a, b) {
+  return a - b | 0;
+}
+
+eq("SORT", Belt_List.sort(/* :: */[
+          5,
+          /* :: */[
+            4,
+            /* :: */[
+              3,
+              /* :: */[
+                2,
+                /* [] */0
+              ]
+            ]
+          ]
+        ], cmp), /* :: */[
+      2,
+      /* :: */[
+        3,
+        /* :: */[
+          4,
+          /* :: */[
+            5,
+            /* [] */0
+          ]
+        ]
+      ]
+    ]);
+
+eq("SORT", Belt_List.sort(/* :: */[
+          3,
+          /* :: */[
+            9,
+            /* :: */[
+              37,
+              /* :: */[
+                3,
+                /* :: */[
+                  1,
+                  /* [] */0
+                ]
+              ]
+            ]
+          ]
+        ], cmp), /* :: */[
+      1,
+      /* :: */[
+        3,
+        /* :: */[
+          3,
+          /* :: */[
+            9,
+            /* :: */[
+              37,
+              /* [] */0
+            ]
+          ]
+        ]
+      ]
+    ]);
+
+b("File \"bs_list_test.ml\", line 326, characters 4-11", 1 - Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2200,7 +2262,7 @@ b("File \"bs_list_test.ml\", line 320, characters 4-11", 1 - Belt_List.eq(/* :: 
             return +(x === y);
           })));
 
-b("File \"bs_list_test.ml\", line 321, characters 4-11", Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 327, characters 4-11", Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2222,7 +2284,7 @@ b("File \"bs_list_test.ml\", line 321, characters 4-11", Belt_List.eq(/* :: */[
             return +(x === y);
           })));
 
-b("File \"bs_list_test.ml\", line 322, characters 4-11", 1 - Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 328, characters 4-11", 1 - Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2244,7 +2306,7 @@ b("File \"bs_list_test.ml\", line 322, characters 4-11", 1 - Belt_List.eq(/* :: 
             return +(x === y);
           })));
 
-b("File \"bs_list_test.ml\", line 323, characters 4-11", 1 - Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 329, characters 4-11", 1 - Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2279,7 +2341,7 @@ var u1 = Belt_List.keepMap(u0, (function (x) {
         }
       }));
 
-eq("File \"bs_list_test.ml\", line 327, characters 5-12", u1, /* :: */[
+eq("File \"bs_list_test.ml\", line 333, characters 5-12", u1, /* :: */[
       1,
       /* :: */[
         8,
@@ -2290,7 +2352,7 @@ eq("File \"bs_list_test.ml\", line 327, characters 5-12", u1, /* :: */[
       ]
     ]);
 
-b("File \"bs_list_test.ml\", line 328, characters 4-11", Caml_obj.caml_equal(Belt_List.keepMap(/* :: */[
+b("File \"bs_list_test.ml\", line 334, characters 4-11", Caml_obj.caml_equal(Belt_List.keepMap(/* :: */[
               1,
               /* :: */[
                 2,
@@ -2316,7 +2378,7 @@ b("File \"bs_list_test.ml\", line 328, characters 4-11", Caml_obj.caml_equal(Bel
           ]
         ]));
 
-b("File \"bs_list_test.ml\", line 332, characters 4-11", +(Belt_List.keepMap(/* :: */[
+b("File \"bs_list_test.ml\", line 338, characters 4-11", +(Belt_List.keepMap(/* :: */[
             1,
             /* :: */[
               2,

--- a/jscomp/test/bs_list_test.ml
+++ b/jscomp/test/bs_list_test.ml
@@ -316,6 +316,12 @@ let () =
   makeTest 2;
   makeTest 3
 
+let () =
+  let (=~) = eq "SORT" in
+  let cmp a b = a - b in
+  N.sort [5; 4; 3; 2] cmp =~ [2; 3; 4; 5];
+  N.sort [3; 9; 37; 3; 1] cmp =~ [1; 3; 3; 9; 37]
+
 let () = 
   b __LOC__ (not @@ N.eq [1;2;3] [1;2] (fun  x y -> x = y));
   b __LOC__ (N.eq [1;2;3] [1;2;3] (fun  x y -> x = y));

--- a/lib/js/belt_List.js
+++ b/lib/js/belt_List.js
@@ -2,6 +2,7 @@
 
 var Curry = require("./curry.js");
 var Belt_Array = require("./belt_Array.js");
+var Belt_SortArray = require("./belt_SortArray.js");
 
 function head(x) {
   if (x) {
@@ -1209,6 +1210,12 @@ function setAssoc(xs, x, k, eq) {
   return setAssocU(xs, x, k, Curry.__2(eq));
 }
 
+function sort(xs, cmp) {
+  var arr = toArray(xs);
+  Belt_SortArray.stableSortInPlaceBy(arr, cmp);
+  return fromArray(arr);
+}
+
 function getByU(_xs, p) {
   while(true) {
     var xs = _xs;
@@ -1445,4 +1452,5 @@ exports.removeAssocU = removeAssocU;
 exports.removeAssoc = removeAssoc;
 exports.setAssocU = setAssocU;
 exports.setAssoc = setAssoc;
+exports.sort = sort;
 /* No side effect */

--- a/lib/js/belt_List.js
+++ b/lib/js/belt_List.js
@@ -1210,16 +1210,14 @@ function setAssoc(xs, x, k, eq) {
   return setAssocU(xs, x, k, Curry.__2(eq));
 }
 
-function sort(xs, cmp) {
-  var arr = toArray(xs);
-  Belt_SortArray.stableSortInPlaceBy(arr, cmp);
-  return fromArray(arr);
-}
-
 function sortU(xs, cmp) {
   var arr = toArray(xs);
   Belt_SortArray.stableSortInPlaceByU(arr, cmp);
   return fromArray(arr);
+}
+
+function sort(xs, cmp) {
+  return sortU(xs, Curry.__2(cmp));
 }
 
 function getByU(_xs, p) {

--- a/lib/js/belt_List.js
+++ b/lib/js/belt_List.js
@@ -1216,6 +1216,12 @@ function sort(xs, cmp) {
   return fromArray(arr);
 }
 
+function sortU(xs, cmp) {
+  var arr = toArray(xs);
+  Belt_SortArray.stableSortInPlaceByU(arr, cmp);
+  return fromArray(arr);
+}
+
 function getByU(_xs, p) {
   while(true) {
     var xs = _xs;
@@ -1452,5 +1458,6 @@ exports.removeAssocU = removeAssocU;
 exports.removeAssoc = removeAssoc;
 exports.setAssocU = setAssocU;
 exports.setAssoc = setAssoc;
+exports.sortU = sortU;
 exports.sort = sort;
 /* No side effect */


### PR DESCRIPTION
Implements Belt.List.sort as specified in the issue.
Adds a couple of simple tests and an example.

Fixes #2586.