### PR TITLE
[Repl] Add +weak.js back into exports.js

### DIFF
--- a/jscomp/repl.js
+++ b/jscomp/repl.js
@@ -118,7 +118,7 @@ var cmi_files =
         `belt_HashMapInt`,
         `belt_HashMapString`,
     ].map(x => `${x}.cmi:/static/cmis/${x}.cmi`).map(x => `--file ${x}`).join(` `)
-e(`js_of_ocaml --disable share --toplevel  ./polyfill.js jsc.byte ${includes} ${cmi_files} -o ${playground}/exports.js`)
+e(`js_of_ocaml --disable share --toplevel +weak.js ./polyfill.js jsc.byte ${includes} ${cmi_files} -o ${playground}/exports.js`)
 
 
 


### PR DESCRIPTION
cc @astrada @bobzhang

I get the following error at runtime if I don't: `"caml_weak_create not implemented"` (wrapped in some jsoo exception data structure)