### PR TITLE
[Design] Minimal extension to record representation for debugging.

### DIFF
--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -529,9 +529,9 @@ and
 
   | Array_copy e ->
     P.group f 1 (fun _ ->
+        P.string f "(function (obj) { const obj2 = obj.slice(); obj2['.labels'] = obj['.labels']; return obj2 })(";
         let cxt = expression 15 cxt f e in
-        P.string f ".slice";
-        P.string f "()" ;
+        P.string f ")";
         cxt
       )
 
@@ -866,8 +866,15 @@ and
        with regard tag  *)
     begin match tag.expression_desc, tag_info with
 
+      | Number (Int { i = 0l ; _}), Blk_record labels
+        ->
+        let labels = List.map (fun l -> "\"" ^ l ^ "\"") (Array.to_list labels) in 
+        P.string f ("(function (x) { x['.labels'] = [" ^ String.concat "," labels ^ "]; return x })(");
+        let ctx = expression_desc cxt l f  (Array (el, mutable_flag)) in
+        P.string f ")";
+        ctx
       | Number (Int { i = 0l ; _})  ,
-        (Blk_tuple | Blk_array | Blk_variant _ | Blk_record _ | Blk_na | Blk_module _
+        (Blk_tuple | Blk_array | Blk_variant _ | Blk_na | Blk_module _
         |  Blk_constructor (_, 1) (* Sync up with {!Js_dump}*)
         )
         -> expression_desc cxt l f  (Array (el, mutable_flag))

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -864,6 +864,13 @@ and
     ->
     (* Note that, if we ignore more than tag [0] we loose some information
        with regard tag  *)
+
+    let constructor = match tag_info with
+      | Blk_constructor (c, _) -> c
+      | _ -> "" in
+    if constructor <> "" then
+      P.string f ("(function (o) { o['cstr']=\'" ^ constructor ^ "\'; return o; })(");
+    let r =
     begin match tag.expression_desc, tag_info with
 
       | Number (Int { i = 0l ; _}), Blk_record labels
@@ -889,7 +896,10 @@ and
         P.string f L.caml_block_create;
         P.paren_group f 1
           (fun _ -> arguments cxt f [tag; E.array mutable_flag el])
-    end
+    end in
+    if constructor <> "" then P.string f ")";
+    r
+
   | Caml_block_tag e ->
     P.group f 1 (fun _ ->
         let cxt = expression 15 cxt f  e in


### PR DESCRIPTION
Minimal extension to the runtime representation of records that could be used for debugging.
A record `{x:12, y:34}` is represented as `[ 12, 34, '.labels': ['x', 'y'] ]`.

This change is minimally invasive compared to a direct representation of records as objects (https://github.com/BuckleScript/bucklescript/pull/2639).
At the same time, the representation is more indirect.

Illustrate with a test that with this representation, the conversion between objects and records can be automated.