### PR TITLE
[Playground] activate super-errors

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -559,7 +559,7 @@ bin/jsoo_reactjs_jsx_ppx_v2.ml:./bin/reactjs_jsx_ppx_v2.bspp.ml ../lib/bspp.exe
 	BS_COMPILER_IN_BROWSER=true ../lib/bspp.exe $^ > $@
 
 bin/js_compiler.ml:./bin/bspack.exe
-	 ./bin/bspack.exe -D BS_COMPILER_IN_BROWSER=true -U BS_DEBUG -bs-MD  -module-alias Config=Config_whole_compiler  -bs-exclude-I config -o $@ -bs-main Jsoo_main -I $(OCAML_SRC_UTILS) -I $(OCAML_SRC_PARSING) -I $(OCAML_SRC_TYPING) -I $(OCAML_SRC_BYTECOMP) -I $(OCAML_SRC_DRIVER) -I stubs -I ext -I syntax -I depends -I common -I core -I outcome_printer
+	 ./bin/bspack.exe -D BS_COMPILER_IN_BROWSER=true -U BS_DEBUG -bs-MD  -module-alias Config=Config_whole_compiler  -bs-exclude-I config -o $@ -bs-main Jsoo_main -I $(OCAML_SRC_UTILS) -I $(OCAML_SRC_PARSING) -I $(OCAML_SRC_TYPING) -I $(OCAML_SRC_BYTECOMP) -I $(OCAML_SRC_DRIVER) -I stubs -I ext -I syntax -I depends -I common -I core -I super_errors -I outcome_printer
 
 bin/all_ounit_tests.ml:./bin/bspack.exe
 	$< -bs-MD    -I ounit -I ounit_tests  -I stubs -I bsb -I common -I ext -I syntax -I depends -I bspp -I core -bs-main Ounit_tests_main -o $@

--- a/jscomp/core/jsoo_main.ml
+++ b/jscomp/core/jsoo_main.ml
@@ -99,6 +99,8 @@ let implementation prefix impl  str  : Js.Unsafe.obj =
       (* Format.fprintf output_ppf {| { "js_code" : %S }|} v ) *)
   with
   | e ->
+      Misc.Color.setup Clflags.Always;
+      Super_main.setup ();
       begin match Location.error_of_exn  e with
       | Some error ->
           Location.report_error Format.std_formatter  error;
@@ -107,7 +109,7 @@ let implementation prefix impl  str  : Js.Unsafe.obj =
           Js.Unsafe.(obj
           [|
             "js_error_msg",
-              inject @@ Js.string (Printf.sprintf "Line %d, %d: %s"  line startchar error.msg);
+              inject @@ Js.string (Printf.sprintf "Line %d, %d:\n  %s"  line startchar error.msg);
                "row"    , inject (line - 1);
                "column" , inject startchar;
                "endRow" , inject (endline - 1);

--- a/jscomp/core/jsoo_main.ml
+++ b/jscomp/core/jsoo_main.ml
@@ -65,7 +65,7 @@ let () =
   Clflags.unsafe_string := false;
   Clflags.record_event_when_debug := false
 
-let implementation prefix impl  str  : Js.Unsafe.obj =
+let implementation ~use_super_errors prefix impl str  : Js.Unsafe.obj =
   let modulename = "Test" in
   (* let env = !Toploop.toplevel_env in *)
   (* Compmisc.init_path false; *)
@@ -99,8 +99,10 @@ let implementation prefix impl  str  : Js.Unsafe.obj =
       (* Format.fprintf output_ppf {| { "js_code" : %S }|} v ) *)
   with
   | e ->
-      Misc.Color.setup Clflags.Always;
-      Super_main.setup ();
+      if use_super_errors then begin
+        Misc.Color.setup Clflags.Always;
+        Super_main.setup ();
+      end;
       begin match Location.error_of_exn  e with
       | Some error ->
           Location.report_error Format.std_formatter  error;
@@ -127,14 +129,12 @@ let implementation prefix impl  str  : Js.Unsafe.obj =
       end
 
 
+let compile impl ~use_super_errors =
+    implementation ~use_super_errors false impl
 
-let compile  impl : string -> Js.Unsafe.obj =
-    implementation  false impl
 (** TODO: add `[@@bs.config{no_export}]\n# 1 "repl.ml"`*)
-let shake_compile impl : string -> Js.Unsafe.obj =
-   implementation true impl
-
-
+let shake_compile impl ~use_super_errors =
+   implementation ~use_super_errors true impl
 
 
 
@@ -159,8 +159,6 @@ let dir_directory d =
 let () =
   dir_directory "/static/cmis"
 
-
-
 let make_compiler name impl =
   export name
     (Js.Unsafe.(obj
@@ -168,12 +166,21 @@ let make_compiler name impl =
                     inject @@
                     Js.wrap_meth_callback
                       (fun _ code ->
-                         (compile impl (Js.to_string code)));
+                         (compile impl ~use_super_errors:false (Js.to_string code)));
                     "shake_compile",
                     inject @@
                     Js.wrap_meth_callback
                       (fun _ code ->
-                         (shake_compile impl (Js.to_string code)));
+                         (shake_compile impl ~use_super_errors:false (Js.to_string code)));
+                    "compile_super_errors",
+                    inject @@
+                    Js.wrap_meth_callback
+                      (fun _ code ->
+                         (compile impl ~use_super_errors:true (Js.to_string code)));
+                    "shake_compile_super_errors",
+                    inject @@
+                    Js.wrap_meth_callback
+                      (fun _ code -> (shake_compile impl ~use_super_errors:true (Js.to_string code)));
                     "version", Js.Unsafe.inject (Js.string (Bs_version.version));
                     "load_module",
                     inject @@


### PR DESCRIPTION
RFC. Feedback welcome. cc @bobzhang

Huge quality improvement for the online experience. This activates
color (needed, otherwise it's a wall of white text). I use a small lib
to parse the raw ANSI color escape chars into html styles. It'd not look
good in the BS playground currently.

This doesn't activate Reason syntax for outcome printer, since it's
compiling ocaml.