### PR TITLE
ocaml boolean -> js boolean by Cristiano

### DIFF
--- a/jscomp/core/j.ml
+++ b/jscomp/core/j.ml
@@ -114,7 +114,6 @@ and expression_desc =
   (* | Tag_ml_obj of expression *)
   | String_append of expression * expression 
 
-  | Int_of_boolean of expression 
   | Anything_to_number of expression
   | Bool of bool (* js true/false*)
   (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence 

--- a/jscomp/core/js_analyzer.ml
+++ b/jscomp/core/js_analyzer.ml
@@ -118,7 +118,6 @@ let rec no_side_effect_expression_desc (x : J.expression_desc)  =
   | Array_of_size _
   | Array_copy _ 
   (* | Tag_ml_obj _ *)
-  | Int_of_boolean _ 
   | J.Anything_to_number _
   | Caml_not _ 
   | Js_not _
@@ -271,7 +270,6 @@ let rec eq_expression
     | Array_copy _ 
     | Array_append _ 
     | String_append _ 
-    | Int_of_boolean _ 
     | Anything_to_number _ 
 
     | Typeof _ 

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -641,7 +641,7 @@ and
     );
     cxt
   | J.Anything_to_number e
-  | Int_of_boolean e ->
+    ->
     let action () =
       P.group f 0 @@ fun _ ->
       P.string f "+" ;
@@ -665,9 +665,7 @@ and
       P.paren_group f 1 action
     else action ()
 
-  | Caml_not e ->
-    expression_desc cxt l f (Bin (Minus, E.one_int_literal, e))
-
+  | Caml_not e
   | Js_not e ->
     let action () =
       P.string f "!" ;
@@ -1157,7 +1155,7 @@ and statement_desc top cxt f (s : J.statement_desc) : Ext_pp_scope.t =
       | Bool _
       | New _
       | J.Anything_to_number _
-      | Int_of_boolean _ -> false
+        -> false
       (* e = function(x){...}(x);  is good
       *)
     in

--- a/jscomp/core/js_exp_make.mli
+++ b/jscomp/core/js_exp_make.mli
@@ -242,6 +242,7 @@ val float_notequal : binary_op
 val float_mod : binary_op  
 
 val int_comp : Lambda.comparison -> binary_op
+val bool_comp : Lambda.comparison -> binary_op
 val string_comp : Js_op.binop -> binary_op
 val float_comp :  Lambda.comparison -> binary_op
 val js_comp :  Lambda.comparison -> binary_op

--- a/jscomp/core/js_fold.ml
+++ b/jscomp/core/js_fold.ml
@@ -374,7 +374,6 @@ class virtual fold =
           let o = o#expression _x in let o = o#expression _x_i1 in o
       | String_append (_x, _x_i1) ->
           let o = o#expression _x in let o = o#expression _x_i1 in o
-      | Int_of_boolean _x -> let o = o#expression _x in o
       | Anything_to_number _x -> let o = o#expression _x in o
       | Bool _x -> let o = o#bool _x in o
       | Typeof _x -> let o = o#expression _x in o

--- a/jscomp/core/js_map.ml
+++ b/jscomp/core/js_map.ml
@@ -402,7 +402,6 @@ class virtual map =
       | String_append (_x, _x_i1) ->
           let _x = o#expression _x in
           let _x_i1 = o#expression _x_i1 in String_append (_x, _x_i1)
-      | Int_of_boolean _x -> let _x = o#expression _x in Int_of_boolean _x
       | Anything_to_number _x ->
           let _x = o#expression _x in Anything_to_number _x
       | Bool _x -> let _x = o#bool _x in Bool _x

--- a/jscomp/core/js_of_lam_array.ml
+++ b/jscomp/core/js_of_lam_array.ml
@@ -56,15 +56,8 @@ module E  = Js_exp_make
 
 (* Parrayref(u|s) *)
 let make_array mt (kind : Lambda.array_kind) args = 
-  match kind with 
-  | Pgenarray
-  | Paddrarray -> 
-    E.array ~comment:"array" mt args 
-  | Pintarray  -> 
-    E.array ~comment:"int array" mt args 
-  | Pfloatarray -> 
-    E.array ~comment:"float array" mt args
-
+  E.array ~comment:"array" mt args 
+ 
 let set_array  e e0 e1 = 
   E.assign (E.access e e0)  e1
 

--- a/jscomp/core/js_pass_flatten_and_mark_dead.ml
+++ b/jscomp/core/js_pass_flatten_and_mark_dead.ml
@@ -196,8 +196,8 @@ let subst_map name = object (self)
         List.fold_left 
           (fun  (i,e,  acc) (x : J.expression) -> 
              match x.expression_desc with 
-             | J.Var _ | Number _ | Str _ 
-               -> 
+             | J.Var _ | Number _ | Str _ | J.Bool _
+               ->  (* TODO: check the optimization *)
                (i + 1, x :: e, acc)
              | _ ->                
                (* tradeoff, 

--- a/jscomp/core/js_stmt_make.ml
+++ b/jscomp/core/js_stmt_make.ml
@@ -246,12 +246,17 @@ let rec if_ ?comment  ?declaration ?else_ (e : J.expression) (then_ : J.block)  
       aux ?comment e ys xs (y::acc)
         
 
-    |  Number ( Int { i = 0l; _}) , _,  _
+    |  (Number ( Int { i = 0l; _}) | Bool false) , _,  _
       ->  
       begin match else_ with 
         | [] -> acc 
         | _ -> block else_ ::acc
       end
+    | Bool true, _, _ ->
+       begin match then_ with 
+       |  []  -> acc 
+       | _ -> block then_ :: acc    
+      end 
     |  (Number _ , _, _
        | (Bin (Ge, 
                ({expression_desc = Length _;
@@ -274,8 +279,7 @@ let rec if_ ?comment  ?declaration ?else_ (e : J.expression) (then_ : J.block)  
              ({expression_desc = 
                  Length _;
                _} as e ), {expression_desc = Number (Int { i = 0l; _})}))
-
-      | Int_of_boolean e), _ , _
+      ), _ , _
       ->
       (** Add comment when simplified *)
       aux ?comment e then_ else_ acc 

--- a/jscomp/core/lam.ml
+++ b/jscomp/core/lam.ml
@@ -22,7 +22,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type array_kind = Lambda.array_kind
+type array_kind = Lambda.array_kind 
+  (*TODO: only [Pfloatarray] makes sense *)
 type boxed_integer = Lambda.boxed_integer
 type comparison = Lambda.comparison
 type bigarray_kind = Lambda.bigarray_kind
@@ -194,7 +195,6 @@ type primitive =
   | Pis_null
   | Pis_undefined
   | Pis_null_undefined
-  | Pjs_boolean_to_bool
   | Pjs_typeof
   | Pjs_function_length
 
@@ -1068,7 +1068,6 @@ let apply fn args loc status : t =
                                 Pnull_undefined_to_opt |
                                 Pis_null |
                                 Pis_null_undefined |
-                                Pjs_boolean_to_bool |
                                 Pjs_typeof ) as wrap;
                              args = [Lprim ({primitive; args = inner_args} as primitive_call)]
                             }
@@ -1198,10 +1197,10 @@ let stringswitch (lam : t) cases default : t =
 
 
 let true_ : t =
-  Lconst (Const_pointer ( 1, Pt_constructor "true"))
+  Lconst (Const_pointer ( 1, Pt_builtin_boolean))
 
 let false_ : t =
-  Lconst (Const_pointer( 0, Pt_constructor "false"))
+  Lconst (Const_pointer( 0, Pt_builtin_boolean))
 
 let unit : t =
   Lconst (Const_pointer( 0, Pt_constructor "()"))
@@ -1472,8 +1471,6 @@ let result_wrap loc (result_type : External_ffi_types.return_wrapper) result  =
   | Return_null_to_opt -> prim ~primitive:Pnull_to_opt ~args:[result] loc
   | Return_null_undefined_to_opt -> prim ~primitive:Pnull_undefined_to_opt ~args:[result] loc
   | Return_undefined_to_opt -> prim ~primitive:Pundefined_to_opt ~args:[result] loc
-  | Return_to_ocaml_bool ->
-    prim ~primitive:Pjs_boolean_to_bool ~args:[result] loc
   | Return_unset
   | Return_identity ->
     result
@@ -1881,8 +1878,6 @@ let convert exports lam : _ * _  =
            we can get rid of it*)
         | "#obj_set_length" -> Pcaml_obj_set_length
         | "#obj_length" -> Pcaml_obj_length
-        | "#boolean_to_bool" -> Pjs_boolean_to_bool
-
         | "#function_length" -> Pjs_function_length
 
         | "#unsafe_lt" -> Pjscomp Clt

--- a/jscomp/core/lam.mli
+++ b/jscomp/core/lam.mli
@@ -190,7 +190,6 @@ type primitive =
   | Pis_undefined
   | Pis_null_undefined
 
-  | Pjs_boolean_to_bool
   | Pjs_typeof
   | Pjs_function_length 
 

--- a/jscomp/core/lam_analysis.ml
+++ b/jscomp/core/lam_analysis.ml
@@ -86,7 +86,6 @@ let rec no_side_effects (lam : Lam.t) : bool =
       
       | Pcreate_extension _
       (* | Pcreate_exception _ *)
-      | Pjs_boolean_to_bool
       | Pjs_typeof
       | Pis_null
       | Pis_undefined
@@ -533,7 +532,6 @@ and eq_primitive ( lhs : Lam.primitive) (rhs : Lam.primitive) =
   | Pis_null -> rhs = Pis_null
   | Pis_undefined -> rhs = Pis_undefined
   | Pis_null_undefined -> rhs = Pis_null_undefined
-  | Pjs_boolean_to_bool -> rhs = Pjs_boolean_to_bool
   | Pjs_typeof -> rhs = Pjs_typeof
   | Pisint -> rhs = Pisint
   | Pisout -> rhs = Pisout

--- a/jscomp/core/lam_compile_const.ml
+++ b/jscomp/core/lam_compile_const.ml
@@ -69,9 +69,13 @@ let rec translate (x : Lam.constant ) : J.expression =
     (* E.str i ~delimiter:Literals.escaped_j_delimiter *)   
 
   | Const_pointer (c,pointer_info) -> 
+    begin match pointer_info with
+    | Pt_builtin_boolean ->
+      E.bool (c <> 0)
+    | _ ->
     E.int ?comment:(Lam_compile_util.comment_of_pointer_info pointer_info)
       (Int32.of_int c )
-
+    end
   | Const_block(tag, tag_info, xs ) -> 
     Js_of_lam_block.make_block NA tag_info 
       (E.small_int  tag) (Ext_list.map translate xs)

--- a/jscomp/core/lam_compile_primitive.ml
+++ b/jscomp/core/lam_compile_primitive.ml
@@ -165,12 +165,6 @@ let translate  loc
         E.is_null_undefined arg
       | _ -> assert false 
     end
-  
-  | Pjs_boolean_to_bool -> 
-    begin match args with 
-      | [e] -> E.bool_of_boolean e 
-      | _ -> assert false 
-    end
   | Pjs_typeof -> 
     begin match args with 
       | [e] -> E.typeof e 

--- a/jscomp/core/lam_compile_util.ml
+++ b/jscomp/core/lam_compile_util.ml
@@ -58,5 +58,6 @@ let comment_of_pointer_info (x :  Lambda.pointer_info)=
   match x with 
   | Pt_constructor x -> Some x 
   | Pt_variant x -> Some x 
+  | Pt_builtin_boolean -> Some "boolean"
   | Lambda.Pt_module_alias -> None (* FIXME *)
   | Pt_na -> None

--- a/jscomp/core/lam_dispatch_primitive.ml
+++ b/jscomp/core/lam_dispatch_primitive.ml
@@ -377,7 +377,48 @@ let translate loc (prim_name : string)
           E.string_comp Ge  e0 e1
         | _ -> assert false 
       end
-    
+    | "caml_bool_notequal"
+      -> 
+      begin match args with 
+        | [e0; e1] -> E.bool_comp Cneq e0 e1
+        (** TODO: specialized in OCaml ones*)
+        | _ -> assert false 
+      end
+    | "caml_bool_lessequal"
+      -> 
+      begin 
+        match args with 
+        | [e0; e1] 
+          -> 
+          E.bool_comp Cle e0 e1
+        | _ -> assert false 
+      end
+    | "caml_bool_lessthan"
+      -> 
+      begin match args with 
+        | [e0; e1] 
+          -> 
+          E.bool_comp Clt e0 e1
+        | _ -> assert false 
+      end
+    | "caml_bool_greaterequal"
+      -> 
+      begin match args with 
+        | [e0; e1] 
+          -> 
+          E.bool_comp Cge  e0 e1
+        | _ -> assert false 
+      end
+        
+    | "caml_bool_equal"  
+    | "caml_bool_equal_null"
+    | "caml_bool_equal_nullable"
+    | "caml_bool_equal_undefined"
+      -> 
+        begin match args with 
+        | [e0; e1] -> E.bool_comp Ceq e0 e1 
+        | _ -> assert false 
+        end 
     | "caml_int_equal_null"
     | "caml_int_equal_nullable"
     | "caml_int_equal_undefined"
@@ -438,7 +479,7 @@ let translate loc (prim_name : string)
         | _ -> 
           call Js_runtime_modules.string 
       end
-
+    | "caml_bool_compare"  
     | "caml_int_compare"
     | "caml_int32_compare"
     | "caml_nativeint_compare"
@@ -447,6 +488,7 @@ let translate loc (prim_name : string)
     -> 
       call Js_runtime_modules.caml_primitive
 
+    | "caml_bool_min"  
     | "caml_int_min"
     | "caml_float_min"
     | "caml_string_min"
@@ -462,6 +504,7 @@ let translate loc (prim_name : string)
             call Js_runtime_modules.caml_primitive
         | _ -> assert false  
       end
+    | "caml_bool_max"
     | "caml_int_max"
     | "caml_float_max"
     | "caml_string_max"

--- a/jscomp/core/lam_print.ml
+++ b/jscomp/core/lam_print.ml
@@ -129,7 +129,6 @@ let primitive ppf (prim : Lam.primitive) = match prim with
   | Lam.Praw_js_code_stmt _ -> fprintf ppf "[raw.stmt]"
   | Pglobal_exception id ->
     fprintf ppf "global exception %a" Ident.print id       
-  | Pjs_boolean_to_bool -> fprintf ppf "[boolean->bool]"
   | Pjs_typeof -> fprintf ppf "[typeof]"
   | Pnull_to_opt -> fprintf ppf "[null->opt]"              
   | Pundefined_to_opt -> fprintf ppf "[undefined->opt]"     

--- a/jscomp/others/js_boolean.ml
+++ b/jscomp/others/js_boolean.ml
@@ -24,4 +24,5 @@
 
 (** Contains functions for dealing with JavaScript booleans *)
 
-let to_js_boolean b = if b then Js.true_ else Js.false_
+external to_js_boolean : bool -> Js.boolean = "%identity"
+

--- a/jscomp/others/js_boolean.mli
+++ b/jscomp/others/js_boolean.mli
@@ -24,4 +24,5 @@
 
 (** Contains functions for dealing with JavaScript booleans *)
 
-val to_js_boolean : bool -> Js.boolean
+external to_js_boolean : bool -> Js.boolean = "%identity"
+[@@ocaml.deprecated "This function is not needed any more"]

--- a/jscomp/others/js_json.ml
+++ b/jscomp/others/js_json.ml
@@ -51,7 +51,7 @@ let classify  (x : t) : tagged_t =
   else if ty = "number" then 
     JSONNumber (Obj.magic x )
   else if ty = "boolean" then
-    if (Obj.magic x) == Js.true_ then JSONTrue
+    if (Obj.magic x) = true then JSONTrue
     else JSONFalse 
   else if (Obj.magic x) == Js.null then
     JSONNull 

--- a/jscomp/others/js_types.ml
+++ b/jscomp/others/js_types.ml
@@ -85,7 +85,7 @@ let classify (x : 'a) : tagged_t =
   if ty = "string" then 
     JSString (Obj.magic x) else 
   if ty = "boolean" then 
-    if (Obj.magic x) ==  Js.true_ then JSTrue 
+    if (Obj.magic x) =  true then JSTrue 
     else JSFalse else 
   if ty = "function" then 
     JSFunction (Obj.magic x) else 

--- a/jscomp/runtime/.depend
+++ b/jscomp/runtime/.depend
@@ -22,7 +22,7 @@ caml_int32.cmj : caml_int32.cmi
 caml_gc.cmj : caml_gc.cmi
 js_typed_array.cmj : js.cmj
 js_primitive.cmj : js_undefined.cmj js.cmj js_primitive.cmi
-caml_basic.cmj : js_undefined.cmj js.cmj caml_basic.cmi
+caml_basic.cmj : js_undefined.cmj caml_basic.cmi
 caml_oo.cmj : bs_obj.cmj caml_oo.cmi
 curry.cmj : caml_array.cmj
 caml_oo_curry.cmj : curry.cmj caml_oo.cmj

--- a/jscomp/runtime/caml_basic.ml
+++ b/jscomp/runtime/caml_basic.ml
@@ -30,10 +30,8 @@ let none = None
 
 let some x = Some x 
 
-let is_none x : Js.boolean = 
-  match x with 
-  | None -> Js.true_ 
-  | _ -> Js.false_ 
+let is_none x : bool =
+  x = None
 
 let to_def x : _ Js_undefined.t = 
   match  x with 
@@ -44,10 +42,8 @@ let to_def x : _ Js_undefined.t =
    [List.cons]
 *)
 let cons x y = x :: y 
+let is_list_empty x : bool =
+  x = []
 
-let is_list_empty x : Js.boolean =  
-  match x with 
-  | [] -> Js.true_
-  | _ -> Js.false_ 
 
 

--- a/jscomp/runtime/caml_primitive.ml
+++ b/jscomp/runtime/caml_primitive.ml
@@ -25,7 +25,11 @@
 
 let caml_int_compare (x : int) (y: int) : int =
   if  x < y then -1 else if x = y then 0 else  1
-
+let caml_bool_compare (x : bool) (y : bool): int = 
+  match x,y with 
+  | true, true | false , false -> 0 
+  | true, false -> 1 
+  | false, true -> -1
 
 let caml_int32_compare = caml_int_compare
 let caml_nativeint_compare = caml_int_compare
@@ -46,6 +50,8 @@ let caml_string_compare (s1 : string) (s2 : string) : int =
 type 'a selector = 'a -> 'a -> 'a 
 
 (* could be replaced by [Math.min], but it seems those built-ins are slower *)
+let caml_bool_min (x : bool) y : bool =  
+    if x then y else x 
 let caml_int_min (x : int) (y : int) : int =
   if x < y then x else y 
 let caml_float_min (x : float) y   =
@@ -57,6 +63,8 @@ let caml_nativeint_min (x : nativeint) y =
 let caml_int32_min (x : int32) y   = 
   if x < y then x else y 
 
+let caml_bool_max (x : bool) y : bool =   
+  if x then x else y
 let caml_int_max (x : int) (y : int) : int =
   if x > y then x else y 
 let caml_float_max (x : float) y   =

--- a/jscomp/runtime/caml_primitive.mli
+++ b/jscomp/runtime/caml_primitive.mli
@@ -33,19 +33,21 @@ type 'a selector = 'a -> 'a -> 'a
 
 
 val caml_int_compare : int -> int -> int
+val caml_bool_compare : bool -> bool -> int
 val caml_float_compare : float -> float -> int 
 val caml_nativeint_compare : int -> int -> int
 val caml_string_compare : string -> string -> int 
 val caml_int32_compare : int -> int -> int
 
 
- 
+val caml_bool_min : bool selector 
 val caml_int_min : int selector
 val caml_float_min : float selector 
 val caml_string_min : string selector  
 val caml_nativeint_min : nativeint selector
 val caml_int32_min : int32 selector 
 
+val caml_bool_max : bool selector
 val caml_int_max : int selector
 val caml_float_max : float selector 
 val caml_string_max : string selector  

--- a/jscomp/runtime/js.ml
+++ b/jscomp/runtime/js.ml
@@ -67,7 +67,7 @@ external nullToOption : 'a null -> 'a option = "#null_to_opt"
 external test : 'a nullable -> bool = "#is_nil_undef"
 external testAny : 'a -> bool = "#is_nil_undef"
 
-type boolean
+type boolean = bool
 (** The JS boolean type, can be [Js.true_] or [Js.false_] *)
 
 (* I'd like to move this and the other types into a Js_core module that can be
@@ -79,8 +79,8 @@ type (+'a, +'e) promise
 
 
 (* tag::predefined_js_values[]*)
-external true_ : boolean = "#true"
-external false_ : boolean = "#false"
+let true_ : boolean = true
+let false_ : boolean = false
 external null : 'a null = "#null"
 (* The same as {!Js.Null.empty} will be compiled as [null]*)
 external undefined : 'a undefined = "#undefined"
@@ -88,8 +88,7 @@ external undefined : 'a undefined = "#undefined"
 (* end::predefined_js_values[]*)
 
 (* tag::utility_functions[]*)
-external to_bool : boolean -> bool = "#boolean_to_bool"
-(** convert Js boolean to OCaml bool *)
+external to_bool : boolean -> bool = "%identity"
 external typeof : 'a -> string = "#typeof"
 (** [typeof x] will be compiled as [typeof x] in JS *)
 external log : 'a -> unit = "log" 

--- a/jscomp/runtime/js.mli
+++ b/jscomp/runtime/js.mli
@@ -82,7 +82,7 @@ external test : 'a nullable -> bool = "#is_nil_undef"
 (** The same as {!test} except that it is more permissive on the types of input *)
 external testAny : 'a -> bool = "#is_nil_undef"
 
-type boolean
+type boolean = bool
 (** The value could be either  {!Js.true_} or {!Js.false_}.
      Note in BuckleScript, [boolean] has different representation from OCaml's [bool],
      see conversion functions in {!Boolean} *)
@@ -93,8 +93,11 @@ type (+'a, +'e) promise
 *)
 
 
-external true_ : boolean = "#true" 
-external false_ : boolean = "#false" 
+val true_ : boolean
+[@@ocaml.deprecated "Use true directly"]
+
+val false_ : boolean
+[@@ocaml.deprecated "Use false directly"]
 
 external null : 'a null = "#null" 
 (** The same as [empty] in {!Js.Null} will be compiled as [null]*)
@@ -103,7 +106,7 @@ external undefined : 'a undefined = "#undefined"
 (** The same as  [empty] {!Js.Undefined} will be compiled as [undefined]*)
 
 
-external to_bool : boolean -> bool = "#boolean_to_bool"
+external to_bool : boolean -> bool = "%identity"
 (** convert Js boolean to OCaml bool *)
 
 external typeof : 'a -> string = "#typeof"

--- a/jscomp/syntax/external_ffi_types.ml
+++ b/jscomp/syntax/external_ffi_types.ml
@@ -133,7 +133,6 @@ type return_wrapper =
   | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
-  | Return_to_ocaml_bool
   | Return_replaced_with_unit
 type t  =
   | Ffi_bs of External_arg_spec.t list  *

--- a/jscomp/syntax/external_ffi_types.mli
+++ b/jscomp/syntax/external_ffi_types.mli
@@ -112,7 +112,6 @@ type return_wrapper =
   | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
-  | Return_to_ocaml_bool
   | Return_replaced_with_unit
 
 type t  =

--- a/jscomp/syntax/external_process.ml
+++ b/jscomp/syntax/external_process.ml
@@ -365,8 +365,6 @@ let check_return_wrapper
   | Return_unset  ->
     if Ast_core_type.is_unit result_type then
       Return_replaced_with_unit
-    else if Ast_core_type.is_user_bool result_type then
-      Return_to_ocaml_bool
     else
       wrapper
   | Return_undefined_to_opt
@@ -377,8 +375,7 @@ let check_return_wrapper
       wrapper
     else
       Bs_syntaxerr.err loc Expect_opt_in_bs_return_to_opt
-  | Return_replaced_with_unit
-  | Return_to_ocaml_bool  ->
+  | Return_replaced_with_unit ->
     assert false (* Not going to happen from user input*)
 
 

--- a/jscomp/test/a_filename_test.js
+++ b/jscomp/test/a_filename_test.js
@@ -27,7 +27,7 @@ function eq(loc, x, y) {
 }
 
 function test(param, param$1) {
-  return Ext_filename_test.node_relative_path(/* true */1, param, param$1);
+  return Ext_filename_test.node_relative_path(true, param, param$1);
 }
 
 eq("File \"a_filename_test.ml\", line 10, characters 5-12", /* tuple */[

--- a/jscomp/test/a_string_test.js
+++ b/jscomp/test/a_string_test.js
@@ -9,7 +9,7 @@ var suites_000 = /* tuple */[
   "split",
   (function () {
       return /* Eq */Block.__(0, [
-                Ext_string_test.split(/* Some */[/* true */1], "hihi", /* "i" */105),
+                Ext_string_test.split(/* Some */[true], "hihi", /* "i" */105),
                 /* :: */[
                   "h",
                   /* :: */[
@@ -45,7 +45,7 @@ var suites_001 = /* :: */[
       "split_empty",
       (function () {
           return /* Eq */Block.__(0, [
-                    Ext_string_test.split(/* Some */[/* true */1], "", /* "i" */105),
+                    Ext_string_test.split(/* Some */[true], "", /* "i" */105),
                     /* [] */0
                   ]);
         })
@@ -55,7 +55,7 @@ var suites_001 = /* :: */[
         "split_normal",
         (function () {
             return /* Eq */Block.__(0, [
-                      Ext_string_test.split(/* Some */[/* true */1], "h i i", /* " " */32),
+                      Ext_string_test.split(/* Some */[true], "h i i", /* " " */32),
                       /* :: */[
                         "h",
                         /* :: */[
@@ -75,12 +75,12 @@ var suites_001 = /* :: */[
           (function () {
               return /* Eq */Block.__(0, [
                         List.filter((function (s) {
-                                  return +(s !== "");
+                                  return s !== "";
                                 }))(Ext_string_test.split_by(/* None */0, (function (x) {
                                     if (x === /* " " */32) {
-                                      return /* true */1;
+                                      return true;
                                     } else {
-                                      return +(x === /* "\t" */9);
+                                      return x === /* "\t" */9;
                                     }
                                   }), "h hgso hgso \t hi")),
                         /* :: */[

--- a/jscomp/test/and_or_tailcall_test.js
+++ b/jscomp/test/and_or_tailcall_test.js
@@ -7,7 +7,7 @@ function f(b, _, _n) {
   while(true) {
     var n = _n;
     if (n > 100000 || !b) {
-      return /* false */0;
+      return false;
     } else {
       _n = n + 1 | 0;
       continue ;
@@ -19,9 +19,9 @@ function or_f(b, _, _n) {
   while(true) {
     var n = _n;
     if (n > 100000) {
-      return /* false */0;
+      return false;
     } else if (b) {
-      return /* true */1;
+      return true;
     } else {
       _n = n + 1 | 0;
       continue ;
@@ -33,8 +33,8 @@ var suites_000 = /* tuple */[
   "and_tail",
   (function () {
       return /* Eq */Block.__(0, [
-                /* false */0,
-                f(/* true */1, 1, 0)
+                false,
+                f(true, 1, 0)
               ]);
     })
 ];
@@ -44,8 +44,8 @@ var suites_001 = /* :: */[
     "or_tail",
     (function () {
         return /* Eq */Block.__(0, [
-                  /* false */0,
-                  or_f(/* false */0, 1, 0)
+                  false,
+                  or_f(false, 1, 0)
                 ]);
       })
   ],

--- a/jscomp/test/argv_test.js
+++ b/jscomp/test/argv_test.js
@@ -9,9 +9,9 @@ function anno_fun() {
 
 var usage_msg = "Usage:\n";
 
-var compile = [/* false */0];
+var compile = [false];
 
-var test = [/* true */1];
+var test = [true];
 
 var arg_spec_000 = /* tuple */[
   "-c",

--- a/jscomp/test/arith_parser.js
+++ b/jscomp/test/arith_parser.js
@@ -16,7 +16,7 @@ var yytransl_const = /* array */[
   0
 ];
 
-var yytransl_block = /* int array */[
+var yytransl_block = /* array */[
   257,
   258,
   0

--- a/jscomp/test/array_subtle_test.js
+++ b/jscomp/test/array_subtle_test.js
@@ -28,7 +28,7 @@ function eq(loc, param) {
   return /* () */0;
 }
 
-var v = /* int array */[
+var v = /* array */[
   1,
   2,
   3,

--- a/jscomp/test/array_test.js
+++ b/jscomp/test/array_test.js
@@ -14,12 +14,12 @@ function is_sorted(x) {
   while(true) {
     var i = _i;
     if (i >= (len - 1 | 0)) {
-      return /* true */1;
+      return true;
     } else if (Caml_obj.caml_lessthan(Caml_array.caml_array_get(x, i), Caml_array.caml_array_get(x, i + 1 | 0))) {
       _i = i + 1 | 0;
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -59,7 +59,7 @@ var array_suites_001 = /* :: */[
         };
         var match = List.split(aux(/* :: */[
                   /* tuple */[
-                    /* int array */[],
+                    /* array */[],
                     /* [] */0
                   ],
                   /* [] */0
@@ -84,20 +84,20 @@ var array_suites_001 = /* :: */[
                       5
                     ],
                     Caml_array.caml_array_concat(/* :: */[
-                          /* int array */[
+                          /* array */[
                             0,
                             1,
                             2
                           ],
                           /* :: */[
-                            /* int array */[
+                            /* array */[
                               3,
                               4
                             ],
                             /* :: */[
-                              /* int array */[],
+                              /* array */[],
                               /* :: */[
-                                /* int array */[5],
+                                /* array */[5],
                                 /* [] */0
                               ]
                             ]
@@ -130,7 +130,7 @@ var array_suites_001 = /* :: */[
                               3,
                               4
                             ], 2, 2),
-                        /* int array */[
+                        /* array */[
                           2,
                           3
                         ]
@@ -141,7 +141,7 @@ var array_suites_001 = /* :: */[
           /* tuple */[
             "blit",
             (function () {
-                var u = /* int array */[
+                var u = /* array */[
                   100,
                   0,
                   0
@@ -152,12 +152,12 @@ var array_suites_001 = /* :: */[
                 $$Array.blit(v, 1, u, 1, 2);
                 return /* Eq */Block.__(0, [
                           /* tuple */[
-                            /* int array */[
+                            /* array */[
                               0,
                               2,
                               4
                             ],
-                            /* int array */[
+                            /* array */[
                               100,
                               2,
                               4
@@ -176,7 +176,7 @@ var array_suites_001 = /* :: */[
               (function () {
                   return /* Eq */Block.__(0, [
                             Caml_array.caml_make_vect(2, 1),
-                            /* int array */[
+                            /* array */[
                               1,
                               1
                             ]
@@ -187,19 +187,19 @@ var array_suites_001 = /* :: */[
               /* tuple */[
                 "sort",
                 (function () {
-                    var u = /* int array */[
+                    var u = /* array */[
                       3,
                       0,
                       1
                     ];
                     $$Array.sort(Caml_primitive.caml_int_compare, u);
                     return /* Eq */Block.__(0, [
-                              Caml_obj.caml_equal(/* int array */[
+                              Caml_obj.caml_equal(/* array */[
                                     0,
                                     1,
                                     3
                                   ], u),
-                              /* true */1
+                              true
                             ]);
                   })
               ],
@@ -212,7 +212,7 @@ var array_suites_001 = /* :: */[
                             }));
                       $$Array.sort(Caml_primitive.caml_int_compare, v);
                       return /* Eq */Block.__(0, [
-                                /* true */1,
+                                true,
                                 is_sorted(v)
                               ]);
                     })

--- a/jscomp/test/ast_abstract_test.js
+++ b/jscomp/test/ast_abstract_test.js
@@ -43,13 +43,13 @@ function tFromJs(param) {
 
 var v0 = {
   x: /* x */3,
-  y: /* y : false */0,
-  z: /* z : false */0
+  y: /* y */false,
+  z: /* z */false
 };
 
 var v1 = {
   x: /* x */3,
-  y: /* y : false */0,
+  y: /* y */false,
   z: /* z */""
 };
 
@@ -90,7 +90,7 @@ idx(/* b */98);
 
 idx(/* c */99);
 
-var jsMapperConstantArray$1 = /* int array */[
+var jsMapperConstantArray$1 = /* array */[
   0,
   3,
   4

--- a/jscomp/test/ast_js_mapper_poly_test.js
+++ b/jscomp/test/ast_js_mapper_poly_test.js
@@ -50,30 +50,30 @@ function uFromJs(param) {
 }
 
 function eqU(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 function eqUOpt(x, y) {
   if (x) {
     if (y) {
-      return +(x[0] === y[0]);
+      return x[0] === y[0];
     } else {
-      return /* false */0;
+      return false;
     }
   } else if (y) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
-eq("File \"ast_js_mapper_poly_test.ml\", line 25, characters 5-12", eqUOpt(uFromJs("x"), /* Some */[/* f */102]), /* true */1);
+eq("File \"ast_js_mapper_poly_test.ml\", line 25, characters 5-12", eqUOpt(uFromJs("x"), /* Some */[/* f */102]), true);
 
-eq("File \"ast_js_mapper_poly_test.ml\", line 26, characters 5-12", eqUOpt(uFromJs("D"), /* Some */[/* D */68]), /* true */1);
+eq("File \"ast_js_mapper_poly_test.ml\", line 26, characters 5-12", eqUOpt(uFromJs("D"), /* Some */[/* D */68]), true);
 
-eq("File \"ast_js_mapper_poly_test.ml\", line 27, characters 5-12", eqUOpt(uFromJs("C"), /* Some */[/* C */67]), /* true */1);
+eq("File \"ast_js_mapper_poly_test.ml\", line 27, characters 5-12", eqUOpt(uFromJs("C"), /* Some */[/* C */67]), true);
 
-eq("File \"ast_js_mapper_poly_test.ml\", line 28, characters 5-12", eqUOpt(uFromJs("f"), /* None */0), /* true */1);
+eq("File \"ast_js_mapper_poly_test.ml\", line 28, characters 5-12", eqUOpt(uFromJs("f"), /* None */0), true);
 
 eq("File \"ast_js_mapper_poly_test.ml\", line 29, characters 5-12", $$Array.map(uToJs, /* array */[
           /* D */68,
@@ -85,7 +85,7 @@ eq("File \"ast_js_mapper_poly_test.ml\", line 29, characters 5-12", $$Array.map(
       "x"
     ]);
 
-var jsMapperConstantArray$1 = /* int array */[
+var jsMapperConstantArray$1 = /* array */[
   0,
   3,
   4,
@@ -101,20 +101,20 @@ function vFromJs(param) {
 }
 
 function eqV(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 function eqVOpt(x, y) {
   if (x) {
     if (y) {
-      return +(x[0] === y[0]);
+      return x[0] === y[0];
     } else {
-      return /* false */0;
+      return false;
     }
   } else if (y) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -132,12 +132,12 @@ function s(param) {
   }
 }
 
-eq("File \"ast_js_mapper_poly_test.ml\", line 54, characters 5-12", $$Array.map(vToJs, /* int array */[
+eq("File \"ast_js_mapper_poly_test.ml\", line 54, characters 5-12", $$Array.map(vToJs, /* array */[
           /* A0 */0,
           /* A1 */1,
           /* A2 */2,
           /* A3 */3
-        ]), /* int array */[
+        ]), /* array */[
       0,
       3,
       4,

--- a/jscomp/test/ast_js_mapper_test.js
+++ b/jscomp/test/ast_js_mapper_test.js
@@ -55,7 +55,7 @@ function searchForSureExists(xs, k) {
   };
 }
 
-var jsMapperConstantArray = /* int array */[
+var jsMapperConstantArray = /* array */[
   0,
   3,
   4,

--- a/jscomp/test/ast_mapper_defensive_test.js
+++ b/jscomp/test/ast_mapper_defensive_test.js
@@ -33,7 +33,7 @@ function aFromJs(param) {
   return param - 0 | 0;
 }
 
-var jsMapperConstantArray = /* int array */[
+var jsMapperConstantArray = /* array */[
   0,
   3,
   4

--- a/jscomp/test/bal_set_mini.js
+++ b/jscomp/test/bal_set_mini.js
@@ -160,13 +160,13 @@ function mem(x, _param) {
     if (param) {
       var c = compare_int(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }

--- a/jscomp/test/bang_primitive.js
+++ b/jscomp/test/bang_primitive.js
@@ -3,12 +3,12 @@
 
 function test(x, y) {
   return /* tuple */[
-          +(x < y),
-          +(x <= y),
-          +(x > y),
-          +(x >= y),
-          +(x === y),
-          +(x !== y)
+          x < y,
+          x <= y,
+          x > y,
+          x >= y,
+          x === y,
+          x !== y
         ];
 }
 

--- a/jscomp/test/bdd.js
+++ b/jscomp/test/bdd.js
@@ -9,9 +9,9 @@ function $$eval(_bdd, vars) {
     var bdd = _bdd;
     if (typeof bdd === "number") {
       if (bdd !== 0) {
-        return /* false */0;
+        return false;
       } else {
-        return /* true */1;
+        return true;
       }
     } else if (Caml_array.caml_array_get(vars, bdd[1])) {
       _bdd = bdd[3];
@@ -333,11 +333,11 @@ var seed = [0];
 
 function random() {
   seed[0] = Caml_int32.imul(seed[0], 25173) + 17431 | 0;
-  return +((seed[0] & 1) > 0);
+  return (seed[0] & 1) > 0;
 }
 
 function random_vars(n) {
-  var vars = Caml_array.caml_make_vect(n, /* false */0);
+  var vars = Caml_array.caml_make_vect(n, false);
   for(var i = 0 ,i_finish = n - 1 | 0; i <= i_finish; ++i){
     Caml_array.caml_array_set(vars, i, random(/* () */0));
   }
@@ -345,16 +345,16 @@ function random_vars(n) {
 }
 
 function bool_equal(a, b) {
-  if (a !== 0) {
-    if (b !== 0) {
-      return /* true */1;
+  if (a) {
+    if (b) {
+      return true;
     } else {
-      return /* false */0;
+      return false;
     }
-  } else if (b !== 0) {
-    return /* false */0;
+  } else if (b) {
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -366,12 +366,12 @@ function test_hwb(bdd, vars) {
     }
     
   }
-  return bool_equal($$eval(bdd, vars), ntrue > 0 ? Caml_array.caml_array_get(vars, ntrue - 1 | 0) : /* false */0);
+  return bool_equal($$eval(bdd, vars), ntrue > 0 ? Caml_array.caml_array_get(vars, ntrue - 1 | 0) : false);
 }
 
 function main() {
   var bdd = hwb(22);
-  var succeeded = /* true */1;
+  var succeeded = true;
   for(var i = 1; i <= 100; ++i){
     succeeded = succeeded && test_hwb(bdd, random_vars(22));
   }

--- a/jscomp/test/big_polyvar_test.js
+++ b/jscomp/test/big_polyvar_test.js
@@ -1217,12 +1217,12 @@ function tFromJs(param) {
 function eq(x, y) {
   if (x) {
     if (y) {
-      return +(x[0] === y[0]);
+      return x[0] === y[0];
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return +(y === /* None */0);
+    return y === /* None */0;
   }
 }
 

--- a/jscomp/test/bigarray_test.js
+++ b/jscomp/test/bigarray_test.js
@@ -14,7 +14,7 @@ function sum() {
 
 function init(v) {
   for(var i = 0 ,i_finish = Caml_missing_polyfill.not_implemented("caml_ba_dim_1 not implemented by bucklescript yet\n") - 1 | 0; i <= i_finish; ++i){
-    v[i] = /* float array */[
+    v[i] = /* array */[
       Caml_int32.imul(i, i),
       Caml_int32.imul(Caml_int32.imul(i, i), i)
     ];

--- a/jscomp/test/bs_MapInt_test.js
+++ b/jscomp/test/bs_MapInt_test.js
@@ -16,7 +16,7 @@ function test() {
     m = Belt_MapInt.set(m, i, i);
   }
   for(var i$1 = 0; i$1 <= 999999; ++i$1){
-    should(+(Belt_MapInt.get(m, i$1) !== /* None */0));
+    should(Belt_MapInt.get(m, i$1) !== /* None */0);
   }
   for(var i$2 = 0; i$2 <= 999999; ++i$2){
     m = Belt_MapInt.remove(m, i$2);

--- a/jscomp/test/bs_abstract_test.js
+++ b/jscomp/test/bs_abstract_test.js
@@ -10,7 +10,7 @@ v.tl = v;
 
 var f = {
   k: (function (x, y) {
-      return +(x === y);
+      return x === y;
     }),
   y: "x"
 };

--- a/jscomp/test/bs_array_test.js
+++ b/jscomp/test/bs_array_test.js
@@ -45,20 +45,20 @@ function neq(loc, x, y) {
   return /* () */0;
 }
 
-console.log(/* int array */[
+console.log(/* array */[
             1,
             2,
             3,
             4
           ].filter((function (x) {
-                return +(x > 2);
+                return x > 2;
               })).map((function (x, i) {
               return x + i | 0;
             })).reduce((function (x, y) {
             return x + y | 0;
           }), 0));
 
-var v = /* int array */[
+var v = /* array */[
   1,
   2
 ];
@@ -78,7 +78,7 @@ eq("File \"bs_array_test.ml\", line 25, characters 5-12", /* tuple */[
     ]);
 
 $$throw("File \"bs_array_test.ml\", line 28, characters 8-15", (function () {
-        Belt_Array.getExn(/* int array */[
+        Belt_Array.getExn(/* array */[
               0,
               1
             ], -1);
@@ -86,14 +86,14 @@ $$throw("File \"bs_array_test.ml\", line 28, characters 8-15", (function () {
       }));
 
 $$throw("File \"bs_array_test.ml\", line 29, characters 8-15", (function () {
-        Belt_Array.getExn(/* int array */[
+        Belt_Array.getExn(/* array */[
               0,
               1
             ], 2);
         return /* () */0;
       }));
 
-var partial_arg = /* int array */[
+var partial_arg = /* array */[
   0,
   1
 ];
@@ -111,25 +111,25 @@ b("File \"bs_array_test.ml\", line 30, characters 4-11", Caml_obj.caml_equal(/* 
         ]));
 
 $$throw("File \"bs_array_test.ml\", line 31, characters 8-15", (function () {
-        return Belt_Array.setExn(/* int array */[
+        return Belt_Array.setExn(/* array */[
                     0,
                     1
                   ], -1, 0);
       }));
 
 $$throw("File \"bs_array_test.ml\", line 32, characters 8-15", (function () {
-        return Belt_Array.setExn(/* int array */[
+        return Belt_Array.setExn(/* array */[
                     0,
                     1
                   ], 2, 0);
       }));
 
-b("File \"bs_array_test.ml\", line 33, characters 4-11", 1 - Belt_Array.set(/* int array */[
+b("File \"bs_array_test.ml\", line 33, characters 4-11", !Belt_Array.set(/* array */[
           1,
           2
         ], 2, 0));
 
-var v$1 = /* int array */[
+var v$1 = /* array */[
   1,
   2
 ];
@@ -145,9 +145,9 @@ if (!Belt_Array.set(v$1, 0, 0)) {
       ];
 }
 
-b("File \"bs_array_test.ml\", line 34, characters 4-11", +(Belt_Array.getExn(v$1, 0) === 0));
+b("File \"bs_array_test.ml\", line 34, characters 4-11", Belt_Array.getExn(v$1, 0) === 0);
 
-var v$2 = /* int array */[
+var v$2 = /* array */[
   1,
   2
 ];
@@ -163,21 +163,21 @@ if (!Belt_Array.set(v$2, 1, 0)) {
       ];
 }
 
-b("File \"bs_array_test.ml\", line 35, characters 4-11", +(Belt_Array.getExn(v$2, 1) === 0));
+b("File \"bs_array_test.ml\", line 35, characters 4-11", Belt_Array.getExn(v$2, 1) === 0);
 
-var v$3 = /* int array */[
+var v$3 = /* array */[
   1,
   2
 ];
 
-b("File \"bs_array_test.ml\", line 36, characters 4-11", (Belt_Array.setExn(v$3, 0, 0), +(Belt_Array.getExn(v$3, 0) === 0)));
+b("File \"bs_array_test.ml\", line 36, characters 4-11", (Belt_Array.setExn(v$3, 0, 0), Belt_Array.getExn(v$3, 0) === 0));
 
-var v$4 = /* int array */[
+var v$4 = /* array */[
   1,
   2
 ];
 
-b("File \"bs_array_test.ml\", line 37, characters 4-11", (Belt_Array.setExn(v$4, 1, 0), +(Belt_Array.getExn(v$4, 1) === 0)));
+b("File \"bs_array_test.ml\", line 37, characters 4-11", (Belt_Array.setExn(v$4, 1, 0), Belt_Array.getExn(v$4, 1) === 0));
 
 function id(x) {
   return eq("File \"bs_array_test.ml\", line 40, characters 5-12", Js_vector.toList(Js_list.toVector(x)), x);
@@ -192,7 +192,7 @@ eq("File \"bs_array_test.ml\", line 44, characters 5-12", Js_list.toVector(/* ::
               /* [] */0
             ]
           ]
-        ]), /* int array */[
+        ]), /* array */[
       1,
       2,
       3
@@ -200,11 +200,11 @@ eq("File \"bs_array_test.ml\", line 44, characters 5-12", Js_list.toVector(/* ::
 
 eq("File \"bs_array_test.ml\", line 45, characters 6-13", Js_vector.map((function (x) {
             return x + 1 | 0;
-          }), /* int array */[
+          }), /* array */[
           1,
           2,
           3
-        ]), /* int array */[
+        ]), /* array */[
       2,
       3,
       4
@@ -223,8 +223,8 @@ var a = Js_vector.init(5, (function (i) {
       }));
 
 eq("File \"bs_array_test.ml\", line 50, characters 5-12", (Js_vector.filterInPlace((function (j) {
-              return +(j % 2 === 0);
-            }), a), a), /* int array */[
+              return j % 2 === 0;
+            }), a), a), /* array */[
       2,
       4
     ]);
@@ -234,8 +234,8 @@ var a$1 = Js_vector.init(5, (function (i) {
       }));
 
 eq("File \"bs_array_test.ml\", line 57, characters 5-12", (Js_vector.filterInPlace((function (j) {
-              return +(j % 2 !== 0);
-            }), a$1), a$1), /* int array */[
+              return j % 2 !== 0;
+            }), a$1), a$1), /* array */[
       1,
       3,
       5
@@ -250,7 +250,7 @@ eq("File \"bs_array_test.ml\", line 64, characters 5-12", Js_list.toVector(/* ::
               /* [] */0
             ]
           ]
-        ]), /* int array */[
+        ]), /* array */[
       1,
       2,
       3
@@ -259,7 +259,7 @@ eq("File \"bs_array_test.ml\", line 64, characters 5-12", Js_list.toVector(/* ::
 eq("File \"bs_array_test.ml\", line 66, characters 5-12", Js_list.toVector(/* :: */[
           1,
           /* [] */0
-        ]), /* int array */[1]);
+        ]), /* array */[1]);
 
 id(/* [] */0);
 
@@ -303,18 +303,18 @@ neq("File \"bs_array_test.ml\", line 77, characters 6-13", u, v$5);
 
 eq("File \"bs_array_test.ml\", line 79, characters 5-12", Belt_Array.reduce(u, 0, add), Belt_Array.reduce(v$5, 0, add));
 
-b("File \"bs_array_test.ml\", line 84, characters 4-11", Caml_obj.caml_equal(Belt_Array.range(0, 3), /* int array */[
+b("File \"bs_array_test.ml\", line 84, characters 4-11", Caml_obj.caml_equal(Belt_Array.range(0, 3), /* array */[
           0,
           1,
           2,
           3
         ]));
 
-b("File \"bs_array_test.ml\", line 85, characters 4-11", Caml_obj.caml_equal(Belt_Array.range(3, 0), /* int array */[]));
+b("File \"bs_array_test.ml\", line 85, characters 4-11", Caml_obj.caml_equal(Belt_Array.range(3, 0), /* array */[]));
 
-b("File \"bs_array_test.ml\", line 86, characters 4-11", Caml_obj.caml_equal(Belt_Array.range(3, 3), /* int array */[3]));
+b("File \"bs_array_test.ml\", line 86, characters 4-11", Caml_obj.caml_equal(Belt_Array.range(3, 3), /* array */[3]));
 
-b("File \"bs_array_test.ml\", line 88, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(0, 10, 3), /* int array */[
+b("File \"bs_array_test.ml\", line 88, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(0, 10, 3), /* array */[
           0,
           3,
           6,
@@ -329,28 +329,28 @@ b("File \"bs_array_test.ml\", line 89, characters 4-11", Caml_obj.caml_equal(Bel
           12
         ]));
 
-b("File \"bs_array_test.ml\", line 90, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(33, 0, 1), /* int array */[]));
+b("File \"bs_array_test.ml\", line 90, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(33, 0, 1), /* array */[]));
 
-b("File \"bs_array_test.ml\", line 91, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(33, 0, -1), /* int array */[]));
+b("File \"bs_array_test.ml\", line 91, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(33, 0, -1), /* array */[]));
 
-b("File \"bs_array_test.ml\", line 92, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(3, 12, -1), /* int array */[]));
+b("File \"bs_array_test.ml\", line 92, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(3, 12, -1), /* array */[]));
 
-b("File \"bs_array_test.ml\", line 93, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(3, 3, 0), /* int array */[]));
+b("File \"bs_array_test.ml\", line 93, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(3, 3, 0), /* array */[]));
 
-b("File \"bs_array_test.ml\", line 94, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(3, 3, 1), /* int array */[3]));
+b("File \"bs_array_test.ml\", line 94, characters 4-11", Caml_obj.caml_equal(Belt_Array.rangeBy(3, 3, 1), /* array */[3]));
 
-eq("File \"bs_array_test.ml\", line 99, characters 5-12", Belt_Array.reduceReverse(/* int array */[], 100, (function (prim, prim$1) {
+eq("File \"bs_array_test.ml\", line 99, characters 5-12", Belt_Array.reduceReverse(/* array */[], 100, (function (prim, prim$1) {
             return prim - prim$1 | 0;
           })), 100);
 
-eq("File \"bs_array_test.ml\", line 100, characters 5-12", Belt_Array.reduceReverse(/* int array */[
+eq("File \"bs_array_test.ml\", line 100, characters 5-12", Belt_Array.reduceReverse(/* array */[
           1,
           2
         ], 100, (function (prim, prim$1) {
             return prim - prim$1 | 0;
           })), 97);
 
-eq("File \"bs_array_test.ml\", line 101, characters 5-12", Belt_Array.reduceReverse(/* int array */[
+eq("File \"bs_array_test.ml\", line 101, characters 5-12", Belt_Array.reduceReverse(/* array */[
           1,
           2,
           3,
@@ -359,16 +359,16 @@ eq("File \"bs_array_test.ml\", line 101, characters 5-12", Belt_Array.reduceReve
             return prim - prim$1 | 0;
           })), 90);
 
-b("File \"bs_array_test.ml\", line 102, characters 4-11", +(Belt_Array.reduceReverse2(/* int array */[
-            1,
-            2,
-            3
-          ], /* int array */[
-            1,
-            2
-          ], 0, (function (acc, x, y) {
-              return (acc + x | 0) + y | 0;
-            })) === 6));
+b("File \"bs_array_test.ml\", line 102, characters 4-11", Belt_Array.reduceReverse2(/* array */[
+          1,
+          2,
+          3
+        ], /* array */[
+          1,
+          2
+        ], 0, (function (acc, x, y) {
+            return (acc + x | 0) + y | 0;
+          })) === 6);
 
 function addone(x) {
   return x + 1 | 0;
@@ -391,30 +391,30 @@ function makeMatrixExn(sx, sy, init) {
 
 eq("File \"bs_array_test.ml\", line 120, characters 5-12", Belt_Array.makeBy(0, (function () {
             return 1;
-          })), /* int array */[]);
+          })), /* array */[]);
 
 eq("File \"bs_array_test.ml\", line 121, characters 5-12", Belt_Array.makeBy(3, (function (i) {
             return i;
-          })), /* int array */[
+          })), /* array */[
       0,
       1,
       2
     ]);
 
 eq("File \"bs_array_test.ml\", line 122, characters 5-12", makeMatrixExn(3, 4, 1), /* array */[
-      /* int array */[
+      /* array */[
         1,
         1,
         1,
         1
       ],
-      /* int array */[
+      /* array */[
         1,
         1,
         1,
         1
       ],
-      /* int array */[
+      /* array */[
         1,
         1,
         1,
@@ -423,28 +423,28 @@ eq("File \"bs_array_test.ml\", line 122, characters 5-12", makeMatrixExn(3, 4, 1
     ]);
 
 eq("File \"bs_array_test.ml\", line 125, characters 5-12", makeMatrixExn(3, 0, 0), /* array */[
-      /* int array */[],
-      /* int array */[],
-      /* int array */[]
+      /* array */[],
+      /* array */[],
+      /* array */[]
     ]);
 
 eq("File \"bs_array_test.ml\", line 126, characters 5-12", makeMatrixExn(0, 3, 1), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 127, characters 5-12", makeMatrixExn(1, 1, 1), /* array */[/* int array */[1]]);
+eq("File \"bs_array_test.ml\", line 127, characters 5-12", makeMatrixExn(1, 1, 1), /* array */[/* array */[1]]);
 
 eq("File \"bs_array_test.ml\", line 128, characters 5-12", Belt_Array.copy(/* array */[]), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 129, characters 5-12", Belt_Array.map(/* int array */[], (function (prim) {
+eq("File \"bs_array_test.ml\", line 129, characters 5-12", Belt_Array.map(/* array */[], (function (prim) {
             return prim + 1 | 0;
-          })), /* int array */[]);
+          })), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 130, characters 5-12", Belt_Array.mapWithIndex(/* int array */[], add), /* int array */[]);
+eq("File \"bs_array_test.ml\", line 130, characters 5-12", Belt_Array.mapWithIndex(/* array */[], add), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 131, characters 5-12", Belt_Array.mapWithIndex(/* int array */[
+eq("File \"bs_array_test.ml\", line 131, characters 5-12", Belt_Array.mapWithIndex(/* array */[
           1,
           2,
           3
-        ], add), /* int array */[
+        ], add), /* array */[
       1,
       3,
       5
@@ -452,12 +452,12 @@ eq("File \"bs_array_test.ml\", line 131, characters 5-12", Belt_Array.mapWithInd
 
 eq("File \"bs_array_test.ml\", line 132, characters 5-12", Belt_List.fromArray(/* array */[]), /* [] */0);
 
-eq("File \"bs_array_test.ml\", line 133, characters 5-12", Belt_List.fromArray(/* int array */[1]), /* :: */[
+eq("File \"bs_array_test.ml\", line 133, characters 5-12", Belt_List.fromArray(/* array */[1]), /* :: */[
       1,
       /* [] */0
     ]);
 
-eq("File \"bs_array_test.ml\", line 134, characters 5-12", Belt_List.fromArray(/* int array */[
+eq("File \"bs_array_test.ml\", line 134, characters 5-12", Belt_List.fromArray(/* array */[
           1,
           2,
           3
@@ -472,13 +472,13 @@ eq("File \"bs_array_test.ml\", line 134, characters 5-12", Belt_List.fromArray(/
       ]
     ]);
 
-eq("File \"bs_array_test.ml\", line 135, characters 5-12", Belt_Array.map(/* int array */[
+eq("File \"bs_array_test.ml\", line 135, characters 5-12", Belt_Array.map(/* array */[
           1,
           2,
           3
         ], (function (prim) {
             return prim + 1 | 0;
-          })), /* int array */[
+          })), /* array */[
       2,
       3,
       4
@@ -489,7 +489,7 @@ eq("File \"bs_array_test.ml\", line 136, characters 5-12", Belt_List.toArray(/* 
 eq("File \"bs_array_test.ml\", line 137, characters 5-12", Belt_List.toArray(/* :: */[
           1,
           /* [] */0
-        ]), /* int array */[1]);
+        ]), /* array */[1]);
 
 eq("File \"bs_array_test.ml\", line 138, characters 5-12", Belt_List.toArray(/* :: */[
           1,
@@ -497,7 +497,7 @@ eq("File \"bs_array_test.ml\", line 138, characters 5-12", Belt_List.toArray(/* 
             2,
             /* [] */0
           ]
-        ]), /* int array */[
+        ]), /* array */[
       1,
       2
     ]);
@@ -511,7 +511,7 @@ eq("File \"bs_array_test.ml\", line 139, characters 5-12", Belt_List.toArray(/* 
               /* [] */0
             ]
           ]
-        ]), /* int array */[
+        ]), /* array */[
       1,
       2,
       3
@@ -522,11 +522,11 @@ var v$6 = Belt_Array.makeBy(10, (function (i) {
       }));
 
 var v0 = Belt_Array.keep(v$6, (function (x) {
-        return +(x % 2 === 0);
+        return x % 2 === 0;
       }));
 
 var v1 = Belt_Array.keep(v$6, (function (x) {
-        return +(x % 3 === 0);
+        return x % 3 === 0;
       }));
 
 var v2 = Belt_Array.keepMap(v$6, (function (x) {
@@ -545,7 +545,7 @@ eq("File \"bs_array_test.ml\", line 146, characters 5-12", v0, /* array */[
       8
     ]);
 
-eq("File \"bs_array_test.ml\", line 147, characters 5-12", v1, /* int array */[
+eq("File \"bs_array_test.ml\", line 147, characters 5-12", v1, /* array */[
       0,
       3,
       6,
@@ -568,7 +568,7 @@ var a$2 = /* array */[
   5
 ];
 
-eq("File \"bs_array_test.ml\", line 152, characters 5-12", Belt_Array.slice(a$2, 0, 2), /* int array */[
+eq("File \"bs_array_test.ml\", line 152, characters 5-12", Belt_Array.slice(a$2, 0, 2), /* array */[
       1,
       2
     ]);
@@ -589,33 +589,33 @@ eq("File \"bs_array_test.ml\", line 154, characters 5-12", Belt_Array.slice(a$2,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 155, characters 5-12", Belt_Array.slice(a$2, 5, 1), /* int array */[]);
+eq("File \"bs_array_test.ml\", line 155, characters 5-12", Belt_Array.slice(a$2, 5, 1), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 156, characters 5-12", Belt_Array.slice(a$2, 4, 1), /* int array */[5]);
+eq("File \"bs_array_test.ml\", line 156, characters 5-12", Belt_Array.slice(a$2, 4, 1), /* array */[5]);
 
-eq("File \"bs_array_test.ml\", line 157, characters 5-12", Belt_Array.slice(a$2, -1, 1), /* int array */[5]);
+eq("File \"bs_array_test.ml\", line 157, characters 5-12", Belt_Array.slice(a$2, -1, 1), /* array */[5]);
 
-eq("File \"bs_array_test.ml\", line 158, characters 5-12", Belt_Array.slice(a$2, -1, 2), /* int array */[5]);
+eq("File \"bs_array_test.ml\", line 158, characters 5-12", Belt_Array.slice(a$2, -1, 2), /* array */[5]);
 
-eq("File \"bs_array_test.ml\", line 159, characters 5-12", Belt_Array.slice(a$2, -2, 1), /* int array */[4]);
+eq("File \"bs_array_test.ml\", line 159, characters 5-12", Belt_Array.slice(a$2, -2, 1), /* array */[4]);
 
-eq("File \"bs_array_test.ml\", line 160, characters 5-12", Belt_Array.slice(a$2, -2, 2), /* int array */[
+eq("File \"bs_array_test.ml\", line 160, characters 5-12", Belt_Array.slice(a$2, -2, 2), /* array */[
       4,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 161, characters 5-12", Belt_Array.slice(a$2, -2, 3), /* int array */[
+eq("File \"bs_array_test.ml\", line 161, characters 5-12", Belt_Array.slice(a$2, -2, 3), /* array */[
       4,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 162, characters 5-12", Belt_Array.slice(a$2, -10, 3), /* int array */[
+eq("File \"bs_array_test.ml\", line 162, characters 5-12", Belt_Array.slice(a$2, -10, 3), /* array */[
       1,
       2,
       3
     ]);
 
-eq("File \"bs_array_test.ml\", line 163, characters 5-12", Belt_Array.slice(a$2, -10, 4), /* int array */[
+eq("File \"bs_array_test.ml\", line 163, characters 5-12", Belt_Array.slice(a$2, -10, 4), /* array */[
       1,
       2,
       3,
@@ -638,9 +638,9 @@ eq("File \"bs_array_test.ml\", line 165, characters 5-12", Belt_Array.slice(a$2,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 166, characters 5-12", Belt_Array.slice(a$2, 0, 0), /* int array */[]);
+eq("File \"bs_array_test.ml\", line 166, characters 5-12", Belt_Array.slice(a$2, 0, 0), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 167, characters 5-12", Belt_Array.slice(a$2, 0, -1), /* int array */[]);
+eq("File \"bs_array_test.ml\", line 167, characters 5-12", Belt_Array.slice(a$2, 0, -1), /* array */[]);
 
 var a$3 = Belt_Array.makeBy(10, (function (x) {
         return x;
@@ -789,7 +789,7 @@ Belt_Array.fill(a$3, 0, -1, 2);
 
 eq("File \"bs_array_test.ml\", line 192, characters 5-12", Belt_Array.copy(a$3), Belt_Array.make(10, 7));
 
-var b$1 = /* int array */[
+var b$1 = /* array */[
   1,
   2,
   3
@@ -797,7 +797,7 @@ var b$1 = /* int array */[
 
 Belt_Array.fill(b$1, 0, 0, 0);
 
-eq("File \"bs_array_test.ml\", line 195, characters 5-12", b$1, /* int array */[
+eq("File \"bs_array_test.ml\", line 195, characters 5-12", b$1, /* array */[
       1,
       2,
       3
@@ -805,7 +805,7 @@ eq("File \"bs_array_test.ml\", line 195, characters 5-12", b$1, /* int array */[
 
 Belt_Array.fill(b$1, 4, 1, 0);
 
-eq("File \"bs_array_test.ml\", line 197, characters 5-12", b$1, /* int array */[
+eq("File \"bs_array_test.ml\", line 197, characters 5-12", b$1, /* array */[
       1,
       2,
       3
@@ -949,11 +949,11 @@ eq("File \"bs_array_test.ml\", line 226, characters 5-12", Belt_Array.copy(aa), 
       9
     ]);
 
-eq("File \"bs_array_test.ml\", line 227, characters 5-12", Belt_Array.make(0, 3), /* int array */[]);
+eq("File \"bs_array_test.ml\", line 227, characters 5-12", Belt_Array.make(0, 3), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 228, characters 5-12", Belt_Array.make(-1, 3), /* int array */[]);
+eq("File \"bs_array_test.ml\", line 228, characters 5-12", Belt_Array.make(-1, 3), /* array */[]);
 
-var c = /* int array */[
+var c = /* array */[
   0,
   1,
   2
@@ -961,17 +961,17 @@ var c = /* int array */[
 
 Belt_Array.blit(c, 4, c, 1, 1);
 
-eq("File \"bs_array_test.ml\", line 231, characters 5-12", c, /* int array */[
+eq("File \"bs_array_test.ml\", line 231, characters 5-12", c, /* array */[
       0,
       1,
       2
     ]);
 
-eq("File \"bs_array_test.ml\", line 234, characters 5-12", Belt_Array.zip(/* int array */[
+eq("File \"bs_array_test.ml\", line 234, characters 5-12", Belt_Array.zip(/* array */[
           1,
           2,
           3
-        ], /* int array */[
+        ], /* array */[
           2,
           3,
           4,
@@ -991,12 +991,12 @@ eq("File \"bs_array_test.ml\", line 234, characters 5-12", Belt_Array.zip(/* int
       ]
     ]);
 
-eq("File \"bs_array_test.ml\", line 235, characters 5-12", Belt_Array.zip(/* int array */[
+eq("File \"bs_array_test.ml\", line 235, characters 5-12", Belt_Array.zip(/* array */[
           2,
           3,
           4,
           1
-        ], /* int array */[
+        ], /* array */[
           1,
           2,
           3
@@ -1015,35 +1015,35 @@ eq("File \"bs_array_test.ml\", line 235, characters 5-12", Belt_Array.zip(/* int
       ]
     ]);
 
-eq("File \"bs_array_test.ml\", line 236, characters 5-12", Belt_Array.zipBy(/* int array */[
+eq("File \"bs_array_test.ml\", line 236, characters 5-12", Belt_Array.zipBy(/* array */[
           2,
           3,
           4,
           1
-        ], /* int array */[
+        ], /* array */[
           1,
           2,
           3
         ], (function (prim, prim$1) {
             return prim - prim$1 | 0;
-          })), /* int array */[
+          })), /* array */[
       1,
       1,
       1
     ]);
 
-eq("File \"bs_array_test.ml\", line 237, characters 5-12", Belt_Array.zipBy(/* int array */[
+eq("File \"bs_array_test.ml\", line 237, characters 5-12", Belt_Array.zipBy(/* array */[
           1,
           2,
           3
-        ], /* int array */[
+        ], /* array */[
           2,
           3,
           4,
           1
         ], (function (prim, prim$1) {
             return prim - prim$1 | 0;
-          })), Belt_Array.map(/* int array */[
+          })), Belt_Array.map(/* array */[
           1,
           1,
           1
@@ -1068,48 +1068,48 @@ eq("File \"bs_array_test.ml\", line 245, characters 5-12", sumUsingForEach(/* ar
           4
         ]), 10);
 
-b("File \"bs_array_test.ml\", line 246, characters 4-11", 1 - Belt_Array.every(/* array */[
+b("File \"bs_array_test.ml\", line 246, characters 4-11", !Belt_Array.every(/* array */[
           0,
           1,
           2,
           3,
           4
         ], (function (x) {
-            return +(x > 2);
+            return x > 2;
           })));
 
-b("File \"bs_array_test.ml\", line 247, characters 4-11", Belt_Array.some(/* int array */[
+b("File \"bs_array_test.ml\", line 247, characters 4-11", Belt_Array.some(/* array */[
           1,
           3,
           7,
           8
         ], (function (x) {
-            return +(x % 2 === 0);
+            return x % 2 === 0;
           })));
 
-b("File \"bs_array_test.ml\", line 248, characters 4-11", 1 - Belt_Array.some(/* int array */[
+b("File \"bs_array_test.ml\", line 248, characters 4-11", !Belt_Array.some(/* array */[
           1,
           3,
           7
         ], (function (x) {
-            return +(x % 2 === 0);
+            return x % 2 === 0;
           })));
 
-b("File \"bs_array_test.ml\", line 249, characters 4-11", 1 - Belt_Array.eq(/* int array */[
+b("File \"bs_array_test.ml\", line 249, characters 4-11", !Belt_Array.eq(/* array */[
           0,
           1
-        ], /* int array */[1], Caml_obj.caml_equal));
+        ], /* array */[1], Caml_obj.caml_equal));
 
 var c$1 = [0];
 
-b("File \"bs_array_test.ml\", line 250, characters 4-11", (Belt_Array.forEachWithIndex(/* int array */[
+b("File \"bs_array_test.ml\", line 250, characters 4-11", (Belt_Array.forEachWithIndex(/* array */[
             1,
             1,
             1
           ], (function (i, v) {
               c$1[0] = (c$1[0] + i | 0) + v | 0;
               return /* () */0;
-            })), +(c$1[0] === 6)));
+            })), c$1[0] === 6));
 
 function id$1(_, x) {
   var u = Belt_Array.copy(x);
@@ -1118,20 +1118,20 @@ function id$1(_, x) {
 
 id$1("File \"bs_array_test.ml\", line 265, characters 5-12", /* array */[]);
 
-id$1("File \"bs_array_test.ml\", line 266, characters 5-12", /* int array */[1]);
+id$1("File \"bs_array_test.ml\", line 266, characters 5-12", /* array */[1]);
 
-id$1("File \"bs_array_test.ml\", line 267, characters 5-12", /* int array */[
+id$1("File \"bs_array_test.ml\", line 267, characters 5-12", /* array */[
       1,
       2
     ]);
 
-id$1("File \"bs_array_test.ml\", line 268, characters 5-12", /* int array */[
+id$1("File \"bs_array_test.ml\", line 268, characters 5-12", /* array */[
       1,
       2,
       3
     ]);
 
-id$1("File \"bs_array_test.ml\", line 269, characters 5-12", /* int array */[
+id$1("File \"bs_array_test.ml\", line 269, characters 5-12", /* array */[
       1,
       2,
       3,
@@ -1158,8 +1158,8 @@ eq("File \"bs_array_test.ml\", line 279, characters 5-12", every2(/* [] */0, /* 
             1,
             /* [] */0
           ])((function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_array_test.ml\", line 280, characters 5-12", every2(/* :: */[
             2,
@@ -1171,8 +1171,8 @@ eq("File \"bs_array_test.ml\", line 280, characters 5-12", every2(/* :: */[
             1,
             /* [] */0
           ])((function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_array_test.ml\", line 281, characters 5-12", every2(/* :: */[
             2,
@@ -1181,8 +1181,8 @@ eq("File \"bs_array_test.ml\", line 281, characters 5-12", every2(/* :: */[
             1,
             /* [] */0
           ])((function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_array_test.ml\", line 282, characters 5-12", every2(/* :: */[
             2,
@@ -1197,8 +1197,8 @@ eq("File \"bs_array_test.ml\", line 282, characters 5-12", every2(/* :: */[
               /* [] */0
             ]
           ])((function (x, y) {
-            return +(x > y);
-          })), /* false */0);
+            return x > y;
+          })), false);
 
 eq("File \"bs_array_test.ml\", line 283, characters 5-12", every2(/* :: */[
             2,
@@ -1213,15 +1213,15 @@ eq("File \"bs_array_test.ml\", line 283, characters 5-12", every2(/* :: */[
               /* [] */0
             ]
           ])((function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_array_test.ml\", line 284, characters 5-12", some2(/* [] */0, /* :: */[
             1,
             /* [] */0
           ])((function (x, y) {
-            return +(x > y);
-          })), /* false */0);
+            return x > y;
+          })), false);
 
 eq("File \"bs_array_test.ml\", line 285, characters 5-12", some2(/* :: */[
             2,
@@ -1233,8 +1233,8 @@ eq("File \"bs_array_test.ml\", line 285, characters 5-12", some2(/* :: */[
             1,
             /* [] */0
           ])((function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_array_test.ml\", line 286, characters 5-12", some2(/* :: */[
             2,
@@ -1249,8 +1249,8 @@ eq("File \"bs_array_test.ml\", line 286, characters 5-12", some2(/* :: */[
               /* [] */0
             ]
           ])((function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_array_test.ml\", line 287, characters 5-12", some2(/* :: */[
             0,
@@ -1265,8 +1265,8 @@ eq("File \"bs_array_test.ml\", line 287, characters 5-12", some2(/* :: */[
               /* [] */0
             ]
           ])((function (x, y) {
-            return +(x > y);
-          })), /* false */0);
+            return x > y;
+          })), false);
 
 eq("File \"bs_array_test.ml\", line 288, characters 5-12", some2(/* :: */[
             0,
@@ -1281,14 +1281,14 @@ eq("File \"bs_array_test.ml\", line 288, characters 5-12", some2(/* :: */[
               /* [] */0
             ]
           ])((function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
-eq("File \"bs_array_test.ml\", line 293, characters 5-12", Belt_Array.concat(/* int array */[], /* int array */[
+eq("File \"bs_array_test.ml\", line 293, characters 5-12", Belt_Array.concat(/* array */[], /* array */[
           1,
           2,
           3
-        ]), /* int array */[
+        ]), /* array */[
       1,
       2,
       3
@@ -1296,10 +1296,10 @@ eq("File \"bs_array_test.ml\", line 293, characters 5-12", Belt_Array.concat(/* 
 
 eq("File \"bs_array_test.ml\", line 294, characters 5-12", Belt_Array.concat(/* array */[], /* array */[]), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 295, characters 5-12", Belt_Array.concat(/* int array */[
+eq("File \"bs_array_test.ml\", line 295, characters 5-12", Belt_Array.concat(/* array */[
           3,
           2
-        ], /* int array */[
+        ], /* array */[
           1,
           2,
           3
@@ -1312,11 +1312,11 @@ eq("File \"bs_array_test.ml\", line 295, characters 5-12", Belt_Array.concat(/* 
     ]);
 
 eq("File \"bs_array_test.ml\", line 296, characters 5-12", Belt_Array.concatMany(/* array */[
-          /* int array */[
+          /* array */[
             3,
             2
           ],
-          /* int array */[
+          /* array */[
             1,
             2,
             3
@@ -1330,17 +1330,17 @@ eq("File \"bs_array_test.ml\", line 296, characters 5-12", Belt_Array.concatMany
     ]);
 
 eq("File \"bs_array_test.ml\", line 297, characters 5-12", Belt_Array.concatMany(/* array */[
-          /* int array */[
+          /* array */[
             3,
             2
           ],
-          /* int array */[
+          /* array */[
             1,
             2,
             3
           ],
-          /* int array */[],
-          /* int array */[0]
+          /* array */[],
+          /* array */[0]
         ]), /* array */[
       3,
       2,
@@ -1351,18 +1351,18 @@ eq("File \"bs_array_test.ml\", line 297, characters 5-12", Belt_Array.concatMany
     ]);
 
 eq("File \"bs_array_test.ml\", line 298, characters 5-12", Belt_Array.concatMany(/* array */[
-          /* int array */[],
-          /* int array */[
+          /* array */[],
+          /* array */[
             3,
             2
           ],
-          /* int array */[
+          /* array */[
             1,
             2,
             3
           ],
-          /* int array */[],
-          /* int array */[0]
+          /* array */[],
+          /* array */[0]
         ]), /* array */[
       3,
       2,
@@ -1377,57 +1377,57 @@ eq("File \"bs_array_test.ml\", line 299, characters 5-12", Belt_Array.concatMany
           /* array */[]
         ]), /* array */[]);
 
-b("File \"bs_array_test.ml\", line 302, characters 4-11", +(Belt_Array.cmp(/* int array */[
-            1,
-            2,
-            3
-          ], /* int array */[
-            0,
-            1,
-            2,
-            3
-          ], Caml_obj.caml_compare) < 0));
+b("File \"bs_array_test.ml\", line 302, characters 4-11", Belt_Array.cmp(/* array */[
+          1,
+          2,
+          3
+        ], /* array */[
+          0,
+          1,
+          2,
+          3
+        ], Caml_obj.caml_compare) < 0);
 
-b("File \"bs_array_test.ml\", line 303, characters 4-11", +(Belt_Array.cmp(/* int array */[
-            0,
-            1,
-            2,
-            3
-          ], /* int array */[
-            1,
-            2,
-            3
-          ], Caml_obj.caml_compare) > 0));
+b("File \"bs_array_test.ml\", line 303, characters 4-11", Belt_Array.cmp(/* array */[
+          0,
+          1,
+          2,
+          3
+        ], /* array */[
+          1,
+          2,
+          3
+        ], Caml_obj.caml_compare) > 0);
 
-b("File \"bs_array_test.ml\", line 304, characters 4-11", +(Belt_Array.cmp(/* int array */[
-            1,
-            2,
-            3
-          ], /* int array */[
-            0,
-            1,
-            2
-          ], Caml_primitive.caml_int_compare) > 0));
+b("File \"bs_array_test.ml\", line 304, characters 4-11", Belt_Array.cmp(/* array */[
+          1,
+          2,
+          3
+        ], /* array */[
+          0,
+          1,
+          2
+        ], Caml_primitive.caml_int_compare) > 0);
 
-b("File \"bs_array_test.ml\", line 305, characters 4-11", +(Belt_Array.cmp(/* int array */[
-            1,
-            2,
-            3
-          ], /* int array */[
-            1,
-            2,
-            3
-          ], Caml_primitive.caml_int_compare) === 0));
+b("File \"bs_array_test.ml\", line 305, characters 4-11", Belt_Array.cmp(/* array */[
+          1,
+          2,
+          3
+        ], /* array */[
+          1,
+          2,
+          3
+        ], Caml_primitive.caml_int_compare) === 0);
 
-b("File \"bs_array_test.ml\", line 306, characters 4-11", +(Belt_Array.cmp(/* int array */[
-            1,
-            2,
-            4
-          ], /* int array */[
-            1,
-            2,
-            3
-          ], Caml_primitive.caml_int_compare) > 0));
+b("File \"bs_array_test.ml\", line 306, characters 4-11", Belt_Array.cmp(/* array */[
+          1,
+          2,
+          4
+        ], /* array */[
+          1,
+          2,
+          3
+        ], Caml_primitive.caml_int_compare) > 0);
 
 Mt.from_pair_suites("File \"bs_array_test.ml\", line 309, characters 23-30", suites[0]);
 

--- a/jscomp/test/bs_auto_uncurry.js
+++ b/jscomp/test/bs_auto_uncurry.js
@@ -2,7 +2,7 @@
 
 var Curry = require("../../lib/js/curry.js");
 
-var xbs = Array.prototype.map.call(/* int array */[
+var xbs = Array.prototype.map.call(/* array */[
       1,
       2,
       3,
@@ -12,7 +12,7 @@ var xbs = Array.prototype.map.call(/* int array */[
       }));
 
 function f(cb) {
-  return Array.prototype.map.call(/* int array */[
+  return Array.prototype.map.call(/* array */[
               1,
               2,
               3,
@@ -20,7 +20,7 @@ function f(cb) {
             ], Curry.__1(cb));
 }
 
-var xs = Array.prototype.map.call(/* int array */[
+var xs = Array.prototype.map.call(/* array */[
       1,
       1,
       2

--- a/jscomp/test/bs_auto_uncurry_test.js
+++ b/jscomp/test/bs_auto_uncurry_test.js
@@ -58,31 +58,31 @@ eq("File \"bs_auto_uncurry_test.ml\", line 27, characters 7-14", xs[0], /* :: */
       ]
     ]);
 
-eq("File \"bs_auto_uncurry_test.ml\", line 33, characters 7-14", /* int array */[
+eq("File \"bs_auto_uncurry_test.ml\", line 33, characters 7-14", /* array */[
         1,
         2,
         3
       ].map((function (x) {
             return x + 1 | 0;
-          })), /* int array */[
+          })), /* array */[
       2,
       3,
       4
     ]);
 
-eq("File \"bs_auto_uncurry_test.ml\", line 36, characters 7-14", /* int array */[
+eq("File \"bs_auto_uncurry_test.ml\", line 36, characters 7-14", /* array */[
         1,
         2,
         3
       ].map((function (x) {
             return x + 1 | 0;
-          })), /* int array */[
+          })), /* array */[
       2,
       3,
       4
     ]);
 
-eq("File \"bs_auto_uncurry_test.ml\", line 40, characters 7-14", /* int array */[
+eq("File \"bs_auto_uncurry_test.ml\", line 40, characters 7-14", /* array */[
         1,
         2,
         3
@@ -90,7 +90,7 @@ eq("File \"bs_auto_uncurry_test.ml\", line 40, characters 7-14", /* int array */
             return prim + prim$1 | 0;
           }), 0), 6);
 
-eq("File \"bs_auto_uncurry_test.ml\", line 44, characters 7-14", /* int array */[
+eq("File \"bs_auto_uncurry_test.ml\", line 44, characters 7-14", /* array */[
         1,
         2,
         3
@@ -98,21 +98,21 @@ eq("File \"bs_auto_uncurry_test.ml\", line 44, characters 7-14", /* int array */
             return (x + y | 0) + i | 0;
           }), 0), 9);
 
-eq("File \"bs_auto_uncurry_test.ml\", line 48, characters 7-14", +/* int array */[
+eq("File \"bs_auto_uncurry_test.ml\", line 48, characters 7-14", /* array */[
         1,
         2,
         3
       ].some((function (x) {
-            return +(x < 1);
-          })), /* false */0);
+            return x < 1;
+          })), false);
 
-eq("File \"bs_auto_uncurry_test.ml\", line 52, characters 7-14", +/* int array */[
+eq("File \"bs_auto_uncurry_test.ml\", line 52, characters 7-14", /* array */[
         1,
         2,
         3
       ].every((function (x) {
-            return +(x > 0);
-          })), /* true */1);
+            return x > 0;
+          })), true);
 
 Mt.from_pair_suites("bs_auto_uncurry_test.ml", suites[0]);
 

--- a/jscomp/test/bs_hashmap_test.js
+++ b/jscomp/test/bs_hashmap_test.js
@@ -22,7 +22,7 @@ function b(loc, x) {
 }
 
 function eq(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 var hash = Hashtbl.hash;

--- a/jscomp/test/bs_hashset_int_test.js
+++ b/jscomp/test/bs_hashset_int_test.js
@@ -95,7 +95,7 @@ var h = Belt_HashSetInt.ofArray(Array_data_util.randomRange(0, 1000000));
 
 var histo = Belt_HashSetInt.getBucketHistogram(h);
 
-b("File \"bs_hashset_int_test.ml\", line 62, characters 4-11", +(histo.length <= 10));
+b("File \"bs_hashset_int_test.ml\", line 62, characters 4-11", histo.length <= 10);
 
 Mt.from_pair_suites("bs_hashset_int_test.ml", suites[0]);
 

--- a/jscomp/test/bs_hashtbl_string_test.js
+++ b/jscomp/test/bs_hashtbl_string_test.js
@@ -28,21 +28,21 @@ var hashString = (function (str) {
                                             );
 
 var $$String = Belt_Id.hashable(Hashtbl.hash, (function (x, y) {
-        return +(x === y);
+        return x === y;
       }));
 
 var String1 = Belt_Id.hashable(hashString, (function (x, y) {
-        return +(x === y);
+        return x === y;
       }));
 
 var String2 = Belt_Id.hashable((function (x) {
         return Caml_hash.caml_hash_final_mix(Caml_hash.caml_hash_mix_string(0, x));
       }), (function (x, y) {
-        return +(x === y);
+        return x === y;
       }));
 
 var Int = Belt_Id.hashable(Hashtbl.hash, (function (x, y) {
-        return +(x === y);
+        return x === y;
       }));
 
 var empty = Belt_HashMap.make(500000, Int);

--- a/jscomp/test/bs_ignore_test.js
+++ b/jscomp/test/bs_ignore_test.js
@@ -23,7 +23,7 @@ function add_dyn(kind,x,y){
 ;
 
 function string_of_kind(kind) {
-  if (kind !== 0) {
+  if (kind) {
     return "string";
   } else {
     return "float";
@@ -31,7 +31,7 @@ function string_of_kind(kind) {
 }
 
 function add2(k, x, y) {
-  return add_dyn(string_of_kind(k), x, y);
+  return add_dyn(k ? "string" : "float", x, y);
 }
 
 console.log(add2(/* Float */0, 3.0, 2.0));

--- a/jscomp/test/bs_list_test.js
+++ b/jscomp/test/bs_list_test.js
@@ -85,7 +85,7 @@ eq("File \"bs_list_test.ml\", line 31, characters 5-12", Belt_List.getBy(/* :: *
             ]
           ]
         ], (function (x) {
-            return +(x % 2 === 0);
+            return x % 2 === 0;
           })), /* Some */[4]);
 
 eq("File \"bs_list_test.ml\", line 32, characters 5-12", Belt_List.getBy(/* :: */[
@@ -101,7 +101,7 @@ eq("File \"bs_list_test.ml\", line 32, characters 5-12", Belt_List.getBy(/* :: *
             ]
           ]
         ], (function (x) {
-            return +(x % 5 === 0);
+            return x % 5 === 0;
           })), /* None */0);
 
 eq("FLATTEN", Belt_List.flatten(/* :: */[
@@ -427,7 +427,7 @@ eq("ZIP", Belt_List.zip(/* :: */[
     ]);
 
 function mod2(x) {
-  return +(x % 2 === 0);
+  return x % 2 === 0;
 }
 
 eq("PARTITION", Belt_List.partition(/* :: */[
@@ -513,7 +513,7 @@ eq("PARTITION", Belt_List.partition(/* :: */[
             ]
           ]
         ], (function (x) {
-            return 1 - mod2(x);
+            return !mod2(x);
           })), /* tuple */[
       /* [] */0,
       /* :: */[
@@ -926,7 +926,7 @@ function succx(x) {
 }
 
 function eqx(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 b("File \"bs_list_test.ml\", line 172, characters 4-11", Belt_List.hasAssoc(/* :: */[
@@ -949,7 +949,7 @@ b("File \"bs_list_test.ml\", line 172, characters 4-11", Belt_List.hasAssoc(/* :
           ]
         ], 2, Caml_obj.caml_equal));
 
-b("File \"bs_list_test.ml\", line 173, characters 4-11", 1 - Belt_List.hasAssoc(/* :: */[
+b("File \"bs_list_test.ml\", line 173, characters 4-11", !Belt_List.hasAssoc(/* :: */[
           /* tuple */[
             1,
             "1"
@@ -988,7 +988,7 @@ b("File \"bs_list_test.ml\", line 174, characters 4-11", Belt_List.hasAssoc(/* :
             ]
           ]
         ], 4, (function (x, y) {
-            return +((x + 1 | 0) === y);
+            return (x + 1 | 0) === y;
           })));
 
 eq("REMOVEASSOQ", Belt_List.removeAssoc(/* :: */[
@@ -1245,7 +1245,7 @@ var ll = /* :: */[
 
 var ll0 = Belt_List.removeAssoc(ll, 0, eqx);
 
-b("File \"bs_list_test.ml\", line 186, characters 5-12", +(ll === ll0));
+b("File \"bs_list_test.ml\", line 186, characters 5-12", ll === ll0);
 
 var ll1 = Belt_List.setAssoc(ll, 2, "22", Caml_obj.caml_equal);
 
@@ -1279,7 +1279,7 @@ b("File \"bs_list_test.ml\", line 190, characters 4-11", Caml_obj.caml_equal(ll2
           ll1
         ]));
 
-b("File \"bs_list_test.ml\", line 191, characters 4-11", +(Belt_List.tailExn(ll2) === ll1));
+b("File \"bs_list_test.ml\", line 191, characters 4-11", Belt_List.tailExn(ll2) === ll1);
 
 b("File \"bs_list_test.ml\", line 192, characters 4-11", Caml_obj.caml_equal(Belt_List.setAssoc(/* :: */[
               /* tuple */[
@@ -1421,25 +1421,25 @@ b("File \"bs_list_test.ml\", line 201, characters 4-11", Caml_obj.caml_equal(Bel
               ]
             ], 2, Caml_obj.caml_equal), /* Some */["b"]));
 
-b("File \"bs_list_test.ml\", line 202, characters 4-11", +(Belt_List.getAssoc(/* :: */[
+b("File \"bs_list_test.ml\", line 202, characters 4-11", Belt_List.getAssoc(/* :: */[
+          /* tuple */[
+            1,
+            "a"
+          ],
+          /* :: */[
             /* tuple */[
-              1,
-              "a"
+              2,
+              "b"
             ],
             /* :: */[
               /* tuple */[
-                2,
-                "b"
+                3,
+                "c"
               ],
-              /* :: */[
-                /* tuple */[
-                  3,
-                  "c"
-                ],
-                /* [] */0
-              ]
+              /* [] */0
             ]
-          ], 4, Caml_obj.caml_equal) === /* None */0));
+          ]
+        ], 4, Caml_obj.caml_equal) === /* None */0);
 
 eq("File \"bs_list_test.ml\", line 206, characters 5-12", /* tuple */[
       Belt_List.head(length_10_id),
@@ -1622,14 +1622,14 @@ eq("File \"bs_list_test.ml\", line 253, characters 5-12", Belt_List.every(/* :: 
               /* [] */0
             ]
           ]
-        ], mod2), /* true */1);
+        ], mod2), true);
 
 eq("File \"bs_list_test.ml\", line 254, characters 5-12", Belt_List.every(/* :: */[
           1,
           /* [] */0
-        ], mod2), /* false */0);
+        ], mod2), false);
 
-eq("File \"bs_list_test.ml\", line 255, characters 5-12", Belt_List.every(/* [] */0, mod2), /* true */1);
+eq("File \"bs_list_test.ml\", line 255, characters 5-12", Belt_List.every(/* [] */0, mod2), true);
 
 eq("File \"bs_list_test.ml\", line 256, characters 5-12", Belt_List.some(/* :: */[
           1,
@@ -1640,7 +1640,7 @@ eq("File \"bs_list_test.ml\", line 256, characters 5-12", Belt_List.some(/* :: *
               /* [] */0
             ]
           ]
-        ], mod2), /* true */1);
+        ], mod2), true);
 
 eq("File \"bs_list_test.ml\", line 257, characters 5-12", Belt_List.some(/* :: */[
           1,
@@ -1651,9 +1651,9 @@ eq("File \"bs_list_test.ml\", line 257, characters 5-12", Belt_List.some(/* :: *
               /* [] */0
             ]
           ]
-        ], mod2), /* false */0);
+        ], mod2), false);
 
-eq("File \"bs_list_test.ml\", line 258, characters 5-12", Belt_List.some(/* [] */0, mod2), /* false */0);
+eq("File \"bs_list_test.ml\", line 258, characters 5-12", Belt_List.some(/* [] */0, mod2), false);
 
 eq("File \"bs_list_test.ml\", line 259, characters 5-12", Belt_List.has(/* :: */[
           1,
@@ -1665,8 +1665,8 @@ eq("File \"bs_list_test.ml\", line 259, characters 5-12", Belt_List.has(/* :: */
             ]
           ]
         ], "2", (function (x, s) {
-            return +(String(x) === s);
-          })), /* true */1);
+            return String(x) === s;
+          })), true);
 
 eq("File \"bs_list_test.ml\", line 260, characters 5-12", Belt_List.has(/* :: */[
           1,
@@ -1678,40 +1678,40 @@ eq("File \"bs_list_test.ml\", line 260, characters 5-12", Belt_List.has(/* :: */
             ]
           ]
         ], "0", (function (x, s) {
-            return +(String(x) === s);
-          })), /* false */0);
+            return String(x) === s;
+          })), false);
 
-b("File \"bs_list_test.ml\", line 262, characters 4-11", +(Belt_List.reduceReverse(/* :: */[
-            1,
+b("File \"bs_list_test.ml\", line 262, characters 4-11", Belt_List.reduceReverse(/* :: */[
+          1,
+          /* :: */[
+            2,
             /* :: */[
-              2,
+              3,
               /* :: */[
-                3,
-                /* :: */[
-                  4,
-                  /* [] */0
-                ]
+                4,
+                /* [] */0
               ]
             ]
-          ], 0, (function (prim, prim$1) {
-              return prim + prim$1 | 0;
-            })) === 10));
+          ]
+        ], 0, (function (prim, prim$1) {
+            return prim + prim$1 | 0;
+          })) === 10);
 
-b("File \"bs_list_test.ml\", line 263, characters 4-11", +(Belt_List.reduceReverse(/* :: */[
-            1,
+b("File \"bs_list_test.ml\", line 263, characters 4-11", Belt_List.reduceReverse(/* :: */[
+          1,
+          /* :: */[
+            2,
             /* :: */[
-              2,
+              3,
               /* :: */[
-                3,
-                /* :: */[
-                  4,
-                  /* [] */0
-                ]
+                4,
+                /* [] */0
               ]
             ]
-          ], 10, (function (prim, prim$1) {
-              return prim - prim$1 | 0;
-            })) === 0));
+          ]
+        ], 10, (function (prim, prim$1) {
+            return prim - prim$1 | 0;
+          })) === 0);
 
 b("File \"bs_list_test.ml\", line 264, characters 4-11", Caml_obj.caml_equal(Belt_List.reduceReverse(/* :: */[
               1,
@@ -1739,37 +1739,37 @@ b("File \"bs_list_test.ml\", line 264, characters 4-11", Caml_obj.caml_equal(Bel
           ]
         ]));
 
-b("File \"bs_list_test.ml\", line 265, characters 4-11", +(Belt_List.reduce(/* :: */[
-            1,
+b("File \"bs_list_test.ml\", line 265, characters 4-11", Belt_List.reduce(/* :: */[
+          1,
+          /* :: */[
+            2,
             /* :: */[
-              2,
+              3,
               /* :: */[
-                3,
-                /* :: */[
-                  4,
-                  /* [] */0
-                ]
+                4,
+                /* [] */0
               ]
             ]
-          ], 0, (function (prim, prim$1) {
-              return prim + prim$1 | 0;
-            })) === 10));
+          ]
+        ], 0, (function (prim, prim$1) {
+            return prim + prim$1 | 0;
+          })) === 10);
 
-b("File \"bs_list_test.ml\", line 266, characters 4-11", +(Belt_List.reduce(/* :: */[
-            1,
+b("File \"bs_list_test.ml\", line 266, characters 4-11", Belt_List.reduce(/* :: */[
+          1,
+          /* :: */[
+            2,
             /* :: */[
-              2,
+              3,
               /* :: */[
-                3,
-                /* :: */[
-                  4,
-                  /* [] */0
-                ]
+                4,
+                /* [] */0
               ]
             ]
-          ], 10, (function (prim, prim$1) {
-              return prim - prim$1 | 0;
-            })) === 0));
+          ]
+        ], 10, (function (prim, prim$1) {
+            return prim - prim$1 | 0;
+          })) === 0);
 
 b("File \"bs_list_test.ml\", line 267, characters 4-11", Caml_obj.caml_equal(Belt_List.reduce(/* :: */[
               1,
@@ -1797,42 +1797,42 @@ b("File \"bs_list_test.ml\", line 267, characters 4-11", Caml_obj.caml_equal(Bel
           ]
         ]));
 
-b("File \"bs_list_test.ml\", line 268, characters 4-11", +(Belt_List.reduceReverse2(/* :: */[
-            1,
+b("File \"bs_list_test.ml\", line 268, characters 4-11", Belt_List.reduceReverse2(/* :: */[
+          1,
+          /* :: */[
+            2,
             /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* [] */0
-              ]
-            ]
-          ], /* :: */[
-            1,
-            /* :: */[
-              2,
+              3,
               /* [] */0
             ]
-          ], 0, (function (acc, x, y) {
-              return (acc + x | 0) + y | 0;
-            })) === 6));
+          ]
+        ], /* :: */[
+          1,
+          /* :: */[
+            2,
+            /* [] */0
+          ]
+        ], 0, (function (acc, x, y) {
+            return (acc + x | 0) + y | 0;
+          })) === 6);
 
 var a$1 = Belt_List.makeBy(10000, (function (i) {
         return i;
       }));
 
-b("File \"bs_list_test.ml\", line 271, characters 4-11", +(Belt_List.reduceReverse2(a$1, /* :: */[
-            0,
-            a$1
-          ], 0, (function (acc, x, y) {
-              return (acc + x | 0) + y | 0;
-            })) === 99980001));
+b("File \"bs_list_test.ml\", line 271, characters 4-11", Belt_List.reduceReverse2(a$1, /* :: */[
+          0,
+          a$1
+        ], 0, (function (acc, x, y) {
+            return (acc + x | 0) + y | 0;
+          })) === 99980001);
 
 eq("File \"bs_list_test.ml\", line 277, characters 5-12", Belt_List.every2(/* [] */0, /* :: */[
           1,
           /* [] */0
         ], (function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_list_test.ml\", line 278, characters 5-12", Belt_List.every2(/* :: */[
           2,
@@ -1844,8 +1844,8 @@ eq("File \"bs_list_test.ml\", line 278, characters 5-12", Belt_List.every2(/* ::
           1,
           /* [] */0
         ], (function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_list_test.ml\", line 279, characters 5-12", Belt_List.every2(/* :: */[
           2,
@@ -1854,8 +1854,8 @@ eq("File \"bs_list_test.ml\", line 279, characters 5-12", Belt_List.every2(/* ::
           1,
           /* [] */0
         ], (function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_list_test.ml\", line 280, characters 5-12", Belt_List.every2(/* :: */[
           2,
@@ -1870,8 +1870,8 @@ eq("File \"bs_list_test.ml\", line 280, characters 5-12", Belt_List.every2(/* ::
             /* [] */0
           ]
         ], (function (x, y) {
-            return +(x > y);
-          })), /* false */0);
+            return x > y;
+          })), false);
 
 eq("File \"bs_list_test.ml\", line 281, characters 5-12", Belt_List.every2(/* :: */[
           2,
@@ -1886,15 +1886,15 @@ eq("File \"bs_list_test.ml\", line 281, characters 5-12", Belt_List.every2(/* ::
             /* [] */0
           ]
         ], (function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_list_test.ml\", line 282, characters 5-12", Belt_List.some2(/* [] */0, /* :: */[
           1,
           /* [] */0
         ], (function (x, y) {
-            return +(x > y);
-          })), /* false */0);
+            return x > y;
+          })), false);
 
 eq("File \"bs_list_test.ml\", line 283, characters 5-12", Belt_List.some2(/* :: */[
           2,
@@ -1906,8 +1906,8 @@ eq("File \"bs_list_test.ml\", line 283, characters 5-12", Belt_List.some2(/* :: 
           1,
           /* [] */0
         ], (function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_list_test.ml\", line 284, characters 5-12", Belt_List.some2(/* :: */[
           2,
@@ -1922,8 +1922,8 @@ eq("File \"bs_list_test.ml\", line 284, characters 5-12", Belt_List.some2(/* :: 
             /* [] */0
           ]
         ], (function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_list_test.ml\", line 285, characters 5-12", Belt_List.some2(/* :: */[
           0,
@@ -1938,8 +1938,8 @@ eq("File \"bs_list_test.ml\", line 285, characters 5-12", Belt_List.some2(/* :: 
             /* [] */0
           ]
         ], (function (x, y) {
-            return +(x > y);
-          })), /* false */0);
+            return x > y;
+          })), false);
 
 eq("File \"bs_list_test.ml\", line 286, characters 5-12", Belt_List.some2(/* :: */[
           0,
@@ -1954,8 +1954,8 @@ eq("File \"bs_list_test.ml\", line 286, characters 5-12", Belt_List.some2(/* :: 
             /* [] */0
           ]
         ], (function (x, y) {
-            return +(x > y);
-          })), /* true */1);
+            return x > y;
+          })), true);
 
 eq("File \"bs_list_test.ml\", line 287, characters 5-12", Belt_List.some2(/* :: */[
           1,
@@ -1973,8 +1973,8 @@ eq("File \"bs_list_test.ml\", line 287, characters 5-12", Belt_List.some2(/* :: 
             /* [] */0
           ]
         ], (function (x, y) {
-            return +(x === y);
-          })), /* false */0);
+            return x === y;
+          })), false);
 
 function makeTest(n) {
   return eq("File \"bs_list_test.ml\", line 290, characters 5-12", Belt_List.make(n, 3), Belt_List.makeBy(n, (function () {
@@ -1996,7 +1996,18 @@ eq("File \"bs_list_test.ml\", line 293, characters 5-12", /* :: */[
       ]
     ]);
 
-b("File \"bs_list_test.ml\", line 299, characters 4-11", +(Belt_List.cmp(/* :: */[
+b("File \"bs_list_test.ml\", line 299, characters 4-11", Belt_List.cmp(/* :: */[
+          1,
+          /* :: */[
+            2,
+            /* :: */[
+              3,
+              /* [] */0
+            ]
+          ]
+        ], /* :: */[
+          0,
+          /* :: */[
             1,
             /* :: */[
               2,
@@ -2005,173 +2016,162 @@ b("File \"bs_list_test.ml\", line 299, characters 4-11", +(Belt_List.cmp(/* :: *
                 /* [] */0
               ]
             ]
-          ], /* :: */[
-            0,
-            /* :: */[
-              1,
-              /* :: */[
-                2,
-                /* :: */[
-                  3,
-                  /* [] */0
-                ]
-              ]
-            ]
-          ], Caml_obj.caml_compare) > 0));
+          ]
+        ], Caml_obj.caml_compare) > 0);
 
-b("File \"bs_list_test.ml\", line 300, characters 4-11", +(Belt_List.cmp(/* :: */[
-            1,
+b("File \"bs_list_test.ml\", line 300, characters 4-11", Belt_List.cmp(/* :: */[
+          1,
+          /* :: */[
+            2,
             /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* :: */[
-                  4,
-                  /* [] */0
-                ]
-              ]
-            ]
-          ], /* :: */[
-            1,
-            /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* [] */0
-              ]
-            ]
-          ], Caml_obj.caml_compare) > 0));
-
-b("File \"bs_list_test.ml\", line 301, characters 4-11", +(Belt_List.cmp(/* :: */[
-            1,
-            /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* [] */0
-              ]
-            ]
-          ], /* :: */[
-            1,
-            /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* :: */[
-                  4,
-                  /* [] */0
-                ]
-              ]
-            ]
-          ], Caml_obj.caml_compare) < 0));
-
-b("File \"bs_list_test.ml\", line 302, characters 4-11", +(Belt_List.cmp(/* :: */[
-            1,
-            /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* [] */0
-              ]
-            ]
-          ], /* :: */[
-            0,
-            /* :: */[
-              1,
-              /* :: */[
-                2,
-                /* [] */0
-              ]
-            ]
-          ], Caml_primitive.caml_int_compare) > 0));
-
-b("File \"bs_list_test.ml\", line 303, characters 4-11", +(Belt_List.cmp(/* :: */[
-            1,
-            /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* [] */0
-              ]
-            ]
-          ], /* :: */[
-            1,
-            /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* [] */0
-              ]
-            ]
-          ], Caml_primitive.caml_int_compare) === 0));
-
-b("File \"bs_list_test.ml\", line 304, characters 4-11", +(Belt_List.cmp(/* :: */[
-            1,
-            /* :: */[
-              2,
+              3,
               /* :: */[
                 4,
                 /* [] */0
               ]
             ]
-          ], /* :: */[
-            1,
-            /* :: */[
-              2,
-              /* :: */[
-                3,
-                /* [] */0
-              ]
-            ]
-          ], Caml_primitive.caml_int_compare) > 0));
-
-b("File \"bs_list_test.ml\", line 305, characters 4-11", +(Belt_List.cmpByLength(/* [] */0, /* [] */0) === 0));
-
-b("File \"bs_list_test.ml\", line 306, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
-            1,
-            /* [] */0
-          ], /* [] */0) > 0));
-
-b("File \"bs_list_test.ml\", line 307, characters 4-11", +(Belt_List.cmpByLength(/* [] */0, /* :: */[
-            1,
-            /* [] */0
-          ]) < 0));
-
-b("File \"bs_list_test.ml\", line 308, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
-            1,
-            /* :: */[
-              2,
-              /* [] */0
-            ]
-          ], /* :: */[
-            1,
-            /* [] */0
-          ]) > 0));
-
-b("File \"bs_list_test.ml\", line 309, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
-            1,
-            /* [] */0
-          ], /* :: */[
-            1,
-            /* :: */[
-              2,
-              /* [] */0
-            ]
-          ]) < 0));
-
-b("File \"bs_list_test.ml\", line 310, characters 4-11", +(Belt_List.cmpByLength(/* :: */[
-            1,
+          ]
+        ], /* :: */[
+          1,
+          /* :: */[
+            2,
             /* :: */[
               3,
               /* [] */0
             ]
-          ], /* :: */[
+          ]
+        ], Caml_obj.caml_compare) > 0);
+
+b("File \"bs_list_test.ml\", line 301, characters 4-11", Belt_List.cmp(/* :: */[
+          1,
+          /* :: */[
+            2,
+            /* :: */[
+              3,
+              /* [] */0
+            ]
+          ]
+        ], /* :: */[
+          1,
+          /* :: */[
+            2,
+            /* :: */[
+              3,
+              /* :: */[
+                4,
+                /* [] */0
+              ]
+            ]
+          ]
+        ], Caml_obj.caml_compare) < 0);
+
+b("File \"bs_list_test.ml\", line 302, characters 4-11", Belt_List.cmp(/* :: */[
+          1,
+          /* :: */[
+            2,
+            /* :: */[
+              3,
+              /* [] */0
+            ]
+          ]
+        ], /* :: */[
+          0,
+          /* :: */[
             1,
             /* :: */[
               2,
               /* [] */0
             ]
-          ]) === 0));
+          ]
+        ], Caml_primitive.caml_int_compare) > 0);
+
+b("File \"bs_list_test.ml\", line 303, characters 4-11", Belt_List.cmp(/* :: */[
+          1,
+          /* :: */[
+            2,
+            /* :: */[
+              3,
+              /* [] */0
+            ]
+          ]
+        ], /* :: */[
+          1,
+          /* :: */[
+            2,
+            /* :: */[
+              3,
+              /* [] */0
+            ]
+          ]
+        ], Caml_primitive.caml_int_compare) === 0);
+
+b("File \"bs_list_test.ml\", line 304, characters 4-11", Belt_List.cmp(/* :: */[
+          1,
+          /* :: */[
+            2,
+            /* :: */[
+              4,
+              /* [] */0
+            ]
+          ]
+        ], /* :: */[
+          1,
+          /* :: */[
+            2,
+            /* :: */[
+              3,
+              /* [] */0
+            ]
+          ]
+        ], Caml_primitive.caml_int_compare) > 0);
+
+b("File \"bs_list_test.ml\", line 305, characters 4-11", Belt_List.cmpByLength(/* [] */0, /* [] */0) === 0);
+
+b("File \"bs_list_test.ml\", line 306, characters 4-11", Belt_List.cmpByLength(/* :: */[
+          1,
+          /* [] */0
+        ], /* [] */0) > 0);
+
+b("File \"bs_list_test.ml\", line 307, characters 4-11", Belt_List.cmpByLength(/* [] */0, /* :: */[
+          1,
+          /* [] */0
+        ]) < 0);
+
+b("File \"bs_list_test.ml\", line 308, characters 4-11", Belt_List.cmpByLength(/* :: */[
+          1,
+          /* :: */[
+            2,
+            /* [] */0
+          ]
+        ], /* :: */[
+          1,
+          /* [] */0
+        ]) > 0);
+
+b("File \"bs_list_test.ml\", line 309, characters 4-11", Belt_List.cmpByLength(/* :: */[
+          1,
+          /* [] */0
+        ], /* :: */[
+          1,
+          /* :: */[
+            2,
+            /* [] */0
+          ]
+        ]) < 0);
+
+b("File \"bs_list_test.ml\", line 310, characters 4-11", Belt_List.cmpByLength(/* :: */[
+          1,
+          /* :: */[
+            3,
+            /* [] */0
+          ]
+        ], /* :: */[
+          1,
+          /* :: */[
+            2,
+            /* [] */0
+          ]
+        ]) === 0);
 
 makeTest(0);
 
@@ -2243,7 +2243,7 @@ eq("SORT", Belt_List.sort(/* :: */[
       ]
     ]);
 
-b("File \"bs_list_test.ml\", line 326, characters 4-11", 1 - Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 326, characters 4-11", !Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2259,7 +2259,7 @@ b("File \"bs_list_test.ml\", line 326, characters 4-11", 1 - Belt_List.eq(/* :: 
             /* [] */0
           ]
         ], (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 b("File \"bs_list_test.ml\", line 327, characters 4-11", Belt_List.eq(/* :: */[
@@ -2281,10 +2281,10 @@ b("File \"bs_list_test.ml\", line 327, characters 4-11", Belt_List.eq(/* :: */[
             ]
           ]
         ], (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
-b("File \"bs_list_test.ml\", line 328, characters 4-11", 1 - Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 328, characters 4-11", !Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2303,10 +2303,10 @@ b("File \"bs_list_test.ml\", line 328, characters 4-11", 1 - Belt_List.eq(/* :: 
             ]
           ]
         ], (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
-b("File \"bs_list_test.ml\", line 329, characters 4-11", 1 - Belt_List.eq(/* :: */[
+b("File \"bs_list_test.ml\", line 329, characters 4-11", !Belt_List.eq(/* :: */[
           1,
           /* :: */[
             2,
@@ -2378,25 +2378,25 @@ b("File \"bs_list_test.ml\", line 334, characters 4-11", Caml_obj.caml_equal(Bel
           ]
         ]));
 
-b("File \"bs_list_test.ml\", line 338, characters 4-11", +(Belt_List.keepMap(/* :: */[
-            1,
+b("File \"bs_list_test.ml\", line 338, characters 4-11", Belt_List.keepMap(/* :: */[
+          1,
+          /* :: */[
+            2,
             /* :: */[
-              2,
+              3,
               /* :: */[
-                3,
-                /* :: */[
-                  4,
-                  /* [] */0
-                ]
+                4,
+                /* [] */0
               ]
             ]
-          ], (function (x) {
-              if (x % 5 === 0) {
-                return /* Some */[x];
-              } else {
-                return /* None */0;
-              }
-            })) === /* [] */0));
+          ]
+        ], (function (x) {
+            if (x % 5 === 0) {
+              return /* Some */[x];
+            } else {
+              return /* None */0;
+            }
+          })) === /* [] */0);
 
 Mt.from_pair_suites("bs_list_test.ml", suites[0]);
 

--- a/jscomp/test/bs_map_set_dict_test.js
+++ b/jscomp/test/bs_map_set_dict_test.js
@@ -112,9 +112,9 @@ b("File \"bs_map_set_dict_test.ml\", line 77, characters 4-11", Belt_Array.every
                       ];
               })), (function (param, param$1) {
             if (param[0] === param$1[0]) {
-              return +(param[1] === param$1[1]);
+              return param[1] === param$1[1];
             } else {
-              return /* false */0;
+              return false;
             }
           })));
 
@@ -125,9 +125,9 @@ b("File \"bs_map_set_dict_test.ml\", line 82, characters 4-11", Belt_List.every2
                           ];
                   }))), (function (param, param$1) {
             if (param[0] === param$1[0]) {
-              return +(param[1] === param$1[1]);
+              return param[1] === param$1[1];
             } else {
-              return /* false */0;
+              return false;
             }
           })));
 

--- a/jscomp/test/bs_mutable_set_test.js
+++ b/jscomp/test/bs_mutable_set_test.js
@@ -31,7 +31,7 @@ var u = {
 
 b("File \"bs_mutable_set_test.ml\", line 20, characters 4-11", Belt_MutableSetInt.removeCheck(u, 0));
 
-b("File \"bs_mutable_set_test.ml\", line 21, characters 4-11", 1 - Belt_MutableSetInt.removeCheck(u, 0));
+b("File \"bs_mutable_set_test.ml\", line 21, characters 4-11", !Belt_MutableSetInt.removeCheck(u, 0));
 
 b("File \"bs_mutable_set_test.ml\", line 22, characters 4-11", Belt_MutableSetInt.removeCheck(u, 30));
 
@@ -41,9 +41,9 @@ eq("File \"bs_mutable_set_test.ml\", line 24, characters 5-12", Belt_internalAVL
 
 var r = Array_data_util.randomRange(0, 30);
 
-b("File \"bs_mutable_set_test.ml\", line 26, characters 4-11", +(29 === Belt_internalAVLset.maxUndefined(u.data)));
+b("File \"bs_mutable_set_test.ml\", line 26, characters 4-11", 29 === Belt_internalAVLset.maxUndefined(u.data));
 
-b("File \"bs_mutable_set_test.ml\", line 27, characters 4-11", +(1 === Belt_internalAVLset.minUndefined(u.data)));
+b("File \"bs_mutable_set_test.ml\", line 27, characters 4-11", 1 === Belt_internalAVLset.minUndefined(u.data));
 
 Belt_MutableSetInt.add(u, 3);
 
@@ -63,7 +63,7 @@ Belt_MutableSetInt.add(u, 0);
 
 eq("File \"bs_mutable_set_test.ml\", line 37, characters 5-12", Belt_internalAVLset.size(u.data), 3);
 
-b("File \"bs_mutable_set_test.ml\", line 38, characters 4-11", 1 - Belt_internalAVLset.isEmpty(u.data));
+b("File \"bs_mutable_set_test.ml\", line 38, characters 4-11", !Belt_internalAVLset.isEmpty(u.data));
 
 for(var i$1 = 0; i$1 <= 3; ++i$1){
   Belt_MutableSetInt.remove(u, i$1);
@@ -162,7 +162,7 @@ eq("File \"bs_mutable_set_test.ml\", line 76, characters 5-12", Belt_MutableSetI
 b("File \"bs_mutable_set_test.ml\", line 77, characters 4-11", Belt_List.eq(Belt_internalAVLset.toList(v.data), Belt_List.makeBy(1501, (function (i) {
                 return i + 500 | 0;
               })), (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 eq("File \"bs_mutable_set_test.ml\", line 78, characters 5-12", Belt_internalAVLset.toArray(v.data), Array_data_util.range(500, 2000));
@@ -184,7 +184,7 @@ var aa = match$1[0];
 b("File \"bs_mutable_set_test.ml\", line 83, characters 4-11", match[1]);
 
 b("File \"bs_mutable_set_test.ml\", line 84, characters 4-11", Belt_Array.eq(Belt_internalAVLset.toArray(aa.data), Array_data_util.range(500, 999), (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 b("File \"bs_mutable_set_test.ml\", line 85, characters 4-11", Belt_Array.eq(Belt_internalAVLset.toArray(bb.data), Array_data_util.range(1001, 2000), Caml_obj.caml_equal));
@@ -209,7 +209,7 @@ var bb$1 = match$3[1];
 
 var aa$1 = match$3[0];
 
-b("File \"bs_mutable_set_test.ml\", line 92, characters 4-11", 1 - match$2[1]);
+b("File \"bs_mutable_set_test.ml\", line 92, characters 4-11", !match$2[1]);
 
 b("File \"bs_mutable_set_test.ml\", line 93, characters 4-11", Belt_Array.eq(Belt_internalAVLset.toArray(aa$1.data), Array_data_util.range(500, 999), Caml_obj.caml_equal));
 
@@ -308,7 +308,7 @@ b("File \"bs_mutable_set_test.ml\", line 126, characters 4-11", Belt_MutableSetI
                     10
                   ])
             }), {
-          data: Belt_internalSetInt.fromArray(/* int array */[
+          data: Belt_internalSetInt.fromArray(/* array */[
                 4,
                 5
               ])
@@ -375,15 +375,15 @@ var a0 = {
 };
 
 var a1 = Belt_MutableSetInt.keep(a0, (function (x) {
-        return +(x % 2 === 0);
+        return x % 2 === 0;
       }));
 
 var a2 = Belt_MutableSetInt.keep(a0, (function (x) {
-        return +(x % 2 !== 0);
+        return x % 2 !== 0;
       }));
 
 var match$4 = Belt_MutableSetInt.partition(a0, (function (x) {
-        return +(x % 2 === 0);
+        return x % 2 === 0;
       }));
 
 var a4 = match$4[1];
@@ -479,11 +479,11 @@ Belt_MutableSetInt.remove(v$4, 30);
 
 Belt_MutableSetInt.remove(v$4, 29);
 
-b("File \"bs_mutable_set_test.ml\", line 213, characters 4-11", +(28 === Belt_internalAVLset.maxUndefined(v$4.data)));
+b("File \"bs_mutable_set_test.ml\", line 213, characters 4-11", 28 === Belt_internalAVLset.maxUndefined(v$4.data));
 
 Belt_MutableSetInt.remove(v$4, 0);
 
-b("File \"bs_mutable_set_test.ml\", line 215, characters 4-11", +(1 === Belt_internalAVLset.minUndefined(v$4.data)));
+b("File \"bs_mutable_set_test.ml\", line 215, characters 4-11", 1 === Belt_internalAVLset.minUndefined(v$4.data));
 
 eq("File \"bs_mutable_set_test.ml\", line 216, characters 5-12", Belt_internalAVLset.size(v$4.data), 28);
 
@@ -501,22 +501,22 @@ function id(loc, x) {
   return b(loc, Belt_Array.every2(Belt_internalAVLset.toArray(u.data), x, Caml_obj.caml_equal));
 }
 
-id("File \"bs_mutable_set_test.ml\", line 229, characters 5-12", /* int array */[]);
+id("File \"bs_mutable_set_test.ml\", line 229, characters 5-12", /* array */[]);
 
-id("File \"bs_mutable_set_test.ml\", line 230, characters 5-12", /* int array */[0]);
+id("File \"bs_mutable_set_test.ml\", line 230, characters 5-12", /* array */[0]);
 
-id("File \"bs_mutable_set_test.ml\", line 231, characters 5-12", /* int array */[
+id("File \"bs_mutable_set_test.ml\", line 231, characters 5-12", /* array */[
       0,
       1
     ]);
 
-id("File \"bs_mutable_set_test.ml\", line 232, characters 5-12", /* int array */[
+id("File \"bs_mutable_set_test.ml\", line 232, characters 5-12", /* array */[
       0,
       1,
       2
     ]);
 
-id("File \"bs_mutable_set_test.ml\", line 233, characters 5-12", /* int array */[
+id("File \"bs_mutable_set_test.ml\", line 233, characters 5-12", /* array */[
       0,
       1,
       2,
@@ -591,15 +591,15 @@ var v$5 = {
 };
 
 var copyV = Belt_MutableSetInt.keep(v$5, (function (x) {
-        return +(x % 8 === 0);
+        return x % 8 === 0;
       }));
 
 var match$5 = Belt_MutableSetInt.partition(v$5, (function (x) {
-        return +(x % 8 === 0);
+        return x % 8 === 0;
       }));
 
 var cc$1 = Belt_MutableSetInt.keep(v$5, (function (x) {
-        return +(x % 8 !== 0);
+        return x % 8 !== 0;
       }));
 
 for(var i$6 = 0; i$6 <= 200; ++i$6){
@@ -753,7 +753,7 @@ b("File \"bs_mutable_set_test.ml\", line 294, characters 4-11", Belt_MutableSetI
                     10
                   ])
             }), {
-          data: Belt_internalSetInt.fromArray(/* int array */[
+          data: Belt_internalSetInt.fromArray(/* array */[
                 4,
                 5
               ])

--- a/jscomp/test/bs_node_string_buffer_test.js
+++ b/jscomp/test/bs_node_string_buffer_test.js
@@ -4,10 +4,10 @@ var Node = require("../../lib/js/node.js");
 
 function f(str) {
   var match = Node.test(str);
-  if (match[0] !== 0) {
+  if (match[0]) {
     console.log(/* tuple */[
           "buffer",
-          +Buffer.isBuffer(match[1])
+          Buffer.isBuffer(match[1])
         ]);
     return /* () */0;
   } else {

--- a/jscomp/test/bs_poly_map_test.js
+++ b/jscomp/test/bs_poly_map_test.js
@@ -138,21 +138,21 @@ var a5 = Belt_Map.remove(a0, 3);
 
 var a6 = Belt_Map.remove(a5, 3);
 
-b("File \"bs_poly_map_test.ml\", line 70, characters 4-11", +(a5 === a6));
+b("File \"bs_poly_map_test.ml\", line 70, characters 4-11", a5 === a6);
 
 b("File \"bs_poly_map_test.ml\", line 71, characters 4-11", Belt_Map.has(a0, 3));
 
-b("File \"bs_poly_map_test.ml\", line 72, characters 4-11", 1 - Belt_Map.has(a5, 3));
+b("File \"bs_poly_map_test.ml\", line 72, characters 4-11", !Belt_Map.has(a5, 3));
 
-b("File \"bs_poly_map_test.ml\", line 73, characters 4-11", +(3 === Belt_Map.getUndefined(a0, 3)));
+b("File \"bs_poly_map_test.ml\", line 73, characters 4-11", 3 === Belt_Map.getUndefined(a0, 3));
 
-b("File \"bs_poly_map_test.ml\", line 74, characters 4-11", +(33 === Belt_Map.getUndefined(a1, 3)));
+b("File \"bs_poly_map_test.ml\", line 74, characters 4-11", 33 === Belt_Map.getUndefined(a1, 3));
 
-b("File \"bs_poly_map_test.ml\", line 75, characters 4-11", +(Belt_Map.getUndefined(a2, 3) === undefined));
+b("File \"bs_poly_map_test.ml\", line 75, characters 4-11", Belt_Map.getUndefined(a2, 3) === undefined);
 
-b("File \"bs_poly_map_test.ml\", line 77, characters 4-11", +(11 === Belt_Map.getUndefined(a3, 3)));
+b("File \"bs_poly_map_test.ml\", line 77, characters 4-11", 11 === Belt_Map.getUndefined(a3, 3));
 
-b("File \"bs_poly_map_test.ml\", line 78, characters 4-11", +(Belt_Map.getUndefined(a4, 3) === undefined));
+b("File \"bs_poly_map_test.ml\", line 78, characters 4-11", Belt_Map.getUndefined(a4, 3) === undefined);
 
 var a7 = Belt_Map.removeMany(a0, /* array */[
       7,
@@ -168,7 +168,7 @@ var a7 = Belt_Map.removeMany(a0, /* array */[
       6
     ]);
 
-eq("File \"bs_poly_map_test.ml\", line 81, characters 5-12", Belt_MapDict.keysToArray(a7.data), /* int array */[
+eq("File \"bs_poly_map_test.ml\", line 81, characters 5-12", Belt_MapDict.keysToArray(a7.data), /* array */[
       9,
       10
     ]);
@@ -216,7 +216,7 @@ var x$8 = Belt_Array.makeBy(31, (function (i) {
       }));
 
 b("File \"bs_poly_map_test.ml\", line 103, characters 4-11", Belt_Map.eq(m1, Belt_Map.ofArray(x$8, Icmp), (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 var v0 = {
@@ -241,7 +241,7 @@ var x$9 = Belt_Array.map(Array_data_util.randomRange(0, 10000), (function (x) {
 var v2 = Belt_Map.ofArray(x$9, Icmp);
 
 b("File \"bs_poly_map_test.ml\", line 117, characters 4-11", Belt_Map.eq(v1, v2, (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 function inc(x) {
@@ -264,15 +264,15 @@ var match$1 = match[0];
 
 var match$2 = Belt_Map.get(v3, 10);
 
-b("File \"bs_poly_map_test.ml\", line 126, characters 4-11", match$2 && match$2[0] === 11 ? /* true */1 : /* false */0);
+b("File \"bs_poly_map_test.ml\", line 126, characters 4-11", match$2 && match$2[0] === 11 ? true : false);
 
 var match$3 = Belt_Map.get(v3, -10);
 
-b("File \"bs_poly_map_test.ml\", line 127, characters 4-11", match$3 ? /* false */0 : /* true */1);
+b("File \"bs_poly_map_test.ml\", line 127, characters 4-11", match$3 ? false : true);
 
 var match$4 = Belt_Map.get(v4, -10);
 
-b("File \"bs_poly_map_test.ml\", line 128, characters 4-11", match$4 && match$4[0] === 0 ? /* true */1 : /* false */0);
+b("File \"bs_poly_map_test.ml\", line 128, characters 4-11", match$4 && match$4[0] === 0 ? true : false);
 
 var map = Belt_Map.remove({
       cmp: Icmp[/* cmp */0],
@@ -284,11 +284,11 @@ b("File \"bs_poly_map_test.ml\", line 129, characters 4-11", Belt_MapDict.isEmpt
 var map$1 = Belt_Map.removeMany({
       cmp: Icmp[/* cmp */0],
       data: Belt_MapDict.empty
-    }, /* int array */[0]);
+    }, /* array */[0]);
 
 b("File \"bs_poly_map_test.ml\", line 130, characters 4-11", Belt_MapDict.isEmpty(map$1.data));
 
-b("File \"bs_poly_map_test.ml\", line 131, characters 4-11", pres && pres[0] === 5000 ? /* true */1 : /* false */0);
+b("File \"bs_poly_map_test.ml\", line 131, characters 4-11", pres && pres[0] === 5000 ? true : false);
 
 b("File \"bs_poly_map_test.ml\", line 132, characters 4-11", Belt_Array.eq(Belt_MapDict.keysToArray(match$1[0].data), Belt_Array.makeBy(5000, (function (i) {
                 return i;
@@ -304,7 +304,7 @@ var match$5 = Belt_Map.split(v7, 5000);
 
 var match$6 = match$5[0];
 
-b("File \"bs_poly_map_test.ml\", line 137, characters 4-11", match$5[1] ? /* false */0 : /* true */1);
+b("File \"bs_poly_map_test.ml\", line 137, characters 4-11", match$5[1] ? false : true);
 
 b("File \"bs_poly_map_test.ml\", line 138, characters 4-11", Belt_Array.eq(Belt_MapDict.keysToArray(match$6[0].data), Belt_Array.makeBy(5000, (function (i) {
                 return i;

--- a/jscomp/test/bs_poly_mutable_map_test.js
+++ b/jscomp/test/bs_poly_mutable_map_test.js
@@ -62,7 +62,7 @@ Belt_MutableMap.removeMany(a0, /* array */[
       6
     ]);
 
-eq("File \"bs_poly_mutable_map_test.ml\", line 29, characters 7-14", Belt_internalAVLtree.keysToArray(a0.data), /* int array */[
+eq("File \"bs_poly_mutable_map_test.ml\", line 29, characters 7-14", Belt_internalAVLtree.keysToArray(a0.data), /* array */[
       9,
       10
     ]);

--- a/jscomp/test/bs_poly_mutable_set_test.js
+++ b/jscomp/test/bs_poly_mutable_set_test.js
@@ -39,7 +39,7 @@ var u = ofArray(Array_data_util.range(0, 30));
 
 b("File \"bs_poly_mutable_set_test.ml\", line 18, characters 4-11", Belt_MutableSet.removeCheck(u, 0));
 
-b("File \"bs_poly_mutable_set_test.ml\", line 19, characters 4-11", 1 - Belt_MutableSet.removeCheck(u, 0));
+b("File \"bs_poly_mutable_set_test.ml\", line 19, characters 4-11", !Belt_MutableSet.removeCheck(u, 0));
 
 b("File \"bs_poly_mutable_set_test.ml\", line 20, characters 4-11", Belt_MutableSet.removeCheck(u, 30));
 
@@ -49,9 +49,9 @@ eq("File \"bs_poly_mutable_set_test.ml\", line 22, characters 5-12", Belt_intern
 
 var r = Array_data_util.randomRange(0, 30);
 
-b("File \"bs_poly_mutable_set_test.ml\", line 24, characters 4-11", +(29 === Belt_internalAVLset.maxUndefined(u.data)));
+b("File \"bs_poly_mutable_set_test.ml\", line 24, characters 4-11", 29 === Belt_internalAVLset.maxUndefined(u.data));
 
-b("File \"bs_poly_mutable_set_test.ml\", line 25, characters 4-11", +(1 === Belt_internalAVLset.minUndefined(u.data)));
+b("File \"bs_poly_mutable_set_test.ml\", line 25, characters 4-11", 1 === Belt_internalAVLset.minUndefined(u.data));
 
 Belt_MutableSet.add(u, 3);
 
@@ -71,7 +71,7 @@ Belt_MutableSet.add(u, 0);
 
 eq("File \"bs_poly_mutable_set_test.ml\", line 35, characters 5-12", Belt_internalAVLset.size(u.data), 3);
 
-b("File \"bs_poly_mutable_set_test.ml\", line 36, characters 4-11", 1 - Belt_internalAVLset.isEmpty(u.data));
+b("File \"bs_poly_mutable_set_test.ml\", line 36, characters 4-11", !Belt_internalAVLset.isEmpty(u.data));
 
 for(var i$1 = 0; i$1 <= 3; ++i$1){
   Belt_MutableSet.remove(u, i$1);
@@ -167,7 +167,7 @@ eq("File \"bs_poly_mutable_set_test.ml\", line 74, characters 5-12", Belt_Mutabl
 b("File \"bs_poly_mutable_set_test.ml\", line 75, characters 4-11", Belt_List.eq(Belt_internalAVLset.toList(v.data), Belt_List.makeBy(1501, (function (i) {
                 return i + 500 | 0;
               })), (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 eq("File \"bs_poly_mutable_set_test.ml\", line 76, characters 5-12", Belt_internalAVLset.toArray(v.data), Array_data_util.range(500, 2000));
@@ -212,7 +212,7 @@ var bb$1 = match$3[1];
 
 var aa$1 = match$3[0];
 
-b("File \"bs_poly_mutable_set_test.ml\", line 90, characters 4-11", 1 - match$2[1]);
+b("File \"bs_poly_mutable_set_test.ml\", line 90, characters 4-11", !match$2[1]);
 
 b("File \"bs_poly_mutable_set_test.ml\", line 91, characters 4-11", Belt_Array.eq(Belt_internalAVLset.toArray(aa$1.data), Array_data_util.range(500, 999), Caml_obj.caml_equal));
 
@@ -264,7 +264,7 @@ b("File \"bs_poly_mutable_set_test.ml\", line 124, characters 4-11", Belt_Mutabl
                   6,
                   8,
                   10
-                ])), ofArray(/* int array */[
+                ])), ofArray(/* array */[
               4,
               5
             ])));
@@ -282,15 +282,15 @@ b("File \"bs_poly_mutable_set_test.ml\", line 147, characters 4-11", Belt_Mutabl
 var a0 = ofArray(Array_data_util.randomRange(0, 1000));
 
 var a1 = Belt_MutableSet.keep(a0, (function (x) {
-        return +(x % 2 === 0);
+        return x % 2 === 0;
       }));
 
 var a2 = Belt_MutableSet.keep(a0, (function (x) {
-        return +(x % 2 !== 0);
+        return x % 2 !== 0;
       }));
 
 var match$4 = Belt_MutableSet.partition(a0, (function (x) {
-        return +(x % 2 === 0);
+        return x % 2 === 0;
       }));
 
 var a4 = match$4[1];

--- a/jscomp/test/bs_poly_set_test.js
+++ b/jscomp/test/bs_poly_set_test.js
@@ -45,14 +45,14 @@ var u5 = Belt_Set.add(u4, 3);
 
 var u6 = Belt_Set.removeMany(u5, r);
 
-var u7 = Belt_Set.mergeMany(u6, /* int array */[
+var u7 = Belt_Set.mergeMany(u6, /* array */[
       0,
       1,
       2,
       0
     ]);
 
-var u8 = Belt_Set.removeMany(u7, /* int array */[
+var u8 = Belt_Set.removeMany(u7, /* array */[
       0,
       1,
       2,
@@ -75,23 +75,23 @@ var u15 = Belt_Set.removeMany(u14, Array_data_util.randomRange(10000, 19999));
 
 var u16 = Belt_Set.removeMany(u15, Array_data_util.randomRange(20000, 21000));
 
-b("File \"bs_poly_set_test.ml\", line 35, characters 4-11", +(u0 !== u1));
+b("File \"bs_poly_set_test.ml\", line 35, characters 4-11", u0 !== u1);
 
-b("File \"bs_poly_set_test.ml\", line 36, characters 4-11", +(u2 === u1));
+b("File \"bs_poly_set_test.ml\", line 36, characters 4-11", u2 === u1);
 
 eq("File \"bs_poly_set_test.ml\", line 37, characters 5-12", Belt_SetDict.size(u4.data), 28);
 
-b("File \"bs_poly_set_test.ml\", line 38, characters 4-11", +(29 === Belt_SetDict.maxUndefined(u4.data)));
+b("File \"bs_poly_set_test.ml\", line 38, characters 4-11", 29 === Belt_SetDict.maxUndefined(u4.data));
 
-b("File \"bs_poly_set_test.ml\", line 39, characters 4-11", +(1 === Belt_SetDict.minUndefined(u4.data)));
+b("File \"bs_poly_set_test.ml\", line 39, characters 4-11", 1 === Belt_SetDict.minUndefined(u4.data));
 
-b("File \"bs_poly_set_test.ml\", line 40, characters 4-11", +(u4 === u5));
+b("File \"bs_poly_set_test.ml\", line 40, characters 4-11", u4 === u5);
 
 b("File \"bs_poly_set_test.ml\", line 41, characters 4-11", Belt_SetDict.isEmpty(u6.data));
 
 eq("File \"bs_poly_set_test.ml\", line 42, characters 6-13", Belt_SetDict.size(u7.data), 3);
 
-b("File \"bs_poly_set_test.ml\", line 43, characters 4-11", 1 - Belt_SetDict.isEmpty(u7.data));
+b("File \"bs_poly_set_test.ml\", line 43, characters 4-11", !Belt_SetDict.isEmpty(u7.data));
 
 b("File \"bs_poly_set_test.ml\", line 44, characters 4-11", Belt_SetDict.isEmpty(u8.data));
 
@@ -113,7 +113,7 @@ eq("File \"bs_poly_set_test.ml\", line 55, characters 5-12", Belt_SetDict.size(u
 
 b("File \"bs_poly_set_test.ml\", line 56, characters 4-11", Belt_Set.has(u15, 20000));
 
-b("File \"bs_poly_set_test.ml\", line 57, characters 4-11", 1 - Belt_Set.has(u15, 2000));
+b("File \"bs_poly_set_test.ml\", line 57, characters 4-11", !Belt_Set.has(u15, 2000));
 
 b("File \"bs_poly_set_test.ml\", line 58, characters 4-11", Belt_SetDict.isEmpty(u16.data));
 
@@ -152,7 +152,7 @@ var u29 = Belt_Set.union(u26, u27);
 
 b("File \"bs_poly_set_test.ml\", line 72, characters 4-11", Belt_Set.eq(u28, u29));
 
-b("File \"bs_poly_set_test.ml\", line 73, characters 4-11", Caml_obj.caml_equal(Belt_SetDict.toArray(u29.data), Belt_SortArray.stableSortBy(Belt_Array.concat(ss, /* int array */[3]), Caml_obj.caml_compare)));
+b("File \"bs_poly_set_test.ml\", line 73, characters 4-11", Caml_obj.caml_equal(Belt_SetDict.toArray(u29.data), Belt_SortArray.stableSortBy(Belt_Array.concat(ss, /* array */[3]), Caml_obj.caml_compare)));
 
 b("File \"bs_poly_set_test.ml\", line 74, characters 4-11", Belt_Set.eq(u19, u20));
 
@@ -166,19 +166,19 @@ eq("File \"bs_poly_set_test.ml\", line 78, characters 5-12", Belt_SetDict.toArra
 
 b("File \"bs_poly_set_test.ml\", line 79, characters 4-11", Belt_Set.subset(u23, u18));
 
-b("File \"bs_poly_set_test.ml\", line 80, characters 4-11", 1 - Belt_Set.subset(u18, u23));
+b("File \"bs_poly_set_test.ml\", line 80, characters 4-11", !Belt_Set.subset(u18, u23));
 
 b("File \"bs_poly_set_test.ml\", line 81, characters 4-11", Belt_Set.subset(u22, u17));
 
 b("File \"bs_poly_set_test.ml\", line 82, characters 4-11", Belt_Set.subset(u21, u17) && Belt_Set.subset(u21, u18));
 
-b("File \"bs_poly_set_test.ml\", line 83, characters 4-11", +(47 === Belt_Set.getUndefined(u22, 47)));
+b("File \"bs_poly_set_test.ml\", line 83, characters 4-11", 47 === Belt_Set.getUndefined(u22, 47));
 
 b("File \"bs_poly_set_test.ml\", line 84, characters 4-11", Caml_obj.caml_equal(/* Some */[47], Belt_Set.get(u22, 47)));
 
-b("File \"bs_poly_set_test.ml\", line 85, characters 4-11", +(Belt_Set.getUndefined(u22, 59) === undefined));
+b("File \"bs_poly_set_test.ml\", line 85, characters 4-11", Belt_Set.getUndefined(u22, 59) === undefined);
 
-b("File \"bs_poly_set_test.ml\", line 86, characters 4-11", +(/* None */0 === Belt_Set.get(u22, 59)));
+b("File \"bs_poly_set_test.ml\", line 86, characters 4-11", /* None */0 === Belt_Set.get(u22, 59));
 
 eq("File \"bs_poly_set_test.ml\", line 88, characters 5-12", Belt_SetDict.size(u25.data), 60);
 
@@ -187,28 +187,28 @@ var m = {
   data: Belt_SetDict.empty
 };
 
-b("File \"bs_poly_set_test.ml\", line 89, characters 4-11", +(Belt_SetDict.minimum(m.data) === /* None */0));
+b("File \"bs_poly_set_test.ml\", line 89, characters 4-11", Belt_SetDict.minimum(m.data) === /* None */0);
 
 var m$1 = {
   cmp: IntCmp[/* cmp */0],
   data: Belt_SetDict.empty
 };
 
-b("File \"bs_poly_set_test.ml\", line 90, characters 4-11", +(Belt_SetDict.maximum(m$1.data) === /* None */0));
+b("File \"bs_poly_set_test.ml\", line 90, characters 4-11", Belt_SetDict.maximum(m$1.data) === /* None */0);
 
 var m$2 = {
   cmp: IntCmp[/* cmp */0],
   data: Belt_SetDict.empty
 };
 
-b("File \"bs_poly_set_test.ml\", line 91, characters 4-11", +(Belt_SetDict.minUndefined(m$2.data) === undefined));
+b("File \"bs_poly_set_test.ml\", line 91, characters 4-11", Belt_SetDict.minUndefined(m$2.data) === undefined);
 
 var m$3 = {
   cmp: IntCmp[/* cmp */0],
   data: Belt_SetDict.empty
 };
 
-b("File \"bs_poly_set_test.ml\", line 92, characters 4-11", +(Belt_SetDict.maxUndefined(m$3.data) === undefined));
+b("File \"bs_poly_set_test.ml\", line 92, characters 4-11", Belt_SetDict.maxUndefined(m$3.data) === undefined);
 
 function testIterToList(xs) {
   var v = [/* [] */0];
@@ -243,63 +243,63 @@ var u2$1 = Belt_Set.add(u1$1, 33);
 b("File \"bs_poly_set_test.ml\", line 109, characters 4-11", Belt_List.every2(testIterToList(u0$1), Belt_List.makeBy(21, (function (i) {
                 return i;
               })), (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 b("File \"bs_poly_set_test.ml\", line 110, characters 4-11", Belt_List.every2(testIterToList2(u0$1), Belt_List.makeBy(21, (function (i) {
                 return i;
               })), (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 b("File \"bs_poly_set_test.ml\", line 111, characters 4-11", Belt_List.every2(testIterToList(u0$1), Belt_SetDict.toList(u0$1.data), (function (x, y) {
-            return +(x === y);
+            return x === y;
           })));
 
 b("File \"bs_poly_set_test.ml\", line 112, characters 4-11", Belt_Set.some(u0$1, (function (x) {
-            return +(x === 17);
+            return x === 17;
           })));
 
-b("File \"bs_poly_set_test.ml\", line 113, characters 4-11", 1 - Belt_Set.some(u1$1, (function (x) {
-            return +(x === 17);
+b("File \"bs_poly_set_test.ml\", line 113, characters 4-11", !Belt_Set.some(u1$1, (function (x) {
+            return x === 17;
           })));
 
 b("File \"bs_poly_set_test.ml\", line 114, characters 4-11", Belt_Set.every(u0$1, (function (x) {
-            return +(x < 24);
+            return x < 24;
           })));
 
 b("File \"bs_poly_set_test.ml\", line 115, characters 4-11", Belt_SetDict.every(u0$1.data, (function (x) {
-            return +(x < 24);
+            return x < 24;
           })));
 
-b("File \"bs_poly_set_test.ml\", line 116, characters 4-11", 1 - Belt_Set.every(u2$1, (function (x) {
-            return +(x < 24);
+b("File \"bs_poly_set_test.ml\", line 116, characters 4-11", !Belt_Set.every(u2$1, (function (x) {
+            return x < 24;
           })));
 
-b("File \"bs_poly_set_test.ml\", line 117, characters 4-11", 1 - Belt_Set.every(Belt_Set.ofArray(/* int array */[
+b("File \"bs_poly_set_test.ml\", line 117, characters 4-11", !Belt_Set.every(Belt_Set.ofArray(/* array */[
               1,
               2,
               3
             ], IntCmp), (function (x) {
-            return +(x === 2);
+            return x === 2;
           })));
 
-b("File \"bs_poly_set_test.ml\", line 118, characters 4-11", +(Belt_Set.cmp(u1$1, u0$1) < 0));
+b("File \"bs_poly_set_test.ml\", line 118, characters 4-11", Belt_Set.cmp(u1$1, u0$1) < 0);
 
-b("File \"bs_poly_set_test.ml\", line 119, characters 4-11", +(Belt_Set.cmp(u0$1, u1$1) > 0));
+b("File \"bs_poly_set_test.ml\", line 119, characters 4-11", Belt_Set.cmp(u0$1, u1$1) > 0);
 
 var a0 = Belt_Set.ofArray(Array_data_util.randomRange(0, 1000), IntCmp);
 
 var a1 = Belt_Set.keep(a0, (function (x) {
-        return +(x % 2 === 0);
+        return x % 2 === 0;
       }));
 
 var a2 = Belt_Set.keep(a0, (function (x) {
-        return +(x % 2 !== 0);
+        return x % 2 !== 0;
       }));
 
 var match = Belt_Set.partition(a0, (function (x) {
-        return +(x % 2 === 0);
+        return x % 2 === 0;
       }));
 
 var a4 = match[1];
@@ -326,7 +326,7 @@ t("File \"bs_poly_set_test.ml\", line 134, characters 4-11", (function () {
 
 eq("File \"bs_poly_set_test.ml\", line 135, characters 5-12", Belt_SetDict.size(a0.data), 1001);
 
-b("File \"bs_poly_set_test.ml\", line 136, characters 4-11", 1 - Belt_SetDict.isEmpty(a0.data));
+b("File \"bs_poly_set_test.ml\", line 136, characters 4-11", !Belt_SetDict.isEmpty(a0.data));
 
 var match$1 = Belt_Set.split(a0, 200);
 
@@ -352,7 +352,7 @@ var a9 = match$4[1];
 
 var a8 = match$4[0];
 
-b("File \"bs_poly_set_test.ml\", line 143, characters 4-11", 1 - match$3[1]);
+b("File \"bs_poly_set_test.ml\", line 143, characters 4-11", !match$3[1]);
 
 eq("File \"bs_poly_set_test.ml\", line 144, characters 5-12", Belt_SetDict.toArray(a8.data), Belt_Array.makeBy(200, (function (i) {
             return i;
@@ -385,10 +385,10 @@ Belt_List.forEach(/* :: */[
         return Belt_SetDict.checkInvariantInternal(x.data);
       }));
 
-var a = Belt_Set.ofArray(/* int array */[], IntCmp);
+var a = Belt_Set.ofArray(/* array */[], IntCmp);
 
 var m$4 = Belt_Set.keep(a, (function (x) {
-        return +(x % 2 === 0);
+        return x % 2 === 0;
       }));
 
 b("File \"bs_poly_set_test.ml\", line 153, characters 4-11", Belt_SetDict.isEmpty(m$4.data));
@@ -404,7 +404,7 @@ b("File \"bs_poly_set_test.ml\", line 157, characters 4-11", Belt_SetDict.isEmpt
 
 b("File \"bs_poly_set_test.ml\", line 158, characters 4-11", Belt_SetDict.isEmpty(match$6[1].data));
 
-b("File \"bs_poly_set_test.ml\", line 159, characters 4-11", 1 - match$5[1]);
+b("File \"bs_poly_set_test.ml\", line 159, characters 4-11", !match$5[1]);
 
 Mt.from_pair_suites("bs_poly_set_test.ml", suites[0]);
 

--- a/jscomp/test/bs_queue_test.js
+++ b/jscomp/test/bs_queue_test.js
@@ -22,10 +22,10 @@ function b(loc, x) {
 function does_raise(f, q) {
   try {
     Curry._1(f, q);
-    return /* false */0;
+    return false;
   }
   catch (exn){
-    return /* true */1;
+    return true;
   }
 }
 
@@ -36,7 +36,7 @@ function $plus$plus(q, x) {
 
 var q = Belt_MutableQueue.make(/* () */0);
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* int array */[]) && q.length === 0)) {
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* array */[]) && q.length === 0)) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -47,7 +47,7 @@ if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* int array */[]) && q.
       ];
 }
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 1), q)), /* int array */[1]) && q.length === 1)) {
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 1), q)), /* array */[1]) && q.length === 1)) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -58,7 +58,7 @@ if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 1)
       ];
 }
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 2), q)), /* int array */[
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 2), q)), /* array */[
           1,
           2
         ]) && q.length === 2)) {
@@ -72,7 +72,7 @@ if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 2)
       ];
 }
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 3), q)), /* int array */[
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 3), q)), /* array */[
           1,
           2,
           3
@@ -87,7 +87,7 @@ if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 3)
       ];
 }
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 4), q)), /* int array */[
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray((Belt_MutableQueue.add(q, 4), q)), /* array */[
           1,
           2,
           3,
@@ -114,7 +114,7 @@ if (Belt_MutableQueue.popExn(q) !== 1) {
       ];
 }
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* int array */[
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* array */[
           2,
           3,
           4
@@ -140,7 +140,7 @@ if (Belt_MutableQueue.popExn(q) !== 2) {
       ];
 }
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* int array */[
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* array */[
           3,
           4
         ]) && q.length === 2)) {
@@ -165,7 +165,7 @@ if (Belt_MutableQueue.popExn(q) !== 3) {
       ];
 }
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* int array */[4]) && q.length === 1)) {
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* array */[4]) && q.length === 1)) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -187,7 +187,7 @@ if (Belt_MutableQueue.popExn(q) !== 4) {
       ];
 }
 
-if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* int array */[]) && q.length === 0)) {
+if (!(Caml_obj.caml_equal(Belt_MutableQueue.toArray(q), /* array */[]) && q.length === 0)) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -765,7 +765,7 @@ if (q1$2.length !== 4) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$2), /* int array */[
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$2), /* array */[
         1,
         2,
         3,
@@ -792,7 +792,7 @@ if (q2$2.length !== 0) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$2), /* int array */[])) {
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$2), /* array */[])) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -816,7 +816,7 @@ if (q1$2.length !== 0) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$2), /* int array */[])) {
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$2), /* array */[])) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -838,7 +838,7 @@ if (q2$2.length !== 4) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$2), /* int array */[
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$2), /* array */[
         1,
         2,
         3,
@@ -873,7 +873,7 @@ if (q1$3.length !== 0) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$3), /* int array */[])) {
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$3), /* array */[])) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -895,7 +895,7 @@ if (q2$3.length !== 4) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$3), /* int array */[
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$3), /* array */[
         5,
         6,
         7,
@@ -924,7 +924,7 @@ if (q1$3.length !== 0) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$3), /* int array */[])) {
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$3), /* array */[])) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -946,7 +946,7 @@ if (q2$3.length !== 4) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$3), /* int array */[
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$3), /* array */[
         5,
         6,
         7,
@@ -985,7 +985,7 @@ if (q1$4.length !== 4) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$4), /* int array */[
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$4), /* array */[
         1,
         2,
         3,
@@ -1012,7 +1012,7 @@ if (q2$4.length !== 4) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$4), /* int array */[
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q2$4), /* array */[
         5,
         6,
         7,
@@ -1041,7 +1041,7 @@ if (q1$4.length !== 0) {
       ];
 }
 
-if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$4), /* int array */[])) {
+if (!Caml_obj.caml_equal(Belt_MutableQueue.toArray(q1$4), /* array */[])) {
   throw [
         Caml_builtin_exceptions.assert_failure,
         [
@@ -1102,7 +1102,7 @@ if (Belt_MutableQueue.reduce(q2$4, 0, (function (x, y) {
 
 console.log("OK");
 
-var q$6 = Belt_MutableQueue.ofArray(/* int array */[
+var q$6 = Belt_MutableQueue.ofArray(/* array */[
       1,
       2,
       3,
@@ -1113,7 +1113,7 @@ var q1$5 = Belt_MutableQueue.map(q$6, (function (x) {
         return x - 1 | 0;
       }));
 
-eq("File \"bs_queue_test.ml\", line 154, characters 5-12", Belt_MutableQueue.toArray(q1$5), /* int array */[
+eq("File \"bs_queue_test.ml\", line 154, characters 5-12", Belt_MutableQueue.toArray(q1$5), /* array */[
       0,
       1,
       2,
@@ -1122,13 +1122,13 @@ eq("File \"bs_queue_test.ml\", line 154, characters 5-12", Belt_MutableQueue.toA
 
 var q$7 = Belt_MutableQueue.ofArray(/* array */[]);
 
-b("File \"bs_queue_test.ml\", line 155, characters 4-11", +(q$7.length === 0));
+b("File \"bs_queue_test.ml\", line 155, characters 4-11", q$7.length === 0);
 
-var q$8 = Belt_MutableQueue.map(Belt_MutableQueue.ofArray(/* int array */[]), (function (x) {
+var q$8 = Belt_MutableQueue.map(Belt_MutableQueue.ofArray(/* array */[]), (function (x) {
         return x + 1 | 0;
       }));
 
-b("File \"bs_queue_test.ml\", line 156, characters 4-11", +(q$8.length === 0));
+b("File \"bs_queue_test.ml\", line 156, characters 4-11", q$8.length === 0);
 
 Mt.from_pair_suites("bs_queue_test.ml", suites[0]);
 

--- a/jscomp/test/bs_set_int_test.js
+++ b/jscomp/test/bs_set_int_test.js
@@ -27,27 +27,27 @@ function $eq$star(a, b) {
   return Belt_SetInt.eq(Belt_SetInt.fromArray(a), Belt_SetInt.fromArray(b));
 }
 
-b("File \"bs_set_int_test.ml\", line 17, characters 4-11", $eq$star(/* int array */[
+b("File \"bs_set_int_test.ml\", line 17, characters 4-11", $eq$star(/* array */[
           1,
           2,
           3
-        ], /* int array */[
+        ], /* array */[
           3,
           2,
           1
         ]));
 
-var u = Belt_SetInt.intersect(Belt_SetInt.fromArray(/* int array */[
+var u = Belt_SetInt.intersect(Belt_SetInt.fromArray(/* array */[
           1,
           2,
           3
-        ]), Belt_SetInt.fromArray(/* int array */[
+        ]), Belt_SetInt.fromArray(/* array */[
           3,
           4,
           5
         ]));
 
-b("File \"bs_set_int_test.ml\", line 23, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(/* int array */[3]), u));
+b("File \"bs_set_int_test.ml\", line 23, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(/* array */[3]), u));
 
 function range(i, j) {
   return $$Array.init((j - i | 0) + 1 | 0, (function (k) {
@@ -68,7 +68,7 @@ var i = range(100, 1500);
 b("File \"bs_set_int_test.ml\", line 36, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(i), v));
 
 var match = Belt_SetInt.partition(v, (function (x) {
-        return +(x % 3 === 0);
+        return x % 3 === 0;
       }));
 
 var l = Belt_SetInt.empty;
@@ -154,7 +154,7 @@ var minv = Belt_SetInt.minUndefined(v$1);
 var maxv = Belt_SetInt.maxUndefined(v$1);
 
 function approx(loc, x, y) {
-  return b(loc, +(x === y));
+  return b(loc, x === y);
 }
 
 eq("File \"bs_set_int_test.ml\", line 74, characters 5-12", Belt_SetInt.reduce(v$1, 0, (function (x, y) {
@@ -241,11 +241,11 @@ b("File \"bs_set_int_test.ml\", line 114, characters 4-11", Belt_SetInt.subset(d
 
 b("File \"bs_set_int_test.ml\", line 115, characters 4-11", Belt_SetInt.subset(Belt_SetInt.add(dd, 200), bb));
 
-b("File \"bs_set_int_test.ml\", line 116, characters 4-11", +(Belt_SetInt.add(dd, 200) === dd));
+b("File \"bs_set_int_test.ml\", line 116, characters 4-11", Belt_SetInt.add(dd, 200) === dd);
 
-b("File \"bs_set_int_test.ml\", line 117, characters 4-11", +(Belt_SetInt.add(dd, 0) === dd));
+b("File \"bs_set_int_test.ml\", line 117, characters 4-11", Belt_SetInt.add(dd, 0) === dd);
 
-b("File \"bs_set_int_test.ml\", line 118, characters 4-11", 1 - Belt_SetInt.subset(Belt_SetInt.add(dd, 201), bb));
+b("File \"bs_set_int_test.ml\", line 118, characters 4-11", !Belt_SetInt.subset(Belt_SetInt.add(dd, 201), bb));
 
 var aa$1 = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100));
 
@@ -259,11 +259,11 @@ var ee = Belt_SetInt.add(dd$1, 101);
 
 b("File \"bs_set_int_test.ml\", line 127, characters 4-11", Belt_SetInt.eq(aa$1, bb$1));
 
-b("File \"bs_set_int_test.ml\", line 128, characters 4-11", 1 - Belt_SetInt.eq(aa$1, cc$1));
+b("File \"bs_set_int_test.ml\", line 128, characters 4-11", !Belt_SetInt.eq(aa$1, cc$1));
 
-b("File \"bs_set_int_test.ml\", line 129, characters 4-11", 1 - Belt_SetInt.eq(dd$1, cc$1));
+b("File \"bs_set_int_test.ml\", line 129, characters 4-11", !Belt_SetInt.eq(dd$1, cc$1));
 
-b("File \"bs_set_int_test.ml\", line 130, characters 4-11", 1 - Belt_SetInt.eq(bb$1, ee));
+b("File \"bs_set_int_test.ml\", line 130, characters 4-11", !Belt_SetInt.eq(bb$1, ee));
 
 var a1 = Belt_SetInt.mergeMany(Belt_SetInt.empty, Array_data_util.randomRange(0, 100));
 
@@ -299,7 +299,7 @@ var match$4 = match$3[0];
 
 var a9 = match$4[1];
 
-b("File \"bs_set_int_test.ml\", line 146, characters 4-11", 1 - match$3[1]);
+b("File \"bs_set_int_test.ml\", line 146, characters 4-11", !match$3[1]);
 
 b("File \"bs_set_int_test.ml\", line 147, characters 4-11", Belt_SetInt.eq(a4, match$4[0]));
 
@@ -321,7 +321,7 @@ b("File \"bs_set_int_test.ml\", line 156, characters 4-11", Belt_SetInt.isEmpty(
 
 b("File \"bs_set_int_test.ml\", line 157, characters 4-11", Belt_SetInt.isEmpty(match$6[1]));
 
-b("File \"bs_set_int_test.ml\", line 158, characters 4-11", 1 - match$5[1]);
+b("File \"bs_set_int_test.ml\", line 158, characters 4-11", !match$5[1]);
 
 var v$12 = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 2000));
 
@@ -331,7 +331,7 @@ var v1 = Belt_SetInt.fromArray(Array_data_util.randomRange(1, 2001));
 
 var v2 = Belt_SetInt.fromArray(Array_data_util.randomRange(3, 2002));
 
-var v3 = Belt_SetInt.removeMany(v2, /* int array */[
+var v3 = Belt_SetInt.removeMany(v2, /* array */[
       2002,
       2001
     ]);
@@ -352,15 +352,15 @@ eq("File \"bs_set_int_test.ml\", line 168, characters 5-12", counted, 1001);
 
 b("File \"bs_set_int_test.ml\", line 169, characters 4-11", Belt_SetInt.eq(v$12, v0));
 
-b("File \"bs_set_int_test.ml\", line 170, characters 4-11", +(Belt_SetInt.cmp(v$12, v0) === 0));
+b("File \"bs_set_int_test.ml\", line 170, characters 4-11", Belt_SetInt.cmp(v$12, v0) === 0);
 
-b("File \"bs_set_int_test.ml\", line 171, characters 4-11", +(Belt_SetInt.cmp(v$12, v1) < 0));
+b("File \"bs_set_int_test.ml\", line 171, characters 4-11", Belt_SetInt.cmp(v$12, v1) < 0);
 
-b("File \"bs_set_int_test.ml\", line 172, characters 4-11", +(Belt_SetInt.cmp(v$12, v2) > 0));
+b("File \"bs_set_int_test.ml\", line 172, characters 4-11", Belt_SetInt.cmp(v$12, v2) > 0);
 
 b("File \"bs_set_int_test.ml\", line 173, characters 4-11", Belt_SetInt.subset(v3, v0));
 
-b("File \"bs_set_int_test.ml\", line 174, characters 4-11", 1 - Belt_SetInt.subset(v1, v0));
+b("File \"bs_set_int_test.ml\", line 174, characters 4-11", !Belt_SetInt.subset(v1, v0));
 
 eq("File \"bs_set_int_test.ml\", line 175, characters 5-12", Belt_SetInt.get(v$12, 30), /* Some */[30]);
 

--- a/jscomp/test/bs_sort_test.js
+++ b/jscomp/test/bs_sort_test.js
@@ -73,7 +73,7 @@ eq("File \"bs_sort_test.ml\", line 40, characters 5-12", inters(Array_data_util.
 
 eq("File \"bs_sort_test.ml\", line 41, characters 5-12", inters(Array_data_util.range(8, 10), Array_data_util.range(9, 13)), Array_data_util.range(9, 10));
 
-eq("File \"bs_sort_test.ml\", line 42, characters 5-12", inters(Array_data_util.range(0, 2), Array_data_util.range(4, 7)), /* int array */[]);
+eq("File \"bs_sort_test.ml\", line 42, characters 5-12", inters(Array_data_util.range(0, 2), Array_data_util.range(4, 7)), /* array */[]);
 
 eq("File \"bs_sort_test.ml\", line 45, characters 5-12", diffs(Array_data_util.range(1, 10), Array_data_util.range(3, 13)), Array_data_util.range(1, 2));
 
@@ -81,7 +81,7 @@ eq("File \"bs_sort_test.ml\", line 46, characters 5-12", diffs(Array_data_util.r
 
 eq("File \"bs_sort_test.ml\", line 47, characters 5-12", diffs(Array_data_util.range(8, 10), Array_data_util.range(9, 13)), Array_data_util.range(8, 8));
 
-eq("File \"bs_sort_test.ml\", line 48, characters 5-12", diffs(Array_data_util.range(0, 2), Array_data_util.range(4, 7)), /* int array */[
+eq("File \"bs_sort_test.ml\", line 48, characters 5-12", diffs(Array_data_util.range(0, 2), Array_data_util.range(4, 7)), /* array */[
       0,
       1,
       2
@@ -99,16 +99,16 @@ b("File \"bs_sort_test.ml\", line 56, characters 4-11", Belt_Range.every(0, 200,
             return Belt_SortArray.isSorted(v, cmp);
           })));
 
-b("File \"bs_sort_test.ml\", line 62, characters 4-11", Belt_SortArray.isSorted(/* int array */[], cmp));
+b("File \"bs_sort_test.ml\", line 62, characters 4-11", Belt_SortArray.isSorted(/* array */[], cmp));
 
-b("File \"bs_sort_test.ml\", line 65, characters 4-11", Belt_SortArray.isSorted(/* int array */[0], cmp));
+b("File \"bs_sort_test.ml\", line 65, characters 4-11", Belt_SortArray.isSorted(/* array */[0], cmp));
 
-b("File \"bs_sort_test.ml\", line 68, characters 4-11", Belt_SortArray.isSorted(/* int array */[
+b("File \"bs_sort_test.ml\", line 68, characters 4-11", Belt_SortArray.isSorted(/* array */[
           0,
           1
         ], cmp));
 
-b("File \"bs_sort_test.ml\", line 70, characters 4-11", 1 - Belt_SortArray.isSorted(/* int array */[
+b("File \"bs_sort_test.ml\", line 70, characters 4-11", !Belt_SortArray.isSorted(/* array */[
           1,
           0
         ], cmp));
@@ -271,7 +271,7 @@ eq("File \"bs_sort_test.ml\", line 102, characters 5-12", Belt_SortArray.stableS
       ]
     ]);
 
-eq("File \"bs_sort_test.ml\", line 111, characters 5-12", Belt_SortArray.binarySearchBy(/* int array */[
+eq("File \"bs_sort_test.ml\", line 111, characters 5-12", Belt_SortArray.binarySearchBy(/* array */[
           1,
           3,
           5,
@@ -331,7 +331,7 @@ eq("File \"bs_sort_test.ml\", line 116, characters 5-12", Belt_SortArray.binaryS
 var aa = Array_data_util.range(0, 1000);
 
 b("File \"bs_sort_test.ml\", line 118, characters 4-11", Belt_Range.every(0, 1000, (function (i) {
-            return +(Belt_SortArray.binarySearchBy(aa, i, cmp) === i);
+            return Belt_SortArray.binarySearchBy(aa, i, cmp) === i;
           })));
 
 var cc = Belt_Array.map(Array_data_util.range(0, 2000), (function (x) {
@@ -347,29 +347,29 @@ eq("File \"bs_sort_test.ml\", line 125, characters 5-12", Belt_SortArray.binaryS
 eq("File \"bs_sort_test.ml\", line 127, characters 5-12", Belt_SortArray.binarySearchBy(cc, 1, cmp) ^ -1, 1);
 
 b("File \"bs_sort_test.ml\", line 128, characters 4-11", Belt_Range.every(0, 1999, (function (i) {
-            return +((Belt_SortArray.binarySearchBy(cc, (i << 1) + 1 | 0, cmp) ^ -1) === (i + 1 | 0));
+            return (Belt_SortArray.binarySearchBy(cc, (i << 1) + 1 | 0, cmp) ^ -1) === (i + 1 | 0);
           })));
 
 function lt(x, y) {
-  return +(x < y);
+  return x < y;
 }
 
-eq("File \"bs_sort_test.ml\", line 135, characters 5-12", Belt_SortArray.strictlySortedLength(/* int array */[], lt), 0);
+eq("File \"bs_sort_test.ml\", line 135, characters 5-12", Belt_SortArray.strictlySortedLength(/* array */[], lt), 0);
 
-eq("File \"bs_sort_test.ml\", line 136, characters 5-12", Belt_SortArray.strictlySortedLength(/* int array */[1], lt), 1);
+eq("File \"bs_sort_test.ml\", line 136, characters 5-12", Belt_SortArray.strictlySortedLength(/* array */[1], lt), 1);
 
-eq("File \"bs_sort_test.ml\", line 137, characters 5-12", Belt_SortArray.strictlySortedLength(/* int array */[
+eq("File \"bs_sort_test.ml\", line 137, characters 5-12", Belt_SortArray.strictlySortedLength(/* array */[
           1,
           1
         ], lt), 1);
 
-eq("File \"bs_sort_test.ml\", line 138, characters 5-12", Belt_SortArray.strictlySortedLength(/* int array */[
+eq("File \"bs_sort_test.ml\", line 138, characters 5-12", Belt_SortArray.strictlySortedLength(/* array */[
           1,
           1,
           2
         ], lt), 1);
 
-eq("File \"bs_sort_test.ml\", line 139, characters 5-12", Belt_SortArray.strictlySortedLength(/* int array */[
+eq("File \"bs_sort_test.ml\", line 139, characters 5-12", Belt_SortArray.strictlySortedLength(/* array */[
           1,
           2
         ], lt), 2);
@@ -390,7 +390,7 @@ eq("File \"bs_sort_test.ml\", line 141, characters 5-12", Belt_SortArray.strictl
           1
         ], lt), 1);
 
-eq("File \"bs_sort_test.ml\", line 142, characters 5-12", Belt_SortArray.strictlySortedLength(/* int array */[
+eq("File \"bs_sort_test.ml\", line 142, characters 5-12", Belt_SortArray.strictlySortedLength(/* array */[
           4,
           3,
           2,

--- a/jscomp/test/bs_stack_test.js
+++ b/jscomp/test/bs_stack_test.js
@@ -54,7 +54,7 @@ function inOrder3(v) {
 }
 
 function inOrder2(v) {
-  var todo = /* true */1;
+  var todo = true;
   var cursor = v;
   var s = {
     root: null
@@ -71,7 +71,7 @@ function inOrder2(v) {
       Belt_MutableQueue.add(q, current.value);
       cursor = current.right;
     } else {
-      todo = /* false */0;
+      todo = false;
     }
   };
   return /* () */0;

--- a/jscomp/test/caml_compare_test.js
+++ b/jscomp/test/caml_compare_test.js
@@ -17,14 +17,14 @@ try {
 }
 catch (raw_exn){
   var exn = Js_exn.internalToOCamlException(raw_exn);
-  function_equal_test = exn[0] === Caml_builtin_exceptions.invalid_argument && exn[1] === "equal: functional value" ? /* true */1 : /* false */0;
+  function_equal_test = exn[0] === Caml_builtin_exceptions.invalid_argument && exn[1] === "equal: functional value" ? true : false;
 }
 
 var suites_000 = /* tuple */[
   "option",
   (function () {
       return /* Eq */Block.__(0, [
-                /* true */1,
+                true,
                 Caml_obj.caml_lessthan(/* None */0, /* Some */[1])
               ]);
     })
@@ -35,7 +35,7 @@ var suites_001 = /* :: */[
     "option2",
     (function () {
         return /* Eq */Block.__(0, [
-                  /* true */1,
+                  true,
                   Caml_obj.caml_lessthan(/* Some */[1], /* Some */[2])
                 ]);
       })
@@ -45,7 +45,7 @@ var suites_001 = /* :: */[
       "list0",
       (function () {
           return /* Eq */Block.__(0, [
-                    /* true */1,
+                    true,
                     Caml_obj.caml_greaterthan(/* :: */[
                           1,
                           /* [] */0
@@ -58,7 +58,7 @@ var suites_001 = /* :: */[
         "listeq",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* true */1,
+                      true,
                       Caml_obj.caml_equal(/* :: */[
                             1,
                             /* :: */[
@@ -86,7 +86,7 @@ var suites_001 = /* :: */[
           "listneq",
           (function () {
               return /* Eq */Block.__(0, [
-                        /* true */1,
+                        true,
                         Caml_obj.caml_greaterthan(/* :: */[
                               1,
                               /* :: */[
@@ -114,19 +114,19 @@ var suites_001 = /* :: */[
             "custom_u",
             (function () {
                 return /* Eq */Block.__(0, [
-                          /* true */1,
+                          true,
                           Caml_obj.caml_greaterthan(/* tuple */[
                                 /* A */Block.__(0, [3]),
                                 /* B */Block.__(1, [
                                     2,
-                                    /* false */0
+                                    false
                                   ]),
                                 /* C */Block.__(2, [1])
                               ], /* tuple */[
                                 /* A */Block.__(0, [3]),
                                 /* B */Block.__(1, [
                                     2,
-                                    /* false */0
+                                    false
                                   ]),
                                 /* C */Block.__(2, [0])
                               ])
@@ -138,19 +138,19 @@ var suites_001 = /* :: */[
               "custom_u2",
               (function () {
                   return /* Eq */Block.__(0, [
-                            /* true */1,
+                            true,
                             Caml_obj.caml_equal(/* tuple */[
                                   /* A */Block.__(0, [3]),
                                   /* B */Block.__(1, [
                                       2,
-                                      /* false */0
+                                      false
                                     ]),
                                   /* C */Block.__(2, [1])
                                 ], /* tuple */[
                                   /* A */Block.__(0, [3]),
                                   /* B */Block.__(1, [
                                       2,
-                                      /* false */0
+                                      false
                                     ]),
                                   /* C */Block.__(2, [1])
                                 ])
@@ -162,7 +162,7 @@ var suites_001 = /* :: */[
                 "function",
                 (function () {
                     return /* Eq */Block.__(0, [
-                              /* true */1,
+                              true,
                               function_equal_test
                             ]);
                   })
@@ -172,7 +172,7 @@ var suites_001 = /* :: */[
                   "File \"caml_compare_test.ml\", line 17, characters 4-11",
                   (function () {
                       return /* Eq */Block.__(0, [
-                                /* true */1,
+                                true,
                                 Caml_obj.caml_lessthan(/* None */0, /* Some */[1])
                               ]);
                     })
@@ -182,8 +182,8 @@ var suites_001 = /* :: */[
                     "File \"caml_compare_test.ml\", line 28, characters 4-11",
                     (function () {
                         return /* Eq */Block.__(0, [
-                                  /* true */1,
-                                  Caml_obj.caml_lessthan(/* None */0, /* Some */[/* int array */[
+                                  true,
+                                  Caml_obj.caml_lessthan(/* None */0, /* Some */[/* array */[
                                           1,
                                           30
                                         ]])
@@ -195,8 +195,8 @@ var suites_001 = /* :: */[
                       "File \"caml_compare_test.ml\", line 31, characters 4-11",
                       (function () {
                           return /* Eq */Block.__(0, [
-                                    /* true */1,
-                                    Caml_obj.caml_greaterthan(/* Some */[/* int array */[
+                                    true,
+                                    Caml_obj.caml_greaterthan(/* Some */[/* array */[
                                             1,
                                             30
                                           ]], /* None */0)
@@ -208,7 +208,7 @@ var suites_001 = /* :: */[
                         "File \"caml_compare_test.ml\", line 34, characters 4-11",
                         (function () {
                             return /* Eq */Block.__(0, [
-                                      /* true */1,
+                                      true,
                                       Caml_obj.caml_lessthan(/* :: */[
                                             2,
                                             /* :: */[
@@ -275,7 +275,7 @@ var suites_001 = /* :: */[
                           "File \"caml_compare_test.ml\", line 37, characters 4-11",
                           (function () {
                               return /* Eq */Block.__(0, [
-                                        /* true */1,
+                                        true,
                                         Caml_obj.caml_greaterthan(/* :: */[
                                               2,
                                               /* :: */[
@@ -342,11 +342,11 @@ var suites_001 = /* :: */[
                             "File \"caml_compare_test.ml\", line 41, characters 4-11",
                             (function () {
                                 return /* Eq */Block.__(0, [
-                                          /* false */0,
-                                          +(/* None */0 === /* Some */[/* int array */[
-                                                1,
-                                                30
-                                              ]])
+                                          false,
+                                          /* None */0 === /* Some */[/* array */[
+                                              1,
+                                              30
+                                            ]]
                                         ]);
                               })
                           ],
@@ -355,11 +355,11 @@ var suites_001 = /* :: */[
                               "File \"caml_compare_test.ml\", line 44, characters 4-11",
                               (function () {
                                   return /* Eq */Block.__(0, [
-                                            /* false */0,
-                                            +(/* Some */[/* int array */[
-                                                  1,
-                                                  30
-                                                ]] === /* None */0)
+                                            false,
+                                            /* Some */[/* array */[
+                                                1,
+                                                30
+                                              ]] === /* None */0
                                           ]);
                                 })
                             ],
@@ -368,7 +368,7 @@ var suites_001 = /* :: */[
                                 "File \"caml_compare_test.ml\", line 47, characters 4-11",
                                 (function () {
                                     return /* Eq */Block.__(0, [
-                                              /* false */0,
+                                              false,
                                               Caml_obj.caml_equal(/* :: */[
                                                     2,
                                                     /* :: */[
@@ -435,7 +435,7 @@ var suites_001 = /* :: */[
                                   "File \"caml_compare_test.ml\", line 50, characters 4-11",
                                   (function () {
                                       return /* Eq */Block.__(0, [
-                                                /* false */0,
+                                                false,
                                                 Caml_obj.caml_equal(/* :: */[
                                                       2,
                                                       /* :: */[
@@ -732,7 +732,7 @@ var suites_001 = /* :: */[
                                                                                     }, {
                                                                                       x: 2
                                                                                     }),
-                                                                                /* false */0
+                                                                                false
                                                                               ]);
                                                                     })
                                                                 ],
@@ -746,7 +746,7 @@ var suites_001 = /* :: */[
                                                                                       }, {
                                                                                         x: 1
                                                                                       }),
-                                                                                  /* false */0
+                                                                                  false
                                                                                 ]);
                                                                       })
                                                                   ],
@@ -756,7 +756,7 @@ var suites_001 = /* :: */[
                                                                       (function () {
                                                                           return /* Eq */Block.__(0, [
                                                                                     Caml_obj.caml_equal(({}), ({})),
-                                                                                    /* true */1
+                                                                                    true
                                                                                   ]);
                                                                         })
                                                                     ],
@@ -766,7 +766,7 @@ var suites_001 = /* :: */[
                                                                         (function () {
                                                                             return /* Eq */Block.__(0, [
                                                                                       Caml_obj.caml_equal(({}), ({x:1})),
-                                                                                      /* false */0
+                                                                                      false
                                                                                     ]);
                                                                           })
                                                                       ],
@@ -789,7 +789,7 @@ var suites_001 = /* :: */[
                                                                             (function () {
                                                                                 return /* Eq */Block.__(0, [
                                                                                           Caml_obj.caml_equal(({x:1}), ({x:1, y:2})),
-                                                                                          /* false */0
+                                                                                          false
                                                                                         ]);
                                                                               })
                                                                           ],
@@ -799,7 +799,7 @@ var suites_001 = /* :: */[
                                                                               (function () {
                                                                                   return /* Eq */Block.__(0, [
                                                                                             Caml_obj.caml_equal(({x:1, y:2}), ({x:1})),
-                                                                                            /* false */0
+                                                                                            false
                                                                                           ]);
                                                                                 })
                                                                             ],
@@ -819,7 +819,7 @@ var suites_001 = /* :: */[
                                                                                                     },
                                                                                                     /* [] */0
                                                                                                   ]),
-                                                                                              /* false */0
+                                                                                              false
                                                                                             ]);
                                                                                   })
                                                                               ],
@@ -839,7 +839,7 @@ var suites_001 = /* :: */[
                                                                                                       },
                                                                                                       /* [] */0
                                                                                                     ]),
-                                                                                                /* true */1
+                                                                                                true
                                                                                               ]);
                                                                                     })
                                                                                 ],
@@ -859,7 +859,7 @@ var suites_001 = /* :: */[
                                                                                                           /* [] */0
                                                                                                         ]
                                                                                                       }),
-                                                                                                  /* true */1
+                                                                                                  true
                                                                                                 ]);
                                                                                       })
                                                                                   ],
@@ -879,7 +879,7 @@ var suites_001 = /* :: */[
                                                                                                             /* [] */0
                                                                                                           ]
                                                                                                         }),
-                                                                                                    /* false */0
+                                                                                                    false
                                                                                                   ]);
                                                                                         })
                                                                                     ],

--- a/jscomp/test/caml_format_test.js
+++ b/jscomp/test/caml_format_test.js
@@ -188,8 +188,8 @@ var suites = Pervasives.$at(from_of_string(of_string), Pervasives.$at(/* :: */[
             "isnan_of_string",
             (function () {
                 return /* Eq */Block.__(0, [
-                          /* true */1,
-                          +(Caml_float.caml_classify_float(Caml_format.caml_float_of_string("nan")) === /* FP_nan */4)
+                          true,
+                          Caml_float.caml_classify_float(Caml_format.caml_float_of_string("nan")) === /* FP_nan */4
                         ]);
               })
           ],
@@ -663,8 +663,8 @@ var formatter_suites_001 = /* :: */[
                           4,
                           5,
                           6,
-                          /* true */1,
-                          /* false */0,
+                          true,
+                          false,
                           0,
                           1,
                           2,
@@ -991,8 +991,8 @@ var formatter_suites_001 = /* :: */[
                             4,
                             5,
                             6,
-                            /* true */1,
-                            /* false */0,
+                            true,
+                            false,
                             0,
                             1,
                             2,

--- a/jscomp/test/class3_test.js
+++ b/jscomp/test/class3_test.js
@@ -258,7 +258,7 @@ Caml_oo_curry.js1(-794843549, 6, my_int);
 
 console.log(Caml_oo_curry.js1(5393365, 7, my_int));
 
-var v = /* int array */[
+var v = /* array */[
   0,
   3
 ];
@@ -300,7 +300,7 @@ var printable_point2 = CamlinternalOO.make_class(shared$9, printable_point2_init
 
 Curry._2(printable_point2[0], 0, 31);
 
-eq("File \"class3_test.ml\", line 81, characters 12-19", v, /* int array */[
+eq("File \"class3_test.ml\", line 81, characters 12-19", v, /* array */[
       30,
       3
     ]);

--- a/jscomp/test/class5_test.js
+++ b/jscomp/test/class5_test.js
@@ -166,7 +166,7 @@ function intlist_init($$class) {
   CamlinternalOO.set_methods($$class, /* array */[
         empty,
         (function (self$4) {
-            return +(self$4[l] === /* [] */0);
+            return self$4[l] === /* [] */0;
           }),
         fold,
         (function (self$4, f, accu) {
@@ -205,7 +205,7 @@ function intlist2_init($$class) {
   CamlinternalOO.set_methods($$class, /* array */[
         empty,
         (function (self$5) {
-            return +(self$5[l] === /* [] */0);
+            return self$5[l] === /* [] */0;
           }),
         fold,
         (function (self$5, f, accu) {

--- a/jscomp/test/class7_test.js
+++ b/jscomp/test/class7_test.js
@@ -204,7 +204,7 @@ eq("File \"class7_test.ml\", line 47, characters 5-12", /* array */[
       1,
       1,
       1
-    ], /* int array */[
+    ], /* array */[
       get(p$1, 0),
       get(p$1, 1),
       get(p$1, 2),
@@ -297,7 +297,7 @@ eq("File \"class7_test.ml\", line 63, characters 5-12", /* array */[
       0,
       0,
       0
-    ], /* int array */[
+    ], /* array */[
       get(p$2, 0),
       get(p$2, 1),
       get(p$2, 2),

--- a/jscomp/test/class8_test.js
+++ b/jscomp/test/class8_test.js
@@ -53,7 +53,7 @@ function money_init($$class) {
           }),
         leq,
         (function (self$2, p) {
-            return +(self$2[repr] <= Caml_oo_curry.js1(834174833, 1, p));
+            return self$2[repr] <= Caml_oo_curry.js1(834174833, 1, p);
           })
       ]);
   return (function (_, self, x) {

--- a/jscomp/test/compare_test.js
+++ b/jscomp/test/compare_test.js
@@ -4,11 +4,11 @@
 function compare(x, y) {
   switch (x) {
     case 0 : 
-        return +(y === /* A */0);
+        return y === /* A */0;
     case 1 : 
-        return +(y === /* B */1);
+        return y === /* B */1;
     case 2 : 
-        return +(y === /* C */2);
+        return y === /* C */2;
     
   }
 }
@@ -17,28 +17,28 @@ function compare2(x, y) {
   switch (x) {
     case 0 : 
         if (y !== 0) {
-          return /* false */0;
+          return false;
         } else {
-          return /* true */1;
+          return true;
         }
     case 1 : 
         if (y !== 1) {
-          return /* false */0;
+          return false;
         } else {
-          return /* true */1;
+          return true;
         }
     case 2 : 
         if (y >= 2) {
-          return /* true */1;
+          return true;
         } else {
-          return /* false */0;
+          return false;
         }
     
   }
 }
 
 function compare3(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 exports.compare = compare;

--- a/jscomp/test/complex_test.js
+++ b/jscomp/test/complex_test.js
@@ -8,7 +8,7 @@ var suites_000 = /* tuple */[
   "basic_add",
   (function () {
       return /* Eq */Block.__(0, [
-                /* float array */[
+                /* array */[
                   2,
                   2
                 ],

--- a/jscomp/test/complex_while_loop.js
+++ b/jscomp/test/complex_while_loop.js
@@ -11,7 +11,7 @@ function f() {
               return fib(n - 1 | 0) + fib(n - 2 | 0) | 0;
             }
           };
-          return +(fib(n) > 10);
+          return fib(n) > 10;
         })()) {
     console.log(String(n));
     n = n + 1 | 0;
@@ -22,7 +22,7 @@ function f() {
 function ff() {
   while((function () {
           var b = 9;
-          return +((3 + b | 0) > 10);
+          return (3 + b | 0) > 10;
         })()) {
     
   };

--- a/jscomp/test/condition_compilation_test.js
+++ b/jscomp/test/condition_compilation_test.js
@@ -42,7 +42,7 @@ var buffer_size = 1;
 
 var vv = 3;
 
-var version_gt_3 = /* true */1;
+var version_gt_3 = true;
 
 var version = -1;
 

--- a/jscomp/test/const_block_test.js
+++ b/jscomp/test/const_block_test.js
@@ -4,13 +4,13 @@ var Mt = require("./mt.js");
 var Block = require("../../lib/js/block.js");
 var Caml_array = require("../../lib/js/caml_array.js");
 
-var a = /* float array */[
+var a = /* array */[
   0,
   1,
   2
 ];
 
-var b = /* int array */[
+var b = /* array */[
   0,
   1,
   2

--- a/jscomp/test/const_defs.js
+++ b/jscomp/test/const_defs.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var v = /* true */1;
+var v = true;
 
 exports.v = v;
 /* No side effect */

--- a/jscomp/test/equal_box_test.js
+++ b/jscomp/test/equal_box_test.js
@@ -30,90 +30,90 @@ function shouldBeNull() {
   return null;
 }
 
-b("File \"equal_box_test.ml\", line 24, characters 4-11", +(3 !== null));
+b("File \"equal_box_test.ml\", line 24, characters 4-11", 3 !== null);
 
-b("File \"equal_box_test.ml\", line 25, characters 4-11", +(/* None */0 !== null));
+b("File \"equal_box_test.ml\", line 25, characters 4-11", /* None */0 !== null);
 
-b("File \"equal_box_test.ml\", line 26, characters 4-11", +("3" !== null));
+b("File \"equal_box_test.ml\", line 26, characters 4-11", "3" !== null);
 
-b("File \"equal_box_test.ml\", line 27, characters 4-11", +(/* "3" */51 !== null));
+b("File \"equal_box_test.ml\", line 27, characters 4-11", /* "3" */51 !== null);
 
-b("File \"equal_box_test.ml\", line 28, characters 4-11", 1 - Caml_int64.equal_null(/* int64 */[
+b("File \"equal_box_test.ml\", line 28, characters 4-11", !Caml_int64.equal_null(/* int64 */[
           /* hi */0,
           /* lo */0
         ], null));
 
-b("File \"equal_box_test.ml\", line 29, characters 4-11", +(0 !== null));
+b("File \"equal_box_test.ml\", line 29, characters 4-11", 0 !== null);
 
-b("File \"equal_box_test.ml\", line 30, characters 4-11", /* true */1);
+b("File \"equal_box_test.ml\", line 30, characters 4-11", true);
 
-b("File \"equal_box_test.ml\", line 31, characters 4-11", 1 - Caml_obj.caml_equal_null(/* None */0, null));
+b("File \"equal_box_test.ml\", line 31, characters 4-11", !Caml_obj.caml_equal_null(/* None */0, null));
 
 b("File \"equal_box_test.ml\", line 32, characters 4-11", Caml_obj.caml_equal_null(null, null));
 
-b("File \"equal_box_test.ml\", line 33, characters 4-11", /* true */1);
+b("File \"equal_box_test.ml\", line 33, characters 4-11", true);
 
-b("File \"equal_box_test.ml\", line 34, characters 4-11", /* true */1);
+b("File \"equal_box_test.ml\", line 34, characters 4-11", true);
 
-b("File \"equal_box_test.ml\", line 35, characters 4-11", 1 - Caml_obj.caml_equal_null(/* Some */[3], /* None */0));
+b("File \"equal_box_test.ml\", line 35, characters 4-11", !Caml_obj.caml_equal_null(/* Some */[3], /* None */0));
 
 var v = null;
 
-b("File \"equal_box_test.ml\", line 39, characters 4-11", +(3 !== v));
+b("File \"equal_box_test.ml\", line 39, characters 4-11", 3 !== v);
 
-b("File \"equal_box_test.ml\", line 40, characters 4-11", +(/* None */0 !== v));
+b("File \"equal_box_test.ml\", line 40, characters 4-11", /* None */0 !== v);
 
-b("File \"equal_box_test.ml\", line 41, characters 4-11", +("3" !== v));
+b("File \"equal_box_test.ml\", line 41, characters 4-11", "3" !== v);
 
-b("File \"equal_box_test.ml\", line 42, characters 4-11", +(/* "3" */51 !== v));
+b("File \"equal_box_test.ml\", line 42, characters 4-11", /* "3" */51 !== v);
 
-b("File \"equal_box_test.ml\", line 43, characters 4-11", 1 - Caml_int64.equal_nullable(/* int64 */[
+b("File \"equal_box_test.ml\", line 43, characters 4-11", !Caml_int64.equal_nullable(/* int64 */[
           /* hi */0,
           /* lo */0
         ], v));
 
-b("File \"equal_box_test.ml\", line 44, characters 4-11", +(0 !== v));
+b("File \"equal_box_test.ml\", line 44, characters 4-11", 0 !== v);
 
-b("File \"equal_box_test.ml\", line 45, characters 4-11", +(0 !== v));
+b("File \"equal_box_test.ml\", line 45, characters 4-11", 0 !== v);
 
-b("File \"equal_box_test.ml\", line 46, characters 4-11", 1 - Caml_obj.caml_equal_nullable(/* None */0, v));
+b("File \"equal_box_test.ml\", line 46, characters 4-11", !Caml_obj.caml_equal_nullable(/* None */0, v));
 
 b("File \"equal_box_test.ml\", line 47, characters 4-11", Caml_obj.caml_equal_nullable(null, v));
 
-b("File \"equal_box_test.ml\", line 48, characters 4-11", /* true */1);
+b("File \"equal_box_test.ml\", line 48, characters 4-11", true);
 
-b("File \"equal_box_test.ml\", line 49, characters 4-11", /* true */1);
+b("File \"equal_box_test.ml\", line 49, characters 4-11", true);
 
-b("File \"equal_box_test.ml\", line 50, characters 4-11", 1 - Caml_obj.caml_equal_nullable(/* Some */[3], /* None */0));
+b("File \"equal_box_test.ml\", line 50, characters 4-11", !Caml_obj.caml_equal_nullable(/* Some */[3], /* None */0));
 
 var v$1 = undefined;
 
-b("File \"equal_box_test.ml\", line 55, characters 4-11", +(3 !== v$1));
+b("File \"equal_box_test.ml\", line 55, characters 4-11", 3 !== v$1);
 
-b("File \"equal_box_test.ml\", line 56, characters 4-11", +(/* None */0 !== v$1));
+b("File \"equal_box_test.ml\", line 56, characters 4-11", /* None */0 !== v$1);
 
-b("File \"equal_box_test.ml\", line 57, characters 4-11", +("3" !== v$1));
+b("File \"equal_box_test.ml\", line 57, characters 4-11", "3" !== v$1);
 
-b("File \"equal_box_test.ml\", line 58, characters 4-11", +(/* "3" */51 !== v$1));
+b("File \"equal_box_test.ml\", line 58, characters 4-11", /* "3" */51 !== v$1);
 
-b("File \"equal_box_test.ml\", line 59, characters 4-11", 1 - Caml_int64.equal_undefined(/* int64 */[
+b("File \"equal_box_test.ml\", line 59, characters 4-11", !Caml_int64.equal_undefined(/* int64 */[
           /* hi */0,
           /* lo */0
         ], v$1));
 
-b("File \"equal_box_test.ml\", line 60, characters 4-11", +(0 !== v$1));
+b("File \"equal_box_test.ml\", line 60, characters 4-11", 0 !== v$1);
 
-b("File \"equal_box_test.ml\", line 61, characters 4-11", +(0 !== v$1));
+b("File \"equal_box_test.ml\", line 61, characters 4-11", 0 !== v$1);
 
-b("File \"equal_box_test.ml\", line 62, characters 4-11", 1 - Caml_obj.caml_equal_undefined(/* None */0, v$1));
+b("File \"equal_box_test.ml\", line 62, characters 4-11", !Caml_obj.caml_equal_undefined(/* None */0, v$1));
 
-b("File \"equal_box_test.ml\", line 63, characters 4-11", 1 - Caml_obj.caml_equal_undefined(null, v$1));
+b("File \"equal_box_test.ml\", line 63, characters 4-11", !Caml_obj.caml_equal_undefined(null, v$1));
 
-b("File \"equal_box_test.ml\", line 64, characters 4-11", /* true */1);
+b("File \"equal_box_test.ml\", line 64, characters 4-11", true);
 
-b("File \"equal_box_test.ml\", line 65, characters 4-11", /* true */1);
+b("File \"equal_box_test.ml\", line 65, characters 4-11", true);
 
-b("File \"equal_box_test.ml\", line 66, characters 4-11", 1 - Caml_obj.caml_equal_undefined(/* Some */[3], /* None */0));
+b("File \"equal_box_test.ml\", line 66, characters 4-11", !Caml_obj.caml_equal_undefined(/* Some */[3], /* None */0));
 
 Mt.from_pair_suites("File \"equal_box_test.ml\", line 71, characters 23-30", suites[0]);
 

--- a/jscomp/test/equal_test.js
+++ b/jscomp/test/equal_test.js
@@ -2,16 +2,16 @@
 
 
 function str_equal(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
-var str_b = /* true */1;
+var str_b = true;
 
 function int_equal(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
-var v = /* false */0;
+var v = false;
 
 exports.str_equal = str_equal;
 exports.str_b = str_b;

--- a/jscomp/test/escape_esmodule.js
+++ b/jscomp/test/escape_esmodule.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var $$__esModule = /* false */0;
+var $$__esModule = false;
 
 var $$default = 4;
 

--- a/jscomp/test/esmodule_ref.js
+++ b/jscomp/test/esmodule_ref.js
@@ -1,6 +1,6 @@
 'use strict';
 
 
-console.log(/* false */0);
+console.log(false);
 
 /*  Not a pure module */

--- a/jscomp/test/ext_array_test.js
+++ b/jscomp/test/ext_array_test.js
@@ -257,9 +257,9 @@ function exists(p, a) {
   while(true) {
     var i = _i;
     if (i === n) {
-      return /* false */0;
+      return false;
     } else if (Curry._1(p, a[i])) {
-      return /* true */1;
+      return true;
     } else {
       _i = i + 1 | 0;
       continue ;
@@ -268,19 +268,19 @@ function exists(p, a) {
 }
 
 function is_empty(arr) {
-  return +(arr.length === 0);
+  return arr.length === 0;
 }
 
 function unsafe_loop(_index, len, p, xs, ys) {
   while(true) {
     var index = _index;
     if (index >= len) {
-      return /* true */1;
+      return true;
     } else if (Curry._2(p, xs[index], ys[index])) {
       _index = index + 1 | 0;
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -291,7 +291,7 @@ function for_all2_no_exn(p, xs, ys) {
   if (len_xs === len_ys) {
     return unsafe_loop(0, len_xs, p, xs, ys);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/jscomp/test/ext_list_test.js
+++ b/jscomp/test/ext_list_test.js
@@ -27,7 +27,7 @@ function filter_map(f, _xs) {
 }
 
 function excludes(p, l) {
-  var excluded = [/* false */0];
+  var excluded = [false];
   var aux = function (_accu, _param) {
     while(true) {
       var param = _param;
@@ -36,7 +36,7 @@ function excludes(p, l) {
         var l = param[1];
         var x = param[0];
         if (Curry._1(p, x)) {
-          excluded[0] = /* true */1;
+          excluded[0] = true;
           _param = l;
           continue ;
         } else {
@@ -55,12 +55,12 @@ function excludes(p, l) {
   var v = aux(/* [] */0, l);
   if (excluded[0]) {
     return /* tuple */[
-            /* true */1,
+            true,
             v
           ];
   } else {
     return /* tuple */[
-            /* false */0,
+            false,
             l
           ];
   }
@@ -148,12 +148,12 @@ function same_length(_xs, _ys) {
         _xs = xs[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (ys) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -343,7 +343,7 @@ function map2_last(f, l1, l2) {
         exit = 1;
       } else {
         return /* :: */[
-                Curry._3(f, /* true */1, u, l2[0]),
+                Curry._3(f, true, u, l2[0]),
                 /* [] */0
               ];
       }
@@ -355,7 +355,7 @@ function map2_last(f, l1, l2) {
     }
     if (exit === 1) {
       if (l2) {
-        var r = Curry._3(f, /* false */0, u, l2[0]);
+        var r = Curry._3(f, false, u, l2[0]);
         return /* :: */[
                 r,
                 map2_last(f, l1$1, l2[1])
@@ -383,14 +383,14 @@ function map_last(f, l1) {
     var l1$1 = l1[1];
     var u = l1[0];
     if (l1$1) {
-      var r = Curry._2(f, /* false */0, u);
+      var r = Curry._2(f, false, u);
       return /* :: */[
               r,
               map_last(f, l1$1)
             ];
     } else {
       return /* :: */[
-              Curry._2(f, /* true */1, u),
+              Curry._2(f, true, u),
               /* [] */0
             ];
     }
@@ -410,7 +410,7 @@ function fold_right2_last(f, l1, l2, accu) {
       if (l2[1]) {
         exit = 1;
       } else {
-        return Curry._4(f, /* true */1, last1, l2[0], accu);
+        return Curry._4(f, true, last1, l2[0], accu);
       }
     } else {
       throw [
@@ -420,7 +420,7 @@ function fold_right2_last(f, l1, l2, accu) {
     }
     if (exit === 1) {
       if (l2) {
-        return Curry._4(f, /* false */0, last1, l2[0], fold_right2_last(f, l1$1, l2[1], accu));
+        return Curry._4(f, false, last1, l2[0], fold_right2_last(f, l1$1, l2[1], accu));
       } else {
         throw [
               Caml_builtin_exceptions.invalid_argument,
@@ -505,10 +505,10 @@ function length_larger_than_n(n, _xs, _ys) {
         _xs = xs[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return +(length_compare(xs, n) === /* Eq */15500);
+      return length_compare(xs, n) === /* Eq */15500;
     }
   };
 }
@@ -698,12 +698,12 @@ function for_all2_no_exn(p, _l1, _l2) {
         _l1 = l1[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (l2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -815,9 +815,9 @@ function ref_top(x) {
 function ref_empty(x) {
   var match = x[0];
   if (match) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 

--- a/jscomp/test/ext_pervasives_test.js
+++ b/jscomp/test/ext_pervasives_test.js
@@ -133,7 +133,7 @@ function dump(r) {
             _r = r[1];
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         }
       };

--- a/jscomp/test/ext_string_test.js
+++ b/jscomp/test/ext_string_test.js
@@ -11,7 +11,7 @@ var Caml_exceptions = require("../../lib/js/caml_exceptions.js");
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js");
 
 function split_by($staropt$star, is_delim, str) {
-  var keep_empty = $staropt$star ? $staropt$star[0] : /* false */0;
+  var keep_empty = $staropt$star ? $staropt$star[0] : false;
   var len = str.length;
   var _acc = /* [] */0;
   var _last_pos = len;
@@ -56,10 +56,10 @@ function trim(s) {
   var i = 0;
   var j = s.length;
   while((function () {
-          var tmp = /* false */0;
+          var tmp = false;
           if (i < j) {
             var u = s.charCodeAt(i);
-            tmp = +(u === /* "\t" */9 || u === /* "\n" */10 || u === /* " " */32);
+            tmp = u === /* "\t" */9 || u === /* "\n" */10 || u === /* " " */32;
           }
           return tmp;
         })()) {
@@ -67,10 +67,10 @@ function trim(s) {
   };
   var k = j - 1 | 0;
   while((function () {
-          var tmp = /* false */0;
+          var tmp = false;
           if (k >= i) {
             var u = s.charCodeAt(k);
-            tmp = +(u === /* "\t" */9 || u === /* "\n" */10 || u === /* " " */32);
+            tmp = u === /* "\t" */9 || u === /* "\n" */10 || u === /* " " */32;
           }
           return tmp;
         })()) {
@@ -84,17 +84,17 @@ function split(keep_empty, str, on) {
     return /* [] */0;
   } else {
     return split_by(keep_empty, (function (x) {
-                  return +(x === on);
+                  return x === on;
                 }), str);
   }
 }
 
 function quick_split_by_ws(str) {
-  return split_by(/* Some */[/* false */0], (function (x) {
+  return split_by(/* Some */[false], (function (x) {
                 if (x === /* "\t" */9 || x === /* "\n" */10) {
-                  return /* true */1;
+                  return true;
                 } else {
-                  return +(x === /* " " */32);
+                  return x === /* " " */32;
                 }
               }), str);
 }
@@ -107,9 +107,9 @@ function starts_with(s, beg) {
     while(i < beg_len && s[i] === beg[i]) {
       i = i + 1 | 0;
     };
-    return +(i === beg_len);
+    return i === beg_len;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -138,7 +138,7 @@ function ends_with_index(s, end_) {
 }
 
 function ends_with(s, end_) {
-  return +(ends_with_index(s, end_) >= 0);
+  return ends_with_index(s, end_) >= 0;
 }
 
 function ends_with_then_chop(s, beg) {
@@ -179,26 +179,26 @@ function escaped(s) {
     while(true) {
       var i = _i;
       if (i >= s.length) {
-        return /* false */0;
+        return false;
       } else {
         var match = s.charCodeAt(i);
         if (match >= 32) {
           var switcher = match - 34 | 0;
           if (switcher > 58 || switcher < 0) {
             if (switcher >= 93) {
-              return /* true */1;
+              return true;
             } else {
               _i = i + 1 | 0;
               continue ;
             }
           } else if (switcher > 57 || switcher < 1) {
-            return /* true */1;
+            return true;
           } else {
             _i = i + 1 | 0;
             continue ;
           }
         } else {
-          return /* true */1;
+          return true;
         }
       }
     };
@@ -214,12 +214,12 @@ function unsafe_for_all_range(s, _start, finish, p) {
   while(true) {
     var start = _start;
     if (start > finish) {
-      return /* true */1;
+      return true;
     } else if (Curry._1(p, s.charCodeAt(start))) {
       _start = start + 1 | 0;
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -241,7 +241,7 @@ function for_all(p, s) {
 }
 
 function is_empty(s) {
-  return +(s.length === 0);
+  return s.length === 0;
 }
 
 function repeat(n, s) {
@@ -259,16 +259,16 @@ function unsafe_is_sub(sub, i, s, j, len) {
     while(true) {
       var k = _k;
       if (k === len) {
-        return /* true */1;
+        return true;
       } else if (sub[i + k | 0] === s[j + k | 0]) {
         _k = k + 1 | 0;
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -298,7 +298,7 @@ function find($staropt$star, sub, s) {
 }
 
 function contain_substring(s, sub) {
-  return +(find(/* None */0, sub, s) >= 0);
+  return find(/* None */0, sub, s) >= 0;
 }
 
 function non_overlap_count(sub, s) {
@@ -398,7 +398,7 @@ function starts_with_and_number(s, offset, beg) {
 }
 
 function equal(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 function unsafe_concat_with_length(len, sep, l) {
@@ -464,14 +464,14 @@ function is_valid_module_file(s) {
     var exit = 0;
     if (match >= 91) {
       if (match > 122 || match < 97) {
-        return /* false */0;
+        return false;
       } else {
         exit = 1;
       }
     } else if (match >= 65) {
       exit = 1;
     } else {
-      return /* false */0;
+      return false;
     }
     if (exit === 1) {
       return unsafe_for_all_range(s, 1, len - 1 | 0, (function (x) {
@@ -479,31 +479,31 @@ function is_valid_module_file(s) {
                       var switcher = x - 91 | 0;
                       if (switcher > 5 || switcher < 0) {
                         if (switcher >= 32) {
-                          return /* false */0;
+                          return false;
                         } else {
-                          return /* true */1;
+                          return true;
                         }
                       } else if (switcher !== 4) {
-                        return /* false */0;
+                        return false;
                       } else {
-                        return /* true */1;
+                        return true;
                       }
                     } else if (x >= 48) {
                       if (x >= 58) {
-                        return /* false */0;
+                        return false;
                       } else {
-                        return /* true */1;
+                        return true;
                       }
                     } else if (x !== 39) {
-                      return /* false */0;
+                      return false;
                     } else {
-                      return /* true */1;
+                      return true;
                     }
                   }));
     }
     
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -514,12 +514,12 @@ function is_valid_npm_package_name(s) {
     var exit = 0;
     if (match >= 97) {
       if (match >= 123) {
-        return /* false */0;
+        return false;
       } else {
         exit = 1;
       }
     } else if (match !== 64) {
-      return /* false */0;
+      return false;
     } else {
       exit = 1;
     }
@@ -528,25 +528,25 @@ function is_valid_npm_package_name(s) {
                     if (x >= 58) {
                       if (x >= 97) {
                         if (x >= 123) {
-                          return /* false */0;
+                          return false;
                         } else {
-                          return /* true */1;
+                          return true;
                         }
                       } else if (x !== 95) {
-                        return /* false */0;
+                        return false;
                       } else {
-                        return /* true */1;
+                        return true;
                       }
                     } else if (x !== 45 && x < 48) {
-                      return /* false */0;
+                      return false;
                     } else {
-                      return /* true */1;
+                      return true;
                     }
                   }));
     }
     
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -579,12 +579,12 @@ function unsafe_no_char(x, ch, _i, last_idx) {
   while(true) {
     var i = _i;
     if (i > last_idx) {
-      return /* true */1;
+      return true;
     } else if (x.charCodeAt(i) !== ch) {
       _i = i + 1 | 0;
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }

--- a/jscomp/test/ffi_arity_test.js
+++ b/jscomp/test/ffi_arity_test.js
@@ -17,7 +17,7 @@ function f(v) {
   }
 }
 
-var v = /* int array */[
+var v = /* array */[
     1,
     2,
     3
@@ -25,7 +25,7 @@ var v = /* int array */[
         return Curry._1(f(param), param$1);
       }));
 
-var vv = /* int array */[
+var vv = /* array */[
     1,
     2,
     3
@@ -74,7 +74,7 @@ Mt.from_pair_suites("ffi_arity_test.ml", /* :: */[
         (function () {
             return /* Eq */Block.__(0, [
                       v,
-                      /* int array */[
+                      /* array */[
                         0,
                         1,
                         4
@@ -88,7 +88,7 @@ Mt.from_pair_suites("ffi_arity_test.ml", /* :: */[
           (function () {
               return /* Eq */Block.__(0, [
                         vv,
-                        /* int array */[
+                        /* array */[
                           1,
                           3,
                           5
@@ -102,7 +102,7 @@ Mt.from_pair_suites("ffi_arity_test.ml", /* :: */[
             (function () {
                 return /* Eq */Block.__(0, [
                           hh,
-                          /* int array */[
+                          /* array */[
                             1,
                             2,
                             3
@@ -115,7 +115,7 @@ Mt.from_pair_suites("ffi_arity_test.ml", /* :: */[
               "File \"ffi_arity_test.ml\", line 48, characters 4-11",
               (function () {
                   return /* Eq */Block.__(0, [
-                            /* int array */[
+                            /* array */[
                                   1,
                                   2,
                                   3
@@ -126,7 +126,7 @@ Mt.from_pair_suites("ffi_arity_test.ml", /* :: */[
                                     })).map((function (y) {
                                     return Caml_int32.imul(Curry._1(y, 0), Curry._1(y, 1));
                                   })),
-                            /* int array */[
+                            /* array */[
                               2,
                               6,
                               12
@@ -139,7 +139,7 @@ Mt.from_pair_suites("ffi_arity_test.ml", /* :: */[
                 "File \"ffi_arity_test.ml\", line 53, characters 4-11",
                 (function () {
                     return /* Eq */Block.__(0, [
-                              /* int array */[
+                              /* array */[
                                   1,
                                   2,
                                   3
@@ -149,7 +149,7 @@ Mt.from_pair_suites("ffi_arity_test.ml", /* :: */[
                                                   return y + i | 0;
                                                 })(param);
                                     })),
-                              /* int array */[
+                              /* array */[
                                 1,
                                 5,
                                 11

--- a/jscomp/test/ffi_array_test.js
+++ b/jscomp/test/ffi_array_test.js
@@ -24,14 +24,14 @@ function eq(loc, x, y) {
   return /* () */0;
 }
 
-eq("File \"ffi_array_test.ml\", line 12, characters 5-12", /* int array */[
+eq("File \"ffi_array_test.ml\", line 12, characters 5-12", /* array */[
         1,
         2,
         3,
         4
       ].map((function (x) {
             return x + 1 | 0;
-          })), /* int array */[
+          })), /* array */[
       2,
       3,
       4,

--- a/jscomp/test/flattern_order_test.js
+++ b/jscomp/test/flattern_order_test.js
@@ -34,7 +34,7 @@ function even(_n) {
   while(true) {
     var n = _n;
     if (n === 0) {
-      return /* true */1;
+      return true;
     } else {
       _n = n - 1 | 0;
       continue ;
@@ -44,11 +44,11 @@ function even(_n) {
 
 function even2(n) {
   if (n === 0) {
-    return /* true */1;
+    return true;
   } else {
     var n$1 = n - 1 | 0;
     if (n$1 === 1) {
-      return /* true */1;
+      return true;
     } else {
       return even2(n$1 - 1 | 0);
     }

--- a/jscomp/test/float_array.js
+++ b/jscomp/test/float_array.js
@@ -3,7 +3,7 @@
 
 function small_float_array(x) {
   return /* tuple */[
-          /* float array */[
+          /* array */[
             1,
             2,
             3
@@ -14,7 +14,7 @@ function small_float_array(x) {
 
 function longer_float_array(x) {
   return /* tuple */[
-          /* float array */[
+          /* array */[
             1,
             2,
             3,

--- a/jscomp/test/float_test.js
+++ b/jscomp/test/float_test.js
@@ -160,9 +160,9 @@ Mt_global.collect_eq(test_id, suites, "File \"float_test.ml\", line 48, characte
 
 var match$3 = Caml_float.caml_modf_float(Number.NaN);
 
-var param_000 = +isNaN(match$3[0]);
+var param_000 = isNaN(match$3[0]);
 
-var param_001 = +isNaN(match$3[1]);
+var param_001 = isNaN(match$3[1]);
 
 var param$2 = /* tuple */[
   param_000,
@@ -170,11 +170,11 @@ var param$2 = /* tuple */[
 ];
 
 Mt_global.collect_eq(test_id, suites, "File \"float_test.ml\", line 49, characters 5-12", param$2, /* tuple */[
-      /* true */1,
-      /* true */1
+      true,
+      true
     ]);
 
-var param$3 = /* int array */[
+var param$3 = /* array */[
   -1,
   1,
   1

--- a/jscomp/test/flow_parser_reg_test.js
+++ b/jscomp/test/flow_parser_reg_test.js
@@ -834,7 +834,7 @@ function new_lex_env(lex_source, lex_lb, enable_types_in_comments) {
   return /* record */[
           /* lex_source */lex_source,
           /* lex_lb */lex_lb,
-          /* lex_in_comment_syntax : false */0,
+          /* lex_in_comment_syntax */false,
           /* lex_enable_comment_syntax */enable_types_in_comments,
           /* lex_state */empty_lex_state
         ];
@@ -1019,7 +1019,7 @@ function start(str) {
           return /* () */0;
         }), Caml_string.bytes_of_string(str));
   return /* record */[
-          /* negative : false */0,
+          /* negative */false,
           /* mantissa */0,
           /* exponent */0,
           /* decimal_exponent : None */0,
@@ -1042,7 +1042,7 @@ function parse_sign(f) {
         case 2 : 
             var init = eat(f);
             return /* record */[
-                    /* negative : true */1,
+                    /* negative */true,
                     /* mantissa */init[/* mantissa */1],
                     /* exponent */init[/* exponent */2],
                     /* decimal_exponent */init[/* decimal_exponent */3],
@@ -1800,7 +1800,7 @@ function token(env, lexbuf) {
             var start = loc_of_lexbuf(env$1, lexbuf$1);
             var buf = $$Buffer.create(127);
             var match = comment(env$1, buf, lexbuf$1);
-            var env$3 = save_comment(match[0], start, match[1], buf, /* true */1);
+            var env$3 = save_comment(match[0], start, match[1], buf, true);
             return token(env$3, lexbuf$1);
         case 4 : 
             var sp = Lexing.sub_lexeme(lexbuf$1, lexbuf$1[/* lex_start_pos */4] + 2 | 0, Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 0));
@@ -1814,7 +1814,7 @@ function token(env, lexbuf) {
               } else {
                 env$4 = env$1;
               }
-              var env$5 = in_comment_syntax(/* true */1, env$4);
+              var env$5 = in_comment_syntax(true, env$4);
               if (escape_type === ":") {
                 return /* tuple */[
                         env$5,
@@ -1829,12 +1829,12 @@ function token(env, lexbuf) {
               $$Buffer.add_string(buf$1, sp);
               $$Buffer.add_string(buf$1, escape_type);
               var match$1 = comment(env$1, buf$1, lexbuf$1);
-              var env$6 = save_comment(match$1[0], start$1, match$1[1], buf$1, /* true */1);
+              var env$6 = save_comment(match$1[0], start$1, match$1[1], buf$1, true);
               return token(env$6, lexbuf$1);
             }
         case 5 : 
             if (env$1[/* lex_in_comment_syntax */2]) {
-              var env$7 = in_comment_syntax(/* false */0, env$1);
+              var env$7 = in_comment_syntax(false, env$1);
               return token(env$7, lexbuf$1);
             } else {
               yyback(1, lexbuf$1);
@@ -1847,7 +1847,7 @@ function token(env, lexbuf) {
             var start$2 = loc_of_lexbuf(env$1, lexbuf$1);
             var buf$2 = $$Buffer.create(127);
             var match$2 = line_comment(env$1, buf$2, lexbuf$1);
-            var env$8 = save_comment(match$2[0], start$2, match$2[1], buf$2, /* false */0);
+            var env$8 = save_comment(match$2[0], start$2, match$2[1], buf$2, false);
             return token(env$8, lexbuf$1);
         case 7 : 
             if (lexbuf$1[/* lex_start_pos */4] === 0) {
@@ -1865,7 +1865,7 @@ function token(env, lexbuf) {
             var buf$3 = $$Buffer.create(127);
             var raw = $$Buffer.create(127);
             $$Buffer.add_char(raw, quote);
-            var match$4 = string_quote(env$1, quote, buf$3, raw, /* false */0, lexbuf$1);
+            var match$4 = string_quote(env$1, quote, buf$3, raw, false, lexbuf$1);
             return /* tuple */[
                     match$4[0],
                     /* T_STRING */Block.__(1, [/* tuple */[
@@ -3146,7 +3146,7 @@ function __ocaml_lex_template_tail_rec(_env, lexbuf, ___ocaml_lex_state) {
             var start = loc_of_lexbuf(env, lexbuf);
             var buf = $$Buffer.create(127);
             var match = line_comment(env, buf, lexbuf);
-            var env$1 = save_comment(match[0], start, match[1], buf, /* true */1);
+            var env$1 = save_comment(match[0], start, match[1], buf, true);
             ___ocaml_lex_state = 393;
             _env = env$1;
             continue ;
@@ -3154,7 +3154,7 @@ function __ocaml_lex_template_tail_rec(_env, lexbuf, ___ocaml_lex_state) {
             var start$1 = loc_of_lexbuf(env, lexbuf);
             var buf$1 = $$Buffer.create(127);
             var match$1 = comment(env, buf$1, lexbuf);
-            var env$2 = save_comment(match$1[0], start$1, match$1[1], buf$1, /* true */1);
+            var env$2 = save_comment(match$1[0], start$1, match$1[1], buf$1, true);
             ___ocaml_lex_state = 393;
             _env = env$2;
             continue ;
@@ -3188,7 +3188,7 @@ function __ocaml_lex_template_tail_rec(_env, lexbuf, ___ocaml_lex_state) {
                             /* raw */"",
                             /* literal */""
                           ],
-                          /* true */1
+                          true
                         ]])
                   ];
         
@@ -3219,21 +3219,21 @@ function template_part(env, start, cooked, raw, literal, lexbuf) {
             return /* tuple */[
                     env$2,
                     btwn(start$1, loc_of_lexbuf(env$2, lexbuf$1)),
-                    /* true */1
+                    true
                   ];
         case 1 : 
             $$Buffer.add_char(literal$1, /* "`" */96);
             return /* tuple */[
                     env$1,
                     btwn(start$1, loc_of_lexbuf(env$1, lexbuf$1)),
-                    /* true */1
+                    true
                   ];
         case 2 : 
             $$Buffer.add_string(literal$1, "${");
             return /* tuple */[
                     env$1,
                     btwn(start$1, loc_of_lexbuf(env$1, lexbuf$1)),
-                    /* false */0
+                    false
                   ];
         case 3 : 
             $$Buffer.add_char(raw$1, /* "\\" */92);
@@ -3286,13 +3286,13 @@ function string_escape(env, buf, lexbuf) {
         case 0 : 
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 1 : 
             $$Buffer.add_string(buf$1, "\\");
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 2 : 
             var a = Caml_bytes.get(lexbuf$1[/* lex_buffer */1], lexbuf$1[/* lex_start_pos */4] + 1 | 0);
@@ -3303,7 +3303,7 @@ function string_escape(env, buf, lexbuf) {
                   }), utf16to8(code));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 3 : 
             var a$1 = Caml_bytes.get(lexbuf$1[/* lex_buffer */1], lexbuf$1[/* lex_start_pos */4]);
@@ -3323,7 +3323,7 @@ function string_escape(env, buf, lexbuf) {
             }
             return /* tuple */[
                     env$1,
-                    /* true */1
+                    true
                   ];
         case 4 : 
             var a$2 = Caml_bytes.get(lexbuf$1[/* lex_buffer */1], lexbuf$1[/* lex_start_pos */4]);
@@ -3334,49 +3334,49 @@ function string_escape(env, buf, lexbuf) {
                   }), utf16to8(code$3));
             return /* tuple */[
                     env$1,
-                    /* true */1
+                    true
                   ];
         case 5 : 
             $$Buffer.add_char(buf$1, Char.chr(0));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 6 : 
             $$Buffer.add_char(buf$1, Char.chr(8));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 7 : 
             $$Buffer.add_char(buf$1, Char.chr(12));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 8 : 
             $$Buffer.add_char(buf$1, Char.chr(10));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 9 : 
             $$Buffer.add_char(buf$1, Char.chr(13));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 10 : 
             $$Buffer.add_char(buf$1, Char.chr(9));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 11 : 
             $$Buffer.add_char(buf$1, Char.chr(11));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 12 : 
             var a$3 = Caml_bytes.get(lexbuf$1[/* lex_buffer */1], lexbuf$1[/* lex_start_pos */4]);
@@ -3386,7 +3386,7 @@ function string_escape(env, buf, lexbuf) {
                   }), utf16to8(code$4));
             return /* tuple */[
                     env$1,
-                    /* true */1
+                    true
                   ];
         case 13 : 
             var a$4 = Caml_bytes.get(lexbuf$1[/* lex_buffer */1], lexbuf$1[/* lex_start_pos */4] + 1 | 0);
@@ -3399,7 +3399,7 @@ function string_escape(env, buf, lexbuf) {
                   }), utf16to8(code$5));
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 14 : 
             var hex_code = Lexing.sub_lexeme(lexbuf$1, lexbuf$1[/* lex_start_pos */4] + 2 | 0, lexbuf$1[/* lex_curr_pos */5] - 1 | 0);
@@ -3410,7 +3410,7 @@ function string_escape(env, buf, lexbuf) {
                   }), utf16to8(code$6));
             return /* tuple */[
                     env$2,
-                    /* false */0
+                    false
                   ];
         case 15 : 
             var c$2 = Caml_bytes.get(lexbuf$1[/* lex_buffer */1], lexbuf$1[/* lex_start_pos */4]);
@@ -3418,20 +3418,20 @@ function string_escape(env, buf, lexbuf) {
             $$Buffer.add_char(buf$1, c$2);
             return /* tuple */[
                     env$3,
-                    /* false */0
+                    false
                   ];
         case 16 : 
             Lexing.new_line(lexbuf$1);
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         case 17 : 
             var c$3 = Caml_bytes.get(lexbuf$1[/* lex_buffer */1], lexbuf$1[/* lex_start_pos */4]);
             $$Buffer.add_char(buf$1, c$3);
             return /* tuple */[
                     env$1,
-                    /* false */0
+                    false
                   ];
         
       }
@@ -3741,7 +3741,7 @@ function type_token(env, lexbuf) {
             var start = loc_of_lexbuf(env$1, lexbuf$1);
             var buf = $$Buffer.create(127);
             var match = comment(env$1, buf, lexbuf$1);
-            var env$2 = save_comment(match[0], start, match[1], buf, /* true */1);
+            var env$2 = save_comment(match[0], start, match[1], buf, true);
             return type_token(env$2, lexbuf$1);
         case 3 : 
             var sp = Lexing.sub_lexeme(lexbuf$1, lexbuf$1[/* lex_start_pos */4] + 2 | 0, Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 0));
@@ -3755,7 +3755,7 @@ function type_token(env, lexbuf) {
               } else {
                 env$3 = env$1;
               }
-              var env$4 = in_comment_syntax(/* true */1, env$3);
+              var env$4 = in_comment_syntax(true, env$3);
               if (escape_type === ":") {
                 return /* tuple */[
                         env$4,
@@ -3770,12 +3770,12 @@ function type_token(env, lexbuf) {
               $$Buffer.add_string(buf$1, sp);
               $$Buffer.add_string(buf$1, escape_type);
               var match$1 = comment(env$1, buf$1, lexbuf$1);
-              var env$5 = save_comment(match$1[0], start$1, match$1[1], buf$1, /* true */1);
+              var env$5 = save_comment(match$1[0], start$1, match$1[1], buf$1, true);
               return type_token(env$5, lexbuf$1);
             }
         case 4 : 
             if (env$1[/* lex_in_comment_syntax */2]) {
-              var env$6 = in_comment_syntax(/* false */0, env$1);
+              var env$6 = in_comment_syntax(false, env$1);
               return type_token(env$6, lexbuf$1);
             } else {
               yyback(1, lexbuf$1);
@@ -3788,7 +3788,7 @@ function type_token(env, lexbuf) {
             var start$2 = loc_of_lexbuf(env$1, lexbuf$1);
             var buf$2 = $$Buffer.create(127);
             var match$2 = line_comment(env$1, buf$2, lexbuf$1);
-            var env$7 = save_comment(match$2[0], start$2, match$2[1], buf$2, /* true */1);
+            var env$7 = save_comment(match$2[0], start$2, match$2[1], buf$2, true);
             return type_token(env$7, lexbuf$1);
         case 6 : 
             var quote = Caml_bytes.get(lexbuf$1[/* lex_buffer */1], lexbuf$1[/* lex_start_pos */4]);
@@ -3796,7 +3796,7 @@ function type_token(env, lexbuf) {
             var buf$3 = $$Buffer.create(127);
             var raw = $$Buffer.create(127);
             $$Buffer.add_char(raw, quote);
-            var match$3 = string_quote(env$1, quote, buf$3, raw, /* false */0, lexbuf$1);
+            var match$3 = string_quote(env$1, quote, buf$3, raw, false, lexbuf$1);
             return /* tuple */[
                     match$3[0],
                     /* T_STRING */Block.__(1, [/* tuple */[
@@ -4102,7 +4102,7 @@ function __ocaml_lex_regexp_rec(_env, lexbuf, ___ocaml_lex_state) {
             var start = loc_of_lexbuf(env, lexbuf);
             var buf = $$Buffer.create(127);
             var match = line_comment(env, buf, lexbuf);
-            var env$1 = save_comment(match[0], start, match[1], buf, /* true */1);
+            var env$1 = save_comment(match[0], start, match[1], buf, true);
             ___ocaml_lex_state = 291;
             _env = env$1;
             continue ;
@@ -4110,7 +4110,7 @@ function __ocaml_lex_regexp_rec(_env, lexbuf, ___ocaml_lex_state) {
             var start$1 = loc_of_lexbuf(env, lexbuf);
             var buf$1 = $$Buffer.create(127);
             var match$1 = comment(env, buf$1, lexbuf);
-            var env$2 = save_comment(match$1[0], start$1, match$1[1], buf$1, /* true */1);
+            var env$2 = save_comment(match$1[0], start$1, match$1[1], buf$1, true);
             ___ocaml_lex_state = 291;
             _env = env$2;
             continue ;
@@ -4169,7 +4169,7 @@ function __ocaml_lex_jsx_tag_rec(_env, lexbuf, ___ocaml_lex_state) {
             var start = loc_of_lexbuf(env, lexbuf);
             var buf = $$Buffer.create(127);
             var match = line_comment(env, buf, lexbuf);
-            var env$1 = save_comment(match[0], start, match[1], buf, /* true */1);
+            var env$1 = save_comment(match[0], start, match[1], buf, true);
             ___ocaml_lex_state = 333;
             _env = env$1;
             continue ;
@@ -4177,7 +4177,7 @@ function __ocaml_lex_jsx_tag_rec(_env, lexbuf, ___ocaml_lex_state) {
             var start$1 = loc_of_lexbuf(env, lexbuf);
             var buf$1 = $$Buffer.create(127);
             var match$1 = comment(env, buf$1, lexbuf);
-            var env$2 = save_comment(match$1[0], start$1, match$1[1], buf$1, /* true */1);
+            var env$2 = save_comment(match$1[0], start$1, match$1[1], buf$1, true);
             ___ocaml_lex_state = 333;
             _env = env$2;
             continue ;
@@ -4454,13 +4454,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -4558,12 +4558,12 @@ function lex_until(t, i) {
 }
 
 var default_parse_options = /* record */[
-  /* esproposal_class_instance_fields : false */0,
-  /* esproposal_class_static_fields : false */0,
-  /* esproposal_decorators : false */0,
-  /* esproposal_export_star_as : false */0,
-  /* types : true */1,
-  /* use_strict : false */0
+  /* esproposal_class_instance_fields */false,
+  /* esproposal_class_static_fields */false,
+  /* esproposal_decorators */false,
+  /* esproposal_export_star_as */false,
+  /* types */true,
+  /* use_strict */false
 ];
 
 function init_env($staropt$star, $staropt$star$1, source, content) {
@@ -4593,15 +4593,15 @@ function init_env($staropt$star, $staropt$star$1, source, content) {
           /* exports */[/* Empty */0],
           /* last_loc */[/* None */0],
           /* in_strict_mode */parse_options$1[/* use_strict */5],
-          /* in_export : false */0,
-          /* in_loop : false */0,
-          /* in_switch : false */0,
-          /* in_function : false */0,
-          /* no_in : false */0,
-          /* no_call : false */0,
-          /* no_let : false */0,
-          /* allow_yield : true */1,
-          /* allow_await : false */0,
+          /* in_export */false,
+          /* in_loop */false,
+          /* in_switch */false,
+          /* in_function */false,
+          /* no_in */false,
+          /* no_call */false,
+          /* no_let */false,
+          /* allow_yield */true,
+          /* allow_await */false,
           /* error_callback : None */0,
           /* lex_mode_stack */[/* :: */[
               /* NORMAL */0,
@@ -4759,9 +4759,9 @@ function add_label(env, label) {
 function enter_function(env, async, generator) {
   var newrecord = env.slice();
   newrecord[/* labels */2] = /* Empty */0;
-  newrecord[/* in_loop */7] = /* false */0;
-  newrecord[/* in_switch */8] = /* false */0;
-  newrecord[/* in_function */9] = /* true */1;
+  newrecord[/* in_loop */7] = false;
+  newrecord[/* in_switch */8] = false;
+  newrecord[/* in_function */9] = true;
   newrecord[/* allow_yield */13] = generator;
   newrecord[/* allow_await */14] = async;
   return newrecord;
@@ -4769,9 +4769,9 @@ function enter_function(env, async, generator) {
 
 function is_future_reserved(param) {
   if (param === "enum") {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4785,9 +4785,9 @@ function is_strict_reserved(param) {
     case "public" : 
     case "static" : 
     case "yield" : 
-        return /* true */1;
+        return true;
     default:
-      return /* false */0;
+      return false;
   }
 }
 
@@ -4795,9 +4795,9 @@ function is_restricted(param) {
   switch (param) {
     case "arguments" : 
     case "eval" : 
-        return /* true */1;
+        return true;
     default:
-      return /* false */0;
+      return false;
   }
 }
 
@@ -4845,9 +4845,9 @@ function lex_env($staropt$star, env) {
 function is_line_terminator(env) {
   var match = env[/* last_loc */4][0];
   if (match) {
-    return +(loc(/* None */0, env)[/* start */1][/* line */0] > match[0][/* start */1][/* line */0]);
+    return loc(/* None */0, env)[/* start */1][/* line */0] > match[0][/* start */1][/* line */0];
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4859,12 +4859,12 @@ function is_implicit_semicolon(env) {
       if ((switcher + 1 >>> 0) > 103) {
         return is_line_terminator(env);
       } else {
-        return /* true */1;
+        return true;
       }
     } else if (switcher !== 4) {
       return is_line_terminator(env);
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
     return is_line_terminator(env);
@@ -4885,33 +4885,33 @@ function is_identifier($staropt$star, env) {
   var name = value(/* Some */[i], env);
   var match = token$2(/* Some */[i], env);
   if (is_strict_reserved(name) || is_restricted(name) || is_future_reserved(name)) {
-    return /* true */1;
+    return true;
   } else if (typeof match === "number") {
     var switcher = match - 1 | 0;
     if (switcher > 56 || switcher < 0) {
       if (switcher >= 62) {
-        return /* false */0;
+        return false;
       } else {
-        return /* true */1;
+        return true;
       }
     } else if (switcher !== 25) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function is_function($staropt$star, env) {
   var i = $staropt$star ? $staropt$star[0] : 0;
   if (token$2(/* Some */[i], env) === /* T_FUNCTION */13) {
-    return /* true */1;
+    return true;
   } else if (token$2(/* Some */[i], env) === /* T_ASYNC */61) {
-    return +(token$2(/* Some */[i + 1 | 0], env) === /* T_FUNCTION */13);
+    return token$2(/* Some */[i + 1 | 0], env) === /* T_FUNCTION */13;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4919,9 +4919,9 @@ function is_class($staropt$star, env) {
   var i = $staropt$star ? $staropt$star[0] : 0;
   var match = token$2(/* Some */[i], env);
   if (typeof match === "number" && !(match !== 12 && match !== 38)) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -5109,9 +5109,9 @@ function token$4(env, t) {
 function maybe(env, t) {
   if (Caml_obj.caml_equal(token$2(/* None */0, env), t)) {
     token$3(env);
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -5173,14 +5173,14 @@ function to_parse(env, parse) {
     var env$1 = env;
     var saved_state$1 = saved_state;
     var result = Curry._1(parse, env);
-    reset_token_sink(/* true */1, env$1, saved_state$1[/* token_buffer */5]);
+    reset_token_sink(true, env$1, saved_state$1[/* token_buffer */5]);
     return /* ParsedSuccessfully */[result];
   }
   catch (exn){
     if (exn === Rollback) {
       var env$2 = env;
       var saved_state$2 = saved_state;
-      reset_token_sink(/* false */0, env$2, saved_state$2[/* token_buffer */5]);
+      reset_token_sink(false, env$2, saved_state$2[/* token_buffer */5]);
       env$2[/* errors */0][0] = saved_state$2[/* saved_errors */0];
       env$2[/* comments */1][0] = saved_state$2[/* saved_comments */1];
       env$2[/* last_loc */4][0] = saved_state$2[/* saved_last_loc */2];
@@ -5316,13 +5316,13 @@ function mem$1(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -5565,13 +5565,13 @@ function mem$2(x, _param) {
     if (param) {
       var c = compare$1(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -5871,7 +5871,7 @@ function primary(env) {
       case 89 : 
           var env$3 = env;
           var start_loc$3 = Curry._2(Parser_env_048[/* loc */2], /* None */0, env$3);
-          var typeParameters = Curry._2(type_parameter_declaration, /* false */0, env$3);
+          var typeParameters = Curry._2(type_parameter_declaration, false, env$3);
           var match$4 = function_param_list(env$3);
           token$4(env$3, /* T_ARROW */10);
           var returnType$1 = union(env$3);
@@ -5959,7 +5959,7 @@ function primary(env) {
     case 2 : 
         var raw$2 = Curry._2(Parser_env_048[/* value */1], /* None */0, env);
         token$4(env, token$5);
-        var value$2 = +(token$5 === /* T_TRUE */29);
+        var value$2 = token$5 === /* T_TRUE */29;
         return /* tuple */[
                 loc,
                 /* BooleanLiteral */Block.__(11, [/* record */[
@@ -6167,13 +6167,13 @@ function params$1(env, allow_default, _require_default, _acc) {
     var loc = match$1[0];
     var match$2 = Curry._2(Parser_env_048[/* token */0], /* None */0, env);
     var match$3;
-    if (allow_default !== 0) {
+    if (allow_default) {
       var exit = 0;
       if (typeof match$2 === "number" && match$2 === 75) {
         token$3(env);
         match$3 = /* tuple */[
           /* Some */[union(env)],
-          /* true */1
+          true
         ];
       } else {
         exit = 1;
@@ -6194,7 +6194,7 @@ function params$1(env, allow_default, _require_default, _acc) {
     } else {
       match$3 = /* tuple */[
         /* None */0,
-        /* false */0
+        false
       ];
     }
     var param_001 = /* record */[
@@ -6239,7 +6239,7 @@ function type_parameter_declaration(allow_default, env) {
       error$1(env, /* UnexpectedTypeAnnotation */6);
     }
     token$4(env, /* T_LESS_THAN */89);
-    var params$2 = params$1(env, allow_default, /* false */0, /* [] */0);
+    var params$2 = params$1(env, allow_default, false, /* [] */0);
     var loc = btwn(start_loc, Curry._2(Parser_env_048[/* loc */2], /* None */0, env));
     token$4(env, /* T_GREATER_THAN */90);
     return /* Some */[/* tuple */[
@@ -6348,7 +6348,7 @@ function types(env, _acc) {
 }
 
 function methodish(env, start_loc) {
-  var typeParameters = Curry._2(type_parameter_declaration, /* false */0, env);
+  var typeParameters = Curry._2(type_parameter_declaration, false, env);
   var match = function_param_list(env);
   token$4(env, /* T_COLON */77);
   var returnType = union(env);
@@ -6377,9 +6377,9 @@ function method_property(env, start_loc, $$static, key) {
           /* record */[
             /* key */key,
             /* value */value$1,
-            /* optional : false */0,
+            /* optional */false,
             /* static */$$static,
-            /* _method : true */1
+            /* _method */true
           ]
         ];
 }
@@ -6409,7 +6409,7 @@ function property(env, start_loc, $$static, key) {
             /* value */value,
             /* optional */optional,
             /* static */$$static,
-            /* _method : false */0
+            /* _method */false
           ]
         ];
 }
@@ -6509,7 +6509,7 @@ function properties(allow_static, env, _param) {
           var match$1 = Curry._2(Parser_env_048[/* token */0], /* None */0, env);
           var match$2;
           var exit$1 = 0;
-          if ($$static !== 0 && typeof match$1 === "number" && match$1 === 77) {
+          if ($$static && typeof match$1 === "number" && match$1 === 77) {
             strict_error_at(env, /* tuple */[
                   start_loc,
                   /* StrictReservedWord */39
@@ -6519,7 +6519,7 @@ function properties(allow_static, env, _param) {
                   /* record */[
                     /* name */"static",
                     /* typeAnnotation : None */0,
-                    /* optional : false */0
+                    /* optional */false
                   ]
                 ]]);
             var static_key = /* tuple */[
@@ -6527,7 +6527,7 @@ function properties(allow_static, env, _param) {
               static_key_001
             ];
             match$2 = /* tuple */[
-              /* false */0,
+              false,
               static_key
             ];
           } else {
@@ -6580,7 +6580,7 @@ function properties(allow_static, env, _param) {
 }
 
 function _object($staropt$star, env) {
-  var allow_static = $staropt$star ? $staropt$star[0] : /* false */0;
+  var allow_static = $staropt$star ? $staropt$star[0] : false;
   var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
   token$4(env, /* T_LCURLY */1);
   var match = properties(allow_static, env, /* tuple */[
@@ -6689,27 +6689,27 @@ function annotation_opt(env) {
 }
 
 function wrap(f, env) {
-  var env$1 = with_strict(/* true */1, env);
+  var env$1 = with_strict(true, env);
   push_lex_mode(env$1, /* TYPE */1);
   var ret = Curry._1(f, env$1);
   pop_lex_mode(env$1);
   return ret;
 }
 
-var partial_arg = Curry._1(type_parameter_declaration, /* true */1);
+var partial_arg = Curry._1(type_parameter_declaration, true);
 
 function type_parameter_declaration_with_defaults(param) {
   return wrap(partial_arg, param);
 }
 
-var partial_arg$1 = Curry._1(type_parameter_declaration, /* false */0);
+var partial_arg$1 = Curry._1(type_parameter_declaration, false);
 
 function type_parameter_declaration$1(param) {
   return wrap(partial_arg$1, param);
 }
 
 function _object$1($staropt$star, env) {
-  var allow_static = $staropt$star ? $staropt$star[0] : /* false */0;
+  var allow_static = $staropt$star ? $staropt$star[0] : false;
   return wrap(Curry._1(_object, /* Some */[allow_static]), env);
 }
 
@@ -6818,7 +6818,7 @@ function identifier_no_dupe_check(param, param$1) {
 
 function strict_post_check(env, strict, simple, id, params) {
   if (strict || !simple) {
-    var env$1 = strict ? with_strict(1 - env[/* in_strict_mode */5], env) : env;
+    var env$1 = strict ? with_strict(!env[/* in_strict_mode */5], env) : env;
     if (id) {
       var match = id[0];
       var name = match[1][/* name */0];
@@ -6886,7 +6886,7 @@ function param_list(env, _param) {
       case 1 : 
           var match = param$1(env);
           var $$default = match[1];
-          var has_default$1 = has_default || +($$default !== /* None */0);
+          var has_default$1 = has_default || $$default !== /* None */0;
           if (Curry._2(Parser_env_048[/* token */0], /* None */0, env) !== /* T_RPAREN */4) {
             token$4(env, /* T_COMMA */8);
           }
@@ -6922,7 +6922,7 @@ function function_params(env) {
   var match = param_list(env, /* tuple */[
         /* [] */0,
         /* [] */0,
-        /* false */0
+        false
       ]);
   token$4(env, /* T_RPAREN */4);
   return /* tuple */[
@@ -6948,9 +6948,9 @@ function function_body(env, async, generator) {
 
 function generator(env, is_async) {
   var match = maybe(env, /* T_MULT */97);
-  if (is_async !== 0 && match !== 0) {
+  if (is_async && match) {
     error$1(env, /* AsyncGenerator */48);
-    return /* true */1;
+    return true;
   } else {
     return match;
   }
@@ -6962,9 +6962,9 @@ function async(env) {
 
 function is_simple_param(param) {
   if (param[1].tag === 3) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -6972,7 +6972,7 @@ function is_simple_function_params(params, defaults, rest) {
   if (defaults === /* [] */0 && rest === /* None */0) {
     return List.for_all(is_simple_param, params);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -6985,7 +6985,7 @@ function _function(env) {
   var match$1 = Curry._2(Parser_env_048[/* token */0], /* None */0, env);
   var match$2;
   var exit = 0;
-  if (match !== 0 && typeof match$1 === "number") {
+  if (match && typeof match$1 === "number") {
     if (match$1 !== 3) {
       if (match$1 !== 89) {
         exit = 1;
@@ -7027,10 +7027,10 @@ function _function(env) {
   var match$5;
   match$5 = body.tag ? /* tuple */[
       body[0][0],
-      /* true */1
+      true
     ] : /* tuple */[
       body[0][0],
-      /* false */0
+      false
     ];
   return /* tuple */[
           btwn(start_loc, match$5[0]),
@@ -7134,7 +7134,7 @@ function declarations(token$5, kind, env) {
 }
 
 function $$const(env) {
-  var env$1 = with_no_let(/* true */1, env);
+  var env$1 = with_no_let(true, env);
   var match = declarations(/* T_CONST */25, /* Const */2, env$1);
   var match$1 = match[0];
   var variable = match$1[1];
@@ -7161,7 +7161,7 @@ function $$const(env) {
 }
 
 function _let(env) {
-  var env$1 = with_no_let(/* true */1, env);
+  var env$1 = with_no_let(true, env);
   return declarations(/* T_LET */26, /* Let */1, env$1);
 }
 
@@ -7210,20 +7210,20 @@ function variable(env) {
 function is_tighter(a, b) {
   var a_prec;
   a_prec = a.tag ? a[0] - 1 | 0 : a[0];
-  return +(a_prec >= b[0]);
+  return a_prec >= b[0];
 }
 
 function is_lhs(param) {
   var tmp = param[1];
   if (typeof tmp === "number") {
-    return /* false */0;
+    return false;
   } else {
     switch (tmp.tag | 0) {
       case 13 : 
       case 18 : 
-          return /* true */1;
+          return true;
       default:
-        return /* false */0;
+        return false;
     }
   }
 }
@@ -7231,16 +7231,16 @@ function is_lhs(param) {
 function is_assignable_lhs(param) {
   var tmp = param[1];
   if (typeof tmp === "number") {
-    return /* false */0;
+    return false;
   } else {
     switch (tmp.tag | 0) {
       case 0 : 
       case 1 : 
       case 13 : 
       case 18 : 
-          return /* true */1;
+          return true;
       default:
-        return /* false */0;
+        return false;
     }
   }
 }
@@ -7310,7 +7310,7 @@ function conditional(env) {
   var expr = Curry._1(logical, env);
   if (Curry._2(Parser_env_048[/* token */0], /* None */0, env) === /* T_PLING */76) {
     token$4(env, /* T_PLING */76);
-    var env$prime = with_no_in(/* false */0, env);
+    var env$prime = with_no_in(false, env);
     var consequent = Curry._1(assignment, env$prime);
     token$4(env, /* T_COLON */77);
     var match = with_loc(assignment, env);
@@ -7401,7 +7401,7 @@ function unary(env) {
             loc,
             /* Unary */Block.__(5, [/* record */[
                   /* operator */operator,
-                  /* prefix : true */1,
+                  /* prefix */true,
                   /* argument */argument
                 ]])
           ];
@@ -7436,7 +7436,7 @@ function unary(env) {
               /* Update */Block.__(8, [/* record */[
                     /* operator */op$1[0],
                     /* argument */argument$1,
-                    /* prefix : true */1
+                    /* prefix */true
                   ]])
             ];
     } else {
@@ -7475,7 +7475,7 @@ function unary(env) {
                   /* Update */Block.__(8, [/* record */[
                         /* operator */op$2[0],
                         /* argument */argument$2,
-                        /* prefix : false */0
+                        /* prefix */false
                       ]])
                 ];
         } else {
@@ -7546,7 +7546,7 @@ function call(env, _left) {
               /* Member */Block.__(13, [/* record */[
                     /* _object */left,
                     /* property : PropertyExpression */Block.__(1, [expr]),
-                    /* computed : true */1
+                    /* computed */true
                   ]])
             ];
             continue ;
@@ -7559,7 +7559,7 @@ function call(env, _left) {
               /* Member */Block.__(13, [/* record */[
                     /* _object */left,
                     /* property : PropertyIdentifier */Block.__(0, [id]),
-                    /* computed : false */0
+                    /* computed */false
                   ]])
             ];
             continue ;
@@ -7617,7 +7617,7 @@ function _new(env, _finish_fn) {
     if (exit === 1) {
       Curry._2(Parser_env_048[/* token */0], /* None */0, env);
       var expr = Curry._2(Parser_env_048[/* is_function */9], /* None */0, env) ? _function$1(env) : primary$1(env);
-      var callee = member(with_no_call(/* true */1, env), expr);
+      var callee = member(with_no_call(true, env), expr);
       var match$1 = Curry._2(Parser_env_048[/* token */0], /* None */0, env);
       var callee$1;
       callee$1 = typeof match$1 === "number" || match$1.tag !== 2 ? callee : tagged_template(env, callee, match$1[0]);
@@ -7644,13 +7644,13 @@ function member(env, left) {
                     /* Member */Block.__(13, [/* record */[
                           /* _object */left,
                           /* property : PropertyIdentifier */Block.__(0, [id]),
-                          /* computed : false */0
+                          /* computed */false
                         ]])
                   ]);
       }
     } else {
       token$4(env, /* T_LBRACKET */5);
-      var expr = Curry._1(Parse[/* expression */6], with_no_call(/* false */0, env));
+      var expr = Curry._1(Parse[/* expression */6], with_no_call(false, env));
       var last_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
       token$4(env, /* T_RBRACKET */6);
       return call(env, /* tuple */[
@@ -7658,7 +7658,7 @@ function member(env, left) {
                   /* Member */Block.__(13, [/* record */[
                         /* _object */left,
                         /* property : PropertyExpression */Block.__(1, [expr]),
-                        /* computed : true */1
+                        /* computed */true
                       ]])
                 ]);
     }
@@ -7700,7 +7700,7 @@ function _function$1(env) {
   var simple = is_simple_function_params(params, defaults, rest);
   strict_post_check(env, match$3[2], simple, id$1, params);
   var expression;
-  expression = body.tag ? /* true */1 : /* false */0;
+  expression = body.tag ? true : false;
   return /* tuple */[
           btwn(start_loc, match$3[0]),
           /* Function */Block.__(2, [/* record */[
@@ -7831,7 +7831,7 @@ function primary$1(env) {
           var id_001 = /* record */[
             /* name */"super",
             /* typeAnnotation : None */0,
-            /* optional : false */0
+            /* optional */false
           ];
           var id = /* tuple */[
             loc$1,
@@ -7997,7 +7997,7 @@ function primary$1(env) {
     case 2 : 
         var raw$4 = Curry._2(Parser_env_048[/* value */1], /* None */0, env);
         token$4(env, token$5);
-        var value$4 = /* Boolean */Block.__(1, [+(token$5 === /* T_TRUE */29)]);
+        var value$4 = /* Boolean */Block.__(1, [token$5 === /* T_TRUE */29]);
         return /* tuple */[
                 loc,
                 /* Literal */Block.__(19, [/* record */[
@@ -8113,7 +8113,7 @@ function identifier_or_reserved_keyword(env) {
               /* record */[
                 /* name */lex_value,
                 /* typeAnnotation : None */0,
-                /* optional : false */0
+                /* optional */false
               ]
             ],
             err
@@ -8225,7 +8225,7 @@ function assignment(env) {
         error$1(env$1, /* IllegalYield */24);
       }
       var delegate = maybe(env$1, /* T_MULT */97);
-      var has_argument = 1 - (+(Curry._2(Parser_env_048[/* token */0], /* None */0, env$1) === /* T_SEMICOLON */7) || Curry._1(Parser_env_048[/* is_implicit_semicolon */6], env$1));
+      var has_argument = !(Curry._2(Parser_env_048[/* token */0], /* None */0, env$1) === /* T_SEMICOLON */7 || Curry._1(Parser_env_048[/* is_implicit_semicolon */6], env$1));
       var argument = delegate || has_argument ? /* Some */[Curry._1(assignment, env$1)] : /* None */0;
       var end_loc;
       if (argument) {
@@ -8248,7 +8248,7 @@ function assignment(env) {
     exit$1 = 2;
   }
   if (exit$1 === 2) {
-    if (match$1 !== 0) {
+    if (match$1) {
       exit = 1;
     } else {
       return assignment_but_not_arrow_function(env);
@@ -8572,8 +8572,8 @@ function binary(env) {
   while(true) {
     var stack = _stack;
     var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env$1);
-    var is_unary = +(peek_unary_op(env$1) !== /* None */0);
-    var right = unary(with_no_in(/* false */0, env$1));
+    var is_unary = peek_unary_op(env$1) !== /* None */0;
+    var right = unary(with_no_in(false, env$1));
     var match = env$1[/* last_loc */4][0];
     var end_loc = match ? match[0] : right[0];
     var right_loc = btwn(start_loc, end_loc);
@@ -8765,7 +8765,7 @@ function template_parts(env, _quasis, _expressions) {
           /* raw */"",
           /* cooked */""
         ],
-        /* tail : true */1
+        /* tail */true
       ];
       var imaginary_quasi = /* tuple */[
         imaginary_quasi_000,
@@ -8924,7 +8924,7 @@ function error_callback$1(_, param) {
 function try_arrow_function(env) {
   var env$1 = with_error_callback(error_callback$1, env);
   var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env$1);
-  var async$1 = +(Curry._2(Parser_env_048[/* token */0], /* Some */[1], env$1) !== /* T_ARROW */10) && async(env$1);
+  var async$1 = Curry._2(Parser_env_048[/* token */0], /* Some */[1], env$1) !== /* T_ARROW */10 && async(env$1);
   var typeParameters = Curry._1(type_parameter_declaration$1, env$1);
   var match;
   if (Curry._2(Parser_env_048[/* is_identifier */8], /* None */0, env$1) && typeParameters === /* None */0) {
@@ -8966,8 +8966,8 @@ function try_arrow_function(env) {
   var match$2 = with_loc((function (param) {
           var env = param;
           var async$2 = async$1;
-          var generator = /* false */0;
-          var env$1 = with_in_function(/* true */1, env);
+          var generator = false;
+          var env$1 = with_in_function(true, env);
           var match = Curry._2(Parser_env_048[/* token */0], /* None */0, env$1);
           var exit = 0;
           if (typeof match === "number" && match === 1) {
@@ -8994,7 +8994,7 @@ function try_arrow_function(env) {
   var simple = is_simple_function_params(params, defaults, rest);
   strict_post_check(env$3, match$3[1], simple, /* None */0, params);
   var expression;
-  expression = body.tag ? /* true */1 : /* false */0;
+  expression = body.tag ? true : false;
   var loc = btwn(start_loc, match$2[0]);
   return /* tuple */[
           loc,
@@ -9005,7 +9005,7 @@ function try_arrow_function(env) {
                 /* rest */rest,
                 /* body */body,
                 /* async */async$1,
-                /* generator : false */0,
+                /* generator */false,
                 /* predicate */predicate,
                 /* expression */expression,
                 /* returnType */match[3],
@@ -9046,7 +9046,7 @@ function key(env) {
     if (match === 5) {
       var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
       token$4(env, /* T_LBRACKET */5);
-      var expr = Curry._1(Parse[/* assignment */7], with_no_in(/* false */0, env));
+      var expr = Curry._1(Parse[/* assignment */7], with_no_in(false, env));
       var end_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
       token$4(env, /* T_RBRACKET */6);
       return /* tuple */[
@@ -9115,7 +9115,7 @@ function key(env) {
 }
 
 function _method(env, kind) {
-  var generator$1 = generator(env, /* false */0);
+  var generator$1 = generator(env, false);
   var match = key(env);
   var typeParameters = kind !== 0 ? /* None */0 : Curry._1(type_parameter_declaration$1, env);
   token$4(env, /* T_LPAREN */3);
@@ -9147,17 +9147,17 @@ function _method(env, kind) {
   }
   token$4(env, /* T_RPAREN */4);
   var returnType = wrap(annotation_opt, env);
-  var match$1 = function_body(env, /* false */0, generator$1);
+  var match$1 = function_body(env, false, generator$1);
   var body = match$1[1];
   var simple = is_simple_function_params(params, /* [] */0, /* None */0);
   strict_post_check(env, match$1[2], simple, /* None */0, params);
   var match$2;
   match$2 = body.tag ? /* tuple */[
       body[0][0],
-      /* true */1
+      true
     ] : /* tuple */[
       body[0][0],
-      /* false */0
+      false
     ];
   var value_000 = match$2[0];
   var value_001 = /* record */[
@@ -9166,7 +9166,7 @@ function _method(env, kind) {
     /* defaults : [] */0,
     /* rest : None */0,
     /* body */body,
-    /* async : false */0,
+    /* async */false,
     /* generator */generator$1,
     /* predicate : None */0,
     /* expression */match$2[1],
@@ -9198,7 +9198,7 @@ function property$1(env) {
     var match$1 = key(env);
     var tmp;
     var exit = 0;
-    if (async$1 !== 0 || match !== 0) {
+    if (async$1 || match) {
       exit = 1;
     } else {
       var key$1 = match$1[1];
@@ -9210,9 +9210,9 @@ function property$1(env) {
                   if (typeof match$2 === "number") {
                     var switcher = match$2 - 3 | 0;
                     tmp = switcher > 74 || switcher < 0 ? (
-                        switcher !== 86 ? get(env, start_loc) : init(env, start_loc, key$1, /* false */0, /* false */0)
+                        switcher !== 86 ? get(env, start_loc) : init(env, start_loc, key$1, false, false)
                       ) : (
-                        switcher > 73 || switcher < 1 ? init(env, start_loc, key$1, /* false */0, /* false */0) : get(env, start_loc)
+                        switcher > 73 || switcher < 1 ? init(env, start_loc, key$1, false, false) : get(env, start_loc)
                       );
                   } else {
                     tmp = get(env, start_loc);
@@ -9223,9 +9223,9 @@ function property$1(env) {
                   if (typeof match$3 === "number") {
                     var switcher$1 = match$3 - 3 | 0;
                     tmp = switcher$1 > 74 || switcher$1 < 0 ? (
-                        switcher$1 !== 86 ? set(env, start_loc) : init(env, start_loc, key$1, /* false */0, /* false */0)
+                        switcher$1 !== 86 ? set(env, start_loc) : init(env, start_loc, key$1, false, false)
                       ) : (
-                        switcher$1 > 73 || switcher$1 < 1 ? init(env, start_loc, key$1, /* false */0, /* false */0) : set(env, start_loc)
+                        switcher$1 > 73 || switcher$1 < 1 ? init(env, start_loc, key$1, false, false) : set(env, start_loc)
                       );
                   } else {
                     tmp = set(env, start_loc);
@@ -9264,8 +9264,8 @@ function get(env, start_loc) {
             /* key */match[0],
             /* value */value,
             /* kind : Get */1,
-            /* _method : false */0,
-            /* shorthand : false */0
+            /* _method */false,
+            /* shorthand */false
           ]
         ];
 }
@@ -9285,8 +9285,8 @@ function set(env, start_loc) {
             /* key */match[0],
             /* value */value,
             /* kind : Set */2,
-            /* _method : false */0,
-            /* shorthand : false */0
+            /* _method */false,
+            /* shorthand */false
           ]
         ];
 }
@@ -9330,8 +9330,8 @@ function init(env, start_loc, key, async, generator) {
         token$4(env, /* T_COLON */77);
         match$1 = /* tuple */[
           Curry._1(Parse[/* assignment */7], env),
-          /* false */0,
-          /* false */0
+          false,
+          false
         ];
         break;
     case 2 : 
@@ -9358,8 +9358,8 @@ function init(env, start_loc, key, async, generator) {
         }
         match$1 = /* tuple */[
           tmp,
-          /* true */1,
-          /* false */0
+          true,
+          false
         ];
         break;
     case 3 : 
@@ -9376,10 +9376,10 @@ function init(env, start_loc, key, async, generator) {
         var match$4;
         match$4 = body.tag ? /* tuple */[
             body[0][0],
-            /* true */1
+            true
           ] : /* tuple */[
             body[0][0],
-            /* false */0
+            false
           ];
         var value_000 = match$4[0];
         var value_001 = /* Function */Block.__(2, [/* record */[
@@ -9401,8 +9401,8 @@ function init(env, start_loc, key, async, generator) {
         ];
         match$1 = /* tuple */[
           value,
-          /* false */0,
-          /* true */1
+          false,
+          true
         ];
         break;
     
@@ -9682,10 +9682,10 @@ function init$1(env, start_loc, decorators, key, async, generator, $$static) {
     var match$3;
     match$3 = body.tag ? /* tuple */[
         body[0][0],
-        /* true */1
+        true
       ] : /* tuple */[
         body[0][0],
-        /* false */0
+        false
       ];
     var end_loc$1 = match$3[0];
     var value_001 = /* record */[
@@ -9737,11 +9737,11 @@ function class_element(env) {
   var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
   var decorators = decorator_list(env);
   var $$static = maybe(env, /* T_STATIC */40);
-  var async$1 = +(Curry._2(Parser_env_048[/* token */0], /* Some */[1], env) !== /* T_LPAREN */3) && +(Curry._2(Parser_env_048[/* token */0], /* Some */[1], env) !== /* T_COLON */77) && async(env);
+  var async$1 = Curry._2(Parser_env_048[/* token */0], /* Some */[1], env) !== /* T_LPAREN */3 && Curry._2(Parser_env_048[/* token */0], /* Some */[1], env) !== /* T_COLON */77 && async(env);
   var generator$1 = generator(env, async$1);
   var match = key(env);
   var exit = 0;
-  if (async$1 !== 0 || generator$1 !== 0) {
+  if (async$1 || generator$1) {
     exit = 1;
   } else {
     var key$1 = match[1];
@@ -9888,7 +9888,7 @@ function _class(env) {
   var match;
   if (Curry._2(Parser_env_048[/* token */0], /* None */0, env) === /* T_EXTENDS */39) {
     token$4(env, /* T_EXTENDS */39);
-    var superClass = left_hand_side(with_allow_yield(/* false */0, env));
+    var superClass = left_hand_side(with_allow_yield(false, env));
     var superTypeParameters = wrap(type_parameter_instantiation, env);
     match = /* tuple */[
       /* Some */[superClass],
@@ -9920,15 +9920,15 @@ function _class(env) {
 }
 
 function class_declaration(env, decorators) {
-  var env$1 = with_strict(/* true */1, env);
+  var env$1 = with_strict(true, env);
   var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env$1);
   var decorators$1 = Pervasives.$at(decorators, decorator_list(env$1));
   token$4(env$1, /* T_CLASS */38);
-  var tmp_env = with_no_let(/* true */1, env$1);
+  var tmp_env = with_no_let(true, env$1);
   var match = env$1[/* in_export */6];
   var match$1 = Curry._2(Parser_env_048[/* is_identifier */8], /* None */0, tmp_env);
-  var id = match !== 0 ? (
-      match$1 !== 0 ? /* Some */[Curry._2(Parse[/* identifier */10], /* None */0, tmp_env)] : /* None */0
+  var id = match ? (
+      match$1 ? /* Some */[Curry._2(Parse[/* identifier */10], /* None */0, tmp_env)] : /* None */0
     ) : /* Some */[Curry._2(Parse[/* identifier */10], /* None */0, tmp_env)];
   var typeParameters = Curry._1(type_parameter_declaration_with_defaults, env$1);
   var match$2 = _class(env$1);
@@ -10088,7 +10088,7 @@ function declare_function(env, start_loc) {
 }
 
 function declare($staropt$star, env) {
-  var in_module = $staropt$star ? $staropt$star[0] : /* false */0;
+  var in_module = $staropt$star ? $staropt$star[0] : false;
   if (!env[/* parse_options */20][/* types */4]) {
     error$1(env, /* UnexpectedTypeDeclaration */7);
   }
@@ -10442,13 +10442,13 @@ function $$interface(env) {
 }
 
 function declare_export_declaration($staropt$star, env) {
-  var allow_export_type = $staropt$star ? $staropt$star[0] : /* false */0;
+  var allow_export_type = $staropt$star ? $staropt$star[0] : false;
   if (!env[/* parse_options */20][/* types */4]) {
     error$1(env, /* UnexpectedTypeDeclaration */7);
   }
   var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
   token$4(env, /* T_DECLARE */58);
-  var env$1 = with_in_export(/* true */1, with_strict(/* true */1, env));
+  var env$1 = with_in_export(true, with_strict(true, env));
   token$4(env$1, /* T_EXPORT */47);
   var match = Curry._2(Parser_env_048[/* token */0], /* None */0, env$1);
   var exit = 0;
@@ -10474,7 +10474,7 @@ function declare_export_declaration($staropt$star, env) {
           return /* tuple */[
                   btwn(start_loc, end_loc),
                   /* DeclareExportDeclaration */Block.__(27, [/* record */[
-                        /* default : false */0,
+                        /* default */false,
                         /* declaration : None */0,
                         /* specifiers */specifiers,
                         /* source */source$1
@@ -10488,7 +10488,7 @@ function declare_export_declaration($staropt$star, env) {
         return /* tuple */[
                 loc$1,
                 /* DeclareExportDeclaration */Block.__(27, [/* record */[
-                      /* default : false */0,
+                      /* default */false,
                       /* declaration : Some */[/* NamedType */Block.__(4, [/* tuple */[
                               alias_loc,
                               match$2[1]
@@ -10508,7 +10508,7 @@ function declare_export_declaration($staropt$star, env) {
         return /* tuple */[
                 loc$2,
                 /* DeclareExportDeclaration */Block.__(27, [/* record */[
-                      /* default : false */0,
+                      /* default */false,
                       /* declaration : Some */[/* Interface */Block.__(5, [/* tuple */[
                               iface_loc,
                               match$3[1]
@@ -10561,7 +10561,7 @@ function declare_export_declaration($staropt$star, env) {
             return /* tuple */[
                     btwn(start_loc, match$5[0]),
                     /* DeclareExportDeclaration */Block.__(27, [/* record */[
-                          /* default : true */1,
+                          /* default */true,
                           /* declaration */match$5[1],
                           /* specifiers : None */0,
                           /* source : None */0
@@ -10634,7 +10634,7 @@ function declare_export_declaration($staropt$star, env) {
         return /* tuple */[
                 btwn(start_loc, end_loc$3),
                 /* DeclareExportDeclaration */Block.__(27, [/* record */[
-                      /* default : false */0,
+                      /* default */false,
                       /* declaration : None */0,
                       /* specifiers */specifiers$1,
                       /* source */source$2
@@ -10704,7 +10704,7 @@ function declare_export_declaration($staropt$star, env) {
         return /* tuple */[
                 btwn(start_loc, match$10[0]),
                 /* DeclareExportDeclaration */Block.__(27, [/* record */[
-                      /* default : false */0,
+                      /* default */false,
                       /* declaration */match$10[1],
                       /* specifiers : None */0,
                       /* source : None */0
@@ -10742,7 +10742,7 @@ function interface_helper(env) {
   var id = Curry._2(Parse[/* identifier */10], /* None */0, env);
   var typeParameters = Curry._1(type_parameter_declaration_with_defaults, env);
   var $$extends = Curry._2(Parser_env_048[/* token */0], /* None */0, env) === /* T_EXTENDS */39 ? (token$4(env, /* T_EXTENDS */39), supers(env, /* [] */0)) : /* [] */0;
-  var body = _object$1(/* Some */[/* true */1], env);
+  var body = _object$1(/* Some */[true], env);
   var loc = btwn(start_loc, body[0]);
   return /* tuple */[
           loc,
@@ -10776,13 +10776,13 @@ function supers$1(env, _acc) {
 }
 
 function declare_class(env, start_loc) {
-  var env$1 = with_strict(/* true */1, env);
+  var env$1 = with_strict(true, env);
   token$4(env$1, /* T_CLASS */38);
   var id = Curry._2(Parse[/* identifier */10], /* None */0, env$1);
   var typeParameters = Curry._1(type_parameter_declaration_with_defaults, env$1);
   var $$extends = Curry._2(Parser_env_048[/* token */0], /* None */0, env$1) === /* T_EXTENDS */39 ? (token$4(env$1, /* T_EXTENDS */39), supers$1(env$1, /* [] */0)) : /* [] */0;
   var mixins = Curry._2(Parser_env_048[/* value */1], /* None */0, env$1) === "mixins" ? (contextual(env$1, "mixins"), supers$1(env$1, /* [] */0)) : /* [] */0;
-  var body = _object$1(/* Some */[/* true */1], env$1);
+  var body = _object$1(/* Some */[true], env$1);
   var loc = btwn(start_loc, body[0]);
   return /* tuple */[
           loc,
@@ -10822,7 +10822,7 @@ function module_items(env, _module_kind, _acc) {
       exit = 1;
     }
     if (exit === 1) {
-      var stmt = declare(/* Some */[/* true */1], env);
+      var stmt = declare(/* Some */[true], env);
       var stmt$1 = stmt[1];
       var loc = stmt[0];
       var module_kind$1;
@@ -11035,7 +11035,7 @@ function case_list(env, _param) {
         token$4(env, /* T_CASE */31);
         test = /* Some */[Curry._1(Parse[/* expression */6], env)];
       }
-      var seen_default$1 = seen_default || +(test === /* None */0);
+      var seen_default$1 = seen_default || test === /* None */0;
       var end_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
       token$4(env, /* T_COLON */77);
       var term_fn = function (param) {
@@ -11043,20 +11043,20 @@ function case_list(env, _param) {
           var switcher = param - 2 | 0;
           if (switcher > 29 || switcher < 0) {
             if (switcher !== 32) {
-              return /* false */0;
+              return false;
             } else {
-              return /* true */1;
+              return true;
             }
           } else if (switcher > 28 || switcher < 1) {
-            return /* true */1;
+            return true;
           } else {
-            return /* false */0;
+            return false;
           }
         } else {
-          return /* false */0;
+          return false;
         }
       };
-      var consequent = Curry._2(Parse[/* statement_list */3], term_fn, with_in_switch(/* true */1, env));
+      var consequent = Curry._2(Parse[/* statement_list */3], term_fn, with_in_switch(true, env));
       var match$2 = List.rev(consequent);
       var end_loc$1 = match$2 ? match$2[0][0] : end_loc;
       var acc_000 = /* tuple */[
@@ -11378,7 +11378,7 @@ function _object$2(restricted_error) {
         token$4(env, /* T_COLON */77);
         prop = /* Some */[/* tuple */[
             pattern$1(env, restricted_error),
-            /* false */0
+            false
           ]];
       } else {
         exit = 1;
@@ -11395,7 +11395,7 @@ function _object$2(restricted_error) {
               ];
               prop = /* Some */[/* tuple */[
                   pattern$2,
-                  /* true */1
+                  true
                 ]];
               break;
           case 0 : 
@@ -11886,7 +11886,7 @@ function attributes(env, _acc) {
 function opening_element_without_lt(env, start_loc) {
   var name$1 = name(env);
   var attributes$1 = attributes(env, /* [] */0);
-  var selfClosing = +(Curry._2(Parser_env_048[/* token */0], /* None */0, env) === /* T_DIV */96);
+  var selfClosing = Curry._2(Parser_env_048[/* token */0], /* None */0, env) === /* T_DIV */96;
   if (selfClosing) {
     token$4(env, /* T_DIV */96);
   }
@@ -12086,7 +12086,7 @@ function module_item(env) {
         case 0 : 
             var env$1 = env;
             var decorators$1 = decorators;
-            var env$2 = with_in_export(/* true */1, with_strict(/* true */1, env$1));
+            var env$2 = with_in_export(true, with_strict(true, env$1));
             var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env$2);
             token$4(env$2, /* T_EXPORT */47);
             var match$1 = Curry._2(Parser_env_048[/* token */0], /* None */0, env$2);
@@ -12124,7 +12124,7 @@ function module_item(env) {
                           return /* tuple */[
                                   btwn(start_loc, end_loc),
                                   /* ExportDeclaration */Block.__(28, [/* record */[
-                                        /* default : false */0,
+                                        /* default */false,
                                         /* declaration : Some */[/* Declaration */Block.__(0, [$$interface$1])],
                                         /* specifiers : None */0,
                                         /* source : None */0,
@@ -12158,7 +12158,7 @@ function module_item(env) {
                             return /* tuple */[
                                     btwn(start_loc, end_loc$1),
                                     /* ExportDeclaration */Block.__(28, [/* record */[
-                                          /* default : false */0,
+                                          /* default */false,
                                           /* declaration : Some */[/* Declaration */Block.__(0, [type_alias$1])],
                                           /* specifiers : None */0,
                                           /* source : None */0,
@@ -12202,7 +12202,7 @@ function module_item(env) {
                   return /* tuple */[
                           btwn(start_loc, end_loc$2),
                           /* ExportDeclaration */Block.__(28, [/* record */[
-                                /* default : false */0,
+                                /* default */false,
                                 /* declaration : None */0,
                                 /* specifiers */specifiers,
                                 /* source */source$2,
@@ -12255,7 +12255,7 @@ function module_item(env) {
                         return /* tuple */[
                                 btwn(start_loc, match$6[0]),
                                 /* ExportDeclaration */Block.__(28, [/* record */[
-                                      /* default : true */1,
+                                      /* default */true,
                                       /* declaration */match$6[1],
                                       /* specifiers : None */0,
                                       /* source : None */0,
@@ -12319,7 +12319,7 @@ function module_item(env) {
                   return /* tuple */[
                           btwn(start_loc, end_loc$5),
                           /* ExportDeclaration */Block.__(28, [/* record */[
-                                /* default : false */0,
+                                /* default */false,
                                 /* declaration : None */0,
                                 /* specifiers */specifiers$1,
                                 /* source */source$3,
@@ -12399,7 +12399,7 @@ function module_item(env) {
                   return /* tuple */[
                           btwn(start_loc, stmt[0]),
                           /* ExportDeclaration */Block.__(28, [/* record */[
-                                /* default : false */0,
+                                /* default */false,
                                 /* declaration */declaration,
                                 /* specifiers : None */0,
                                 /* source : None */0,
@@ -12411,7 +12411,7 @@ function module_item(env) {
         case 1 : 
             error_on_decorators(env)(decorators);
             var env$3 = env;
-            var env$4 = with_strict(/* true */1, env$3);
+            var env$4 = with_strict(true, env$3);
             var start_loc$1 = Curry._2(Parser_env_048[/* loc */2], /* None */0, env$4);
             token$4(env$4, /* T_IMPORT */48);
             var match$14 = Curry._2(Parser_env_048[/* token */0], /* None */0, env$4);
@@ -12499,7 +12499,7 @@ function module_item(env) {
               exit$3 = 2;
             }
             if (exit$3 === 2) {
-              if (match$17 !== 0) {
+              if (match$17) {
                 exit$2 = 1;
               } else {
                 var specifiers$2 = named_or_namespace_specifier(env$4);
@@ -12645,7 +12645,7 @@ function statement(env) {
                 token$4(env$4, /* T_RPAREN */4);
                 token$4(env$4, /* T_LCURLY */1);
                 var cases = case_list(env$4, /* tuple */[
-                      /* false */0,
+                      false,
                       /* [] */0
                     ]);
                 var end_loc$1 = Curry._2(Parser_env_048[/* loc */2], /* None */0, env$4);
@@ -12655,7 +12655,7 @@ function statement(env) {
                         /* Switch */Block.__(8, [/* record */[
                               /* discriminant */discriminant,
                               /* cases */cases,
-                              /* lexical : false */0
+                              /* lexical */false
                             ]])
                       ];
             case 20 : 
@@ -12734,7 +12734,7 @@ function statement(env) {
                 token$4(env$7, /* T_LPAREN */3);
                 var test = Curry._1(Parse[/* expression */6], env$7);
                 token$4(env$7, /* T_RPAREN */4);
-                var body$1 = Curry._1(Parse[/* statement */1], with_in_loop(/* true */1, env$7));
+                var body$1 = Curry._1(Parse[/* statement */1], with_in_loop(true, env$7));
                 return /* tuple */[
                         btwn(start_loc$5, body$1[0]),
                         /* While */Block.__(12, [/* record */[
@@ -12828,7 +12828,7 @@ function statement(env) {
                 var env$11 = env;
                 var start_loc$9 = Curry._2(Parser_env_048[/* loc */2], /* None */0, env$11);
                 token$4(env$11, /* T_DO */35);
-                var body$3 = Curry._1(Parse[/* statement */1], with_in_loop(/* true */1, env$11));
+                var body$3 = Curry._1(Parse[/* statement */1], with_in_loop(true, env$11));
                 token$4(env$11, /* T_WHILE */23);
                 token$4(env$11, /* T_LPAREN */3);
                 var test$1 = Curry._1(Parse[/* expression */6], env$11);
@@ -12861,7 +12861,7 @@ function statement(env) {
                     } else {
                       switch (match$9 - 22 | 0) {
                         case 0 : 
-                            var match$11 = declarations(/* T_VAR */22, /* Var */0, with_no_in(/* true */1, env$12));
+                            var match$11 = declarations(/* T_VAR */22, /* Var */0, with_no_in(true, env$12));
                             match$10 = /* tuple */[
                               /* Some */[/* InitDeclaration */Block.__(0, [match$11[0]])],
                               match$11[1]
@@ -12872,14 +12872,14 @@ function statement(env) {
                             exit$2 = 1;
                             break;
                         case 3 : 
-                            var match$12 = $$const(with_no_in(/* true */1, env$12));
+                            var match$12 = $$const(with_no_in(true, env$12));
                             match$10 = /* tuple */[
                               /* Some */[/* InitDeclaration */Block.__(0, [match$12[0]])],
                               match$12[1]
                             ];
                             break;
                         case 4 : 
-                            var match$13 = _let(with_no_in(/* true */1, env$12));
+                            var match$13 = _let(with_no_in(true, env$12));
                             match$10 = /* tuple */[
                               /* Some */[/* InitDeclaration */Block.__(0, [match$13[0]])],
                               match$13[1]
@@ -12900,7 +12900,7 @@ function statement(env) {
                   exit$2 = 1;
                 }
                 if (exit$2 === 1) {
-                  var expr = Curry._1(Parse[/* expression */6], with_no_let(/* true */1, with_no_in(/* true */1, env$12)));
+                  var expr = Curry._1(Parse[/* expression */6], with_no_let(true, with_no_in(true, env$12)));
                   match$10 = /* tuple */[
                     /* Some */[/* InitExpression */Block.__(1, [expr])],
                     /* [] */0
@@ -12932,7 +12932,7 @@ function statement(env) {
                       token$4(env$12, /* T_OF */60);
                       var right = Curry._1(Parse[/* assignment */7], env$12);
                       token$4(env$12, /* T_RPAREN */4);
-                      var body$4 = Curry._1(Parse[/* statement */1], with_in_loop(/* true */1, env$12));
+                      var body$4 = Curry._1(Parse[/* statement */1], with_in_loop(true, env$12));
                       return /* tuple */[
                               btwn(start_loc$10, body$4[0]),
                               /* ForOf */Block.__(16, [/* record */[
@@ -12961,14 +12961,14 @@ function statement(env) {
                     token$4(env$12, /* T_IN */15);
                     var right$1 = Curry._1(Parse[/* expression */6], env$12);
                     token$4(env$12, /* T_RPAREN */4);
-                    var body$5 = Curry._1(Parse[/* statement */1], with_in_loop(/* true */1, env$12));
+                    var body$5 = Curry._1(Parse[/* statement */1], with_in_loop(true, env$12));
                     return /* tuple */[
                             btwn(start_loc$10, body$5[0]),
                             /* ForIn */Block.__(15, [/* record */[
                                   /* left */left$1,
                                   /* right */right$1,
                                   /* body */body$5,
-                                  /* each : false */0
+                                  /* each */false
                                 ]])
                           ];
                   }
@@ -12992,7 +12992,7 @@ function statement(env) {
                       match$18 !== 4 ? /* Some */[Curry._1(Parse[/* expression */6], env$12)] : /* None */0
                     ) : /* Some */[Curry._1(Parse[/* expression */6], env$12)];
                   token$4(env$12, /* T_RPAREN */4);
-                  var body$6 = Curry._1(Parse[/* statement */1], with_in_loop(/* true */1, env$12));
+                  var body$6 = Curry._1(Parse[/* statement */1], with_in_loop(true, env$12));
                   return /* tuple */[
                           btwn(start_loc$10, body$6[0]),
                           /* For */Block.__(14, [/* record */[
@@ -13203,7 +13203,7 @@ function statement_list_item($staropt$star, env) {
         token$4(env$1, /* T_LET */26);
         if (Curry._2(Parser_env_048[/* token */0], /* None */0, env$1) === /* T_LPAREN */3) {
           token$4(env$1, /* T_LPAREN */3);
-          var match$1 = helper(with_no_let(/* true */1, env$1), /* [] */0, /* [] */0);
+          var match$1 = helper(with_no_let(true, env$1), /* [] */0, /* [] */0);
           var head = List.map((function (param) {
                   var match = param[1];
                   return /* record */[
@@ -13227,7 +13227,7 @@ function statement_list_item($staropt$star, env) {
                       ]])
                 ];
         } else {
-          var match$3 = helper(with_no_let(/* true */1, env$1), /* [] */0, /* [] */0);
+          var match$3 = helper(with_no_let(true, env$1), /* [] */0, /* [] */0);
           var declaration = /* VariableDeclaration */Block.__(19, [/* record */[
                 /* declarations */match$3[1],
                 /* kind : Let */1
@@ -13383,7 +13383,7 @@ function statement_list(_env, term_fn, item_fn, _param) {
             } else {
               var loc = match$1[0];
               var len = loc[/* _end */2][/* column */1] - loc[/* start */1][/* column */1] | 0;
-              var strict = env[/* in_strict_mode */5] || +(match$3[0] === "use strict" && len === 12);
+              var strict = env[/* in_strict_mode */5] || match$3[0] === "use strict" && len === 12;
               var string_tokens$1 = /* :: */[
                 string_token,
                 string_tokens
@@ -13518,7 +13518,7 @@ function identifier$2(restricted_error, env) {
           /* record */[
             /* name */name,
             /* typeAnnotation : None */0,
-            /* optional : false */0
+            /* optional */false
           ]
         ];
 }
@@ -13554,7 +13554,7 @@ function module_body_with_directives(env, term_fn) {
 
 function program(env) {
   var stmts = module_body_with_directives(env, (function () {
-          return /* false */0;
+          return false;
         }));
   var end_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
   token$4(env, /* T_EOF */105);
@@ -13596,7 +13596,7 @@ function identifier_with_type(env, restricted_error) {
       /* record */[
         /* name */id[/* name */0],
         /* typeAnnotation */id[/* typeAnnotation */1],
-        /* optional : true */1
+        /* optional */true
       ]
     ];
   } else {
@@ -13631,7 +13631,7 @@ function block_body(env) {
   var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
   token$4(env, /* T_LCURLY */1);
   var term_fn = function (t) {
-    return +(t === /* T_RCURLY */2);
+    return t === /* T_RCURLY */2;
   };
   var body = Curry._2(statement_list$1, term_fn, env);
   var end_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
@@ -13646,7 +13646,7 @@ function function_block_body(env) {
   var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
   token$4(env, /* T_LCURLY */1);
   var term_fn = function (t) {
-    return +(t === /* T_RCURLY */2);
+    return t === /* T_RCURLY */2;
   };
   var match = statement_list_with_directives(term_fn, env);
   var end_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
@@ -13733,7 +13733,7 @@ Caml_module.update_mod([[
     ]);
 
 function program$1($staropt$star, $staropt$star$1, $staropt$star$2, content) {
-  var fail = $staropt$star ? $staropt$star[0] : /* true */1;
+  var fail = $staropt$star ? $staropt$star[0] : true;
   var token_sink = $staropt$star$1 ? $staropt$star$1[0] : /* None */0;
   var parse_options = $staropt$star$2 ? $staropt$star$2[0] : /* None */0;
   var fail$1 = fail;
@@ -13793,7 +13793,7 @@ function regexp$1(loc, pattern, flags) {
 
 function parse(content, _) {
   try {
-    var match = program$1(/* Some */[/* false */0], /* None */0, /* Some */[/* None */0], content);
+    var match = program$1(/* Some */[false], /* None */0, /* Some */[/* None */0], content);
     translation_errors[0] = /* [] */0;
     var array_of_list = function (fn, list) {
       return Curry._1(array, $$Array.of_list(List.map(fn, list)));
@@ -14161,7 +14161,7 @@ function parse(content, _) {
           case 8 : 
               var update = match[0];
               var match$6 = update[/* operator */0];
-              var operator$3 = match$6 !== 0 ? "--" : "++";
+              var operator$3 = match$6 ? "--" : "++";
               return node("UpdateExpression", loc, /* array */[
                           /* tuple */[
                             "operator",
@@ -14179,7 +14179,7 @@ function parse(content, _) {
           case 9 : 
               var logical = match[0];
               var match$7 = logical[/* operator */0];
-              var operator$4 = match$7 !== 0 ? "&&" : "||";
+              var operator$4 = match$7 ? "&&" : "||";
               return node("LogicalExpression", loc, /* array */[
                           /* tuple */[
                             "operator",
@@ -14650,19 +14650,19 @@ function parse(content, _) {
           case 0 : 
               match$1 = /* tuple */[
                 literal(match[0]),
-                /* false */0
+                false
               ];
               break;
           case 1 : 
               match$1 = /* tuple */[
                 identifier(match[0]),
-                /* false */0
+                false
               ];
               break;
           case 2 : 
               match$1 = /* tuple */[
                 expression(match[0]),
-                /* true */1
+                true
               ];
               break;
           
@@ -14698,19 +14698,19 @@ function parse(content, _) {
           case 0 : 
               match$2 = /* tuple */[
                 literal(key[0]),
-                /* false */0
+                false
               ];
               break;
           case 1 : 
               match$2 = /* tuple */[
                 identifier(key[0]),
-                /* false */0
+                false
               ];
               break;
           case 2 : 
               match$2 = /* tuple */[
                 expression(key[0]),
-                /* true */1
+                true
               ];
               break;
           
@@ -15360,7 +15360,7 @@ function parse(content, _) {
                           ],
                           /* tuple */[
                             "exportKind",
-                            Curry._1(string, export_kind($$export$1[/* exportKind */4]))
+                            Curry._1(string, $$export$1[/* exportKind */4] ? "value" : "type")
                           ]
                         ]);
           case 29 : 
@@ -15548,13 +15548,6 @@ function parse(content, _) {
                     array_of_list(interface_extends, i[/* extends */3])
                   ]
                 ]);
-    };
-    var export_kind = function (param) {
-      if (param !== 0) {
-        return "value";
-      } else {
-        return "type";
-      }
     };
     var let_assignment = function (assignment) {
       return Curry._1(obj, /* array */[
@@ -15817,7 +15810,7 @@ function parse(content, _) {
     var type_param = function (param) {
       var tp = param[1];
       var variance = function (param) {
-        if (param !== 0) {
+        if (param) {
           return Curry._1(string, "minus");
         } else {
           return Curry._1(string, "plus");
@@ -15928,19 +15921,19 @@ function parse(content, _) {
           case 0 : 
               match$3 = /* tuple */[
                 literal(match$2[0]),
-                /* false */0
+                false
               ];
               break;
           case 1 : 
               match$3 = /* tuple */[
                 identifier(match$2[0]),
-                /* false */0
+                false
               ];
               break;
           case 2 : 
               match$3 = /* tuple */[
                 expression(match$2[0]),
-                /* true */1
+                true
               ];
               break;
           
@@ -16020,19 +16013,19 @@ function parse(content, _) {
           case 0 : 
               match$3 = /* tuple */[
                 literal(match$2[0]),
-                /* false */0
+                false
               ];
               break;
           case 1 : 
               match$3 = /* tuple */[
                 identifier(match$2[0]),
-                /* false */0
+                false
               ];
               break;
           case 2 : 
               match$3 = /* tuple */[
                 expression(match$2[0]),
-                /* true */1
+                true
               ];
               break;
           

--- a/jscomp/test/for_loop_test.js
+++ b/jscomp/test/for_loop_test.js
@@ -98,7 +98,7 @@ function for_6(x, u) {
   $$Array.iter((function (x) {
           return Curry._1(x, /* () */0);
         }), arr);
-  return /* int array */[
+  return /* array */[
           v[0],
           v4[0],
           v5[0],
@@ -239,7 +239,7 @@ var suites_001 = /* :: */[
         "for_loop_test_6",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* int array */[
+                      /* array */[
                         30,
                         1,
                         2,
@@ -276,7 +276,7 @@ var suites_001 = /* :: */[
                   return /* Eq */Block.__(0, [
                             /* array */[/* tuple */[
                                 10,
-                                /* int array */[
+                                /* array */[
                                   1,
                                   2,
                                   2,

--- a/jscomp/test/google_closure_test.js
+++ b/jscomp/test/google_closure_test.js
@@ -17,7 +17,7 @@ Mt.from_pair_suites("Closure", /* :: */[
                       /* tuple */[
                         "3",
                         101,
-                        /* int array */[
+                        /* array */[
                           1,
                           2
                         ]

--- a/jscomp/test/gpr496_test.js
+++ b/jscomp/test/gpr496_test.js
@@ -2,7 +2,7 @@
 
 var Mt = require("./mt.js");
 var Block = require("../../lib/js/block.js");
-var Caml_obj = require("../../lib/js/caml_obj.js");
+var Curry = require("../../lib/js/curry.js");
 var Caml_primitive = require("../../lib/js/caml_primitive.js");
 
 var suites = [/* [] */0];
@@ -26,53 +26,64 @@ function eq(loc, x, y) {
   return /* () */0;
 }
 
-var expected_004 = Caml_primitive.caml_int_compare(/* false */0, /* true */1);
+var expected_004 = Caml_primitive.caml_bool_compare(false, true);
 
-var expected_005 = Caml_primitive.caml_int_compare(/* true */1, /* false */0);
+var expected_005 = Caml_primitive.caml_bool_compare(true, false);
 
-var expected_006 = Caml_primitive.caml_int_compare(/* false */0, /* false */0);
+var expected_006 = Caml_primitive.caml_bool_compare(false, false);
 
-var expected_007 = Caml_primitive.caml_int_compare(/* true */1, /* true */1);
+var expected_007 = Caml_primitive.caml_bool_compare(true, true);
 
 var expected = /* tuple */[
-  /* false */0,
-  /* false */0,
-  /* true */1,
-  /* true */1,
+  false,
+  false,
+  true,
+  true,
   expected_004,
   expected_005,
   expected_006,
   expected_007
 ];
 
-var u_000 = +(true === false);
+var expected2 = /* tuple */[
+  false,
+  false,
+  true,
+  true,
+  -1,
+  1,
+  0,
+  0
+];
 
-var u_001 = +(false === true);
+var u_004 = Caml_primitive.caml_bool_compare(false, true);
 
-var u_002 = +(false === false);
+var u_005 = Caml_primitive.caml_bool_compare(true, false);
 
-var u_003 = +(true === true);
+var u_006 = Caml_primitive.caml_bool_compare(false, false);
 
-var u_004 = Caml_obj.caml_compare(false, true);
-
-var u_005 = Caml_obj.caml_compare(true, false);
-
-var u_006 = Caml_obj.caml_compare(false, false);
-
-var u_007 = Caml_obj.caml_compare(true, true);
+var u_007 = Caml_primitive.caml_bool_compare(true, true);
 
 var u = /* tuple */[
-  u_000,
-  u_001,
-  u_002,
-  u_003,
+  false,
+  false,
+  true,
+  true,
   u_004,
   u_005,
   u_006,
   u_007
 ];
 
-eq("File \"gpr496_test.ml\", line 32, characters 12-19", expected, u);
+eq("File \"gpr496_test.ml\", line 42, characters 12-19", expected, u);
+
+eq("File \"gpr496_test.ml\", line 44, characters 12-19", expected, expected2);
+
+function ff(x, y) {
+  return Caml_primitive.caml_bool_min(x, Curry._1(y, /* () */0));
+}
+
+eq("File \"gpr496_test.ml\", line 48, characters 5-12", true < false ? true : false, false);
 
 Mt.from_pair_suites("gpr496_test.ml", suites[0]);
 
@@ -80,5 +91,7 @@ exports.suites = suites;
 exports.test_id = test_id;
 exports.eq = eq;
 exports.expected = expected;
+exports.expected2 = expected2;
 exports.u = u;
+exports.ff = ff;
 /* expected Not a pure module */

--- a/jscomp/test/gpr496_test.ml
+++ b/jscomp/test/gpr496_test.ml
@@ -1,38 +1,50 @@
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
-let eq loc x y = 
-  incr test_id ; 
-  suites := 
+let eq loc x y =
+  incr test_id ;
+  suites :=
     (loc ^" id " ^ (string_of_int !test_id), (fun _ -> Mt.Eq(x,y))) :: !suites
 
 
-let expected = 
+let expected =
   (true = false,
-   false = true, 
-   false = false, 
+   false = true,
+   false = false,
    true = true,
-   Pervasives.compare false true , 
+   Pervasives.compare false true ,
    Pervasives.compare true false,
    Pervasives.compare false false,
    Pervasives.compare true true
-  ) 
+  )
 
-let u = 
+let expected2 =
+  ( false,
+    false,
+    true,
+    true,
+    -1,
+    1,
+    0,
+    0
+  )
+let u =
   (Js.true_ = Js.false_,
-   Js.false_ = Js.true_, 
-   Js.false_ = Js.false_, 
+   Js.false_ = Js.true_,
+   Js.false_ = Js.false_,
    Js.true_ = Js.true_,
-   Pervasives.compare Js.false_ Js.true_ , 
+   Pervasives.compare Js.false_ Js.true_ ,
    Pervasives.compare Js.true_ Js.false_,
    Pervasives.compare Js.false_ Js.false_,
    Pervasives.compare Js.true_ Js.true_
-  ) 
+  )
 
 
-let () = eq __LOC__ expected u 
+let () = eq __LOC__ expected u
 
-(* let () = Js.log (expected, u) *)
+let () = eq __LOC__ expected expected2
 
-
+let ff (x: bool) y = min x (y ())
+let () =
+  eq __LOC__ (min true false) false
 
 let () = Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/gpr_1409_test.js
+++ b/jscomp/test/gpr_1409_test.js
@@ -136,7 +136,7 @@ function keys(xs, ys) {
 eq("File \"gpr_1409_test.ml\", line 69, characters 6-13", keys(/* :: */[
           "hi",
           /* [] */0
-        ], Object.keys(test3(/* None */0, /* None */0))), /* true */1);
+        ], Object.keys(test3(/* None */0, /* None */0))), true);
 
 eq("File \"gpr_1409_test.ml\", line 71, characters 6-13", keys(/* :: */[
           "hi",
@@ -144,7 +144,7 @@ eq("File \"gpr_1409_test.ml\", line 71, characters 6-13", keys(/* :: */[
             "open",
             /* [] */0
           ]
-        ], Object.keys(test3(/* Some */[2], /* None */0))), /* true */1);
+        ], Object.keys(test3(/* Some */[2], /* None */0))), true);
 
 eq("File \"gpr_1409_test.ml\", line 73, characters 6-13", keys(/* :: */[
           "hi",
@@ -155,7 +155,7 @@ eq("File \"gpr_1409_test.ml\", line 73, characters 6-13", keys(/* :: */[
               /* [] */0
             ]
           ]
-        ], Object.keys(test3(/* Some */[2], /* Some */[2]))), /* true */1);
+        ], Object.keys(test3(/* Some */[2], /* Some */[2]))), true);
 
 Mt.from_pair_suites("gpr_1409_test.ml", suites[0]);
 

--- a/jscomp/test/gpr_1600_test.js
+++ b/jscomp/test/gpr_1600_test.js
@@ -20,7 +20,7 @@ var eventObj = {
     }),
   needRebuild: (function () {
       var self = this ;
-      return +(self.events.length !== 0);
+      return self.events.length !== 0;
     }),
   currentEvents: (function () {
       var self = this ;

--- a/jscomp/test/gpr_1658_test.js
+++ b/jscomp/test/gpr_1658_test.js
@@ -30,12 +30,12 @@ eq("File \"gpr_1658_test.ml\", line 11, characters 7-14", null, null);
 var match = Js_types.reify_type(null);
 
 if (match[0] !== 1) {
-  eq("File \"gpr_1658_test.ml\", line 16, characters 11-18", /* true */1, /* false */0);
+  eq("File \"gpr_1658_test.ml\", line 16, characters 11-18", true, false);
 } else {
-  eq("File \"gpr_1658_test.ml\", line 14, characters 11-18", /* true */1, /* true */1);
+  eq("File \"gpr_1658_test.ml\", line 14, characters 11-18", true, true);
 }
 
-eq("File \"gpr_1658_test.ml\", line 17, characters 7-14", /* true */1, Js_types.test(null, /* Null */1));
+eq("File \"gpr_1658_test.ml\", line 17, characters 7-14", true, Js_types.test(null, /* Null */1));
 
 Mt.from_pair_suites("File \"gpr_1658_test.ml\", line 19, characters 22-29", suites[0]);
 

--- a/jscomp/test/gpr_1667_test.js
+++ b/jscomp/test/gpr_1667_test.js
@@ -24,11 +24,11 @@ function eq(loc, x, y) {
   return /* () */0;
 }
 
-+((function () {
-        return 0;
-      })((function (_, _$1) {
-          return /* false */0;
-        })) === 0);
+(function () {
+      return 0;
+    })((function (_, _$1) {
+        return false;
+      })) === 0;
 
 eq("File \"gpr_1667_test.ml\", line 18, characters 7-14", 0, 0);
 

--- a/jscomp/test/gpr_1698_test.js
+++ b/jscomp/test/gpr_1698_test.js
@@ -9,9 +9,9 @@ function is_number(_expr) {
     switch (expr.tag | 0) {
       case 0 : 
           if (expr[0].tag) {
-            return /* false */0;
+            return false;
           } else {
-            return /* true */1;
+            return true;
           }
       case 1 : 
           _expr = expr[0];
@@ -20,7 +20,7 @@ function is_number(_expr) {
       case 3 : 
       case 4 : 
       case 5 : 
-          return /* false */0;
+          return false;
       
     }
   };
@@ -167,8 +167,8 @@ function compare(context, state, _a, _b) {
           }
       case 2 : 
           var denom = compare(context, state, da, db);
-          var match = +(denom === 0);
-          if (match !== 0) {
+          var match = denom === 0;
+          if (match) {
             _b = nb;
             _a = na;
             continue ;
@@ -190,6 +190,6 @@ var a = /* Sum */Block.__(2, [/* :: */[
 
 var b = /* Val */Block.__(0, [/* Symbol */Block.__(1, ["x"])]);
 
-console.log(compare(/* InSum */0, /* record */[/* complex : true */1], a, b));
+console.log(compare(/* InSum */0, /* record */[/* complex */true], a, b));
 
 /*  Not a pure module */

--- a/jscomp/test/gpr_1716_test.js
+++ b/jscomp/test/gpr_1716_test.js
@@ -34,10 +34,10 @@ Caml_obj.caml_update_dummy(a, /* record */[/* b */b]);
 Caml_obj.caml_update_dummy(b, /* record */[/* a */a]);
 
 function is_inifite(x) {
-  return +(x[/* b */0][/* a */0] === x);
+  return x[/* b */0][/* a */0] === x;
 }
 
-eq("File \"gpr_1716_test.ml\", line 26, characters 6-13", /* true */1, is_inifite(a));
+eq("File \"gpr_1716_test.ml\", line 26, characters 6-13", true, is_inifite(a));
 
 Mt.from_pair_suites("gpr_1716_test.ml", suites[0]);
 

--- a/jscomp/test/gpr_1728_test.js
+++ b/jscomp/test/gpr_1728_test.js
@@ -26,7 +26,7 @@ function eq(loc, x, y) {
 }
 
 function foo(x) {
-  return +(Caml_format.caml_int_of_string(x) !== 3);
+  return Caml_format.caml_int_of_string(x) !== 3;
 }
 
 function badInlining(obj) {

--- a/jscomp/test/gpr_1749_test.js
+++ b/jscomp/test/gpr_1749_test.js
@@ -24,10 +24,10 @@ function eq(loc, x, y) {
   return /* () */0;
 }
 
-var match = +(1 < 1);
+var match = 1 < 1;
 
 var a = 1 < (
-  match !== 0 ? 1 : 10
+  match ? 1 : 10
 ) ? 0 : 1;
 
 eq("File \"gpr_1749_test.ml\", line 18, characters 6-13", 0, a);

--- a/jscomp/test/gpr_1762_test.js
+++ b/jscomp/test/gpr_1762_test.js
@@ -28,7 +28,7 @@ var v = [3];
 
 function update() {
   v[0] = v[0] + 1 | 0;
-  return /* true */1;
+  return true;
 }
 
 v[0] = v[0] + 1 | 0;

--- a/jscomp/test/gpr_1817_test.js
+++ b/jscomp/test/gpr_1817_test.js
@@ -31,7 +31,7 @@ function f() {
   return /* tuple */[
           Caml_obj.caml_greaterthan(y, x),
           Caml_obj.caml_lessthan(y, x),
-          /* true */1
+          true
         ];
 }
 
@@ -45,7 +45,7 @@ var a0 = match[0];
 
 console.log(a0, a1);
 
-eq("File \"gpr_1817_test.ml\", line 19, characters 6-13", a2, /* true */1);
+eq("File \"gpr_1817_test.ml\", line 19, characters 6-13", a2, true);
 
 Mt.from_pair_suites("gpr_1817_test.ml", suites[0]);
 

--- a/jscomp/test/gpr_2487.js
+++ b/jscomp/test/gpr_2487.js
@@ -3,11 +3,11 @@
 var Caml_obj = require("../../lib/js/caml_obj.js");
 var Belt_Array = require("../../lib/js/belt_Array.js");
 
-var b = Belt_Array.eq(/* int array */[
+var b = Belt_Array.eq(/* array */[
       1,
       2,
       3
-    ], /* int array */[
+    ], /* array */[
       1,
       2,
       3

--- a/jscomp/test/gpr_2503_test.js
+++ b/jscomp/test/gpr_2503_test.js
@@ -85,15 +85,15 @@ function makeWrapper4(foo, _) {
   return tmp;
 }
 
-b("File \"gpr_2503_test.ml\", line 31, characters 5-12", +("a" === makeWrapper3(/* Some */[/* a */97], /* () */0).foo));
+b("File \"gpr_2503_test.ml\", line 31, characters 5-12", "a" === makeWrapper3(/* Some */[/* a */97], /* () */0).foo);
 
-b("File \"gpr_2503_test.ml\", line 34, characters 5-12", +(undefined === makeWrapper3(/* None */0, /* () */0).foo));
+b("File \"gpr_2503_test.ml\", line 34, characters 5-12", undefined === makeWrapper3(/* None */0, /* () */0).foo);
 
-b("File \"gpr_2503_test.ml\", line 37, characters 5-12", +("a" === makeWrapper4(1, /* () */0).foo));
+b("File \"gpr_2503_test.ml\", line 37, characters 5-12", "a" === makeWrapper4(1, /* () */0).foo);
 
-b("File \"gpr_2503_test.ml\", line 40, characters 5-12", +("b" === makeWrapper4(11, /* () */0).foo));
+b("File \"gpr_2503_test.ml\", line 40, characters 5-12", "b" === makeWrapper4(11, /* () */0).foo);
 
-b("File \"gpr_2503_test.ml\", line 43, characters 5-12", +(undefined === makeWrapper4(111, /* () */0).foo));
+b("File \"gpr_2503_test.ml\", line 43, characters 5-12", undefined === makeWrapper4(111, /* () */0).foo);
 
 Mt.from_pair_suites("gpr_2503_test.ml", suites[0]);
 

--- a/jscomp/test/gpr_2608_test.js
+++ b/jscomp/test/gpr_2608_test.js
@@ -16,27 +16,27 @@ var oppHeroes = /* :: */[
   /* [] */0
 ];
 
-var huntGrootCondition = /* false */0;
+var huntGrootCondition = false;
 
 if (List.length(/* [] */0) > 0) {
   var x = List.filter((function () {
-            return +(List.hd(/* [] */0) <= 1000);
+            return List.hd(/* [] */0) <= 1000;
           }))(oppHeroes);
-  huntGrootCondition = +(List.length(x) === 0);
+  huntGrootCondition = List.length(x) === 0;
 }
 
-var huntGrootCondition2 = /* true */1;
+var huntGrootCondition2 = true;
 
 if (List.length(/* [] */0) < 0) {
   var x$1 = List.filter((function () {
-            return +(List.hd(/* [] */0) <= 1000);
+            return List.hd(/* [] */0) <= 1000;
           }))(oppHeroes);
-  huntGrootCondition2 = +(List.length(x$1) === 0);
+  huntGrootCondition2 = List.length(x$1) === 0;
 }
 
-eq("File \"gpr_2608_test.ml\", line 23, characters 5-12", huntGrootCondition, /* false */0);
+eq("File \"gpr_2608_test.ml\", line 23, characters 5-12", huntGrootCondition, false);
 
-eq("File \"gpr_2608_test.ml\", line 24, characters 5-12", huntGrootCondition2, /* true */1);
+eq("File \"gpr_2608_test.ml\", line 24, characters 5-12", huntGrootCondition2, true);
 
 Mt.from_pair_suites("gpr_2608_test.ml", suites[0]);
 

--- a/jscomp/test/gpr_2642_test.js
+++ b/jscomp/test/gpr_2642_test.js
@@ -6,13 +6,13 @@ function isfree(id, _param) {
     var param = _param;
     switch (param.tag | 0) {
       case 0 : 
-          return +(id === param[0]);
+          return id === param[0];
       case 1 : 
           _param = param[0];
           continue ;
       case 2 : 
           if (isfree(id, param[0])) {
-            return /* true */1;
+            return true;
           } else {
             _param = param[1];
             continue ;

--- a/jscomp/test/gpr_405_test.js
+++ b/jscomp/test/gpr_405_test.js
@@ -17,7 +17,7 @@ function Make(funarg) {
     }
     catch (exn){
       if (exn === Caml_builtin_exceptions.not_found) {
-        return /* false */0;
+        return false;
       } else {
         throw exn;
       }
@@ -51,11 +51,11 @@ function Make(funarg) {
               ]
             ];
       }
-      Curry._3(H[/* add */4], on_the_stack, top, /* true */1);
+      Curry._3(H[/* add */4], on_the_stack, top, true);
       Curry._3(H[/* add */4], n_labels, top, counter[0]);
       counter[0] = counter[0] + 1 | 0;
       Curry._3(H[/* add */4], l_labels, top, 0);
-      Curry._3(H[/* add */4], already_processed, top, /* true */1);
+      Curry._3(H[/* add */4], already_processed, top, true);
       var _successors = Curry._2(funarg[/* succ */1], gr, top);
       var _top = top;
       var _rest_of_stack = rest_of_stack;
@@ -95,7 +95,7 @@ function Make(funarg) {
           } else if (rest_of_stack$1) {
             var match = rest_of_stack$1[0];
             var new_top = match[0];
-            Curry._3(H[/* add */4], on_the_stack, top$1, /* false */0);
+            Curry._3(H[/* add */4], on_the_stack, top$1, false);
             Curry._3(H[/* add */4], l_labels, new_top, Caml_primitive.caml_int_max(Curry._2(H[/* find */6], l_labels, top$1), Curry._2(H[/* find */6], l_labels, new_top)));
             _rest_of_stack = rest_of_stack$1[1];
             _top = new_top;

--- a/jscomp/test/gpr_904_test.js
+++ b/jscomp/test/gpr_904_test.js
@@ -26,34 +26,34 @@ function eq(loc, x, y) {
 
 function check_healty(check) {
   if (!check.a && !check.b) {
-    return 1 - check.c;
+    return !check.c;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function basic_not(x) {
-  return 1 - x;
+  return !x;
 }
 
 function f(check) {
   if (check.x) {
     return check.y;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 eq("File \"gpr_904_test.ml\", line 23, characters 5-12", f({
-          x: /* true */1,
-          y: /* false */0
-        }), /* false */0);
+          x: true,
+          y: false
+        }), false);
 
 eq("File \"gpr_904_test.ml\", line 26, characters 5-12", check_healty({
-          a: /* false */0,
-          b: /* false */0,
-          c: /* true */1
-        }), /* false */0);
+          a: false,
+          b: false,
+          c: true
+        }), false);
 
 Mt.from_pair_suites("gpr_904_test.ml", suites[0]);
 

--- a/jscomp/test/imm_map_bench.js
+++ b/jscomp/test/imm_map_bench.js
@@ -33,7 +33,7 @@ var shuffledDataAdd = Belt_Array.makeByAndShuffle(1000001, (function (i) {
 function test() {
   var v = ofArray(shuffledDataAdd);
   for(var j = 0; j <= 1000000; ++j){
-    should(+v.has(j));
+    should(v.has(j));
   }
   return /* () */0;
 }

--- a/jscomp/test/inline_map2_test.js
+++ b/jscomp/test/inline_map2_test.js
@@ -94,9 +94,9 @@ function Make(Ord) {
   };
   var is_empty = function (param) {
     if (param) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
   var add = function (x, data, param) {
@@ -151,13 +151,13 @@ function Make(Ord) {
       if (param) {
         var c = Curry._2(Ord[/* compare */0], x, param[1]);
         if (c === 0) {
-          return /* true */1;
+          return true;
         } else {
           _param = c < 0 ? param[0] : param[3];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };
@@ -310,10 +310,10 @@ function Make(Ord) {
           _param = param[3];
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* true */1;
+        return true;
       }
     };
   };
@@ -322,13 +322,13 @@ function Make(Ord) {
       var param = _param;
       if (param) {
         if (Curry._2(p, param[1], param[2]) || exists(p, param[0])) {
-          return /* true */1;
+          return true;
         } else {
           _param = param[3];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };
@@ -559,12 +559,12 @@ function Make(Ord) {
           _e1 = cons_enum(e1[2], e1[3]);
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else if (e2) {
-        return /* false */0;
+        return false;
       } else {
-        return /* true */1;
+        return true;
       }
     };
   };
@@ -726,9 +726,9 @@ function bal(l, x, d, r) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -786,13 +786,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_int_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -964,10 +964,10 @@ function for_all(p, _param) {
         _param = param[3];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -977,13 +977,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._2(p, param[1], param[2]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1231,12 +1231,12 @@ function equal(cmp, m1, m2) {
         _e1 = cons_enum(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -1429,9 +1429,9 @@ function bal$1(l, x, d, r) {
 
 function is_empty$1(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -1489,13 +1489,13 @@ function mem$1(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1667,10 +1667,10 @@ function for_all$1(p, _param) {
         _param = param[3];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -1680,13 +1680,13 @@ function exists$1(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._2(p, param[1], param[2]) || exists$1(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1934,12 +1934,12 @@ function equal$1(cmp, m1, m2) {
         _e1 = cons_enum$1(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }

--- a/jscomp/test/inline_regression_test.js
+++ b/jscomp/test/inline_regression_test.js
@@ -40,7 +40,7 @@ function generic_basename(is_dir_sep, current_dir_name, name) {
 
 function basename(param) {
   return generic_basename((function (s, i) {
-                return +(Caml_string.get(s, i) === /* "/" */47);
+                return Caml_string.get(s, i) === /* "/" */47;
               }), Filename.current_dir_name, param);
 }
 

--- a/jscomp/test/installation_test.js
+++ b/jscomp/test/installation_test.js
@@ -57,7 +57,7 @@ if (match !== undefined) {
     var files = Fs.readdirSync(dir);
     var exists = files.indexOf("pervasives.cmi");
     var non_exists = files.indexOf("pervasive.cmi");
-    var v = +(exists >= 0 && non_exists < 0);
+    var v = exists >= 0 && non_exists < 0;
     console.log(v);
   }
   

--- a/jscomp/test/int64_mul_div_test.js
+++ b/jscomp/test/int64_mul_div_test.js
@@ -872,15 +872,15 @@ var to_floats = /* array */[
   ]
 ];
 
-var check_complete_compare = /* int array */[
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* true */1
+var check_complete_compare = /* array */[
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true
 ];
 
 var of_float_pairs = /* array */[
@@ -1763,7 +1763,7 @@ Mt.from_pair_suites("int64_mul_div_test.ml", Pervasives.$at(from_pairs("random",
                             (function () {
                                 return /* Eq */Block.__(0, [
                                           $$Array.map((function () {
-                                                  return /* true */1;
+                                                  return true;
                                                 }), check_complete_compare),
                                           check_complete_compare
                                         ]);

--- a/jscomp/test/int64_test.js
+++ b/jscomp/test/int64_test.js
@@ -13,7 +13,7 @@ var Pervasives = require("../../lib/js/pervasives.js");
 var Ext_array_test = require("./ext_array_test.js");
 
 function f(u, v) {
-  return +(u > v);
+  return u > v;
 }
 
 var v = Caml_int64.add(Caml_int64.of_int32(Int32.max_int), Int64.one);
@@ -2140,14 +2140,14 @@ var suites = Pervasives.$at(/* :: */[
                                                                   "generic_compare",
                                                                   (function () {
                                                                       return /* Eq */Block.__(0, [
-                                                                                +(Caml_obj.caml_compare(/* int64 */[
-                                                                                        /* hi */1,
-                                                                                        /* lo */0
-                                                                                      ], /* int64 */[
-                                                                                        /* hi */0,
-                                                                                        /* lo */1
-                                                                                      ]) > 0),
-                                                                                /* true */1
+                                                                                Caml_obj.caml_compare(/* int64 */[
+                                                                                      /* hi */1,
+                                                                                      /* lo */0
+                                                                                    ], /* int64 */[
+                                                                                      /* hi */0,
+                                                                                      /* lo */1
+                                                                                    ]) > 0,
+                                                                                true
                                                                               ]);
                                                                     })
                                                                 ],
@@ -2172,14 +2172,14 @@ var suites = Pervasives.$at(/* :: */[
                                                                       "generic_compare2",
                                                                       (function () {
                                                                           return /* Eq */Block.__(0, [
-                                                                                    +(Caml_obj.caml_compare(/* int64 */[
-                                                                                            /* hi */0,
-                                                                                            /* lo */2147483648
-                                                                                          ], /* int64 */[
-                                                                                            /* hi */0,
-                                                                                            /* lo */1
-                                                                                          ]) > 0),
-                                                                                    /* true */1
+                                                                                    Caml_obj.caml_compare(/* int64 */[
+                                                                                          /* hi */0,
+                                                                                          /* lo */2147483648
+                                                                                        ], /* int64 */[
+                                                                                          /* hi */0,
+                                                                                          /* lo */1
+                                                                                        ]) > 0,
+                                                                                    true
                                                                                   ]);
                                                                         })
                                                                     ],

--- a/jscomp/test/int_hashtbl_test.js
+++ b/jscomp/test/int_hashtbl_test.js
@@ -52,7 +52,7 @@ function g(H) {
 var hash = Hashtbl.hash;
 
 function equal(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 var Int_hash = Hashtbl.Make(/* module */[

--- a/jscomp/test/int_map.js
+++ b/jscomp/test/int_map.js
@@ -94,9 +94,9 @@ function bal(l, x, d, r) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -154,13 +154,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_int_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -322,10 +322,10 @@ function for_all(p, _param) {
         _param = param[3];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -335,13 +335,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._2(p, param[1], param[2]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -584,12 +584,12 @@ function equal(cmp, m1, m2) {
         _e1 = cons_enum(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }

--- a/jscomp/test/int_overflow_test.js
+++ b/jscomp/test/int_overflow_test.js
@@ -44,8 +44,8 @@ Mt.from_pair_suites("int_overflow_test.ml", /* :: */[
         "plus_overflow",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* true */1,
-                      +((Int32.max_int + 1 | 0) === Int32.min_int)
+                      true,
+                      (Int32.max_int + 1 | 0) === Int32.min_int
                     ]);
           })
       ],
@@ -54,8 +54,8 @@ Mt.from_pair_suites("int_overflow_test.ml", /* :: */[
           "minus_overflow",
           (function () {
               return /* Eq */Block.__(0, [
-                        /* true */1,
-                        +((Int32.min_int - Int32.one | 0) === Int32.max_int)
+                        true,
+                        (Int32.min_int - Int32.one | 0) === Int32.max_int
                       ]);
             })
         ],

--- a/jscomp/test/js_array_test.js
+++ b/jscomp/test/js_array_test.js
@@ -16,12 +16,12 @@ var suites_000 = /* tuple */[
         5
       ];
       return /* Eq */Block.__(0, [
-                /* int array */[
+                /* array */[
                   2,
                   4
                 ],
                 (Js_vector.filterInPlace((function (x) {
-                          return +(x % 2 === 0);
+                          return x % 2 === 0;
                         }), x), x)
               ]);
     })
@@ -39,10 +39,10 @@ var suites_001 = /* :: */[
           5
         ];
         return /* Eq */Block.__(0, [
-                  /* true */1,
+                  true,
                   (Js_vector.filterInPlace((function (x) {
-                            return +(x > 10);
-                          }), x), +(x.length === 0))
+                            return x > 10;
+                          }), x), x.length === 0)
                 ]);
       })
   ],
@@ -51,8 +51,8 @@ var suites_001 = /* :: */[
       "isArray_array",
       (function () {
           return /* Eq */Block.__(0, [
-                    /* true */1,
-                    +Array.isArray(/* array */[])
+                    true,
+                    Array.isArray(/* array */[])
                   ]);
         })
     ],
@@ -61,8 +61,8 @@ var suites_001 = /* :: */[
         "isArray_int",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* false */0,
-                      +Array.isArray(34)
+                      false,
+                      Array.isArray(34)
                     ]);
           })
       ],
@@ -72,7 +72,7 @@ var suites_001 = /* :: */[
           (function () {
               return /* Eq */Block.__(0, [
                         3,
-                        /* int array */[
+                        /* array */[
                           1,
                           2,
                           3
@@ -151,12 +151,12 @@ var suites_001 = /* :: */[
                   "fillInPlace",
                   (function () {
                       return /* Eq */Block.__(0, [
-                                /* int array */[
+                                /* array */[
                                   4,
                                   4,
                                   4
                                 ],
-                                /* int array */[
+                                /* array */[
                                     1,
                                     2,
                                     3
@@ -169,12 +169,12 @@ var suites_001 = /* :: */[
                     "fillFromInPlace",
                     (function () {
                         return /* Eq */Block.__(0, [
-                                  /* int array */[
+                                  /* array */[
                                     1,
                                     4,
                                     4
                                   ],
-                                  /* int array */[
+                                  /* array */[
                                       1,
                                       2,
                                       3
@@ -187,12 +187,12 @@ var suites_001 = /* :: */[
                       "fillRangeInPlace",
                       (function () {
                           return /* Eq */Block.__(0, [
-                                    /* int array */[
+                                    /* array */[
                                       1,
                                       4,
                                       3
                                     ],
-                                    /* int array */[
+                                    /* array */[
                                         1,
                                         2,
                                         3
@@ -206,7 +206,7 @@ var suites_001 = /* :: */[
                         (function () {
                             return /* Eq */Block.__(0, [
                                       /* Some */[3],
-                                      Js_primitive.undefined_to_opt(/* int array */[
+                                      Js_primitive.undefined_to_opt(/* array */[
                                               1,
                                               2,
                                               3
@@ -230,7 +230,7 @@ var suites_001 = /* :: */[
                             (function () {
                                 return /* Eq */Block.__(0, [
                                           4,
-                                          /* int array */[
+                                          /* array */[
                                               1,
                                               2,
                                               3
@@ -244,7 +244,7 @@ var suites_001 = /* :: */[
                               (function () {
                                   return /* Eq */Block.__(0, [
                                             5,
-                                            /* int array */[
+                                            /* array */[
                                                 1,
                                                 2,
                                                 3
@@ -257,12 +257,12 @@ var suites_001 = /* :: */[
                                 "reverseInPlace",
                                 (function () {
                                     return /* Eq */Block.__(0, [
-                                              /* int array */[
+                                              /* array */[
                                                 3,
                                                 2,
                                                 1
                                               ],
-                                              /* int array */[
+                                              /* array */[
                                                   1,
                                                   2,
                                                   3
@@ -276,7 +276,7 @@ var suites_001 = /* :: */[
                                   (function () {
                                       return /* Eq */Block.__(0, [
                                                 /* Some */[1],
-                                                Js_primitive.undefined_to_opt(/* int array */[
+                                                Js_primitive.undefined_to_opt(/* array */[
                                                         1,
                                                         2,
                                                         3
@@ -299,12 +299,12 @@ var suites_001 = /* :: */[
                                       "sortInPlace",
                                       (function () {
                                           return /* Eq */Block.__(0, [
-                                                    /* int array */[
+                                                    /* array */[
                                                       1,
                                                       2,
                                                       3
                                                     ],
-                                                    /* int array */[
+                                                    /* array */[
                                                         3,
                                                         1,
                                                         2
@@ -317,12 +317,12 @@ var suites_001 = /* :: */[
                                         "sortInPlaceWith",
                                         (function () {
                                             return /* Eq */Block.__(0, [
-                                                      /* int array */[
+                                                      /* array */[
                                                         3,
                                                         2,
                                                         1
                                                       ],
-                                                      /* int array */[
+                                                      /* array */[
                                                           3,
                                                           1,
                                                           2
@@ -336,7 +336,7 @@ var suites_001 = /* :: */[
                                         /* tuple */[
                                           "spliceInPlace",
                                           (function () {
-                                              var arr = /* int array */[
+                                              var arr = /* array */[
                                                 1,
                                                 2,
                                                 3,
@@ -352,7 +352,7 @@ var suites_001 = /* :: */[
                                                             3,
                                                             4
                                                           ],
-                                                          /* int array */[]
+                                                          /* array */[]
                                                         ],
                                                         /* tuple */[
                                                           arr,
@@ -365,7 +365,7 @@ var suites_001 = /* :: */[
                                           /* tuple */[
                                             "removeFromInPlace",
                                             (function () {
-                                                var arr = /* int array */[
+                                                var arr = /* array */[
                                                   1,
                                                   2,
                                                   3,
@@ -374,11 +374,11 @@ var suites_001 = /* :: */[
                                                 var removed = arr.splice(2);
                                                 return /* Eq */Block.__(0, [
                                                           /* tuple */[
-                                                            /* int array */[
+                                                            /* array */[
                                                               1,
                                                               2
                                                             ],
-                                                            /* int array */[
+                                                            /* array */[
                                                               3,
                                                               4
                                                             ]
@@ -394,7 +394,7 @@ var suites_001 = /* :: */[
                                             /* tuple */[
                                               "removeCountInPlace",
                                               (function () {
-                                                  var arr = /* int array */[
+                                                  var arr = /* array */[
                                                     1,
                                                     2,
                                                     3,
@@ -403,12 +403,12 @@ var suites_001 = /* :: */[
                                                   var removed = arr.splice(2, 1);
                                                   return /* Eq */Block.__(0, [
                                                             /* tuple */[
-                                                              /* int array */[
+                                                              /* array */[
                                                                 1,
                                                                 2,
                                                                 4
                                                               ],
-                                                              /* int array */[3]
+                                                              /* array */[3]
                                                             ],
                                                             /* tuple */[
                                                               arr,
@@ -423,7 +423,7 @@ var suites_001 = /* :: */[
                                                 (function () {
                                                     return /* Eq */Block.__(0, [
                                                               4,
-                                                              /* int array */[
+                                                              /* array */[
                                                                   1,
                                                                   2,
                                                                   3
@@ -437,7 +437,7 @@ var suites_001 = /* :: */[
                                                   (function () {
                                                       return /* Eq */Block.__(0, [
                                                                 5,
-                                                                /* int array */[
+                                                                /* array */[
                                                                     1,
                                                                     2,
                                                                     3
@@ -450,13 +450,13 @@ var suites_001 = /* :: */[
                                                     "append",
                                                     (function () {
                                                         return /* Eq */Block.__(0, [
-                                                                  /* int array */[
+                                                                  /* array */[
                                                                     1,
                                                                     2,
                                                                     3,
                                                                     4
                                                                   ],
-                                                                  /* int array */[
+                                                                  /* array */[
                                                                       1,
                                                                       2,
                                                                       3
@@ -476,11 +476,11 @@ var suites_001 = /* :: */[
                                                                       4,
                                                                       5
                                                                     ],
-                                                                    /* int array */[
+                                                                    /* array */[
                                                                         1,
                                                                         2,
                                                                         3
-                                                                      ].concat(/* int array */[
+                                                                      ].concat(/* array */[
                                                                           4,
                                                                           5
                                                                         ])
@@ -501,14 +501,14 @@ var suites_001 = /* :: */[
                                                                         6,
                                                                         7
                                                                       ],
-                                                                      /* int array */[
+                                                                      /* array */[
                                                                           1,
                                                                           2,
                                                                           3
-                                                                        ].concat(/* int array */[
+                                                                        ].concat(/* array */[
                                                                             4,
                                                                             5
-                                                                          ], /* int array */[
+                                                                          ], /* array */[
                                                                             6,
                                                                             7
                                                                           ])
@@ -520,8 +520,8 @@ var suites_001 = /* :: */[
                                                           "includes",
                                                           (function () {
                                                               return /* Eq */Block.__(0, [
-                                                                        /* true */1,
-                                                                        +/* int array */[
+                                                                        true,
+                                                                        /* array */[
                                                                             1,
                                                                             2,
                                                                             3
@@ -535,7 +535,7 @@ var suites_001 = /* :: */[
                                                             (function () {
                                                                 return /* Eq */Block.__(0, [
                                                                           1,
-                                                                          /* int array */[
+                                                                          /* array */[
                                                                               1,
                                                                               2,
                                                                               3
@@ -549,7 +549,7 @@ var suites_001 = /* :: */[
                                                               (function () {
                                                                   return /* Eq */Block.__(0, [
                                                                             3,
-                                                                            /* int array */[
+                                                                            /* array */[
                                                                                 1,
                                                                                 2,
                                                                                 3,
@@ -564,7 +564,7 @@ var suites_001 = /* :: */[
                                                                 (function () {
                                                                     return /* Eq */Block.__(0, [
                                                                               "1,2,3",
-                                                                              /* int array */[
+                                                                              /* array */[
                                                                                   1,
                                                                                   2,
                                                                                   3
@@ -578,7 +578,7 @@ var suites_001 = /* :: */[
                                                                   (function () {
                                                                       return /* Eq */Block.__(0, [
                                                                                 "1;2;3",
-                                                                                /* int array */[
+                                                                                /* array */[
                                                                                     1,
                                                                                     2,
                                                                                     3
@@ -592,7 +592,7 @@ var suites_001 = /* :: */[
                                                                     (function () {
                                                                         return /* Eq */Block.__(0, [
                                                                                   1,
-                                                                                  /* int array */[
+                                                                                  /* array */[
                                                                                       1,
                                                                                       2,
                                                                                       3
@@ -606,7 +606,7 @@ var suites_001 = /* :: */[
                                                                       (function () {
                                                                           return /* Eq */Block.__(0, [
                                                                                     1,
-                                                                                    /* int array */[
+                                                                                    /* array */[
                                                                                         1,
                                                                                         2,
                                                                                         3,
@@ -620,7 +620,7 @@ var suites_001 = /* :: */[
                                                                         "slice",
                                                                         (function () {
                                                                             return /* Eq */Block.__(0, [
-                                                                                      /* int array */[
+                                                                                      /* array */[
                                                                                         2,
                                                                                         3
                                                                                       ],
@@ -661,7 +661,7 @@ var suites_001 = /* :: */[
                                                                             "sliceFrom",
                                                                             (function () {
                                                                                 return /* Eq */Block.__(0, [
-                                                                                          /* int array */[
+                                                                                          /* array */[
                                                                                             3,
                                                                                             4,
                                                                                             5
@@ -682,7 +682,7 @@ var suites_001 = /* :: */[
                                                                               (function () {
                                                                                   return /* Eq */Block.__(0, [
                                                                                             "1,2,3",
-                                                                                            /* int array */[
+                                                                                            /* array */[
                                                                                                 1,
                                                                                                 2,
                                                                                                 3
@@ -696,7 +696,7 @@ var suites_001 = /* :: */[
                                                                                 (function () {
                                                                                     return /* Eq */Block.__(0, [
                                                                                               "1,2,3",
-                                                                                              /* int array */[
+                                                                                              /* array */[
                                                                                                   1,
                                                                                                   2,
                                                                                                   3
@@ -709,13 +709,13 @@ var suites_001 = /* :: */[
                                                                                   "every",
                                                                                   (function () {
                                                                                       return /* Eq */Block.__(0, [
-                                                                                                /* true */1,
-                                                                                                +/* int array */[
+                                                                                                true,
+                                                                                                /* array */[
                                                                                                     1,
                                                                                                     2,
                                                                                                     3
                                                                                                   ].every((function (n) {
-                                                                                                        return +(n > 0);
+                                                                                                        return n > 0;
                                                                                                       }))
                                                                                               ]);
                                                                                     })
@@ -725,13 +725,13 @@ var suites_001 = /* :: */[
                                                                                     "everyi",
                                                                                     (function () {
                                                                                         return /* Eq */Block.__(0, [
-                                                                                                  /* false */0,
-                                                                                                  +/* int array */[
+                                                                                                  false,
+                                                                                                  /* array */[
                                                                                                       1,
                                                                                                       2,
                                                                                                       3
                                                                                                     ].every((function (_, i) {
-                                                                                                          return +(i > 0);
+                                                                                                          return i > 0;
                                                                                                         }))
                                                                                                 ]);
                                                                                       })
@@ -741,17 +741,17 @@ var suites_001 = /* :: */[
                                                                                       "filter",
                                                                                       (function () {
                                                                                           return /* Eq */Block.__(0, [
-                                                                                                    /* int array */[
+                                                                                                    /* array */[
                                                                                                       2,
                                                                                                       4
                                                                                                     ],
-                                                                                                    /* int array */[
+                                                                                                    /* array */[
                                                                                                         1,
                                                                                                         2,
                                                                                                         3,
                                                                                                         4
                                                                                                       ].filter((function (n) {
-                                                                                                            return +(n % 2 === 0);
+                                                                                                            return n % 2 === 0;
                                                                                                           }))
                                                                                                   ]);
                                                                                         })
@@ -761,17 +761,17 @@ var suites_001 = /* :: */[
                                                                                         "filteri",
                                                                                         (function () {
                                                                                             return /* Eq */Block.__(0, [
-                                                                                                      /* int array */[
+                                                                                                      /* array */[
                                                                                                         1,
                                                                                                         3
                                                                                                       ],
-                                                                                                      /* int array */[
+                                                                                                      /* array */[
                                                                                                           1,
                                                                                                           2,
                                                                                                           3,
                                                                                                           4
                                                                                                         ].filter((function (_, i) {
-                                                                                                              return +(i % 2 === 0);
+                                                                                                              return i % 2 === 0;
                                                                                                             }))
                                                                                                     ]);
                                                                                           })
@@ -782,13 +782,13 @@ var suites_001 = /* :: */[
                                                                                           (function () {
                                                                                               return /* Eq */Block.__(0, [
                                                                                                         /* Some */[2],
-                                                                                                        Js_primitive.undefined_to_opt(/* int array */[
+                                                                                                        Js_primitive.undefined_to_opt(/* array */[
                                                                                                                 1,
                                                                                                                 2,
                                                                                                                 3,
                                                                                                                 4
                                                                                                               ].find((function (n) {
-                                                                                                                    return +(n % 2 === 0);
+                                                                                                                    return n % 2 === 0;
                                                                                                                   })))
                                                                                                       ]);
                                                                                             })
@@ -799,13 +799,13 @@ var suites_001 = /* :: */[
                                                                                             (function () {
                                                                                                 return /* Eq */Block.__(0, [
                                                                                                           /* None */0,
-                                                                                                          Js_primitive.undefined_to_opt(/* int array */[
+                                                                                                          Js_primitive.undefined_to_opt(/* array */[
                                                                                                                   1,
                                                                                                                   2,
                                                                                                                   3,
                                                                                                                   4
                                                                                                                 ].find((function (n) {
-                                                                                                                      return +(n % 2 === 5);
+                                                                                                                      return n % 2 === 5;
                                                                                                                     })))
                                                                                                         ]);
                                                                                               })
@@ -816,13 +816,13 @@ var suites_001 = /* :: */[
                                                                                               (function () {
                                                                                                   return /* Eq */Block.__(0, [
                                                                                                             /* Some */[1],
-                                                                                                            Js_primitive.undefined_to_opt(/* int array */[
+                                                                                                            Js_primitive.undefined_to_opt(/* array */[
                                                                                                                     1,
                                                                                                                     2,
                                                                                                                     3,
                                                                                                                     4
                                                                                                                   ].find((function (_, i) {
-                                                                                                                        return +(i % 2 === 0);
+                                                                                                                        return i % 2 === 0;
                                                                                                                       })))
                                                                                                           ]);
                                                                                                 })
@@ -833,13 +833,13 @@ var suites_001 = /* :: */[
                                                                                                 (function () {
                                                                                                     return /* Eq */Block.__(0, [
                                                                                                               /* None */0,
-                                                                                                              Js_primitive.undefined_to_opt(/* int array */[
+                                                                                                              Js_primitive.undefined_to_opt(/* array */[
                                                                                                                       1,
                                                                                                                       2,
                                                                                                                       3,
                                                                                                                       4
                                                                                                                     ].find((function (_, i) {
-                                                                                                                          return +(i % 2 === 5);
+                                                                                                                          return i % 2 === 5;
                                                                                                                         })))
                                                                                                             ]);
                                                                                                   })
@@ -850,13 +850,13 @@ var suites_001 = /* :: */[
                                                                                                   (function () {
                                                                                                       return /* Eq */Block.__(0, [
                                                                                                                 1,
-                                                                                                                /* int array */[
+                                                                                                                /* array */[
                                                                                                                     1,
                                                                                                                     2,
                                                                                                                     3,
                                                                                                                     4
                                                                                                                   ].findIndex((function (n) {
-                                                                                                                        return +(n % 2 === 0);
+                                                                                                                        return n % 2 === 0;
                                                                                                                       }))
                                                                                                               ]);
                                                                                                     })
@@ -867,13 +867,13 @@ var suites_001 = /* :: */[
                                                                                                     (function () {
                                                                                                         return /* Eq */Block.__(0, [
                                                                                                                   0,
-                                                                                                                  /* int array */[
+                                                                                                                  /* array */[
                                                                                                                       1,
                                                                                                                       2,
                                                                                                                       3,
                                                                                                                       4
                                                                                                                     ].findIndex((function (_, i) {
-                                                                                                                          return +(i % 2 === 0);
+                                                                                                                          return i % 2 === 0;
                                                                                                                         }))
                                                                                                                 ]);
                                                                                                       })
@@ -883,7 +883,7 @@ var suites_001 = /* :: */[
                                                                                                       "forEach",
                                                                                                       (function () {
                                                                                                           var sum = [0];
-                                                                                                          /* int array */[
+                                                                                                          /* array */[
                                                                                                               1,
                                                                                                               2,
                                                                                                               3
@@ -902,7 +902,7 @@ var suites_001 = /* :: */[
                                                                                                         "forEachi",
                                                                                                         (function () {
                                                                                                             var sum = [0];
-                                                                                                            /* int array */[
+                                                                                                            /* array */[
                                                                                                                 1,
                                                                                                                 2,
                                                                                                                 3
@@ -921,13 +921,13 @@ var suites_001 = /* :: */[
                                                                                                           "map",
                                                                                                           (function () {
                                                                                                               return /* Eq */Block.__(0, [
-                                                                                                                        /* int array */[
+                                                                                                                        /* array */[
                                                                                                                           2,
                                                                                                                           4,
                                                                                                                           6,
                                                                                                                           8
                                                                                                                         ],
-                                                                                                                        /* int array */[
+                                                                                                                        /* array */[
                                                                                                                             1,
                                                                                                                             2,
                                                                                                                             3,
@@ -943,13 +943,13 @@ var suites_001 = /* :: */[
                                                                                                             "map",
                                                                                                             (function () {
                                                                                                                 return /* Eq */Block.__(0, [
-                                                                                                                          /* int array */[
+                                                                                                                          /* array */[
                                                                                                                             0,
                                                                                                                             2,
                                                                                                                             4,
                                                                                                                             6
                                                                                                                           ],
-                                                                                                                          /* int array */[
+                                                                                                                          /* array */[
                                                                                                                               1,
                                                                                                                               2,
                                                                                                                               3,
@@ -966,7 +966,7 @@ var suites_001 = /* :: */[
                                                                                                               (function () {
                                                                                                                   return /* Eq */Block.__(0, [
                                                                                                                             -10,
-                                                                                                                            /* int array */[
+                                                                                                                            /* array */[
                                                                                                                                 1,
                                                                                                                                 2,
                                                                                                                                 3,
@@ -983,7 +983,7 @@ var suites_001 = /* :: */[
                                                                                                                 (function () {
                                                                                                                     return /* Eq */Block.__(0, [
                                                                                                                               -6,
-                                                                                                                              /* int array */[
+                                                                                                                              /* array */[
                                                                                                                                   1,
                                                                                                                                   2,
                                                                                                                                   3,
@@ -1000,7 +1000,7 @@ var suites_001 = /* :: */[
                                                                                                                   (function () {
                                                                                                                       return /* Eq */Block.__(0, [
                                                                                                                                 -10,
-                                                                                                                                /* int array */[
+                                                                                                                                /* array */[
                                                                                                                                     1,
                                                                                                                                     2,
                                                                                                                                     3,
@@ -1017,7 +1017,7 @@ var suites_001 = /* :: */[
                                                                                                                     (function () {
                                                                                                                         return /* Eq */Block.__(0, [
                                                                                                                                   -6,
-                                                                                                                                  /* int array */[
+                                                                                                                                  /* array */[
                                                                                                                                       1,
                                                                                                                                       2,
                                                                                                                                       3,
@@ -1033,14 +1033,14 @@ var suites_001 = /* :: */[
                                                                                                                       "some",
                                                                                                                       (function () {
                                                                                                                           return /* Eq */Block.__(0, [
-                                                                                                                                    /* false */0,
-                                                                                                                                    +/* int array */[
+                                                                                                                                    false,
+                                                                                                                                    /* array */[
                                                                                                                                         1,
                                                                                                                                         2,
                                                                                                                                         3,
                                                                                                                                         4
                                                                                                                                       ].some((function (n) {
-                                                                                                                                            return +(n <= 0);
+                                                                                                                                            return n <= 0;
                                                                                                                                           }))
                                                                                                                                   ]);
                                                                                                                         })
@@ -1050,14 +1050,14 @@ var suites_001 = /* :: */[
                                                                                                                         "somei",
                                                                                                                         (function () {
                                                                                                                             return /* Eq */Block.__(0, [
-                                                                                                                                      /* true */1,
-                                                                                                                                      +/* int array */[
+                                                                                                                                      true,
+                                                                                                                                      /* array */[
                                                                                                                                           1,
                                                                                                                                           2,
                                                                                                                                           3,
                                                                                                                                           4
                                                                                                                                         ].some((function (_, i) {
-                                                                                                                                              return +(i <= 0);
+                                                                                                                                              return i <= 0;
                                                                                                                                             }))
                                                                                                                                     ]);
                                                                                                                           })

--- a/jscomp/test/js_bool_test.js
+++ b/jscomp/test/js_bool_test.js
@@ -5,9 +5,9 @@ var Block = require("../../lib/js/block.js");
 
 function f(x) {
   if (x) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -27,7 +27,7 @@ function f4(x) {
   }
 }
 
-var f3 = /* true */1;
+var f3 = true;
 
 var u = ( 1);
 
@@ -38,7 +38,7 @@ var suites_000 = /* tuple */[
   (function () {
       return /* Eq */Block.__(0, [
                 u,
-                /* true */1
+                true
               ]);
     })
 ];
@@ -58,8 +58,8 @@ var suites_001 = /* :: */[
       "js_bool_neq_acml_bool",
       (function () {
           return /* Eq */Block.__(0, [
-                    /* false */0,
-                    +(/* true */1 === (true))
+                    true,
+                    true === (true)
                   ]);
         })
     ],
@@ -80,6 +80,27 @@ function ff(u) {
   }
 }
 
+function fi(x, y) {
+  return x === y;
+}
+
+function fb(x, y) {
+  return x === y;
+}
+
+function fadd(x, y) {
+  return x + y | 0;
+}
+
+function ffadd(x, y) {
+  return x + y;
+}
+
+var bool_array = /* array */[
+  true,
+  false
+];
+
 Mt.from_pair_suites("js_bool_test.ml", suites);
 
 exports.f = f;
@@ -90,4 +111,9 @@ exports.u = u;
 exports.v = v;
 exports.suites = suites;
 exports.ff = ff;
+exports.fi = fi;
+exports.fb = fb;
+exports.fadd = fadd;
+exports.ffadd = ffadd;
+exports.bool_array = bool_array;
 /* u Not a pure module */

--- a/jscomp/test/js_bool_test.ml
+++ b/jscomp/test/js_bool_test.ml
@@ -1,30 +1,36 @@
 
 
-let f x = 
+let f x =
   if Js.to_bool x then true else false
 
-let f2 x = 
+let f2 x =
   if Js.to_bool x then Js.true_ else Js.false_
 
-let f4 x = 
+let f4 x =
   if  x then Js.true_ else Js.false_
 
-let f3 = 
+let f3 =
   if Js.to_bool Js.true_ then true else false
 
-let u : bool = [%bs.raw{| 1|}] 
+let u : bool = [%bs.raw{| 1|}]
 
 let v : Js.boolean = [%bs.raw{| true|}]
 
 let suites = Mt.[
     "caml_bool_eq_caml_bool", (fun _ -> Eq (u, f Js.true_));
     "js_bool_eq_js_bool",(fun _ -> Eq(v, f4 true));
-    "js_bool_neq_acml_bool",(fun _ -> 
-        Eq( false, (f Js.true_ = [%bs.raw {|true|} ] (* not type check*))));
+    "js_bool_neq_acml_bool",(fun _ ->
+        Eq( true, (f Js.true_ = [%bs.raw {|true|} ] (* not type check*))));
 ]
 
 let ff u =
-    if u = Js.true_ then 1 
-    else 2 
+    if u = Js.true_ then 1
+    else 2
 
+let fi (x : int) y =  x = y
+let fb (x : bool) y = x = y
+let fadd (x : int) y = x + y
+let ffadd (x : float) y = x +. y
+
+let bool_array = [|true; false|] 
 ;; Mt.from_pair_suites __FILE__ suites

--- a/jscomp/test/js_cast_test.js
+++ b/jscomp/test/js_cast_test.js
@@ -29,9 +29,9 @@ function eq(loc, x, y) {
               }));
 }
 
-eq("File \"js_cast_test.ml\", line 13, characters 12-19", /* true */1, 1);
+eq("File \"js_cast_test.ml\", line 13, characters 12-19", true, 1);
 
-eq("File \"js_cast_test.ml\", line 15, characters 12-19", /* false */0, 0);
+eq("File \"js_cast_test.ml\", line 15, characters 12-19", false, 0);
 
 eq("File \"js_cast_test.ml\", line 17, characters 12-19", 0, 0.0);
 

--- a/jscomp/test/js_date_test.js
+++ b/jscomp/test/js_date_test.js
@@ -21,7 +21,7 @@ var suites_001 = /* :: */[
   /* tuple */[
     "make",
     (function () {
-        return /* Ok */Block.__(4, [+(new Date().getTime() > 1487223505382)]);
+        return /* Ok */Block.__(4, [new Date().getTime() > 1487223505382]);
       })
   ],
   /* :: */[
@@ -48,7 +48,7 @@ var suites_001 = /* :: */[
         /* tuple */[
           "fromString_invalid",
           (function () {
-              return /* Ok */Block.__(4, [+isNaN(new Date("gibberish").getTime())]);
+              return /* Ok */Block.__(4, [isNaN(new Date("gibberish").getTime())]);
             })
         ],
         /* :: */[

--- a/jscomp/test/js_dict_test.js
+++ b/jscomp/test/js_dict_test.js
@@ -119,7 +119,7 @@ var suites_001 = /* :: */[
                 "values",
                 (function () {
                     return /* Eq */Block.__(0, [
-                              /* int array */[
+                              /* array */[
                                 43,
                                 86
                               ],

--- a/jscomp/test/js_exception_catch_test.js
+++ b/jscomp/test/js_exception_catch_test.js
@@ -35,13 +35,13 @@ function eq(loc, x, y) {
 
 function false_(loc) {
   return add_test(loc, (function () {
-                return /* Ok */Block.__(4, [/* false */0]);
+                return /* Ok */Block.__(4, [false]);
               }));
 }
 
 function true_(loc) {
   return add_test(loc, (function () {
-                return /* Ok */Block.__(4, [/* true */1]);
+                return /* Ok */Block.__(4, [true]);
               }));
 }
 
@@ -57,7 +57,7 @@ catch (raw_exn){
   var exn = Js_exn.internalToOCamlException(raw_exn);
   if (exn[0] === Js_exn.$$Error) {
     add_test("File \"js_exception_catch_test.ml\", line 21, characters 10-17", (function () {
-            return /* Ok */Block.__(4, [/* true */1]);
+            return /* Ok */Block.__(4, [true]);
           }));
   } else {
     throw exn;
@@ -66,7 +66,7 @@ catch (raw_exn){
 
 if (exit === 1) {
   add_test("File \"js_exception_catch_test.ml\", line 22, characters 16-23", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 }
 

--- a/jscomp/test/js_float_test.js
+++ b/jscomp/test/js_float_test.js
@@ -7,8 +7,8 @@ var suites_000 = /* tuple */[
   "_NaN <> _NaN",
   (function () {
       return /* Eq */Block.__(0, [
-                /* false */0,
-                +(NaN === NaN)
+                false,
+                NaN === NaN
               ]);
     })
 ];
@@ -18,8 +18,8 @@ var suites_001 = /* :: */[
     "isNaN - _NaN",
     (function () {
         return /* Eq */Block.__(0, [
-                  /* true */1,
-                  +isNaN(NaN)
+                  true,
+                  isNaN(NaN)
                 ]);
       })
   ],
@@ -28,8 +28,8 @@ var suites_001 = /* :: */[
       "isNaN - 0.",
       (function () {
           return /* Eq */Block.__(0, [
-                    /* false */0,
-                    +isNaN(0)
+                    false,
+                    isNaN(0)
                   ]);
         })
     ],
@@ -38,8 +38,8 @@ var suites_001 = /* :: */[
         "isFinite - infinity",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* false */0,
-                      +isFinite(Number.POSITIVE_INFINITY)
+                      false,
+                      isFinite(Number.POSITIVE_INFINITY)
                     ]);
           })
       ],
@@ -48,8 +48,8 @@ var suites_001 = /* :: */[
           "isFinite - neg_infinity",
           (function () {
               return /* Eq */Block.__(0, [
-                        /* false */0,
-                        +isFinite(Number.NEGATIVE_INFINITY)
+                        false,
+                        isFinite(Number.NEGATIVE_INFINITY)
                       ]);
             })
         ],
@@ -58,8 +58,8 @@ var suites_001 = /* :: */[
             "isFinite - _NaN",
             (function () {
                 return /* Eq */Block.__(0, [
-                          /* false */0,
-                          +isFinite(NaN)
+                          false,
+                          isFinite(NaN)
                         ]);
               })
           ],
@@ -68,8 +68,8 @@ var suites_001 = /* :: */[
               "isFinite - 0.",
               (function () {
                   return /* Eq */Block.__(0, [
-                            /* true */1,
-                            +isFinite(0)
+                            true,
+                            isFinite(0)
                           ]);
                 })
             ],
@@ -428,8 +428,8 @@ var suites_001 = /* :: */[
                                                                                       "fromString - invalid string",
                                                                                       (function () {
                                                                                           return /* Eq */Block.__(0, [
-                                                                                                    /* true */1,
-                                                                                                    +isNaN(Number("foo"))
+                                                                                                    true,
+                                                                                                    isNaN(Number("foo"))
                                                                                                   ]);
                                                                                         })
                                                                                     ],

--- a/jscomp/test/js_global_test.js
+++ b/jscomp/test/js_global_test.js
@@ -10,7 +10,7 @@ var suites_000 = /* tuple */[
               return /* () */0;
             }), 0);
       clearTimeout(handle);
-      return /* Ok */Block.__(4, [/* true */1]);
+      return /* Ok */Block.__(4, [true]);
     })
 ];
 
@@ -22,7 +22,7 @@ var suites_001 = /* :: */[
                 return /* () */0;
               }), 0);
         clearInterval(handle);
-        return /* Ok */Block.__(4, [/* true */1]);
+        return /* Ok */Block.__(4, [true]);
       })
   ],
   /* :: */[

--- a/jscomp/test/js_json_test.js
+++ b/jscomp/test/js_json_test.js
@@ -5,7 +5,6 @@ var $$Array = require("../../lib/js/array.js");
 var Block = require("../../lib/js/block.js");
 var Js_json = require("../../lib/js/js_json.js");
 var Caml_array = require("../../lib/js/caml_array.js");
-var Js_boolean = require("../../lib/js/js_boolean.js");
 var Js_primitive = require("../../lib/js/js_primitive.js");
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js");
 
@@ -37,13 +36,13 @@ function eq(loc, x, y) {
 
 function false_(loc) {
   return add_test(loc, (function () {
-                return /* Ok */Block.__(4, [/* false */0]);
+                return /* Ok */Block.__(4, [false]);
               }));
 }
 
 function true_(loc) {
   return add_test(loc, (function () {
-                return /* Ok */Block.__(4, [/* true */1]);
+                return /* Ok */Block.__(4, [true]);
               }));
 }
 
@@ -52,13 +51,13 @@ var v = JSON.parse(" { \"x\" : [1, 2, 3 ] } ");
 add_test("File \"js_json_test.ml\", line 23, characters 11-18", (function () {
         var ty = Js_json.classify(v);
         if (typeof ty === "number") {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         } else if (ty.tag === 2) {
           var match = ty[0]["x"];
           if (match !== undefined) {
             var ty2 = Js_json.classify(match);
             if (typeof ty2 === "number") {
-              return /* Ok */Block.__(4, [/* false */0]);
+              return /* Ok */Block.__(4, [false]);
             } else if (ty2.tag === 3) {
               ty2[0].forEach((function (x) {
                       var ty3 = Js_json.classify(x);
@@ -84,19 +83,19 @@ add_test("File \"js_json_test.ml\", line 23, characters 11-18", (function () {
                             ];
                       }
                     }));
-              return /* Ok */Block.__(4, [/* true */1]);
+              return /* Ok */Block.__(4, [true]);
             } else {
-              return /* Ok */Block.__(4, [/* false */0]);
+              return /* Ok */Block.__(4, [false]);
             }
           } else {
-            return /* Ok */Block.__(4, [/* false */0]);
+            return /* Ok */Block.__(4, [false]);
           }
         } else {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }
       }));
 
-eq("File \"js_json_test.ml\", line 48, characters 5-12", Js_json.test(v, /* Object */2), /* true */1);
+eq("File \"js_json_test.ml\", line 48, characters 5-12", Js_json.test(v, /* Object */2), true);
 
 var json = JSON.parse(JSON.stringify(null));
 
@@ -105,18 +104,18 @@ var ty = Js_json.classify(json);
 if (typeof ty === "number") {
   if (ty >= 2) {
     add_test("File \"js_json_test.ml\", line 54, characters 30-37", (function () {
-            return /* Ok */Block.__(4, [/* true */1]);
+            return /* Ok */Block.__(4, [true]);
           }));
   } else {
     console.log(ty);
     add_test("File \"js_json_test.ml\", line 55, characters 27-34", (function () {
-            return /* Ok */Block.__(4, [/* false */0]);
+            return /* Ok */Block.__(4, [false]);
           }));
   }
 } else {
   console.log(ty);
   add_test("File \"js_json_test.ml\", line 55, characters 27-34", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 }
 
@@ -126,11 +125,11 @@ var ty$1 = Js_json.classify(json$1);
 
 if (typeof ty$1 === "number") {
   add_test("File \"js_json_test.ml\", line 65, characters 16-23", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 } else if (ty$1.tag) {
   add_test("File \"js_json_test.ml\", line 65, characters 16-23", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 } else {
   eq("File \"js_json_test.ml\", line 64, characters 31-38", ty$1[0], "test string");
@@ -150,7 +149,7 @@ if (typeof ty$2 === "number" || ty$2.tag !== 1) {
 
 if (exit === 1) {
   add_test("File \"js_json_test.ml\", line 75, characters 18-25", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 }
 
@@ -168,7 +167,7 @@ if (typeof ty$3 === "number" || ty$3.tag !== 1) {
 
 if (exit$1 === 1) {
   add_test("File \"js_json_test.ml\", line 85, characters 18-25", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 }
 
@@ -183,13 +182,13 @@ function test(v) {
           return eq("File \"js_json_test.ml\", line 94, characters 30-37", true, v);
       case 2 : 
           return add_test("File \"js_json_test.ml\", line 96, characters 18-25", (function () {
-                        return /* Ok */Block.__(4, [/* false */0]);
+                        return /* Ok */Block.__(4, [false]);
                       }));
       
     }
   } else {
     return add_test("File \"js_json_test.ml\", line 96, characters 18-25", (function () {
-                  return /* Ok */Block.__(4, [/* false */0]);
+                  return /* Ok */Block.__(4, [false]);
                 }));
   }
 }
@@ -225,28 +224,28 @@ var ty$4 = Js_json.classify(json$4);
 
 if (typeof ty$4 === "number") {
   add_test("File \"js_json_test.ml\", line 134, characters 16-23", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 } else if (ty$4.tag === 2) {
   var x = ty$4[0];
   var ta = Js_json.classify(option_get(Js_primitive.undefined_to_opt(x["a"])));
   if (typeof ta === "number") {
     add_test("File \"js_json_test.ml\", line 132, characters 18-25", (function () {
-            return /* Ok */Block.__(4, [/* false */0]);
+            return /* Ok */Block.__(4, [false]);
           }));
   } else if (ta.tag) {
     add_test("File \"js_json_test.ml\", line 132, characters 18-25", (function () {
-            return /* Ok */Block.__(4, [/* false */0]);
+            return /* Ok */Block.__(4, [false]);
           }));
   } else if (ta[0] !== "test string") {
     add_test("File \"js_json_test.ml\", line 123, characters 18-25", (function () {
-            return /* Ok */Block.__(4, [/* false */0]);
+            return /* Ok */Block.__(4, [false]);
           }));
   } else {
     var ty$5 = Js_json.classify(option_get(Js_primitive.undefined_to_opt(x["b"])));
     if (typeof ty$5 === "number") {
       add_test("File \"js_json_test.ml\", line 130, characters 22-29", (function () {
-              return /* Ok */Block.__(4, [/* false */0]);
+              return /* Ok */Block.__(4, [false]);
             }));
     } else if (ty$5.tag === 1) {
       var b = ty$5[0];
@@ -258,13 +257,13 @@ if (typeof ty$4 === "number") {
             }));
     } else {
       add_test("File \"js_json_test.ml\", line 130, characters 22-29", (function () {
-              return /* Ok */Block.__(4, [/* false */0]);
+              return /* Ok */Block.__(4, [false]);
             }));
     }
   }
 } else {
   add_test("File \"js_json_test.ml\", line 134, characters 16-23", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 }
 
@@ -272,7 +271,7 @@ function eq_at_i(loc, json, i, kind, expected) {
   var ty = Js_json.classify(json);
   if (typeof ty === "number") {
     return add_test(loc, (function () {
-                  return /* Ok */Block.__(4, [/* false */0]);
+                  return /* Ok */Block.__(4, [false]);
                 }));
   } else if (ty.tag === 3) {
     var ty$1 = Js_json.classify(Caml_array.caml_array_get(ty[0], i));
@@ -280,11 +279,11 @@ function eq_at_i(loc, json, i, kind, expected) {
       case 0 : 
           if (typeof ty$1 === "number") {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           } else if (ty$1.tag) {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           } else {
             return eq(loc, ty$1[0], expected);
@@ -292,37 +291,37 @@ function eq_at_i(loc, json, i, kind, expected) {
       case 1 : 
           if (typeof ty$1 === "number") {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           } else if (ty$1.tag === 1) {
             return eq(loc, ty$1[0], expected);
           } else {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           }
       case 2 : 
           if (typeof ty$1 === "number") {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           } else if (ty$1.tag === 2) {
             return eq(loc, ty$1[0], expected);
           } else {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           }
       case 3 : 
           if (typeof ty$1 === "number") {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           } else if (ty$1.tag === 3) {
             return eq(loc, ty$1[0], expected);
           } else {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           }
       case 4 : 
@@ -334,36 +333,36 @@ function eq_at_i(loc, json, i, kind, expected) {
                   return eq(loc, true, expected);
               case 2 : 
                   return add_test(loc, (function () {
-                                return /* Ok */Block.__(4, [/* false */0]);
+                                return /* Ok */Block.__(4, [false]);
                               }));
               
             }
           } else {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           }
       case 5 : 
           if (typeof ty$1 === "number") {
             if (ty$1 >= 2) {
               return add_test(loc, (function () {
-                            return /* Ok */Block.__(4, [/* true */1]);
+                            return /* Ok */Block.__(4, [true]);
                           }));
             } else {
               return add_test(loc, (function () {
-                            return /* Ok */Block.__(4, [/* false */0]);
+                            return /* Ok */Block.__(4, [false]);
                           }));
             }
           } else {
             return add_test(loc, (function () {
-                          return /* Ok */Block.__(4, [/* false */0]);
+                          return /* Ok */Block.__(4, [false]);
                         }));
           }
       
     }
   } else {
     return add_test(loc, (function () {
-                  return /* Ok */Block.__(4, [/* false */0]);
+                  return /* Ok */Block.__(4, [false]);
                 }));
   }
 }
@@ -394,7 +393,7 @@ eq_at_i("File \"js_json_test.ml\", line 206, characters 10-17", json$6, 1, /* St
 
 eq_at_i("File \"js_json_test.ml\", line 207, characters 10-17", json$6, 2, /* String */0, "string 2");
 
-var a = /* float array */[
+var a = /* array */[
   1.0000001,
   10000000000.1,
   123.0
@@ -408,7 +407,7 @@ eq_at_i("File \"js_json_test.ml\", line 220, characters 10-17", json$7, 1, /* Nu
 
 eq_at_i("File \"js_json_test.ml\", line 221, characters 10-17", json$7, 2, /* Number */1, Caml_array.caml_array_get(a, 2));
 
-var a$1 = /* int array */[
+var a$1 = /* array */[
   0,
   -1347440721,
   -268391749
@@ -424,25 +423,21 @@ eq_at_i("File \"js_json_test.ml\", line 235, characters 10-17", json$8, 1, /* Nu
 
 eq_at_i("File \"js_json_test.ml\", line 236, characters 10-17", json$8, 2, /* Number */1, Caml_array.caml_array_get(a$1, 2));
 
-var a$2 = /* int array */[
-  /* true */1,
-  /* false */0,
-  /* true */1
+var a$2 = /* array */[
+  true,
+  false,
+  true
 ];
 
-var json$9 = JSON.parse(JSON.stringify($$Array.map(Js_boolean.to_js_boolean, a$2)));
+var json$9 = JSON.parse(JSON.stringify($$Array.map((function (prim) {
+                return prim;
+              }), a$2)));
 
-var b$1 = Caml_array.caml_array_get(a$2, 0);
+eq_at_i("File \"js_json_test.ml\", line 249, characters 10-17", json$9, 0, /* Boolean */4, Caml_array.caml_array_get(a$2, 0));
 
-eq_at_i("File \"js_json_test.ml\", line 249, characters 10-17", json$9, 0, /* Boolean */4, b$1 ? true : false);
+eq_at_i("File \"js_json_test.ml\", line 250, characters 10-17", json$9, 1, /* Boolean */4, Caml_array.caml_array_get(a$2, 1));
 
-var b$2 = Caml_array.caml_array_get(a$2, 1);
-
-eq_at_i("File \"js_json_test.ml\", line 250, characters 10-17", json$9, 1, /* Boolean */4, b$2 ? true : false);
-
-var b$3 = Caml_array.caml_array_get(a$2, 2);
-
-eq_at_i("File \"js_json_test.ml\", line 251, characters 10-17", json$9, 2, /* Boolean */4, b$3 ? true : false);
+eq_at_i("File \"js_json_test.ml\", line 251, characters 10-17", json$9, 2, /* Boolean */4, Caml_array.caml_array_get(a$2, 2));
 
 function make_d(s, i) {
   var d = { };
@@ -462,51 +457,51 @@ var ty$6 = Js_json.classify(json$10);
 
 if (typeof ty$6 === "number") {
   add_test("File \"js_json_test.ml\", line 283, characters 16-23", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 } else if (ty$6.tag === 3) {
   var ty$7 = Js_json.classify(Caml_array.caml_array_get(ty$6[0], 1));
   if (typeof ty$7 === "number") {
     add_test("File \"js_json_test.ml\", line 281, characters 18-25", (function () {
-            return /* Ok */Block.__(4, [/* false */0]);
+            return /* Ok */Block.__(4, [false]);
           }));
   } else if (ty$7.tag === 2) {
     var ty$8 = Js_json.classify(option_get(Js_primitive.undefined_to_opt(ty$7[0]["a"])));
     if (typeof ty$8 === "number") {
       add_test("File \"js_json_test.ml\", line 279, characters 20-27", (function () {
-              return /* Ok */Block.__(4, [/* false */0]);
+              return /* Ok */Block.__(4, [false]);
             }));
     } else if (ty$8.tag) {
       add_test("File \"js_json_test.ml\", line 279, characters 20-27", (function () {
-              return /* Ok */Block.__(4, [/* false */0]);
+              return /* Ok */Block.__(4, [false]);
             }));
     } else {
       eq("File \"js_json_test.ml\", line 278, characters 40-47", ty$8[0], "bbb");
     }
   } else {
     add_test("File \"js_json_test.ml\", line 281, characters 18-25", (function () {
-            return /* Ok */Block.__(4, [/* false */0]);
+            return /* Ok */Block.__(4, [false]);
           }));
   }
 } else {
   add_test("File \"js_json_test.ml\", line 283, characters 16-23", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 }
 
 try {
   JSON.parse("{{ A}");
   add_test("File \"js_json_test.ml\", line 289, characters 11-18", (function () {
-          return /* Ok */Block.__(4, [/* false */0]);
+          return /* Ok */Block.__(4, [false]);
         }));
 }
 catch (exn){
   add_test("File \"js_json_test.ml\", line 292, characters 10-17", (function () {
-          return /* Ok */Block.__(4, [/* true */1]);
+          return /* Ok */Block.__(4, [true]);
         }));
 }
 
-eq("File \"js_json_test.ml\", line 296, characters 12-19", Js_primitive.undefined_to_opt(JSON.stringify(/* int array */[
+eq("File \"js_json_test.ml\", line 296, characters 12-19", Js_primitive.undefined_to_opt(JSON.stringify(/* array */[
               1,
               2,
               3

--- a/jscomp/test/js_list_test.js
+++ b/jscomp/test/js_list_test.js
@@ -151,7 +151,7 @@ eq("File \"js_list_test.ml\", line 17, characters 7-14", Js_list.filterMap((func
     ]);
 
 eq("File \"js_list_test.ml\", line 20, characters 7-14", Js_list.countBy((function (x) {
-            return +(x % 2 === 0);
+            return x % 2 === 0;
           }), /* :: */[
           1,
           /* :: */[
@@ -179,7 +179,7 @@ function f(i) {
 var v = Js_vector.toList(Js_vector.init(100000, f));
 
 eq("File \"js_list_test.ml\", line 23, characters 7-14", Js_list.countBy((function (x) {
-            return +(x % 2 === 0);
+            return x % 2 === 0;
           }), v), 50000);
 
 var vv = Js_list.foldRight((function (x, y) {
@@ -189,12 +189,12 @@ var vv = Js_list.foldRight((function (x, y) {
               ];
       }), v, /* [] */0);
 
-eq("File \"js_list_test.ml\", line 27, characters 7-14", /* true */1, Js_list.equal((function (x, y) {
-            return +(x === y);
+eq("File \"js_list_test.ml\", line 27, characters 7-14", true, Js_list.equal((function (x, y) {
+            return x === y;
           }), v, vv));
 
 var vvv = Js_list.filter((function (x) {
-        return +(x % 10 === 0);
+        return x % 10 === 0;
       }), vv);
 
 eq("File \"js_list_test.ml\", line 31, characters 7-14", Js_list.length(vvv), 10000);
@@ -203,8 +203,8 @@ function f$1(x) {
   return Caml_int32.imul(x, 10);
 }
 
-eq("File \"js_list_test.ml\", line 32, characters 7-14", /* true */1, Js_list.equal((function (x, y) {
-            return +(x === y);
+eq("File \"js_list_test.ml\", line 32, characters 7-14", true, Js_list.equal((function (x, y) {
+            return x === y;
           }), vvv, Js_vector.toList(Js_vector.init(10000, f$1))));
 
 Mt.from_pair_suites("js_list_test.ml", suites[0]);

--- a/jscomp/test/js_math_test.js
+++ b/jscomp/test/js_math_test.js
@@ -474,7 +474,7 @@ var suites_001 = /* :: */[
                                                                                           "random",
                                                                                           (function () {
                                                                                               var a = Math.random();
-                                                                                              return /* Ok */Block.__(4, [+(a >= 0 && a < 1)]);
+                                                                                              return /* Ok */Block.__(4, [a >= 0 && a < 1]);
                                                                                             })
                                                                                         ],
                                                                                         /* :: */[
@@ -482,7 +482,7 @@ var suites_001 = /* :: */[
                                                                                             "random_int",
                                                                                             (function () {
                                                                                                 var a = Js_math.random_int(1, 3);
-                                                                                                return /* Ok */Block.__(4, [+(a >= 1 && a < 3)]);
+                                                                                                return /* Ok */Block.__(4, [a >= 1 && a < 3]);
                                                                                               })
                                                                                           ],
                                                                                           /* :: */[

--- a/jscomp/test/js_null_test.js
+++ b/jscomp/test/js_null_test.js
@@ -60,8 +60,8 @@ var suites_001 = /* :: */[
             "test - empty",
             (function () {
                 return /* Eq */Block.__(0, [
-                          /* true */1,
-                          /* true */1
+                          true,
+                          true
                         ]);
               })
           ],
@@ -70,8 +70,8 @@ var suites_001 = /* :: */[
               "test - 'a",
               (function () {
                   return /* Eq */Block.__(0, [
-                            /* false */0,
-                            /* false */0
+                            false,
+                            false
                           ]);
                 })
             ],
@@ -103,13 +103,13 @@ var suites_001 = /* :: */[
                   /* tuple */[
                     "iter - empty",
                     (function () {
-                        var hit = [/* false */0];
+                        var hit = [false];
                         Js_null.iter(null, (function () {
-                                hit[0] = /* true */1;
+                                hit[0] = true;
                                 return /* () */0;
                               }));
                         return /* Eq */Block.__(0, [
-                                  /* false */0,
+                                  false,
                                   hit[0]
                                 ]);
                       })

--- a/jscomp/test/js_null_undefined_test.js
+++ b/jscomp/test/js_null_undefined_test.js
@@ -60,8 +60,8 @@ var suites_001 = /* :: */[
             "test - null",
             (function () {
                 return /* Eq */Block.__(0, [
-                          /* true */1,
-                          /* true */1
+                          true,
+                          true
                         ]);
               })
           ],
@@ -70,8 +70,8 @@ var suites_001 = /* :: */[
               "test - undefined",
               (function () {
                   return /* Eq */Block.__(0, [
-                            /* true */1,
-                            /* true */1
+                            true,
+                            true
                           ]);
                 })
             ],
@@ -80,8 +80,8 @@ var suites_001 = /* :: */[
                 "test - empty",
                 (function () {
                     return /* Eq */Block.__(0, [
-                              /* true */1,
-                              /* true */1
+                              true,
+                              true
                             ]);
                   })
               ],
@@ -90,8 +90,8 @@ var suites_001 = /* :: */[
                   "test - 'a",
                   (function () {
                       return /* Eq */Block.__(0, [
-                                /* false */0,
-                                /* false */0
+                                false,
+                                false
                               ]);
                     })
                 ],
@@ -147,13 +147,13 @@ var suites_001 = /* :: */[
                           /* tuple */[
                             "iter - null",
                             (function () {
-                                var hit = [/* false */0];
+                                var hit = [false];
                                 Js_null_undefined.iter(null, (function () {
-                                        hit[0] = /* true */1;
+                                        hit[0] = true;
                                         return /* () */0;
                                       }));
                                 return /* Eq */Block.__(0, [
-                                          /* false */0,
+                                          false,
                                           hit[0]
                                         ]);
                               })
@@ -162,13 +162,13 @@ var suites_001 = /* :: */[
                             /* tuple */[
                               "iter - undefined",
                               (function () {
-                                  var hit = [/* false */0];
+                                  var hit = [false];
                                   Js_null_undefined.iter(undefined, (function () {
-                                          hit[0] = /* true */1;
+                                          hit[0] = true;
                                           return /* () */0;
                                         }));
                                   return /* Eq */Block.__(0, [
-                                            /* false */0,
+                                            false,
                                             hit[0]
                                           ]);
                                 })
@@ -177,13 +177,13 @@ var suites_001 = /* :: */[
                               /* tuple */[
                                 "iter - empty",
                                 (function () {
-                                    var hit = [/* false */0];
+                                    var hit = [false];
                                     Js_null_undefined.iter(undefined, (function () {
-                                            hit[0] = /* true */1;
+                                            hit[0] = true;
                                             return /* () */0;
                                           }));
                                     return /* Eq */Block.__(0, [
-                                              /* false */0,
+                                              false,
                                               hit[0]
                                             ]);
                                   })
@@ -227,28 +227,28 @@ var suites_001 = /* :: */[
                                       /* tuple */[
                                         "null <> undefined",
                                         (function () {
-                                            return /* Ok */Block.__(4, [/* true */1]);
+                                            return /* Ok */Block.__(4, [true]);
                                           })
                                       ],
                                       /* :: */[
                                         /* tuple */[
                                           "null <> empty",
                                           (function () {
-                                              return /* Ok */Block.__(4, [/* true */1]);
+                                              return /* Ok */Block.__(4, [true]);
                                             })
                                         ],
                                         /* :: */[
                                           /* tuple */[
                                             "undefined = empty",
                                             (function () {
-                                                return /* Ok */Block.__(4, [/* true */1]);
+                                                return /* Ok */Block.__(4, [true]);
                                               })
                                           ],
                                           /* :: */[
                                             /* tuple */[
                                               "File \"js_null_undefined_test.ml\", line 42, characters 2-9",
                                               (function () {
-                                                  return /* Ok */Block.__(4, [/* true */1]);
+                                                  return /* Ok */Block.__(4, [true]);
                                                 })
                                             ],
                                             /* [] */0

--- a/jscomp/test/js_nullable_test.js
+++ b/jscomp/test/js_nullable_test.js
@@ -39,13 +39,13 @@ function f(x, y) {
   return x + y | 0;
 }
 
-eq("File \"js_nullable_test.ml\", line 26, characters 7-14", /* false */0, /* false */0);
+eq("File \"js_nullable_test.ml\", line 26, characters 7-14", false, false);
 
-eq("File \"js_nullable_test.ml\", line 28, characters 7-14", +(f(1, 2) == null), /* false */0);
+eq("File \"js_nullable_test.ml\", line 28, characters 7-14", (f(1, 2) == null), false);
 
-eq("File \"js_nullable_test.ml\", line 30, characters 6-13", +((null) == null), /* true */1);
+eq("File \"js_nullable_test.ml\", line 30, characters 6-13", ((null) == null), true);
 
-eq("File \"js_nullable_test.ml\", line 34, characters 3-10", /* false */0, /* false */0);
+eq("File \"js_nullable_test.ml\", line 34, characters 3-10", false, false);
 
 Mt.from_pair_suites("js_nullable_test.ml", suites[0]);
 

--- a/jscomp/test/js_option_test.js
+++ b/jscomp/test/js_option_test.js
@@ -5,15 +5,15 @@ var Block = require("../../lib/js/block.js");
 var Js_option = require("../../lib/js/js_option.js");
 
 function simpleEq(a, b) {
-  return +(a === b);
+  return a === b;
 }
 
 var option_suites_000 = /* tuple */[
   "option_isSome_Some",
   (function () {
       return /* Eq */Block.__(0, [
-                /* true */1,
-                /* true */1
+                true,
+                true
               ]);
     })
 ];
@@ -23,8 +23,8 @@ var option_suites_001 = /* :: */[
     "option_isSome_None",
     (function () {
         return /* Eq */Block.__(0, [
-                  /* false */0,
-                  /* false */0
+                  false,
+                  false
                 ]);
       })
   ],
@@ -33,8 +33,8 @@ var option_suites_001 = /* :: */[
       "option_isNone_Some",
       (function () {
           return /* Eq */Block.__(0, [
-                    /* false */0,
-                    /* false */0
+                    false,
+                    false
                   ]);
         })
     ],
@@ -43,8 +43,8 @@ var option_suites_001 = /* :: */[
         "option_isNone_None",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* true */1,
-                      /* true */1
+                      true,
+                      true
                     ]);
           })
       ],
@@ -53,7 +53,7 @@ var option_suites_001 = /* :: */[
           "option_isSomeValue_Eq",
           (function () {
               return /* Eq */Block.__(0, [
-                        /* true */1,
+                        true,
                         Js_option.isSomeValue(simpleEq, 2, /* Some */[2])
                       ]);
             })
@@ -63,7 +63,7 @@ var option_suites_001 = /* :: */[
             "option_isSomeValue_Diff",
             (function () {
                 return /* Eq */Block.__(0, [
-                          /* false */0,
+                          false,
                           Js_option.isSomeValue(simpleEq, 1, /* Some */[2])
                         ]);
               })
@@ -73,7 +73,7 @@ var option_suites_001 = /* :: */[
               "option_isSomeValue_DiffNone",
               (function () {
                   return /* Eq */Block.__(0, [
-                            /* false */0,
+                            false,
                             Js_option.isSomeValue(simpleEq, 1, /* None */0)
                           ]);
                 })
@@ -93,7 +93,7 @@ var option_suites_001 = /* :: */[
                   "option_equal_Eq",
                   (function () {
                       return /* Eq */Block.__(0, [
-                                /* true */1,
+                                true,
                                 Js_option.equal(simpleEq, /* Some */[2], /* Some */[2])
                               ]);
                     })
@@ -103,7 +103,7 @@ var option_suites_001 = /* :: */[
                     "option_equal_Diff",
                     (function () {
                         return /* Eq */Block.__(0, [
-                                  /* false */0,
+                                  false,
                                   Js_option.equal(simpleEq, /* Some */[1], /* Some */[2])
                                 ]);
                       })
@@ -113,7 +113,7 @@ var option_suites_001 = /* :: */[
                       "option_equal_DiffNone",
                       (function () {
                           return /* Eq */Block.__(0, [
-                                    /* false */0,
+                                    false,
                                     Js_option.equal(simpleEq, /* Some */[1], /* None */0)
                                   ]);
                         })
@@ -123,7 +123,7 @@ var option_suites_001 = /* :: */[
                         "option_andThen_SomeSome",
                         (function () {
                             return /* Eq */Block.__(0, [
-                                      /* true */1,
+                                      true,
                                       Js_option.isSomeValue(simpleEq, 3, Js_option.andThen((function (a) {
                                                   return /* Some */[a + 1 | 0];
                                                 }), /* Some */[2]))
@@ -135,7 +135,7 @@ var option_suites_001 = /* :: */[
                           "option_andThen_SomeNone",
                           (function () {
                               return /* Eq */Block.__(0, [
-                                        /* false */0,
+                                        false,
                                         Js_option.isSomeValue(simpleEq, 3, Js_option.andThen((function () {
                                                     return /* None */0;
                                                   }), /* Some */[2]))
@@ -147,7 +147,7 @@ var option_suites_001 = /* :: */[
                             "option_map_Some",
                             (function () {
                                 return /* Eq */Block.__(0, [
-                                          /* true */1,
+                                          true,
                                           Js_option.isSomeValue(simpleEq, 3, Js_option.map((function (a) {
                                                       return a + 1 | 0;
                                                     }), /* Some */[2]))
@@ -191,9 +191,9 @@ var option_suites_001 = /* :: */[
                                     "option_filter_Pass",
                                     (function () {
                                         return /* Eq */Block.__(0, [
-                                                  /* true */1,
+                                                  true,
                                                   Js_option.isSomeValue(simpleEq, 2, Js_option.filter((function (a) {
-                                                              return +(a % 2 === 0);
+                                                              return a % 2 === 0;
                                                             }), /* Some */[2]))
                                                 ]);
                                       })
@@ -205,7 +205,7 @@ var option_suites_001 = /* :: */[
                                           return /* Eq */Block.__(0, [
                                                     /* None */0,
                                                     Js_option.filter((function (a) {
-                                                            return +(a % 3 === 0);
+                                                            return a % 3 === 0;
                                                           }), /* Some */[2])
                                                   ]);
                                         })
@@ -217,7 +217,7 @@ var option_suites_001 = /* :: */[
                                             return /* Eq */Block.__(0, [
                                                       /* None */0,
                                                       Js_option.filter((function (a) {
-                                                              return +(a % 3 === 0);
+                                                              return a % 3 === 0;
                                                             }), /* None */0)
                                                     ]);
                                           })
@@ -227,7 +227,7 @@ var option_suites_001 = /* :: */[
                                           "option_firstSome_First",
                                           (function () {
                                               return /* Eq */Block.__(0, [
-                                                        /* true */1,
+                                                        true,
                                                         Js_option.isSomeValue(simpleEq, 3, Js_option.firstSome(/* Some */[3], /* Some */[2]))
                                                       ]);
                                             })
@@ -237,7 +237,7 @@ var option_suites_001 = /* :: */[
                                             "option_firstSome_First",
                                             (function () {
                                                 return /* Eq */Block.__(0, [
-                                                          /* true */1,
+                                                          true,
                                                           Js_option.isSomeValue(simpleEq, 2, Js_option.firstSome(/* None */0, /* Some */[2]))
                                                         ]);
                                               })

--- a/jscomp/test/js_promise_basic_test.js
+++ b/jscomp/test/js_promise_basic_test.js
@@ -54,7 +54,7 @@ function fail() {
 function thenTest() {
   var p = Promise.resolve(4);
   return p.then((function (x) {
-                return Promise.resolve(assert_bool(+(x === 4)));
+                return Promise.resolve(assert_bool(x === 4));
               }));
 }
 
@@ -63,7 +63,7 @@ function andThenTest() {
   return p.then((function () {
                   return Promise.resolve(12);
                 })).then((function (y) {
-                return Promise.resolve(assert_bool(+(y === 12)));
+                return Promise.resolve(assert_bool(y === 12));
               }));
 }
 
@@ -95,7 +95,7 @@ function orResolvedTest() {
   return p.catch((function () {
                     return Promise.resolve(22);
                   })).then((function (value) {
-                  return Promise.resolve(assert_bool(+(value === 42)));
+                  return Promise.resolve(assert_bool(value === 42));
                 })).catch(fail);
 }
 
@@ -104,7 +104,7 @@ function orRejectedTest() {
   return p.catch((function () {
                     return Promise.resolve(22);
                   })).then((function (value) {
-                  return Promise.resolve(assert_bool(+(value === 22)));
+                  return Promise.resolve(assert_bool(value === 22));
                 })).catch(fail);
 }
 
@@ -113,7 +113,7 @@ function orElseResolvedTest() {
   return p.catch((function () {
                     return Promise.resolve(22);
                   })).then((function (value) {
-                  return Promise.resolve(assert_bool(+(value === 42)));
+                  return Promise.resolve(assert_bool(value === 42));
                 })).catch(fail);
 }
 
@@ -122,7 +122,7 @@ function orElseRejectedResolveTest() {
   return p.catch((function () {
                     return Promise.resolve(22);
                   })).then((function (value) {
-                  return Promise.resolve(assert_bool(+(value === 22)));
+                  return Promise.resolve(assert_bool(value === 22));
                 })).catch(fail);
 }
 
@@ -150,7 +150,7 @@ function orElseRejectedRejectTest() {
 function resolveTest() {
   var p1 = Promise.resolve(10);
   return p1.then((function (x) {
-                return Promise.resolve(assert_bool(+(x === 10)));
+                return Promise.resolve(assert_bool(x === 10));
               }));
 }
 
@@ -162,7 +162,7 @@ function rejectTest() {
 function thenCatchChainResolvedTest() {
   var p = Promise.resolve(20);
   return p.then((function (value) {
-                  return Promise.resolve(assert_bool(+(value === 20)));
+                  return Promise.resolve(assert_bool(value === 20));
                 })).catch(fail);
 }
 
@@ -181,9 +181,9 @@ function allResolvedTest() {
     p3
   ];
   return Promise.all(promises).then((function (resolved) {
-                assert_bool(+(Caml_array.caml_array_get(resolved, 0) === 1));
-                assert_bool(+(Caml_array.caml_array_get(resolved, 1) === 2));
-                assert_bool(+(Caml_array.caml_array_get(resolved, 2) === 3));
+                assert_bool(Caml_array.caml_array_get(resolved, 0) === 1);
+                assert_bool(Caml_array.caml_array_get(resolved, 1) === 2);
+                assert_bool(Caml_array.caml_array_get(resolved, 2) === 3);
                 return h;
               }));
 }
@@ -198,7 +198,7 @@ function allRejectTest() {
     p3
   ];
   return Promise.all(promises).then(fail).catch((function (error) {
-                assert_bool(+(error === Caml_builtin_exceptions.not_found));
+                assert_bool(error === Caml_builtin_exceptions.not_found);
                 return h;
               }));
 }
@@ -221,7 +221,7 @@ function createPromiseRejectTest() {
   return new Promise((function (_, reject) {
                   return reject(Caml_builtin_exceptions.not_found);
                 })).catch((function (error) {
-                assert_bool(+(error === Caml_builtin_exceptions.not_found));
+                assert_bool(error === Caml_builtin_exceptions.not_found);
                 return h;
               }));
 }
@@ -230,7 +230,7 @@ function createPromiseFulfillTest() {
   return new Promise((function (resolve, _) {
                     return resolve("success");
                   })).then((function (resolved) {
-                  assert_bool(+(resolved === "success"));
+                  assert_bool(resolved === "success");
                   return h;
                 })).catch(fail);
 }

--- a/jscomp/test/js_re_test.js
+++ b/jscomp/test/js_re_test.js
@@ -70,7 +70,7 @@ var suites_001 = /* :: */[
             if (match !== null) {
               return /* FailWith */Block.__(9, ["regex should not match"]);
             } else {
-              return /* Ok */Block.__(4, [/* true */1]);
+              return /* Ok */Block.__(4, [true]);
             }
           })
       ],
@@ -78,9 +78,9 @@ var suites_001 = /* :: */[
         /* tuple */[
           "test_str",
           (function () {
-              var res = +new RegExp("foo").test("#foo#");
+              var res = new RegExp("foo").test("#foo#");
               return /* Eq */Block.__(0, [
-                        /* true */1,
+                        true,
                         res
                       ]);
             })
@@ -91,8 +91,8 @@ var suites_001 = /* :: */[
             (function () {
                 var res = new RegExp("foo", "g");
                 return /* Eq */Block.__(0, [
-                          /* true */1,
-                          +res.global
+                          true,
+                          res.global
                         ]);
               })
           ],
@@ -142,8 +142,8 @@ var suites_001 = /* :: */[
                     "t_global",
                     (function () {
                         return /* Eq */Block.__(0, [
-                                  /* true */1,
-                                  +(/./ig).global
+                                  true,
+                                  (/./ig).global
                                 ]);
                       })
                   ],
@@ -152,8 +152,8 @@ var suites_001 = /* :: */[
                       "t_ignoreCase",
                       (function () {
                           return /* Eq */Block.__(0, [
-                                    /* true */1,
-                                    +(/./ig).ignoreCase
+                                    true,
+                                    (/./ig).ignoreCase
                                   ]);
                         })
                     ],
@@ -194,8 +194,8 @@ var suites_001 = /* :: */[
                             "t_multiline",
                             (function () {
                                 return /* Eq */Block.__(0, [
-                                          /* false */0,
-                                          +(/./ig).multiline
+                                          false,
+                                          (/./ig).multiline
                                         ]);
                               })
                           ],
@@ -214,8 +214,8 @@ var suites_001 = /* :: */[
                                 "t_sticky",
                                 (function () {
                                     return /* Eq */Block.__(0, [
-                                              /* true */1,
-                                              +(/./yg).sticky
+                                              true,
+                                              (/./yg).sticky
                                             ]);
                                   })
                               ],
@@ -224,8 +224,8 @@ var suites_001 = /* :: */[
                                   "t_unicode",
                                   (function () {
                                       return /* Eq */Block.__(0, [
-                                                /* false */0,
-                                                +(/./yg).unicode
+                                                false,
+                                                (/./yg).unicode
                                               ]);
                                     })
                                 ],

--- a/jscomp/test/js_string_test.js
+++ b/jscomp/test/js_string_test.js
@@ -139,8 +139,8 @@ var suites_001 = /* :: */[
                             "endsWith",
                             (function () {
                                 return /* Eq */Block.__(0, [
-                                          /* true */1,
-                                          +"foobar".endsWith("bar")
+                                          true,
+                                          "foobar".endsWith("bar")
                                         ]);
                               })
                           ],
@@ -149,8 +149,8 @@ var suites_001 = /* :: */[
                               "endsWithFrom",
                               (function () {
                                   return /* Eq */Block.__(0, [
-                                            /* false */0,
-                                            +"foobar".endsWith("bar", 1)
+                                            false,
+                                            "foobar".endsWith("bar", 1)
                                           ]);
                                 })
                             ],
@@ -159,8 +159,8 @@ var suites_001 = /* :: */[
                                 "includes",
                                 (function () {
                                     return /* Eq */Block.__(0, [
-                                              /* true */1,
-                                              +"foobarbaz".includes("bar")
+                                              true,
+                                              "foobarbaz".includes("bar")
                                             ]);
                                   })
                               ],
@@ -169,8 +169,8 @@ var suites_001 = /* :: */[
                                   "includesFrom",
                                   (function () {
                                       return /* Eq */Block.__(0, [
-                                                /* false */0,
-                                                +"foobarbaz".includes("bar", 4)
+                                                false,
+                                                "foobarbaz".includes("bar", 4)
                                               ]);
                                     })
                                 ],
@@ -454,8 +454,8 @@ var suites_001 = /* :: */[
                                                                                   "startsWith",
                                                                                   (function () {
                                                                                       return /* Eq */Block.__(0, [
-                                                                                                /* true */1,
-                                                                                                +"foobarbaz".startsWith("foo")
+                                                                                                true,
+                                                                                                "foobarbaz".startsWith("foo")
                                                                                               ]);
                                                                                     })
                                                                                 ],
@@ -464,8 +464,8 @@ var suites_001 = /* :: */[
                                                                                     "startsWithFrom",
                                                                                     (function () {
                                                                                         return /* Eq */Block.__(0, [
-                                                                                                  /* false */0,
-                                                                                                  +"foobarbaz".startsWith("foo", 1)
+                                                                                                  false,
+                                                                                                  "foobarbaz".startsWith("foo", 1)
                                                                                                 ]);
                                                                                       })
                                                                                   ],
@@ -583,7 +583,7 @@ var suites_001 = /* :: */[
                                                                                                           /* tuple */[
                                                                                                             "File \"js_string_test.ml\", line 211, characters 4-11",
                                                                                                             (function () {
-                                                                                                                return /* Ok */Block.__(4, [+"ab".includes("a")]);
+                                                                                                                return /* Ok */Block.__(4, ["ab".includes("a")]);
                                                                                                               })
                                                                                                           ],
                                                                                                           /* [] */0

--- a/jscomp/test/js_typed_array_test.js
+++ b/jscomp/test/js_typed_array_test.js
@@ -19,7 +19,7 @@ function viaInt8(_, _$1) {
     });
 }
 
-var x = new Int8Array(/* int array */[
+var x = new Int8Array(/* array */[
       1,
       2,
       3
@@ -104,7 +104,7 @@ var suites_001 = /* :: */[
               "typed_array - buffer",
               (function () {
                   return /* Eq */Block.__(0, [
-                            new Int8Array(/* int array */[
+                            new Int8Array(/* array */[
                                   3,
                                   4,
                                   5
@@ -156,7 +156,7 @@ var suites_001 = /* :: */[
                     "typed_array - setArray",
                     (function () {
                         var f = function (a) {
-                          a.set(/* int array */[
+                          a.set(/* array */[
                                 9,
                                 8,
                                 7
@@ -186,7 +186,7 @@ var suites_001 = /* :: */[
                       "typed_array - setArrayOffset",
                       (function () {
                           var f = function (a) {
-                            a.set(/* int array */[
+                            a.set(/* array */[
                                   9,
                                   8,
                                   7
@@ -298,12 +298,12 @@ var suites_001 = /* :: */[
                                 "typed_array - fillInPlace",
                                 (function () {
                                     return /* Eq */Block.__(0, [
-                                              new Int8Array(/* int array */[
+                                              new Int8Array(/* array */[
                                                     4,
                                                     4,
                                                     4
                                                   ]),
-                                              new Int8Array(/* int array */[
+                                              new Int8Array(/* array */[
                                                       1,
                                                       2,
                                                       3
@@ -316,12 +316,12 @@ var suites_001 = /* :: */[
                                   "typed_array - fillFromInPlace",
                                   (function () {
                                       return /* Eq */Block.__(0, [
-                                                new Int8Array(/* int array */[
+                                                new Int8Array(/* array */[
                                                       1,
                                                       4,
                                                       4
                                                     ]),
-                                                new Int8Array(/* int array */[
+                                                new Int8Array(/* array */[
                                                         1,
                                                         2,
                                                         3
@@ -334,12 +334,12 @@ var suites_001 = /* :: */[
                                     "typed_array - fillRangeInPlace",
                                     (function () {
                                         return /* Eq */Block.__(0, [
-                                                  new Int8Array(/* int array */[
+                                                  new Int8Array(/* array */[
                                                         1,
                                                         4,
                                                         3
                                                       ]),
-                                                  new Int8Array(/* int array */[
+                                                  new Int8Array(/* array */[
                                                           1,
                                                           2,
                                                           3
@@ -352,12 +352,12 @@ var suites_001 = /* :: */[
                                       "typed_array - reverseInPlace",
                                       (function () {
                                           return /* Eq */Block.__(0, [
-                                                    new Int8Array(/* int array */[
+                                                    new Int8Array(/* array */[
                                                           3,
                                                           2,
                                                           1
                                                         ]),
-                                                    new Int8Array(/* int array */[
+                                                    new Int8Array(/* array */[
                                                             1,
                                                             2,
                                                             3
@@ -370,12 +370,12 @@ var suites_001 = /* :: */[
                                         "typed_array - sortInPlace",
                                         (function () {
                                             return /* Eq */Block.__(0, [
-                                                      new Int8Array(/* int array */[
+                                                      new Int8Array(/* array */[
                                                             1,
                                                             2,
                                                             3
                                                           ]),
-                                                      new Int8Array(/* int array */[
+                                                      new Int8Array(/* array */[
                                                               3,
                                                               1,
                                                               2
@@ -388,12 +388,12 @@ var suites_001 = /* :: */[
                                           "typed_array - sortInPlaceWith",
                                           (function () {
                                               return /* Eq */Block.__(0, [
-                                                        new Int8Array(/* int array */[
+                                                        new Int8Array(/* array */[
                                                               3,
                                                               2,
                                                               1
                                                             ]),
-                                                        new Int8Array(/* int array */[
+                                                        new Int8Array(/* array */[
                                                                 3,
                                                                 1,
                                                                 2
@@ -409,7 +409,7 @@ var suites_001 = /* :: */[
                                             (function () {
                                                 return /* Eq */Block.__(0, [
                                                           true,
-                                                          new Int8Array(/* int array */[
+                                                          new Int8Array(/* array */[
                                                                   1,
                                                                   2,
                                                                   3
@@ -423,7 +423,7 @@ var suites_001 = /* :: */[
                                               (function () {
                                                   return /* Eq */Block.__(0, [
                                                             1,
-                                                            new Int8Array(/* int array */[
+                                                            new Int8Array(/* array */[
                                                                     1,
                                                                     2,
                                                                     3
@@ -437,7 +437,7 @@ var suites_001 = /* :: */[
                                                 (function () {
                                                     return /* Eq */Block.__(0, [
                                                               3,
-                                                              new Int8Array(/* int array */[
+                                                              new Int8Array(/* array */[
                                                                       1,
                                                                       2,
                                                                       3,
@@ -452,7 +452,7 @@ var suites_001 = /* :: */[
                                                   (function () {
                                                       return /* Eq */Block.__(0, [
                                                                 "1,2,3",
-                                                                new Int8Array(/* int array */[
+                                                                new Int8Array(/* array */[
                                                                         1,
                                                                         2,
                                                                         3
@@ -466,7 +466,7 @@ var suites_001 = /* :: */[
                                                     (function () {
                                                         return /* Eq */Block.__(0, [
                                                                   "1;2;3",
-                                                                  new Int8Array(/* int array */[
+                                                                  new Int8Array(/* array */[
                                                                           1,
                                                                           2,
                                                                           3
@@ -480,7 +480,7 @@ var suites_001 = /* :: */[
                                                       (function () {
                                                           return /* Eq */Block.__(0, [
                                                                     1,
-                                                                    new Int8Array(/* int array */[
+                                                                    new Int8Array(/* array */[
                                                                             1,
                                                                             2,
                                                                             3
@@ -494,7 +494,7 @@ var suites_001 = /* :: */[
                                                         (function () {
                                                             return /* Eq */Block.__(0, [
                                                                       1,
-                                                                      new Int8Array(/* int array */[
+                                                                      new Int8Array(/* array */[
                                                                               1,
                                                                               2,
                                                                               3,
@@ -508,7 +508,7 @@ var suites_001 = /* :: */[
                                                           "typed_array - slice",
                                                           (function () {
                                                               return /* Eq */Block.__(0, [
-                                                                        new Int8Array(/* int array */[
+                                                                        new Int8Array(/* array */[
                                                                               2,
                                                                               3
                                                                             ]),
@@ -549,7 +549,7 @@ var suites_001 = /* :: */[
                                                               "typed_array - sliceFrom",
                                                               (function () {
                                                                   return /* Eq */Block.__(0, [
-                                                                            new Int8Array(/* int array */[
+                                                                            new Int8Array(/* array */[
                                                                                   3,
                                                                                   4,
                                                                                   5
@@ -569,7 +569,7 @@ var suites_001 = /* :: */[
                                                                 "typed_array - subarray",
                                                                 (function () {
                                                                     return /* Eq */Block.__(0, [
-                                                                              new Int8Array(/* int array */[
+                                                                              new Int8Array(/* array */[
                                                                                     2,
                                                                                     3
                                                                                   ]),
@@ -588,7 +588,7 @@ var suites_001 = /* :: */[
                                                                   "typed_array - subarrayFrom",
                                                                   (function () {
                                                                       return /* Eq */Block.__(0, [
-                                                                                new Int8Array(/* int array */[
+                                                                                new Int8Array(/* array */[
                                                                                       3,
                                                                                       4,
                                                                                       5
@@ -609,7 +609,7 @@ var suites_001 = /* :: */[
                                                                     (function () {
                                                                         return /* Eq */Block.__(0, [
                                                                                   "1,2,3",
-                                                                                  new Int8Array(/* int array */[
+                                                                                  new Int8Array(/* array */[
                                                                                           1,
                                                                                           2,
                                                                                           3
@@ -623,7 +623,7 @@ var suites_001 = /* :: */[
                                                                       (function () {
                                                                           return /* Eq */Block.__(0, [
                                                                                     "1,2,3",
-                                                                                    new Int8Array(/* int array */[
+                                                                                    new Int8Array(/* array */[
                                                                                             1,
                                                                                             2,
                                                                                             3
@@ -637,17 +637,12 @@ var suites_001 = /* :: */[
                                                                         (function () {
                                                                             return /* Eq */Block.__(0, [
                                                                                       true,
-                                                                                      new Int8Array(/* int array */[
+                                                                                      new Int8Array(/* array */[
                                                                                               1,
                                                                                               2,
                                                                                               3
                                                                                             ]).every((function (n) {
-                                                                                              var b = +(n > 0);
-                                                                                              if (b) {
-                                                                                                return true;
-                                                                                              } else {
-                                                                                                return false;
-                                                                                              }
+                                                                                              return n > 0;
                                                                                             }))
                                                                                     ]);
                                                                           })
@@ -658,17 +653,12 @@ var suites_001 = /* :: */[
                                                                           (function () {
                                                                               return /* Eq */Block.__(0, [
                                                                                         false,
-                                                                                        new Int8Array(/* int array */[
+                                                                                        new Int8Array(/* array */[
                                                                                                 1,
                                                                                                 2,
                                                                                                 3
                                                                                               ]).every((function (_, i) {
-                                                                                                var b = +(i > 0);
-                                                                                                if (b) {
-                                                                                                  return true;
-                                                                                                } else {
-                                                                                                  return false;
-                                                                                                }
+                                                                                                return i > 0;
                                                                                               }))
                                                                                       ]);
                                                                             })
@@ -678,17 +668,17 @@ var suites_001 = /* :: */[
                                                                             "typed_array - filter",
                                                                             (function () {
                                                                                 return /* Eq */Block.__(0, [
-                                                                                          new Int8Array(/* int array */[
+                                                                                          new Int8Array(/* array */[
                                                                                                 2,
                                                                                                 4
                                                                                               ]),
-                                                                                          new Int8Array(/* int array */[
+                                                                                          new Int8Array(/* array */[
                                                                                                   1,
                                                                                                   2,
                                                                                                   3,
                                                                                                   4
                                                                                                 ]).filter((function (n) {
-                                                                                                  return +(n % 2 === 0);
+                                                                                                  return n % 2 === 0;
                                                                                                 }))
                                                                                         ]);
                                                                               })
@@ -698,22 +688,17 @@ var suites_001 = /* :: */[
                                                                               "typed_array - filteri",
                                                                               (function () {
                                                                                   return /* Eq */Block.__(0, [
-                                                                                            new Int8Array(/* int array */[
+                                                                                            new Int8Array(/* array */[
                                                                                                   1,
                                                                                                   3
                                                                                                 ]),
-                                                                                            new Int8Array(/* int array */[
+                                                                                            new Int8Array(/* array */[
                                                                                                     1,
                                                                                                     2,
                                                                                                     3,
                                                                                                     4
                                                                                                   ]).filter((function (_, i) {
-                                                                                                    var b = +(i % 2 === 0);
-                                                                                                    if (b) {
-                                                                                                      return true;
-                                                                                                    } else {
-                                                                                                      return false;
-                                                                                                    }
+                                                                                                    return i % 2 === 0;
                                                                                                   }))
                                                                                           ]);
                                                                                 })
@@ -724,13 +709,13 @@ var suites_001 = /* :: */[
                                                                                 (function () {
                                                                                     return /* Eq */Block.__(0, [
                                                                                               2,
-                                                                                              new Int8Array(/* int array */[
+                                                                                              new Int8Array(/* array */[
                                                                                                       1,
                                                                                                       2,
                                                                                                       3,
                                                                                                       4
                                                                                                     ]).find((function (n) {
-                                                                                                      return +(n % 2 === 0);
+                                                                                                      return n % 2 === 0;
                                                                                                     }))
                                                                                             ]);
                                                                                   })
@@ -741,13 +726,13 @@ var suites_001 = /* :: */[
                                                                                   (function () {
                                                                                       return /* Eq */Block.__(0, [
                                                                                                 1,
-                                                                                                new Int8Array(/* int array */[
+                                                                                                new Int8Array(/* array */[
                                                                                                         1,
                                                                                                         2,
                                                                                                         3,
                                                                                                         4
                                                                                                       ]).find((function (_, i) {
-                                                                                                        return +(i % 2 === 0);
+                                                                                                        return i % 2 === 0;
                                                                                                       }))
                                                                                               ]);
                                                                                     })
@@ -758,13 +743,13 @@ var suites_001 = /* :: */[
                                                                                     (function () {
                                                                                         return /* Eq */Block.__(0, [
                                                                                                   1,
-                                                                                                  new Int8Array(/* int array */[
+                                                                                                  new Int8Array(/* array */[
                                                                                                           1,
                                                                                                           2,
                                                                                                           3,
                                                                                                           4
                                                                                                         ]).findIndex((function (n) {
-                                                                                                          return +(n % 2 === 0);
+                                                                                                          return n % 2 === 0;
                                                                                                         }))
                                                                                                 ]);
                                                                                       })
@@ -775,13 +760,13 @@ var suites_001 = /* :: */[
                                                                                       (function () {
                                                                                           return /* Eq */Block.__(0, [
                                                                                                     0,
-                                                                                                    new Int8Array(/* int array */[
+                                                                                                    new Int8Array(/* array */[
                                                                                                             1,
                                                                                                             2,
                                                                                                             3,
                                                                                                             4
                                                                                                           ]).findIndex((function (_, i) {
-                                                                                                            return +(i % 2 === 0);
+                                                                                                            return i % 2 === 0;
                                                                                                           }))
                                                                                                   ]);
                                                                                         })
@@ -791,7 +776,7 @@ var suites_001 = /* :: */[
                                                                                         "typed_array - forEach",
                                                                                         (function () {
                                                                                             var sum = [0];
-                                                                                            new Int8Array(/* int array */[
+                                                                                            new Int8Array(/* array */[
                                                                                                     1,
                                                                                                     2,
                                                                                                     3
@@ -810,7 +795,7 @@ var suites_001 = /* :: */[
                                                                                           "typed_array - forEachi",
                                                                                           (function () {
                                                                                               var sum = [0];
-                                                                                              new Int8Array(/* int array */[
+                                                                                              new Int8Array(/* array */[
                                                                                                       1,
                                                                                                       2,
                                                                                                       3
@@ -829,13 +814,13 @@ var suites_001 = /* :: */[
                                                                                             "typed_array - map",
                                                                                             (function () {
                                                                                                 return /* Eq */Block.__(0, [
-                                                                                                          new Int8Array(/* int array */[
+                                                                                                          new Int8Array(/* array */[
                                                                                                                 2,
                                                                                                                 4,
                                                                                                                 6,
                                                                                                                 8
                                                                                                               ]),
-                                                                                                          new Int8Array(/* int array */[
+                                                                                                          new Int8Array(/* array */[
                                                                                                                   1,
                                                                                                                   2,
                                                                                                                   3,
@@ -851,13 +836,13 @@ var suites_001 = /* :: */[
                                                                                               "typed_array - map",
                                                                                               (function () {
                                                                                                   return /* Eq */Block.__(0, [
-                                                                                                            new Int8Array(/* int array */[
+                                                                                                            new Int8Array(/* array */[
                                                                                                                   0,
                                                                                                                   2,
                                                                                                                   4,
                                                                                                                   6
                                                                                                                 ]),
-                                                                                                            new Int8Array(/* int array */[
+                                                                                                            new Int8Array(/* array */[
                                                                                                                     1,
                                                                                                                     2,
                                                                                                                     3,
@@ -874,7 +859,7 @@ var suites_001 = /* :: */[
                                                                                                 (function () {
                                                                                                     return /* Eq */Block.__(0, [
                                                                                                               -10,
-                                                                                                              new Int8Array(/* int array */[
+                                                                                                              new Int8Array(/* array */[
                                                                                                                       1,
                                                                                                                       2,
                                                                                                                       3,
@@ -891,7 +876,7 @@ var suites_001 = /* :: */[
                                                                                                   (function () {
                                                                                                       return /* Eq */Block.__(0, [
                                                                                                                 -6,
-                                                                                                                new Int8Array(/* int array */[
+                                                                                                                new Int8Array(/* array */[
                                                                                                                         1,
                                                                                                                         2,
                                                                                                                         3,
@@ -908,7 +893,7 @@ var suites_001 = /* :: */[
                                                                                                     (function () {
                                                                                                         return /* Eq */Block.__(0, [
                                                                                                                   -10,
-                                                                                                                  new Int8Array(/* int array */[
+                                                                                                                  new Int8Array(/* array */[
                                                                                                                           1,
                                                                                                                           2,
                                                                                                                           3,
@@ -925,7 +910,7 @@ var suites_001 = /* :: */[
                                                                                                       (function () {
                                                                                                           return /* Eq */Block.__(0, [
                                                                                                                     -6,
-                                                                                                                    new Int8Array(/* int array */[
+                                                                                                                    new Int8Array(/* array */[
                                                                                                                             1,
                                                                                                                             2,
                                                                                                                             3,
@@ -942,18 +927,13 @@ var suites_001 = /* :: */[
                                                                                                         (function () {
                                                                                                             return /* Eq */Block.__(0, [
                                                                                                                       false,
-                                                                                                                      new Int8Array(/* int array */[
+                                                                                                                      new Int8Array(/* array */[
                                                                                                                               1,
                                                                                                                               2,
                                                                                                                               3,
                                                                                                                               4
                                                                                                                             ]).some((function (n) {
-                                                                                                                              var b = +(n <= 0);
-                                                                                                                              if (b) {
-                                                                                                                                return true;
-                                                                                                                              } else {
-                                                                                                                                return false;
-                                                                                                                              }
+                                                                                                                              return n <= 0;
                                                                                                                             }))
                                                                                                                     ]);
                                                                                                           })
@@ -964,18 +944,13 @@ var suites_001 = /* :: */[
                                                                                                           (function () {
                                                                                                               return /* Eq */Block.__(0, [
                                                                                                                         true,
-                                                                                                                        new Int8Array(/* int array */[
+                                                                                                                        new Int8Array(/* array */[
                                                                                                                                 1,
                                                                                                                                 2,
                                                                                                                                 3,
                                                                                                                                 4
                                                                                                                               ]).some((function (_, i) {
-                                                                                                                                var b = +(i <= 0);
-                                                                                                                                if (b) {
-                                                                                                                                  return true;
-                                                                                                                                } else {
-                                                                                                                                  return false;
-                                                                                                                                }
+                                                                                                                                return i <= 0;
                                                                                                                               }))
                                                                                                                       ]);
                                                                                                             })
@@ -996,7 +971,7 @@ var suites_001 = /* :: */[
                                                                                                               (function () {
                                                                                                                   return /* Eq */Block.__(0, [
                                                                                                                             3,
-                                                                                                                            new Int8Array(/* int array */[
+                                                                                                                            new Int8Array(/* array */[
                                                                                                                                   1,
                                                                                                                                   2,
                                                                                                                                   3
@@ -1080,7 +1055,7 @@ var suites_001 = /* :: */[
                                                                                                                             (function () {
                                                                                                                                 return /* Eq */Block.__(0, [
                                                                                                                                           3,
-                                                                                                                                          new Uint8Array(/* int array */[
+                                                                                                                                          new Uint8Array(/* array */[
                                                                                                                                                 1,
                                                                                                                                                 2,
                                                                                                                                                 3
@@ -1164,7 +1139,7 @@ var suites_001 = /* :: */[
                                                                                                                                           (function () {
                                                                                                                                               return /* Eq */Block.__(0, [
                                                                                                                                                         3,
-                                                                                                                                                        new Uint8ClampedArray(/* int array */[
+                                                                                                                                                        new Uint8ClampedArray(/* array */[
                                                                                                                                                               1,
                                                                                                                                                               2,
                                                                                                                                                               3
@@ -1248,7 +1223,7 @@ var suites_001 = /* :: */[
                                                                                                                                                         (function () {
                                                                                                                                                             return /* Eq */Block.__(0, [
                                                                                                                                                                       6,
-                                                                                                                                                                      new Int16Array(/* int array */[
+                                                                                                                                                                      new Int16Array(/* array */[
                                                                                                                                                                             1,
                                                                                                                                                                             2,
                                                                                                                                                                             3
@@ -1332,7 +1307,7 @@ var suites_001 = /* :: */[
                                                                                                                                                                       (function () {
                                                                                                                                                                           return /* Eq */Block.__(0, [
                                                                                                                                                                                     6,
-                                                                                                                                                                                    new Uint16Array(/* int array */[
+                                                                                                                                                                                    new Uint16Array(/* array */[
                                                                                                                                                                                           1,
                                                                                                                                                                                           2,
                                                                                                                                                                                           3
@@ -1418,7 +1393,7 @@ var suites_001 = /* :: */[
                                                                                                                                                                                                   12,
                                                                                                                                                                                                   new Int32Array($$Array.map((function (prim) {
                                                                                                                                                                                                               return prim;
-                                                                                                                                                                                                            }), /* int array */[
+                                                                                                                                                                                                            }), /* array */[
                                                                                                                                                                                                             1,
                                                                                                                                                                                                             2,
                                                                                                                                                                                                             3
@@ -1504,7 +1479,7 @@ var suites_001 = /* :: */[
                                                                                                                                                                                                   (function () {
                                                                                                                                                                                                       return /* Eq */Block.__(0, [
                                                                                                                                                                                                                 12,
-                                                                                                                                                                                                                new Uint32Array(/* int array */[
+                                                                                                                                                                                                                new Uint32Array(/* array */[
                                                                                                                                                                                                                       1,
                                                                                                                                                                                                                       2,
                                                                                                                                                                                                                       3
@@ -1588,7 +1563,7 @@ var suites_001 = /* :: */[
                                                                                                                                                                                                                 (function () {
                                                                                                                                                                                                                     return /* Eq */Block.__(0, [
                                                                                                                                                                                                                               12,
-                                                                                                                                                                                                                              new Float32Array(/* float array */[
+                                                                                                                                                                                                                              new Float32Array(/* array */[
                                                                                                                                                                                                                                     1,
                                                                                                                                                                                                                                     2,
                                                                                                                                                                                                                                     3
@@ -1642,7 +1617,7 @@ var suites_001 = /* :: */[
                                                                                                                                                                                                                         /* tuple */[
                                                                                                                                                                                                                           "float32_array - unsafe_set - typed_array sanity check",
                                                                                                                                                                                                                           (function () {
-                                                                                                                                                                                                                              var a = new Float32Array(/* float array */[
+                                                                                                                                                                                                                              var a = new Float32Array(/* array */[
                                                                                                                                                                                                                                     1,
                                                                                                                                                                                                                                     2,
                                                                                                                                                                                                                                     3,
@@ -1672,7 +1647,7 @@ var suites_001 = /* :: */[
                                                                                                                                                                                                                               (function () {
                                                                                                                                                                                                                                   return /* Eq */Block.__(0, [
                                                                                                                                                                                                                                             24,
-                                                                                                                                                                                                                                            new Float64Array(/* float array */[
+                                                                                                                                                                                                                                            new Float64Array(/* array */[
                                                                                                                                                                                                                                                   1,
                                                                                                                                                                                                                                                   2,
                                                                                                                                                                                                                                                   3
@@ -1726,7 +1701,7 @@ var suites_001 = /* :: */[
                                                                                                                                                                                                                                       /* tuple */[
                                                                                                                                                                                                                                         "float64_array - unsafe_set - typed_array sanity check",
                                                                                                                                                                                                                                         (function () {
-                                                                                                                                                                                                                                            var a = new Float64Array(/* float array */[
+                                                                                                                                                                                                                                            var a = new Float64Array(/* array */[
                                                                                                                                                                                                                                                   1,
                                                                                                                                                                                                                                                   2,
                                                                                                                                                                                                                                                   3,

--- a/jscomp/test/js_undefined_test.js
+++ b/jscomp/test/js_undefined_test.js
@@ -40,8 +40,8 @@ var suites_001 = /* :: */[
         "test - empty",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* true */1,
-                      /* true */1
+                      true,
+                      true
                     ]);
           })
       ],
@@ -50,8 +50,8 @@ var suites_001 = /* :: */[
           "test - 'a",
           (function () {
               return /* Eq */Block.__(0, [
-                        /* false */0,
-                        /* false */0
+                        false,
+                        false
                       ]);
             })
         ],
@@ -83,13 +83,13 @@ var suites_001 = /* :: */[
               /* tuple */[
                 "iter - empty",
                 (function () {
-                    var hit = [/* false */0];
+                    var hit = [false];
                     Js_undefined.iter(undefined, (function () {
-                            hit[0] = /* true */1;
+                            hit[0] = true;
                             return /* () */0;
                           }));
                     return /* Eq */Block.__(0, [
-                              /* false */0,
+                              false,
                               hit[0]
                             ]);
                   })

--- a/jscomp/test/libarg_test.js
+++ b/jscomp/test/libarg_test.js
@@ -45,9 +45,9 @@ function f_bool(b) {
                 ]), b);
 }
 
-var r_set = [/* false */0];
+var r_set = [false];
 
-var r_clear = [/* true */1];
+var r_clear = [true];
 
 function f_string(s) {
   return Curry._1(record(/* Format */[
@@ -359,8 +359,8 @@ function check(r, v, msg) {
 
 function test(argv) {
   current[0] = 0;
-  r_set[0] = /* false */0;
-  r_clear[0] = /* true */1;
+  r_set[0] = false;
+  r_clear[0] = true;
   r_string[0] = "";
   r_int[0] = 0;
   r_float[0] = 0.0;
@@ -443,8 +443,8 @@ function test(argv) {
     };
     List.iter2(f, result, reference);
   }
-  check(r_set, /* true */1, "Set");
-  check(r_clear, /* false */0, "Clear");
+  check(r_set, true, "Set");
+  check(r_clear, false, "Clear");
   check(r_string, "bar", "Set_string");
   check(r_int, 42, "Set_int");
   return check(r_float, 2.72, "Set_float");

--- a/jscomp/test/libqueue_test.js
+++ b/jscomp/test/libqueue_test.js
@@ -37,11 +37,11 @@ var Q = /* module */[
 function does_raise(f, q) {
   try {
     Curry._1(f, q);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Queue.Empty) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }

--- a/jscomp/test/local_exception_test.js
+++ b/jscomp/test/local_exception_test.js
@@ -7,7 +7,7 @@ var A = Caml_exceptions.create("Local_exception_test.A");
 var v = [
   A,
   3,
-  /* true */1
+  true
 ];
 
 var B = Caml_exceptions.create("Local_exception_test.B");

--- a/jscomp/test/map_test.js
+++ b/jscomp/test/map_test.js
@@ -180,12 +180,12 @@ function equal(cmp, m1, m2) {
         _e1 = cons_enum(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -450,9 +450,9 @@ var int_map_suites_001 = /* :: */[
                 ]
               ]);
           return /* Eq */Block.__(0, [
-                    /* true */1,
+                    true,
                     equal((function (x, y) {
-                            return +(x === y);
+                            return x === y;
                           }), u, v)
                   ]);
         })

--- a/jscomp/test/mario_game.js
+++ b/jscomp/test/mario_game.js
@@ -16,7 +16,7 @@ var Actors = /* module */[];
 var Dom_html = /* module */[];
 
 function setup_sprite($staropt$star, $staropt$star$1, $staropt$star$2, img_src, max_frames, max_ticks, frame_size, src_offset) {
-  var loop = $staropt$star ? $staropt$star[0] : /* true */1;
+  var loop = $staropt$star ? $staropt$star[0] : true;
   var bbox_offset = $staropt$star$1 ? $staropt$star$1[0] : /* tuple */[
       0,
       0
@@ -60,7 +60,7 @@ function make_enemy(param) {
                     128
                   ]);
     case 1 : 
-        if (dir !== 0) {
+        if (dir) {
           return setup_sprite(/* None */0, /* Some */[/* tuple */[
                         1,
                         10
@@ -90,7 +90,7 @@ function make_enemy(param) {
                     ]);
         }
     case 2 : 
-        if (dir !== 0) {
+        if (dir) {
           return setup_sprite(/* None */0, /* Some */[/* tuple */[
                         1,
                         10
@@ -253,10 +253,10 @@ function make_type(typ, dir) {
           typ[1],
           dir
         ];
-        if (pt !== 0) {
+        if (pt) {
           var param = spr_type;
           var typ$1 = param[0];
-          if (param[1] !== 0) {
+          if (param[1]) {
             switch (typ$1) {
               case 0 : 
                   return setup_sprite(/* None */0, /* Some */[/* tuple */[
@@ -380,7 +380,7 @@ function make_type(typ, dir) {
         } else {
           var param$1 = spr_type;
           var typ$2 = param$1[0];
-          if (param$1[1] !== 0) {
+          if (param$1[1]) {
             switch (typ$2) {
               case 0 : 
                   return setup_sprite(/* None */0, /* Some */[/* tuple */[
@@ -694,7 +694,7 @@ var Sprite = /* module */[
 ];
 
 function pair_to_xy(pair) {
-  return /* float array */[
+  return /* array */[
           pair[0],
           pair[1]
         ];
@@ -735,7 +735,7 @@ function make$1($staropt$star, $staropt$star$1, part_type, pos, ctx) {
           /* pos */pos$1,
           /* vel */vel$1,
           /* acc */acc$1,
-          /* kill : false */0,
+          /* kill */false,
           /* life */params[/* lifetime */2]
         ];
 }
@@ -775,7 +775,7 @@ function update_vel(part) {
 function $$process(part) {
   part[/* life */6] = part[/* life */6] - 1 | 0;
   if (part[/* life */6] === 0) {
-    part[/* kill */5] = /* true */1;
+    part[/* kill */5] = true;
   }
   update_vel(part);
   var part$1 = part;
@@ -793,7 +793,7 @@ var Particle = /* module */[
 var id_counter = [Pervasives.min_int];
 
 function setup_obj($staropt$star, $staropt$star$1, _) {
-  var has_gravity = $staropt$star ? $staropt$star[0] : /* true */1;
+  var has_gravity = $staropt$star ? $staropt$star[0] : true;
   var speed = $staropt$star$1 ? $staropt$star$1[0] : 1;
   return /* record */[
           /* has_gravity */has_gravity,
@@ -804,7 +804,7 @@ function setup_obj($staropt$star, $staropt$star$1, _) {
 function set_vel_to_speed(obj) {
   var speed = obj[/* params */0][/* speed */1];
   var match = obj[/* dir */6];
-  if (match !== 0) {
+  if (match) {
     obj[/* vel */2][/* x */0] = speed;
     return /* () */0;
   } else {
@@ -827,12 +827,12 @@ function make_type$2(param) {
     case 2 : 
         var param$2 = param[0];
         if (param$2 >= 3) {
-          return setup_obj(/* Some */[/* false */0], /* None */0, /* () */0);
+          return setup_obj(/* Some */[false], /* None */0, /* () */0);
         } else {
           return setup_obj(/* None */0, /* None */0, /* () */0);
         }
     case 3 : 
-        return setup_obj(/* Some */[/* false */0], /* None */0, /* () */0);
+        return setup_obj(/* Some */[false], /* None */0, /* () */0);
     
   }
 }
@@ -850,22 +850,22 @@ function make$2($staropt$star, $staropt$star$1, spawnable, context, param) {
   var id$1 = id ? id[0] : new_id(/* () */0);
   var obj = /* record */[
     /* params */params,
-    /* pos : float array */[
+    /* pos : array */[
       param[0],
       param[1]
     ],
-    /* vel : float array */[
+    /* vel : array */[
       0.0,
       0.0
     ],
     /* id */id$1,
-    /* jumping : false */0,
-    /* grounded : false */0,
+    /* jumping */false,
+    /* grounded */false,
     /* dir */dir,
     /* invuln */0,
-    /* kill : false */0,
+    /* kill */false,
     /* health */1,
-    /* crouch : false */0,
+    /* crouch */false,
     /* score */0
   ];
   return /* tuple */[
@@ -921,22 +921,22 @@ function get_obj(param) {
 
 function is_player(param) {
   if (param.tag) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
 function is_enemy(param) {
   if (param.tag === 1) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function equals(col1, col2) {
-  return +(col1[2][/* id */3] === col2[2][/* id */3]);
+  return col1[2][/* id */3] === col2[2][/* id */3];
 }
 
 function normalize_pos(pos, p1, p2) {
@@ -980,8 +980,8 @@ function update_player(player, keys, context) {
                 }
             case 2 : 
                 if (!player$1[/* jumping */4] && player$1[/* grounded */5]) {
-                  player$1[/* jumping */4] = /* true */1;
-                  player$1[/* grounded */5] = /* false */0;
+                  player$1[/* jumping */4] = true;
+                  player$1[/* grounded */5] = false;
                   player$1[/* vel */2][/* y */1] = Caml_primitive.caml_float_max(player$1[/* vel */2][/* y */1] - (5.7 + Math.abs(player$1[/* vel */2][/* x */0]) * 0.25), -6);
                   return /* () */0;
                 } else {
@@ -989,7 +989,7 @@ function update_player(player, keys, context) {
                 }
             case 3 : 
                 if (!player$1[/* jumping */4] && player$1[/* grounded */5]) {
-                  player$1[/* crouch */10] = /* true */1;
+                  player$1[/* crouch */10] = true;
                   return /* () */0;
                 } else {
                   return 0;
@@ -1072,7 +1072,7 @@ function process_obj(obj, mapy) {
   update_vel$1(obj);
   update_pos(obj);
   if (obj[/* pos */1][/* y */1] > mapy) {
-    obj[/* kill */8] = /* true */1;
+    obj[/* kill */8] = true;
     return /* () */0;
   } else {
     return 0;
@@ -1089,7 +1089,7 @@ function normalize_origin(pos, spr) {
 }
 
 function collide_block($staropt$star, dir, obj) {
-  var check_x = $staropt$star ? $staropt$star[0] : /* true */1;
+  var check_x = $staropt$star ? $staropt$star[0] : true;
   if (dir !== 1) {
     if (dir !== 0) {
       if (check_x) {
@@ -1104,23 +1104,15 @@ function collide_block($staropt$star, dir, obj) {
     }
   } else {
     obj[/* vel */2][/* y */1] = 0;
-    obj[/* grounded */5] = /* true */1;
-    obj[/* jumping */4] = /* false */0;
+    obj[/* grounded */5] = true;
+    obj[/* jumping */4] = false;
     return /* () */0;
-  }
-}
-
-function opposite_dir(dir) {
-  if (dir !== 0) {
-    return /* Left */0;
-  } else {
-    return /* Right */1;
   }
 }
 
 function reverse_left_right(obj) {
   obj[/* vel */2][/* x */0] = -obj[/* vel */2][/* x */0];
-  obj[/* dir */6] = opposite_dir(obj[/* dir */6]);
+  obj[/* dir */6] = obj[/* dir */6] ? /* Left */0 : /* Right */1;
   return /* () */0;
 }
 
@@ -1128,7 +1120,7 @@ function evolve_enemy(player_dir, typ, spr, obj, context) {
   var exit = 0;
   switch (typ) {
     case 0 : 
-        obj[/* kill */8] = /* true */1;
+        obj[/* kill */8] = true;
         return /* None */0;
     case 1 : 
         var match = make$2(/* None */0, /* Some */[obj[/* dir */6]], /* SEnemy */Block.__(1, [/* GKoopaShell */3]), context, /* tuple */[
@@ -1184,7 +1176,7 @@ function rev_dir(o, t, s) {
 function dec_health(obj) {
   var health = obj[/* health */9] - 1 | 0;
   if (health === 0) {
-    obj[/* kill */8] = /* true */1;
+    obj[/* kill */8] = true;
     return /* () */0;
   } else if (obj[/* invuln */7] === 0) {
     obj[/* health */9] = health;
@@ -1214,7 +1206,7 @@ function spawn_above(player_dir, obj, typ, context) {
       ]);
   var item_obj = item[2];
   item_obj[/* pos */1][/* y */1] = item_obj[/* pos */1][/* y */1] - item[1][/* params */0][/* frame_size */3][1];
-  item_obj[/* dir */6] = opposite_dir(player_dir);
+  item_obj[/* dir */6] = player_dir ? /* Left */0 : /* Right */1;
   set_vel_to_speed(item_obj);
   return item;
 }
@@ -1229,11 +1221,11 @@ function get_aabb(obj) {
   var sy = match$1[1];
   var sx = match$1[0];
   return /* record */[
-          /* center : float array */[
+          /* center : array */[
             box + sx / 2,
             boy + sy / 2
           ],
-          /* half : float array */[
+          /* half : array */[
             sx / 2,
             sy / 2
           ]
@@ -1246,31 +1238,31 @@ function col_bypass(c1, c2) {
   var ctypes;
   switch (c1.tag | 0) {
     case 0 : 
-        ctypes = c2.tag === 1 && c1[2][/* invuln */7] > 0 ? /* true */1 : /* false */0;
+        ctypes = c2.tag === 1 && c1[2][/* invuln */7] > 0 ? true : false;
         break;
     case 1 : 
-        ctypes = c2.tag === 2 ? /* true */1 : /* false */0;
+        ctypes = c2.tag === 2 ? true : false;
         break;
     case 2 : 
         switch (c2.tag | 0) {
           case 1 : 
           case 2 : 
-              ctypes = /* true */1;
+              ctypes = true;
               break;
           case 0 : 
           case 3 : 
-              ctypes = /* false */0;
+              ctypes = false;
               break;
           
         }
         break;
     case 3 : 
-        ctypes = /* false */0;
+        ctypes = false;
         break;
     
   }
   if (o1[/* kill */8] || o2[/* kill */8]) {
-    return /* true */1;
+    return true;
   } else {
     return ctypes;
   }
@@ -1520,15 +1512,15 @@ var Draw = /* module */[
 
 function make$3(param, param$1) {
   return /* record */[
-          /* pos : float array */[
+          /* pos : array */[
             0,
             0
           ],
-          /* v_dim : float array */[
+          /* v_dim : array */[
             param[0],
             param[1]
           ],
-          /* m_dim : float array */[
+          /* m_dim : array */[
             param$1[0],
             param$1[1]
           ]
@@ -1548,19 +1540,19 @@ function in_viewport(v, pos) {
   var x = pos[/* x */0];
   var y = pos[/* y */1];
   if (x >= v_min_x && x <= v_max_x && y >= v_min_y) {
-    return +(y <= v_max_y);
+    return y <= v_max_y;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function out_of_viewport_below(v, y) {
   var v_max_y = v[/* pos */0][/* y */1] + v[/* v_dim */1][/* y */1];
-  return +(y >= v_max_y);
+  return y >= v_max_y;
 }
 
 function coord_to_viewport(viewport, coord) {
-  return /* float array */[
+  return /* array */[
           coord[/* x */0] - viewport[/* pos */0][/* x */0],
           coord[/* y */1] - viewport[/* pos */0][/* y */1]
         ];
@@ -1569,7 +1561,7 @@ function coord_to_viewport(viewport, coord) {
 function update(vpt, ctr) {
   var new_x = calc_viewport_point(ctr[/* x */0], vpt[/* v_dim */1][/* x */0], vpt[/* m_dim */2][/* x */0]);
   var new_y = calc_viewport_point(ctr[/* y */1], vpt[/* v_dim */1][/* y */1], vpt[/* m_dim */2][/* y */1]);
-  var pos = /* float array */[
+  var pos = /* array */[
     new_x,
     new_y
   ];
@@ -1590,10 +1582,10 @@ var Viewport = /* module */[
 ];
 
 var pressed_keys = /* record */[
-  /* left : false */0,
-  /* right : false */0,
-  /* up : false */0,
-  /* down : false */0,
+  /* left */false,
+  /* right */false,
+  /* up */false,
+  /* down */false,
   /* bbox */0
 ];
 
@@ -1934,8 +1926,8 @@ function process_collision(dir, c1, c2, state) {
         var state$1 = state;
         var context$1 = context;
         o1$7[/* invuln */7] = 10;
-        o1$7[/* jumping */4] = /* false */0;
-        o1$7[/* grounded */5] = /* true */1;
+        o1$7[/* jumping */4] = false;
+        o1$7[/* grounded */5] = true;
         if (typ$2 >= 3) {
           var r2 = evolve_enemy(o1$7[/* dir */6], typ$2, s2$4, o2$8, context$1);
           o1$7[/* vel */2][/* y */1] = -4;
@@ -2025,7 +2017,7 @@ function broad_phase(collid, all_collids, state) {
   var obj = collid[2];
   return List.filter((function () {
                   if (in_viewport(state[/* vpt */2], obj[/* pos */1]) || is_player(collid)) {
-                    return /* true */1;
+                    return true;
                   } else {
                     return out_of_viewport_below(state[/* vpt */2], obj[/* pos */1][/* y */1]);
                   }
@@ -2106,7 +2098,7 @@ function update_collidable(state, collid, all_collids) {
   obj[/* invuln */7] = obj[/* invuln */7] > 0 ? obj[/* invuln */7] - 1 | 0 : 0;
   var viewport_filter = in_viewport(state[/* vpt */2], obj[/* pos */1]) || is_player(collid) || out_of_viewport_below(state[/* vpt */2], obj[/* pos */1][/* y */1]);
   if (!obj[/* kill */8] && viewport_filter) {
-    obj[/* grounded */5] = /* false */0;
+    obj[/* grounded */5] = false;
     process_obj(obj, state[/* map */3]);
     var evolved = check_collisions(collid, all_collids, state);
     var vpt_adj_xy = coord_to_viewport(state[/* vpt */2], obj[/* pos */1]);
@@ -2185,7 +2177,7 @@ function run_update_collid(state, collid, all_collids) {
   } else {
     var o = collid[2];
     var keys = translate_keys(/* () */0);
-    o[/* crouch */10] = /* false */0;
+    o[/* crouch */10] = false;
     var match = update_player(o, keys, state[/* ctx */1]);
     var player;
     if (match) {
@@ -2223,11 +2215,11 @@ function update_loop(canvas, param, map_dim) {
     /* score */0,
     /* coins */0,
     /* multiplier */1,
-    /* game_over : false */0
+    /* game_over */false
   ];
   state[/* ctx */1].scale(1, 1);
   var update_helper = function (time, state, player, objs, parts) {
-    if (state[/* game_over */7] === /* true */1) {
+    if (state[/* game_over */7] === true) {
       return game_win(state[/* ctx */1]);
     } else {
       collid_objs[0] = /* [] */0;
@@ -2239,7 +2231,7 @@ function update_loop(canvas, param, map_dim) {
       var bgd_width = state[/* bgd */0][/* params */0][/* frame_size */3][0] | 0;
       draw_bgd(state[/* bgd */0], Caml_int32.mod_(vpos_x_int, bgd_width));
       var player$1 = run_update_collid(state, player, objs);
-      if (player$1[2][/* kill */8] === /* true */1) {
+      if (player$1[2][/* kill */8] === true) {
         return game_loss(state[/* ctx */1]);
       } else {
         var newrecord = state.slice();
@@ -2287,16 +2279,16 @@ function keydown(evt) {
     if (!(switcher > 22 || switcher < 0)) {
       switch (switcher) {
         case 0 : 
-            pressed_keys[/* left */0] = /* true */1;
+            pressed_keys[/* left */0] = true;
             break;
         case 1 : 
             pressed_keys[/* bbox */4] = (pressed_keys[/* bbox */4] + 1 | 0) % 2;
             break;
         case 3 : 
-            pressed_keys[/* right */1] = /* true */1;
+            pressed_keys[/* right */1] = true;
             break;
         case 18 : 
-            pressed_keys[/* down */3] = /* true */1;
+            pressed_keys[/* down */3] = true;
             break;
         case 2 : 
         case 4 : 
@@ -2318,7 +2310,7 @@ function keydown(evt) {
         case 21 : 
             break;
         case 22 : 
-            pressed_keys[/* up */2] = /* true */1;
+            pressed_keys[/* up */2] = true;
             break;
         
       }
@@ -2332,17 +2324,17 @@ function keydown(evt) {
       case 4 : 
           break;
       case 5 : 
-          pressed_keys[/* left */0] = /* true */1;
+          pressed_keys[/* left */0] = true;
           break;
       case 0 : 
       case 6 : 
-          pressed_keys[/* up */2] = /* true */1;
+          pressed_keys[/* up */2] = true;
           break;
       case 7 : 
-          pressed_keys[/* right */1] = /* true */1;
+          pressed_keys[/* right */1] = true;
           break;
       case 8 : 
-          pressed_keys[/* down */3] = /* true */1;
+          pressed_keys[/* down */3] = true;
           break;
       
     }
@@ -2358,17 +2350,17 @@ function keyup(evt) {
         if (match >= 69) {
           
         } else {
-          pressed_keys[/* right */1] = /* false */0;
+          pressed_keys[/* right */1] = false;
         }
       } else {
-        pressed_keys[/* up */2] = /* false */0;
+        pressed_keys[/* up */2] = false;
       }
     } else {
-      pressed_keys[/* down */3] = /* false */0;
+      pressed_keys[/* down */3] = false;
     }
   } else if (match >= 41) {
     if (match === 65) {
-      pressed_keys[/* left */0] = /* false */0;
+      pressed_keys[/* left */0] = false;
     }
     
   } else if (match >= 32) {
@@ -2379,17 +2371,17 @@ function keyup(evt) {
       case 4 : 
           break;
       case 5 : 
-          pressed_keys[/* left */0] = /* false */0;
+          pressed_keys[/* left */0] = false;
           break;
       case 0 : 
       case 6 : 
-          pressed_keys[/* up */2] = /* false */0;
+          pressed_keys[/* up */2] = false;
           break;
       case 7 : 
-          pressed_keys[/* right */1] = /* false */0;
+          pressed_keys[/* right */1] = false;
           break;
       case 8 : 
-          pressed_keys[/* down */3] = /* false */0;
+          pressed_keys[/* down */3] = false;
           break;
       
     }
@@ -2408,13 +2400,13 @@ function mem_loc(checkloc, _loclist) {
     var loclist = _loclist;
     if (loclist) {
       if (Caml_obj.caml_equal(checkloc, loclist[0][1])) {
-        return /* true */1;
+        return true;
       } else {
         _loclist = loclist[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }

--- a/jscomp/test/module_as_function.js
+++ b/jscomp/test/module_as_function.js
@@ -3,7 +3,7 @@
 var Nightmare = require("nightmare");
 
 var v = Nightmare({
-      show: /* true */1
+      show: true
     });
 
 exports.v = v;

--- a/jscomp/test/mt.js
+++ b/jscomp/test/mt.js
@@ -20,15 +20,15 @@ function is_mocha() {
     if (match$1) {
       var exec = Path.basename(match$1[0]);
       if (exec === "mocha") {
-        return /* true */1;
+        return true;
       } else {
-        return +(exec === "_mocha");
+        return exec === "_mocha";
       }
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -52,7 +52,7 @@ function from_suites(name, suite) {
 
 function close_enough($staropt$star, a, b) {
   var threshold = $staropt$star ? $staropt$star[0] : 0.0000001;
-  return +(Math.abs(a - b) < threshold);
+  return Math.abs(a - b) < threshold;
 }
 
 function handleCode(spec) {
@@ -70,25 +70,24 @@ function handleCode(spec) {
         Assert.notStrictEqual(spec[0], spec[1]);
         return /* () */0;
     case 4 : 
-        var b = spec[0];
-        Assert.ok(b ? true : false);
+        Assert.ok(spec[0]);
         return /* () */0;
     case 5 : 
-        var b$1 = spec[1];
+        var b = spec[1];
         var a = spec[0];
-        if (close_enough(/* None */0, a, b$1)) {
+        if (close_enough(/* None */0, a, b)) {
           return 0;
         } else {
-          Assert.deepEqual(a, b$1);
+          Assert.deepEqual(a, b);
           return /* () */0;
         }
     case 6 : 
-        var b$2 = spec[2];
+        var b$1 = spec[2];
         var a$1 = spec[1];
-        if (close_enough(/* Some */[spec[0]], a$1, b$2)) {
+        if (close_enough(/* Some */[spec[0]], a$1, b$1)) {
           return 0;
         } else {
-          Assert.deepEqual(a$1, b$2);
+          Assert.deepEqual(a$1, b$1);
           return /* () */0;
         }
     case 7 : 

--- a/jscomp/test/obj_literal_ppx.js
+++ b/jscomp/test/obj_literal_ppx.js
@@ -3,12 +3,12 @@
 
 var a = {
   x: 3,
-  y: /* int array */[1]
+  y: /* array */[1]
 };
 
 var b = {
   x: 3,
-  y: /* int array */[1],
+  y: /* array */[1],
   z: 3,
   u: (function (x, y) {
       return x + y | 0;

--- a/jscomp/test/obj_magic_test.js
+++ b/jscomp/test/obj_magic_test.js
@@ -14,7 +14,7 @@ var suites_000 = /* tuple */[
   "is_block_test1",
   (function () {
       return /* Eq */Block.__(0, [
-                /* false */0,
+                false,
                 (3).length !== undefined
               ]);
     })
@@ -25,7 +25,7 @@ var suites_001 = /* :: */[
     "is_block_test2",
     (function () {
         return /* Eq */Block.__(0, [
-                  /* true */1,
+                  true,
                   /* :: */[
                     3,
                     /* [] */0
@@ -38,7 +38,7 @@ var suites_001 = /* :: */[
       "is_block_test3",
       (function () {
           return /* Eq */Block.__(0, [
-                    /* true */1,
+                    true,
                     "x".length !== undefined
                   ]);
         })
@@ -48,7 +48,7 @@ var suites_001 = /* :: */[
         "is_block_test4",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* false */0,
+                      false,
                       (3.0).length !== undefined
                     ]);
           })

--- a/jscomp/test/obj_test.js
+++ b/jscomp/test/obj_test.js
@@ -164,11 +164,11 @@ var suites_000 = /* tuple */[
   "single_obj",
   (function () {
       return /* Eq */Block.__(0, [
-                /* int array */[
+                /* array */[
                   3,
                   32
                 ],
-                /* int array */[
+                /* array */[
                   Caml_oo_curry.js1(120, 1, v),
                   Caml_oo_curry.js1(121, 2, v)
                 ]
@@ -181,11 +181,11 @@ var suites_001 = /* :: */[
     "single_obj_cache",
     (function () {
         return /* Eq */Block.__(0, [
-                  /* int array */[
+                  /* array */[
                     3,
                     32
                   ],
-                  /* int array */[
+                  /* array */[
                     Caml_oo_curry.js1(120, 3, v),
                     Caml_oo_curry.js1(121, 4, v)
                   ]

--- a/jscomp/test/ocaml_parsetree_test.js
+++ b/jscomp/test/ocaml_parsetree_test.js
@@ -36,18 +36,18 @@ var CamlinternalLazy = require("../../lib/js/camlinternalLazy.js");
 var Caml_missing_polyfill = require("../../lib/js/caml_missing_polyfill.js");
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js");
 
-var fast = [/* false */0];
+var fast = [false];
 
-var applicative_functors = [/* true */1];
+var applicative_functors = [true];
 
 var bs_vscode;
 
 try {
   Caml_sys.caml_sys_getenv("BS_VSCODE");
-  bs_vscode = /* true */1;
+  bs_vscode = true;
 }
 catch (exn){
-  bs_vscode = /* false */0;
+  bs_vscode = false;
 }
 
 var color = [/* Auto */0];
@@ -156,7 +156,7 @@ function style_of_tag(s) {
   }
 }
 
-var color_enabled = [/* true */1];
+var color_enabled = [true];
 
 function set_color_tag_handling(ppf) {
   var functions = Format.pp_get_formatter_tag_functions(ppf, /* () */0);
@@ -211,11 +211,11 @@ function set_color_tag_handling(ppf) {
     functions$prime_002,
     functions$prime_003
   ];
-  ppf[/* pp_mark_tags */21] = /* true */1;
+  ppf[/* pp_mark_tags */21] = true;
   return Format.pp_set_formatter_tag_functions(ppf, functions$prime);
 }
 
-var first = [/* true */1];
+var first = [true];
 
 var formatter_l_001 = /* :: */[
   Format.err_formatter,
@@ -232,17 +232,17 @@ var formatter_l = /* :: */[
 
 function setup(o) {
   if (first[0]) {
-    first[0] = /* false */0;
-    Format.set_mark_tags(/* true */1);
+    first[0] = false;
+    Format.set_mark_tags(true);
     List.iter(set_color_tag_handling, formatter_l);
     var tmp;
     switch (o) {
       case 1 : 
-          tmp = /* true */1;
+          tmp = true;
           break;
       case 0 : 
       case 2 : 
-          tmp = /* false */0;
+          tmp = false;
           break;
       
     }
@@ -552,8 +552,8 @@ function letter(param) {
 }
 
 var current = [/* record */[
-    /* active */Caml_array.caml_make_vect(51, /* true */1),
-    /* error */Caml_array.caml_make_vect(51, /* false */0)
+    /* active */Caml_array.caml_make_vect(51, true),
+    /* error */Caml_array.caml_make_vect(51, false)
   ]];
 
 function is_active(x) {
@@ -562,14 +562,14 @@ function is_active(x) {
 
 function parse_opt(error, active, flags, s) {
   var set = function (i) {
-    return Caml_array.caml_array_set(flags, i, /* true */1);
+    return Caml_array.caml_array_set(flags, i, true);
   };
   var clear = function (i) {
-    return Caml_array.caml_array_set(flags, i, /* false */0);
+    return Caml_array.caml_array_set(flags, i, false);
   };
   var set_all = function (i) {
-    Caml_array.caml_array_set(active, i, /* true */1);
-    return Caml_array.caml_array_set(error, i, /* true */1);
+    Caml_array.caml_array_set(active, i, true);
+    return Caml_array.caml_array_set(error, i, true);
   };
   var get_num = function (_n, _i) {
     while(true) {
@@ -737,9 +737,9 @@ function parse_options(errflag, s) {
   return /* () */0;
 }
 
-parse_options(/* false */0, "+a-4-6-7-9-27-29-32..39-41..42-44-45-48-50");
+parse_options(false, "+a-4-6-7-9-27-29-32..39-41..42-44-45-48-50");
 
-parse_options(/* true */1, "-a");
+parse_options(true, "-a");
 
 function message(param) {
   if (typeof param === "number") {
@@ -938,18 +938,18 @@ function message(param) {
           return "unused ancestor variable " + (param[0] + ".");
       case 21 : 
           var s$2 = param[0];
-          if (param[1] !== 0) {
+          if (param[1]) {
             return "constructor " + (s$2 + " is never used to build values.\n(However, this constructor appears in patterns.)");
-          } else if (param[2] !== 0) {
+          } else if (param[2]) {
             return "constructor " + (s$2 + " is never used to build values.\nIts type is exported as a private type.");
           } else {
             return "unused constructor " + (s$2 + ".");
           }
       case 22 : 
           var s$3 = param[0];
-          if (param[1] !== 0) {
+          if (param[1]) {
             return "extension constructor " + (s$3 + " is never used to build values.\n(However, this constructor appears in patterns.)");
-          } else if (param[2] !== 0) {
+          } else if (param[2]) {
             return "extension constructor " + (s$3 + " is never used to build values.\nIt is exported or rebound as a private extension.");
           } else {
             return "unused extension constructor " + (s$3 + ".");
@@ -958,13 +958,13 @@ function message(param) {
           var slist$2 = param[1];
           var ty = param[0];
           var exit = 0;
-          if (slist$2 && !(slist$2[1] || param[2] !== 0)) {
+          if (slist$2 && !(slist$2[1] || param[2])) {
             return slist$2[0] + (" was selected from type " + (ty + ".\nIt is not visible in the current scope, and will not \nbe selected if the type becomes unknown."));
           } else {
             exit = 1;
           }
           if (exit === 1) {
-            if (param[2] !== 0) {
+            if (param[2]) {
               return "this record of type " + (ty + (" contains fields that are \nnot visible in the current scope: " + ($$String.concat(" ", slist$2) + ".\nThey will not be selected if the type becomes unknown.")));
             } else {
               throw [
@@ -981,13 +981,13 @@ function message(param) {
       case 24 : 
           var slist$3 = param[0];
           var exit$1 = 0;
-          if (slist$3 && !(slist$3[1] || param[2] !== 0)) {
+          if (slist$3 && !(slist$3[1] || param[2])) {
             return slist$3[0] + (" belongs to several types: " + ($$String.concat(" ", param[1]) + "\nThe first one was selected. Please disambiguate if this is wrong."));
           } else {
             exit$1 = 1;
           }
           if (exit$1 === 1) {
-            if (param[2] !== 0) {
+            if (param[2]) {
               return "these field labels belong to several types: " + ($$String.concat(" ", param[1]) + "\nThe first one was selected. Please disambiguate if this is wrong.");
             } else {
               throw [
@@ -1141,7 +1141,7 @@ function print(ppf, w) {
 
 var Errors = Caml_exceptions.create("Ocaml_parsetree_test.Warnings.Errors");
 
-var absname = [/* false */0];
+var absname = [false];
 
 function in_file(name) {
   var loc = /* record */[
@@ -1153,7 +1153,7 @@ function in_file(name) {
   return /* record */[
           /* loc_start */loc,
           /* loc_end */loc,
-          /* loc_ghost : true */1
+          /* loc_ghost */true
         ];
 }
 
@@ -1163,7 +1163,7 @@ function curr(lexbuf) {
   return /* record */[
           /* loc_start */lexbuf[/* lex_start_p */10],
           /* loc_end */lexbuf[/* lex_curr_p */11],
-          /* loc_ghost : false */0
+          /* loc_ghost */false
         ];
 }
 
@@ -1171,7 +1171,7 @@ function symbol_rloc() {
   return /* record */[
           /* loc_start */Parsing.symbol_start_pos(/* () */0),
           /* loc_end */Parsing.symbol_end_pos(/* () */0),
-          /* loc_ghost : false */0
+          /* loc_ghost */false
         ];
 }
 
@@ -1179,7 +1179,7 @@ function symbol_gloc() {
   return /* record */[
           /* loc_start */Parsing.symbol_start_pos(/* () */0),
           /* loc_end */Parsing.symbol_end_pos(/* () */0),
-          /* loc_ghost : true */1
+          /* loc_ghost */true
         ];
 }
 
@@ -1187,7 +1187,7 @@ function rhs_loc(n) {
   return /* record */[
           /* loc_start */Parsing.rhs_start_pos(n),
           /* loc_end */Parsing.rhs_end_pos(n),
-          /* loc_ghost : false */0
+          /* loc_ghost */false
         ];
 }
 
@@ -1217,30 +1217,30 @@ function highlight_terminfo(ppf, num_lines, lb, locs) {
   }
   Caml_io.caml_ml_flush(Pervasives.stdout);
   Caml_missing_polyfill.not_implemented("caml_terminfo_backup not implemented by bucklescript yet\n");
-  var bol = /* false */0;
+  var bol = false;
   Pervasives.print_string("# ");
   for(var pos = 0 ,pos_finish = (lb[/* lex_buffer_len */2] - pos0 | 0) - 1 | 0; pos <= pos_finish; ++pos){
     if (bol) {
       Pervasives.print_string("  ");
-      bol = /* false */0;
+      bol = false;
     }
     if (List.exists((function(pos){
           return function (loc) {
-            return +(pos === loc[/* loc_start */0][/* pos_cnum */3]);
+            return pos === loc[/* loc_start */0][/* pos_cnum */3];
           }
           }(pos)), locs)) {
       Caml_missing_polyfill.not_implemented("caml_terminfo_standout not implemented by bucklescript yet\n");
     }
     if (List.exists((function(pos){
           return function (loc) {
-            return +(pos === loc[/* loc_end */1][/* pos_cnum */3]);
+            return pos === loc[/* loc_end */1][/* pos_cnum */3];
           }
           }(pos)), locs)) {
       Caml_missing_polyfill.not_implemented("caml_terminfo_standout not implemented by bucklescript yet\n");
     }
     var c = Caml_bytes.get(lb[/* lex_buffer */1], pos + pos0 | 0);
     Pervasives.print_char(c);
-    bol = +(c === /* "\n" */10);
+    bol = c === /* "\n" */10;
   }
   Caml_missing_polyfill.not_implemented("caml_terminfo_standout not implemented by bucklescript yet\n");
   Caml_missing_polyfill.not_implemented("caml_terminfo_resume not implemented by bucklescript yet\n");
@@ -1368,33 +1368,33 @@ function highlight_locations(ppf, locs) {
         if (match$1) {
           var norepeat;
           try {
-            norepeat = +(Caml_sys.caml_sys_getenv("TERM") === "norepeat");
+            norepeat = Caml_sys.caml_sys_getenv("TERM") === "norepeat";
           }
           catch (exn){
             if (exn === Caml_builtin_exceptions.not_found) {
-              norepeat = /* false */0;
+              norepeat = false;
             } else {
               throw exn;
             }
           }
           if (norepeat) {
-            return /* false */0;
+            return false;
           } else {
             var loc1 = List.hd(locs);
             try {
               highlight_dumb(ppf, match$1[0], loc1);
-              return /* true */1;
+              return true;
             }
             catch (exn$1){
               if (exn$1 === Pervasives.Exit) {
-                return /* false */0;
+                return false;
               } else {
                 throw exn$1;
               }
             }
           }
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
         status[0] = Caml_missing_polyfill.not_implemented("caml_terminfo_setup not implemented by bucklescript yet\n");
@@ -1405,17 +1405,17 @@ function highlight_locations(ppf, locs) {
       if (match$2) {
         try {
           highlight_terminfo(ppf, match[0], match$2[0], locs);
-          return /* true */1;
+          return true;
         }
         catch (exn$2){
           if (exn$2 === Pervasives.Exit) {
-            return /* false */0;
+            return false;
           } else {
             throw exn$2;
           }
         }
       } else {
-        return /* false */0;
+        return false;
       }
     }
   };
@@ -1820,21 +1820,21 @@ function is_mocha() {
     if (match$1) {
       var exec = Path.basename(match$1[0]);
       if (exec === "mocha") {
-        return /* true */1;
+        return true;
       } else {
-        return +(exec === "_mocha");
+        return exec === "_mocha";
       }
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function close_enough($staropt$star, a, b) {
   var threshold = $staropt$star ? $staropt$star[0] : 0.0000001;
-  return +(Math.abs(a - b) < threshold);
+  return Math.abs(a - b) < threshold;
 }
 
 function from_pair_suites(name, suites) {
@@ -1860,25 +1860,24 @@ function from_pair_suites(name, suites) {
                                           Assert.notStrictEqual(match[0], match[1]);
                                           return /* () */0;
                                       case 4 : 
-                                          var b = match[0];
-                                          Assert.ok(b ? true : false);
+                                          Assert.ok(match[0]);
                                           return /* () */0;
                                       case 5 : 
-                                          var b$1 = match[1];
+                                          var b = match[1];
                                           var a = match[0];
-                                          if (close_enough(/* None */0, a, b$1)) {
+                                          if (close_enough(/* None */0, a, b)) {
                                             return 0;
                                           } else {
-                                            Assert.deepEqual(a, b$1);
+                                            Assert.deepEqual(a, b);
                                             return /* () */0;
                                           }
                                       case 6 : 
-                                          var b$2 = match[2];
+                                          var b$1 = match[2];
                                           var a$1 = match[1];
-                                          if (close_enough(/* Some */[match[0]], a$1, b$2)) {
+                                          if (close_enough(/* Some */[match[0]], a$1, b$1)) {
                                             return 0;
                                           } else {
-                                            Assert.deepEqual(a$1, b$2);
+                                            Assert.deepEqual(a$1, b$1);
                                             return /* () */0;
                                           }
                                       case 7 : 
@@ -1984,18 +1983,18 @@ function from_pair_suites(name, suites) {
 var docstrings = [/* [] */0];
 
 function warn_bad_docstrings() {
-  if (is_active(/* Bad_docstring */Block.__(33, [/* true */1]))) {
+  if (is_active(/* Bad_docstring */Block.__(33, [true]))) {
     return List.iter((function (ds) {
                   var match = ds[/* ds_attached */2];
                   switch (match) {
                     case 0 : 
-                        return prerr_warning(ds[/* ds_loc */1], /* Bad_docstring */Block.__(33, [/* true */1]));
+                        return prerr_warning(ds[/* ds_loc */1], /* Bad_docstring */Block.__(33, [true]));
                     case 1 : 
                         return /* () */0;
                     case 2 : 
                         var match$1 = ds[/* ds_associated */3];
                         if (match$1 >= 2) {
-                          return prerr_warning(ds[/* ds_loc */1], /* Bad_docstring */Block.__(33, [/* false */0]));
+                          return prerr_warning(ds[/* ds_loc */1], /* Bad_docstring */Block.__(33, [false]));
                         } else {
                           return /* () */0;
                         }
@@ -2200,7 +2199,7 @@ function get_pre_docs(pos) {
   try {
     var dsl = Hashtbl.find(pre_table, pos);
     associate_docstrings(dsl);
-    return get_docstring(/* false */0, dsl);
+    return get_docstring(false, dsl);
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
@@ -2238,7 +2237,7 @@ function get_post_docs(pos) {
   try {
     var dsl = Hashtbl.find(post_table, pos);
     associate_docstrings(dsl);
-    return get_docstring(/* false */0, dsl);
+    return get_docstring(false, dsl);
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
@@ -2265,7 +2264,7 @@ function mark_post_docs(pos) {
 function get_info(pos) {
   try {
     var dsl = Hashtbl.find(post_table, pos);
-    return get_docstring(/* true */1, dsl);
+    return get_docstring(true, dsl);
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
@@ -3410,7 +3409,7 @@ function mkoption(d) {
   var loc = /* record */[
     loc_000,
     loc_001,
-    /* loc_ghost : true */1
+    /* loc_ghost */true
   ];
   return mk(/* Some */[loc], /* None */0, /* Ptyp_constr */Block.__(3, [
                 /* record */[
@@ -3530,7 +3529,7 @@ function mktailexp(nilloc, param) {
     var loc = /* record */[
       loc_000,
       loc_001,
-      /* loc_ghost : true */1
+      /* loc_ghost */true
     ];
     var arg = Curry._3(Ast_helper_004[/* mk */0], /* Some */[loc], /* None */0, /* Pexp_tuple */Block.__(8, [/* :: */[
               e1,
@@ -3542,7 +3541,7 @@ function mktailexp(nilloc, param) {
     return mkexp_cons(/* record */[
                 loc_000,
                 loc_001,
-                /* loc_ghost : true */1
+                /* loc_ghost */true
               ], arg, loc);
   } else {
     var loc_000$1 = /* loc_start */nilloc[/* loc_start */0];
@@ -3550,7 +3549,7 @@ function mktailexp(nilloc, param) {
     var loc$1 = /* record */[
       loc_000$1,
       loc_001$1,
-      /* loc_ghost : true */1
+      /* loc_ghost */true
     ];
     var nil_000 = /* txt : Lident */Block.__(0, ["[]"]);
     var nil = /* record */[
@@ -3573,7 +3572,7 @@ function mktailpat(nilloc, param) {
     var loc = /* record */[
       loc_000,
       loc_001,
-      /* loc_ghost : true */1
+      /* loc_ghost */true
     ];
     var arg = mk$1(/* Some */[loc], /* None */0, /* Ppat_tuple */Block.__(4, [/* :: */[
               p1,
@@ -3585,7 +3584,7 @@ function mktailpat(nilloc, param) {
     return mkpat_cons(/* record */[
                 loc_000,
                 loc_001,
-                /* loc_ghost : true */1
+                /* loc_ghost */true
               ], arg, loc);
   } else {
     var loc_000$1 = /* loc_start */nilloc[/* loc_start */0];
@@ -3593,7 +3592,7 @@ function mktailpat(nilloc, param) {
     var loc$1 = /* record */[
       loc_000$1,
       loc_001$1,
-      /* loc_ghost : true */1
+      /* loc_ghost */true
     ];
     var nil_000 = /* txt : Lident */Block.__(0, ["[]"]);
     var nil = /* record */[
@@ -3963,7 +3962,7 @@ function extra_csig(pos, items) {
 }
 
 function add_nonrec(rf, attrs, pos) {
-  if (rf !== 0) {
+  if (rf) {
     return attrs;
   } else {
     var name_001 = /* loc */rhs_loc(pos);
@@ -8316,15 +8315,15 @@ var yyact = /* array */[
       return /* Rtag */Block.__(0, [
                 _1,
                 _2,
-                /* true */1,
+                true,
                 /* [] */0
               ]);
     }),
   (function () {
-      return /* true */1;
+      return true;
     }),
   (function () {
-      return /* false */0;
+      return false;
     }),
   (function (__caml_parser_env) {
       var _1 = Parsing.peek_val(__caml_parser_env, 0);
@@ -8815,14 +8814,14 @@ var yyact = /* array */[
       var _2 = Parsing.peek_val(__caml_parser_env, 1);
       return /* Ptop_dir */Block.__(1, [
                 _2,
-                /* Pdir_bool */Block.__(3, [/* false */0])
+                /* Pdir_bool */Block.__(3, [false])
               ]);
     }),
   (function (__caml_parser_env) {
       var _2 = Parsing.peek_val(__caml_parser_env, 1);
       return /* Ptop_dir */Block.__(1, [
                 _2,
-                /* Pdir_bool */Block.__(3, [/* true */1])
+                /* Pdir_bool */Block.__(3, [true])
               ]);
     }),
   (function (__caml_parser_env) {
@@ -9413,17 +9412,17 @@ function defined(str) {
   catch (exn){
     try {
       Caml_sys.caml_sys_getenv(str);
-      return /* true */1;
+      return true;
     }
     catch (exn$1){
-      return /* false */0;
+      return false;
     }
   }
   if (exit === 1) {
     if (typeof val === "number") {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   }
   
@@ -9446,7 +9445,7 @@ function query(_, str) {
       }
       catch (exn$1){
         if (exn$1 === Caml_builtin_exceptions.not_found) {
-          return /* Dir_bool */Block.__(0, [/* false */0]);
+          return /* Dir_bool */Block.__(0, [false]);
         } else {
           throw exn$1;
         }
@@ -9476,7 +9475,7 @@ function query(_, str) {
   }
   if (exit === 1) {
     if (typeof v === "number") {
-      return /* Dir_bool */Block.__(0, [/* false */0]);
+      return /* Dir_bool */Block.__(0, [false]);
     } else {
       return v;
     }
@@ -9488,9 +9487,9 @@ function value_of_token(loc, t) {
   if (typeof t === "number") {
     switch (t) {
       case 29 : 
-          return /* Dir_bool */Block.__(0, [/* false */0]);
+          return /* Dir_bool */Block.__(0, [false]);
       case 91 : 
-          return /* Dir_bool */Block.__(0, [/* true */1]);
+          return /* Dir_bool */Block.__(0, [true]);
       default:
         throw [
               $$Error$2,
@@ -9686,7 +9685,7 @@ function directive_parse(token_with_comments, lexbuf) {
                     if (pred >= 17049) {
                       if (pred >= 172069535) {
                         if (pred >= 785637236) {
-                          return +(major === l_major);
+                          return major === l_major;
                         } else {
                           return Caml_obj.caml_equal(lversion, version);
                         }
@@ -9699,9 +9698,9 @@ function directive_parse(token_with_comments, lexbuf) {
                       if (pred >= 15949) {
                         return Caml_obj.caml_greaterthan(lversion, version);
                       } else if (major === l_major) {
-                        return +(version[1] === lversion[1]);
+                        return version[1] === lversion[1];
                       } else {
-                        return /* false */0;
+                        return false;
                       }
                     } else {
                       return Caml_obj.caml_greaterequal(lversion, version);
@@ -9732,7 +9731,7 @@ function directive_parse(token_with_comments, lexbuf) {
               }
               
             } else {
-              return /* true */1;
+              return true;
             }
             break;
         case "<=" : 
@@ -9792,7 +9791,7 @@ function directive_parse(token_with_comments, lexbuf) {
       if (calc) {
         return Curry._2(f, lhs, assert_same_type(lexbuf, lhs, rhs$1));
       } else {
-        return /* true */1;
+        return true;
       }
     }
     
@@ -9804,10 +9803,10 @@ function directive_parse(token_with_comments, lexbuf) {
         push(e);
         return v;
       } else {
-        var calc$1 = calc && 1 - v;
+        var calc$1 = calc && !v;
         var b = parse_or_aux(calc$1, parse_and_aux(calc$1, parse_relation(calc$1)));
         if (v) {
-          return /* true */1;
+          return true;
         } else {
           return b;
         }
@@ -9829,7 +9828,7 @@ function directive_parse(token_with_comments, lexbuf) {
         if (v) {
           return b;
         } else {
-          return /* false */0;
+          return false;
         }
       }
     } else {
@@ -9843,7 +9842,7 @@ function directive_parse(token_with_comments, lexbuf) {
     if (typeof curr_token === "number") {
       switch (curr_token) {
         case 29 : 
-            return /* false */0;
+            return false;
         case 54 : 
             var v = parse_or_aux(calc, parse_and_aux(calc, parse_relation(calc)));
             var match = token(/* () */0);
@@ -9865,7 +9864,7 @@ function directive_parse(token_with_comments, lexbuf) {
                   ];
             }
         case 91 : 
-            return /* true */1;
+            return true;
         default:
           throw [
                 $$Error$2,
@@ -9925,12 +9924,12 @@ function directive_parse(token_with_comments, lexbuf) {
                 var s = t[0];
                 if (calc) {
                   if (Caml_string.get(r, 0) === /* "u" */117) {
-                    return 1 - defined(s);
+                    return !defined(s);
                   } else {
                     return defined(s);
                   }
                 } else {
-                  return /* true */1;
+                  return true;
                 }
               } else {
                 throw [
@@ -9984,7 +9983,7 @@ function directive_parse(token_with_comments, lexbuf) {
       }
     }
   };
-  var v = parse_or_aux(/* true */1, parse_and_aux(/* true */1, parse_relation(/* true */1)));
+  var v = parse_or_aux(true, parse_and_aux(true, parse_relation(true)));
   var match = token(/* () */0);
   if (typeof match === "number") {
     if (match !== 88) {
@@ -10007,9 +10006,9 @@ function directive_parse(token_with_comments, lexbuf) {
 
 function is_elif(i) {
   if (typeof i === "number" || !(i.tag === 11 && i[0] === "elif")) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -10391,9 +10390,9 @@ var string_start_loc = [none];
 
 var comment_start_loc = [/* [] */0];
 
-var is_in_string = [/* false */0];
+var is_in_string = [false];
 
-var print_warnings = [/* true */1];
+var print_warnings = [true];
 
 var if_then_else = [/* Dir_out */2];
 
@@ -10551,7 +10550,7 @@ function update_loc(lexbuf, file, line, absolute, chars) {
 
 var preprocessor = [/* None */0];
 
-var escaped_newlines = [/* false */0];
+var escaped_newlines = [false];
 
 function warn_latin1(lexbuf) {
   return prerr_warning(curr(lexbuf), /* Deprecated */Block.__(0, ["ISO-Latin1 characters in identifiers"]));
@@ -10791,10 +10790,10 @@ function token(lexbuf) {
                     curr(lexbuf$1)
                   ];
             }
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf$1, /* None */0, 1, false, 0);
             return token(lexbuf$1);
         case 1 : 
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf$1, /* None */0, 1, false, 0);
             return /* EOL */100;
         case 2 : 
             return token(lexbuf$1);
@@ -10902,11 +10901,11 @@ function token(lexbuf) {
             }
         case 19 : 
             reset_string_buffer(/* () */0);
-            is_in_string[0] = /* true */1;
+            is_in_string[0] = true;
             var string_start = lexbuf$1[/* lex_start_p */10];
             string_start_loc[0] = curr(lexbuf$1);
             string(lexbuf$1);
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             lexbuf$1[/* lex_start_p */10] = string_start;
             return /* STRING */Block.__(16, [/* tuple */[
                         get_stored_string(/* () */0),
@@ -10916,18 +10915,18 @@ function token(lexbuf) {
             reset_string_buffer(/* () */0);
             var delim = Lexing.lexeme(lexbuf$1);
             var delim$1 = $$String.sub(delim, 1, delim.length - 2 | 0);
-            is_in_string[0] = /* true */1;
+            is_in_string[0] = true;
             var string_start$1 = lexbuf$1[/* lex_start_p */10];
             string_start_loc[0] = curr(lexbuf$1);
             __ocaml_lex_quoted_string_rec(delim$1, lexbuf$1, 183);
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             lexbuf$1[/* lex_start_p */10] = string_start$1;
             return /* STRING */Block.__(16, [/* tuple */[
                         get_stored_string(/* () */0),
                         /* Some */[delim$1]
                       ]]);
         case 21 : 
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, 1);
+            update_loc(lexbuf$1, /* None */0, 1, false, 1);
             return /* CHAR */Block.__(0, [Lexing.lexeme_char(lexbuf$1, 1)]);
         case 22 : 
             return /* CHAR */Block.__(0, [Lexing.lexeme_char(lexbuf$1, 1)]);
@@ -10996,7 +10995,7 @@ function token(lexbuf) {
         case 33 : 
             var num = Lexing.sub_lexeme(lexbuf$1, Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 0), Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 1));
             var name = Lexing.sub_lexeme_opt(lexbuf$1, Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 3), Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 2));
-            update_loc(lexbuf$1, name, Caml_format.caml_int_of_string(num), /* true */1, 0);
+            update_loc(lexbuf$1, name, Caml_format.caml_int_of_string(num), true, 0);
             return token(lexbuf$1);
         case 34 : 
             return /* SHARP */84;
@@ -11150,12 +11149,12 @@ function __ocaml_lex_quoted_string_rec(delim, lexbuf, ___ocaml_lex_state) {
     } else {
       switch (__ocaml_lex_state$1) {
         case 0 : 
-            update_loc(lexbuf, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf, /* None */0, 1, false, 0);
             store_string(Lexing.lexeme(lexbuf));
             ___ocaml_lex_state = 183;
             continue ;
         case 1 : 
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             throw [
                   $$Error$2,
                   /* Unterminated_string */0,
@@ -11202,7 +11201,7 @@ function string(lexbuf) {
             return /* () */0;
         case 1 : 
             var space = Lexing.sub_lexeme(lexbuf$1, Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 0), lexbuf$1[/* lex_curr_pos */5]);
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, space.length);
+            update_loc(lexbuf$1, /* None */0, 1, false, space.length);
             return string(lexbuf$1);
         case 2 : 
             store_string_char(char_for_backslash(Lexing.lexeme_char(lexbuf$1, 1)));
@@ -11227,11 +11226,11 @@ function string(lexbuf) {
             if (comment_start_loc[0] === /* [] */0) {
               prerr_warning(curr(lexbuf$1), /* Eol_in_string */14);
             }
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf$1, /* None */0, 1, false, 0);
             store_string(Lexing.lexeme(lexbuf$1));
             return string(lexbuf$1);
         case 7 : 
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             throw [
                   $$Error$2,
                   /* Unterminated_string */0,
@@ -11290,7 +11289,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
         case 2 : 
             string_start_loc[0] = curr(lexbuf);
             store_string_char(/* "\"" */34);
-            is_in_string[0] = /* true */1;
+            is_in_string[0] = true;
             try {
               string(lexbuf);
             }
@@ -11332,7 +11331,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
                 throw exn;
               }
             }
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             store_string_char(/* "\"" */34);
             ___ocaml_lex_state = 132;
             continue ;
@@ -11341,7 +11340,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
             var delim$1 = $$String.sub(delim, 1, delim.length - 2 | 0);
             string_start_loc[0] = curr(lexbuf);
             store_string(Lexing.lexeme(lexbuf));
-            is_in_string[0] = /* true */1;
+            is_in_string[0] = true;
             try {
               __ocaml_lex_quoted_string_rec(delim$1, lexbuf, 183);
             }
@@ -11383,14 +11382,14 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
                 throw exn$1;
               }
             }
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             store_string_char(/* "|" */124);
             store_string(delim$1);
             store_string_char(/* "}" */125);
             ___ocaml_lex_state = 132;
             continue ;
         case 5 : 
-            update_loc(lexbuf, /* None */0, 1, /* false */0, 1);
+            update_loc(lexbuf, /* None */0, 1, false, 1);
             store_string(Lexing.lexeme(lexbuf));
             ___ocaml_lex_state = 132;
             continue ;
@@ -11415,7 +11414,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
                   ];
             }
         case 11 : 
-            update_loc(lexbuf, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf, /* None */0, 1, false, 0);
             store_string(Lexing.lexeme(lexbuf));
             ___ocaml_lex_state = 132;
             continue ;
@@ -11436,7 +11435,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
 
 function at_bol(lexbuf) {
   var pos = lexbuf[/* lex_start_p */10];
-  return +(pos[/* pos_cnum */3] === pos[/* pos_bol */2]);
+  return pos[/* pos_cnum */3] === pos[/* pos_bol */2];
 }
 
 function token_with_comments(lexbuf) {
@@ -11610,7 +11609,7 @@ function token$1(lexbuf) {
                   if (if_then_else$1 !== 0) {
                     return Curry._1(look_ahead, match);
                   } else {
-                    var _else_seen = +(match === /* ELSE */23);
+                    var _else_seen = match === /* ELSE */23;
                     while(true) {
                       var else_seen = _else_seen;
                       var token$2 = token_with_comments(lexbuf$1);
@@ -11636,7 +11635,7 @@ function token$1(lexbuf) {
                                     curr(lexbuf$1)
                                   ];
                             } else {
-                              _else_seen = /* true */1;
+                              _else_seen = true;
                               continue ;
                             }
                           } else if (switcher$1 !== 14) {
@@ -11767,7 +11766,7 @@ function token$1(lexbuf) {
 function init$1() {
   sharp_look_ahead[0] = /* None */0;
   if_then_else[0] = /* Dir_out */2;
-  is_in_string[0] = /* false */0;
+  is_in_string[0] = false;
   comment_start_loc[0] = /* [] */0;
   comment_list[0] = /* [] */0;
   var match = preprocessor[0];
@@ -11902,14 +11901,14 @@ var match = wrap(implementation, Lexing.from_string("let v str = \n  str  \n  |>
 
 if (match) {
   var match$1 = match[0][/* pstr_desc */0];
-  if (match$1.tag === 1 && match$1[0] === 0) {
+  if (match$1.tag === 1 && !match$1[0]) {
     var match$2 = match$1[1];
     if (match$2) {
       var match$3 = match$2[0];
       var match$4 = match$3[/* pvb_pat */0];
       var match$5 = match$4[/* ppat_desc */0];
       if (typeof match$5 === "number" || match$5.tag) {
-        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
       } else {
         var match$6 = match$5[0];
         if (match$6[/* txt */0] === "v") {
@@ -11917,19 +11916,19 @@ if (match) {
           var match$8 = match$7[/* loc_start */0];
           if (match$8[/* pos_fname */0] === "" && !(match$8[/* pos_lnum */1] !== 1 || match$8[/* pos_bol */2] !== 0 || match$8[/* pos_cnum */3] !== 4)) {
             var match$9 = match$7[/* loc_end */1];
-            if (match$9[/* pos_fname */0] === "" && !(match$9[/* pos_lnum */1] !== 1 || match$9[/* pos_bol */2] !== 0 || match$9[/* pos_cnum */3] !== 5 || match$7[/* loc_ghost */2] !== 0)) {
+            if (match$9[/* pos_fname */0] === "" && !(match$9[/* pos_lnum */1] !== 1 || match$9[/* pos_bol */2] !== 0 || match$9[/* pos_cnum */3] !== 5 || match$7[/* loc_ghost */2])) {
               var match$10 = match$4[/* ppat_loc */1];
               var match$11 = match$10[/* loc_start */0];
               if (match$11[/* pos_fname */0] === "" && !(match$11[/* pos_lnum */1] !== 1 || match$11[/* pos_bol */2] !== 0 || match$11[/* pos_cnum */3] !== 4)) {
                 var match$12 = match$10[/* loc_end */1];
-                if (match$12[/* pos_fname */0] === "" && !(match$12[/* pos_lnum */1] !== 1 || match$12[/* pos_bol */2] !== 0 || match$12[/* pos_cnum */3] !== 5 || match$10[/* loc_ghost */2] !== 0 || match$4[/* ppat_attributes */2])) {
+                if (match$12[/* pos_fname */0] === "" && !(match$12[/* pos_lnum */1] !== 1 || match$12[/* pos_bol */2] !== 0 || match$12[/* pos_cnum */3] !== 5 || match$10[/* loc_ghost */2] || match$4[/* ppat_attributes */2])) {
                   var match$13 = match$3[/* pvb_expr */1];
                   var match$14 = match$13[/* pexp_desc */0];
                   if (match$14.tag === 4 && match$14[0] === "" && !match$14[1]) {
                     var match$15 = match$14[2];
                     var match$16 = match$15[/* ppat_desc */0];
                     if (typeof match$16 === "number" || match$16.tag) {
-                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                     } else {
                       var match$17 = match$16[0];
                       if (match$17[/* txt */0] === "str") {
@@ -11937,19 +11936,19 @@ if (match) {
                         var match$19 = match$18[/* loc_start */0];
                         if (match$19[/* pos_fname */0] === "" && !(match$19[/* pos_lnum */1] !== 1 || match$19[/* pos_bol */2] !== 0 || match$19[/* pos_cnum */3] !== 6)) {
                           var match$20 = match$18[/* loc_end */1];
-                          if (match$20[/* pos_fname */0] === "" && !(match$20[/* pos_lnum */1] !== 1 || match$20[/* pos_bol */2] !== 0 || match$20[/* pos_cnum */3] !== 9 || match$18[/* loc_ghost */2] !== 0)) {
+                          if (match$20[/* pos_fname */0] === "" && !(match$20[/* pos_lnum */1] !== 1 || match$20[/* pos_bol */2] !== 0 || match$20[/* pos_cnum */3] !== 9 || match$18[/* loc_ghost */2])) {
                             var match$21 = match$15[/* ppat_loc */1];
                             var match$22 = match$21[/* loc_start */0];
                             if (match$22[/* pos_fname */0] === "" && !(match$22[/* pos_lnum */1] !== 1 || match$22[/* pos_bol */2] !== 0 || match$22[/* pos_cnum */3] !== 6)) {
                               var match$23 = match$21[/* loc_end */1];
-                              if (match$23[/* pos_fname */0] === "" && !(match$23[/* pos_lnum */1] !== 1 || match$23[/* pos_bol */2] !== 0 || match$23[/* pos_cnum */3] !== 9 || match$21[/* loc_ghost */2] !== 0 || match$15[/* ppat_attributes */2])) {
+                              if (match$23[/* pos_fname */0] === "" && !(match$23[/* pos_lnum */1] !== 1 || match$23[/* pos_bol */2] !== 0 || match$23[/* pos_cnum */3] !== 9 || match$21[/* loc_ghost */2] || match$15[/* ppat_attributes */2])) {
                                 var match$24 = match$14[3];
                                 var match$25 = match$24[/* pexp_desc */0];
                                 if (match$25.tag === 5) {
                                   var match$26 = match$25[0];
                                   var match$27 = match$26[/* pexp_desc */0];
                                   if (match$27.tag) {
-                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                   } else {
                                     var match$28 = match$27[0];
                                     var match$29 = match$28[/* txt */0];
@@ -11960,12 +11959,12 @@ if (match) {
                                             var match$31 = match$30[/* loc_start */0];
                                             if (match$31[/* pos_fname */0] === "" && !(match$31[/* pos_lnum */1] !== 4 || match$31[/* pos_bol */2] !== 46 || match$31[/* pos_cnum */3] !== 48)) {
                                               var match$32 = match$30[/* loc_end */1];
-                                              if (match$32[/* pos_fname */0] === "" && !(match$32[/* pos_lnum */1] !== 4 || match$32[/* pos_bol */2] !== 46 || match$32[/* pos_cnum */3] !== 50 || match$30[/* loc_ghost */2] !== 0)) {
+                                              if (match$32[/* pos_fname */0] === "" && !(match$32[/* pos_lnum */1] !== 4 || match$32[/* pos_bol */2] !== 46 || match$32[/* pos_cnum */3] !== 50 || match$30[/* loc_ghost */2])) {
                                                 var match$33 = match$26[/* pexp_loc */1];
                                                 var match$34 = match$33[/* loc_start */0];
                                                 if (match$34[/* pos_fname */0] === "" && !(match$34[/* pos_lnum */1] !== 4 || match$34[/* pos_bol */2] !== 46 || match$34[/* pos_cnum */3] !== 48)) {
                                                   var match$35 = match$33[/* loc_end */1];
-                                                  if (match$35[/* pos_fname */0] === "" && !(match$35[/* pos_lnum */1] !== 4 || match$35[/* pos_bol */2] !== 46 || match$35[/* pos_cnum */3] !== 50 || match$33[/* loc_ghost */2] !== 0 || match$26[/* pexp_attributes */2])) {
+                                                  if (match$35[/* pos_fname */0] === "" && !(match$35[/* pos_lnum */1] !== 4 || match$35[/* pos_bol */2] !== 46 || match$35[/* pos_cnum */3] !== 50 || match$33[/* loc_ghost */2] || match$26[/* pexp_attributes */2])) {
                                                     var match$36 = match$25[1];
                                                     if (match$36) {
                                                       var match$37 = match$36[0];
@@ -11976,7 +11975,7 @@ if (match) {
                                                           var match$40 = match$39[0];
                                                           var match$41 = match$40[/* pexp_desc */0];
                                                           if (match$41.tag) {
-                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                           } else {
                                                             var match$42 = match$41[0];
                                                             var match$43 = match$42[/* txt */0];
@@ -11987,12 +11986,12 @@ if (match) {
                                                                     var match$45 = match$44[/* loc_start */0];
                                                                     if (match$45[/* pos_fname */0] === "" && !(match$45[/* pos_lnum */1] !== 3 || match$45[/* pos_bol */2] !== 21 || match$45[/* pos_cnum */3] !== 23)) {
                                                                       var match$46 = match$44[/* loc_end */1];
-                                                                      if (match$46[/* pos_fname */0] === "" && !(match$46[/* pos_lnum */1] !== 3 || match$46[/* pos_bol */2] !== 21 || match$46[/* pos_cnum */3] !== 25 || match$44[/* loc_ghost */2] !== 0)) {
+                                                                      if (match$46[/* pos_fname */0] === "" && !(match$46[/* pos_lnum */1] !== 3 || match$46[/* pos_bol */2] !== 21 || match$46[/* pos_cnum */3] !== 25 || match$44[/* loc_ghost */2])) {
                                                                         var match$47 = match$40[/* pexp_loc */1];
                                                                         var match$48 = match$47[/* loc_start */0];
                                                                         if (match$48[/* pos_fname */0] === "" && !(match$48[/* pos_lnum */1] !== 3 || match$48[/* pos_bol */2] !== 21 || match$48[/* pos_cnum */3] !== 23)) {
                                                                           var match$49 = match$47[/* loc_end */1];
-                                                                          if (match$49[/* pos_fname */0] === "" && !(match$49[/* pos_lnum */1] !== 3 || match$49[/* pos_bol */2] !== 21 || match$49[/* pos_cnum */3] !== 25 || match$47[/* loc_ghost */2] !== 0 || match$40[/* pexp_attributes */2])) {
+                                                                          if (match$49[/* pos_fname */0] === "" && !(match$49[/* pos_lnum */1] !== 3 || match$49[/* pos_bol */2] !== 21 || match$49[/* pos_cnum */3] !== 25 || match$47[/* loc_ghost */2] || match$40[/* pexp_attributes */2])) {
                                                                             var match$50 = match$39[1];
                                                                             if (match$50) {
                                                                               var match$51 = match$50[0];
@@ -12000,7 +11999,7 @@ if (match) {
                                                                                 var match$52 = match$51[1];
                                                                                 var match$53 = match$52[/* pexp_desc */0];
                                                                                 if (match$53.tag) {
-                                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                 } else {
                                                                                   var match$54 = match$53[0];
                                                                                   var match$55 = match$54[/* txt */0];
@@ -12011,12 +12010,12 @@ if (match) {
                                                                                           var match$57 = match$56[/* loc_start */0];
                                                                                           if (match$57[/* pos_fname */0] === "" && !(match$57[/* pos_lnum */1] !== 2 || match$57[/* pos_bol */2] !== 13 || match$57[/* pos_cnum */3] !== 15)) {
                                                                                             var match$58 = match$56[/* loc_end */1];
-                                                                                            if (match$58[/* pos_fname */0] === "" && !(match$58[/* pos_lnum */1] !== 2 || match$58[/* pos_bol */2] !== 13 || match$58[/* pos_cnum */3] !== 18 || match$56[/* loc_ghost */2] !== 0)) {
+                                                                                            if (match$58[/* pos_fname */0] === "" && !(match$58[/* pos_lnum */1] !== 2 || match$58[/* pos_bol */2] !== 13 || match$58[/* pos_cnum */3] !== 18 || match$56[/* loc_ghost */2])) {
                                                                                               var match$59 = match$52[/* pexp_loc */1];
                                                                                               var match$60 = match$59[/* loc_start */0];
                                                                                               if (match$60[/* pos_fname */0] === "" && !(match$60[/* pos_lnum */1] !== 2 || match$60[/* pos_bol */2] !== 13 || match$60[/* pos_cnum */3] !== 15)) {
                                                                                                 var match$61 = match$59[/* loc_end */1];
-                                                                                                if (match$61[/* pos_fname */0] === "" && !(match$61[/* pos_lnum */1] !== 2 || match$61[/* pos_bol */2] !== 13 || match$61[/* pos_cnum */3] !== 18 || match$59[/* loc_ghost */2] !== 0 || match$52[/* pexp_attributes */2])) {
+                                                                                                if (match$61[/* pos_fname */0] === "" && !(match$61[/* pos_lnum */1] !== 2 || match$61[/* pos_bol */2] !== 13 || match$61[/* pos_cnum */3] !== 18 || match$59[/* loc_ghost */2] || match$52[/* pexp_attributes */2])) {
                                                                                                   var match$62 = match$50[1];
                                                                                                   if (match$62) {
                                                                                                     var match$63 = match$62[0];
@@ -12024,7 +12023,7 @@ if (match) {
                                                                                                       var match$64 = match$63[1];
                                                                                                       var match$65 = match$64[/* pexp_desc */0];
                                                                                                       if (match$65.tag) {
-                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                       } else {
                                                                                                         var match$66 = match$65[0];
                                                                                                         var match$67 = match$66[/* txt */0];
@@ -12038,17 +12037,17 @@ if (match) {
                                                                                                                       var match$70 = match$69[/* loc_start */0];
                                                                                                                       if (match$70[/* pos_fname */0] === "" && !(match$70[/* pos_lnum */1] !== 3 || match$70[/* pos_bol */2] !== 21 || match$70[/* pos_cnum */3] !== 26)) {
                                                                                                                         var match$71 = match$69[/* loc_end */1];
-                                                                                                                        if (match$71[/* pos_fname */0] === "" && !(match$71[/* pos_lnum */1] !== 3 || match$71[/* pos_bol */2] !== 21 || match$71[/* pos_cnum */3] !== 44 || match$69[/* loc_ghost */2] !== 0)) {
+                                                                                                                        if (match$71[/* pos_fname */0] === "" && !(match$71[/* pos_lnum */1] !== 3 || match$71[/* pos_bol */2] !== 21 || match$71[/* pos_cnum */3] !== 44 || match$69[/* loc_ghost */2])) {
                                                                                                                           var match$72 = match$64[/* pexp_loc */1];
                                                                                                                           var match$73 = match$72[/* loc_start */0];
                                                                                                                           if (match$73[/* pos_fname */0] === "" && !(match$73[/* pos_lnum */1] !== 3 || match$73[/* pos_bol */2] !== 21 || match$73[/* pos_cnum */3] !== 26)) {
                                                                                                                             var match$74 = match$72[/* loc_end */1];
-                                                                                                                            if (match$74[/* pos_fname */0] === "" && !(match$74[/* pos_lnum */1] !== 3 || match$74[/* pos_bol */2] !== 21 || match$74[/* pos_cnum */3] !== 44 || match$72[/* loc_ghost */2] !== 0 || match$64[/* pexp_attributes */2] || match$62[1])) {
+                                                                                                                            if (match$74[/* pos_fname */0] === "" && !(match$74[/* pos_lnum */1] !== 3 || match$74[/* pos_bol */2] !== 21 || match$74[/* pos_cnum */3] !== 44 || match$72[/* loc_ghost */2] || match$64[/* pexp_attributes */2] || match$62[1])) {
                                                                                                                               var match$75 = match$38[/* pexp_loc */1];
                                                                                                                               var match$76 = match$75[/* loc_start */0];
                                                                                                                               if (match$76[/* pos_fname */0] === "" && !(match$76[/* pos_lnum */1] !== 2 || match$76[/* pos_bol */2] !== 13 || match$76[/* pos_cnum */3] !== 15)) {
                                                                                                                                 var match$77 = match$75[/* loc_end */1];
-                                                                                                                                if (match$77[/* pos_fname */0] === "" && !(match$77[/* pos_lnum */1] !== 3 || match$77[/* pos_bol */2] !== 21 || match$77[/* pos_cnum */3] !== 44 || match$75[/* loc_ghost */2] !== 0 || match$38[/* pexp_attributes */2])) {
+                                                                                                                                if (match$77[/* pos_fname */0] === "" && !(match$77[/* pos_lnum */1] !== 3 || match$77[/* pos_bol */2] !== 21 || match$77[/* pos_cnum */3] !== 44 || match$75[/* loc_ghost */2] || match$38[/* pexp_attributes */2])) {
                                                                                                                                   var match$78 = match$36[1];
                                                                                                                                   if (match$78) {
                                                                                                                                     var match$79 = match$78[0];
@@ -12056,7 +12055,7 @@ if (match) {
                                                                                                                                       var match$80 = match$79[1];
                                                                                                                                       var match$81 = match$80[/* pexp_desc */0];
                                                                                                                                       if (match$81.tag) {
-                                                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                       } else {
                                                                                                                                         var match$82 = match$81[0];
                                                                                                                                         var match$83 = match$82[/* txt */0];
@@ -12070,254 +12069,254 @@ if (match) {
                                                                                                                                                       var match$86 = match$85[/* loc_start */0];
                                                                                                                                                       if (match$86[/* pos_fname */0] === "" && !(match$86[/* pos_lnum */1] !== 4 || match$86[/* pos_bol */2] !== 46 || match$86[/* pos_cnum */3] !== 51)) {
                                                                                                                                                         var match$87 = match$85[/* loc_end */1];
-                                                                                                                                                        if (match$87[/* pos_fname */0] === "" && !(match$87[/* pos_lnum */1] !== 4 || match$87[/* pos_bol */2] !== 46 || match$87[/* pos_cnum */3] !== 71 || match$85[/* loc_ghost */2] !== 0)) {
+                                                                                                                                                        if (match$87[/* pos_fname */0] === "" && !(match$87[/* pos_lnum */1] !== 4 || match$87[/* pos_bol */2] !== 46 || match$87[/* pos_cnum */3] !== 71 || match$85[/* loc_ghost */2])) {
                                                                                                                                                           var match$88 = match$80[/* pexp_loc */1];
                                                                                                                                                           var match$89 = match$88[/* loc_start */0];
                                                                                                                                                           if (match$89[/* pos_fname */0] === "" && !(match$89[/* pos_lnum */1] !== 4 || match$89[/* pos_bol */2] !== 46 || match$89[/* pos_cnum */3] !== 51)) {
                                                                                                                                                             var match$90 = match$88[/* loc_end */1];
-                                                                                                                                                            if (match$90[/* pos_fname */0] === "" && !(match$90[/* pos_lnum */1] !== 4 || match$90[/* pos_bol */2] !== 46 || match$90[/* pos_cnum */3] !== 71 || match$88[/* loc_ghost */2] !== 0 || match$80[/* pexp_attributes */2] || match$78[1])) {
+                                                                                                                                                            if (match$90[/* pos_fname */0] === "" && !(match$90[/* pos_lnum */1] !== 4 || match$90[/* pos_bol */2] !== 46 || match$90[/* pos_cnum */3] !== 71 || match$88[/* loc_ghost */2] || match$80[/* pexp_attributes */2] || match$78[1])) {
                                                                                                                                                               var match$91 = match$24[/* pexp_loc */1];
                                                                                                                                                               var match$92 = match$91[/* loc_start */0];
                                                                                                                                                               if (match$92[/* pos_fname */0] === "" && !(match$92[/* pos_lnum */1] !== 2 || match$92[/* pos_bol */2] !== 13 || match$92[/* pos_cnum */3] !== 15)) {
                                                                                                                                                                 var match$93 = match$91[/* loc_end */1];
-                                                                                                                                                                if (match$93[/* pos_fname */0] === "" && !(match$93[/* pos_lnum */1] !== 4 || match$93[/* pos_bol */2] !== 46 || match$93[/* pos_cnum */3] !== 71 || match$91[/* loc_ghost */2] !== 0 || match$24[/* pexp_attributes */2])) {
+                                                                                                                                                                if (match$93[/* pos_fname */0] === "" && !(match$93[/* pos_lnum */1] !== 4 || match$93[/* pos_bol */2] !== 46 || match$93[/* pos_cnum */3] !== 71 || match$91[/* loc_ghost */2] || match$24[/* pexp_attributes */2])) {
                                                                                                                                                                   var match$94 = match$13[/* pexp_loc */1];
                                                                                                                                                                   var match$95 = match$94[/* loc_start */0];
                                                                                                                                                                   if (match$95[/* pos_fname */0] === "" && !(match$95[/* pos_lnum */1] !== 1 || match$95[/* pos_bol */2] !== 0 || match$95[/* pos_cnum */3] !== 6)) {
                                                                                                                                                                     var match$96 = match$94[/* loc_end */1];
-                                                                                                                                                                    if (match$96[/* pos_fname */0] === "" && !(match$96[/* pos_lnum */1] !== 4 || match$96[/* pos_bol */2] !== 46 || match$96[/* pos_cnum */3] !== 71 || !(match$94[/* loc_ghost */2] !== 0 && !(match$13[/* pexp_attributes */2] || match$3[/* pvb_attributes */2])))) {
+                                                                                                                                                                    if (match$96[/* pos_fname */0] === "" && !(match$96[/* pos_lnum */1] !== 4 || match$96[/* pos_bol */2] !== 46 || match$96[/* pos_cnum */3] !== 71 || !(match$94[/* loc_ghost */2] && !(match$13[/* pexp_attributes */2] || match$3[/* pvb_attributes */2])))) {
                                                                                                                                                                       var match$97 = match$3[/* pvb_loc */3];
                                                                                                                                                                       var match$98 = match$97[/* loc_start */0];
                                                                                                                                                                       if (match$98[/* pos_fname */0] === "" && !(match$98[/* pos_lnum */1] !== 1 || match$98[/* pos_bol */2] !== 0 || match$98[/* pos_cnum */3] !== 0)) {
                                                                                                                                                                         var match$99 = match$97[/* loc_end */1];
-                                                                                                                                                                        if (match$99[/* pos_fname */0] === "" && !(match$99[/* pos_lnum */1] !== 4 || match$99[/* pos_bol */2] !== 46 || match$99[/* pos_cnum */3] !== 71 || match$97[/* loc_ghost */2] !== 0 || match$2[1])) {
-                                                                                                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 215, characters 10-17", /* true */1, /* true */1);
+                                                                                                                                                                        if (match$99[/* pos_fname */0] === "" && !(match$99[/* pos_lnum */1] !== 4 || match$99[/* pos_bol */2] !== 46 || match$99[/* pos_cnum */3] !== 71 || match$97[/* loc_ghost */2] || match$2[1])) {
+                                                                                                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 215, characters 10-17", true, true);
                                                                                                                                                                         } else {
-                                                                                                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                                         }
                                                                                                                                                                       } else {
-                                                                                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                                       }
                                                                                                                                                                     } else {
-                                                                                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                                     }
                                                                                                                                                                   } else {
-                                                                                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                                   }
                                                                                                                                                                 } else {
-                                                                                                                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                                 }
                                                                                                                                                               } else {
-                                                                                                                                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                               }
                                                                                                                                                             } else {
-                                                                                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                             }
                                                                                                                                                           } else {
-                                                                                                                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                           }
                                                                                                                                                         } else {
-                                                                                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                         }
                                                                                                                                                       } else {
-                                                                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                       }
                                                                                                                                                     } else {
-                                                                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                     }
                                                                                                                                                     break;
                                                                                                                                                 case 1 : 
                                                                                                                                                 case 2 : 
-                                                                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                                     break;
                                                                                                                                                 
                                                                                                                                               }
                                                                                                                                               break;
                                                                                                                                           case 0 : 
                                                                                                                                           case 2 : 
-                                                                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                               break;
                                                                                                                                           
                                                                                                                                         }
                                                                                                                                       }
                                                                                                                                     } else {
-                                                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                     }
                                                                                                                                   } else {
-                                                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                   }
                                                                                                                                 } else {
-                                                                                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                                 }
                                                                                                                               } else {
-                                                                                                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                               }
                                                                                                                             } else {
-                                                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                             }
                                                                                                                           } else {
-                                                                                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                           }
                                                                                                                         } else {
-                                                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                         }
                                                                                                                       } else {
-                                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                       }
                                                                                                                     } else {
-                                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                     }
                                                                                                                     break;
                                                                                                                 case 1 : 
                                                                                                                 case 2 : 
-                                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                                     break;
                                                                                                                 
                                                                                                               }
                                                                                                               break;
                                                                                                           case 0 : 
                                                                                                           case 2 : 
-                                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                               break;
                                                                                                           
                                                                                                         }
                                                                                                       }
                                                                                                     } else {
-                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                     }
                                                                                                   } else {
-                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                   }
                                                                                                 } else {
-                                                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                                 }
                                                                                               } else {
-                                                                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                               }
                                                                                             } else {
-                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                             }
                                                                                           } else {
-                                                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                           }
                                                                                         } else {
-                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                         }
                                                                                         break;
                                                                                     case 1 : 
                                                                                     case 2 : 
-                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                                         break;
                                                                                     
                                                                                   }
                                                                                 }
                                                                               } else {
-                                                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                               }
                                                                             } else {
-                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                             }
                                                                           } else {
-                                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                           }
                                                                         } else {
-                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                         }
                                                                       } else {
-                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                       }
                                                                     } else {
-                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                     }
                                                                   } else {
-                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                   }
                                                                   break;
                                                               case 1 : 
                                                               case 2 : 
-                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                                   break;
                                                               
                                                             }
                                                           }
                                                         } else {
-                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                         }
                                                       } else {
-                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                       }
                                                     } else {
-                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                     }
                                                   } else {
-                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                   }
                                                 } else {
-                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                                 }
                                               } else {
-                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                               }
                                             } else {
-                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                             }
                                           } else {
-                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                           }
                                           break;
                                       case 1 : 
                                       case 2 : 
-                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                           break;
                                       
                                     }
                                   }
                                 } else {
-                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                                 }
                               } else {
-                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                               }
                             } else {
-                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                             }
                           } else {
-                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                           }
                         } else {
-                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                         }
                       } else {
-                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                        eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                       }
                     }
                   } else {
-                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                   }
                 } else {
-                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
                 }
               } else {
-                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+                eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
               }
             } else {
-              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+              eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
             }
           } else {
-            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+            eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
           }
         } else {
-          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+          eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
         }
       }
     } else {
-      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+      eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
     }
   } else {
-    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+    eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
   }
 } else {
-  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", /* true */1, /* false */0);
+  eq("File \"ocaml_parsetree_main.ml\", line 216, characters 12-19", true, false);
 }
 
 from_pair_suites("ocaml_parsetree_main.ml", suites[0]);

--- a/jscomp/test/ocaml_proto_test.js
+++ b/jscomp/test/ocaml_proto_test.js
@@ -75,7 +75,7 @@ function message(content, message_name) {
 function $$import($$public, file_name) {
   return /* record */[
           /* file_name */file_name,
-          /* public */$$public ? /* true */1 : /* false */0
+          /* public */$$public ? true : false
         ];
 }
 
@@ -1247,9 +1247,9 @@ var yyact = /* array */[
       var litteral = _1[1];
       switch (litteral) {
         case "false" : 
-            return /* Constant_bool */Block.__(1, [/* false */0]);
+            return /* Constant_bool */Block.__(1, [false]);
         case "true" : 
-            return /* Constant_bool */Block.__(1, [/* true */1]);
+            return /* Constant_bool */Block.__(1, [true]);
         default:
           return /* Constant_litteral */Block.__(4, [litteral]);
       }
@@ -1735,14 +1735,6 @@ function string_of_field_type(param) {
   }
 }
 
-function string_of_repeated_type(param) {
-  if (param !== 0) {
-    return "Pbrt.Repeated_field.t";
-  } else {
-    return "list";
-  }
-}
-
 function string_of_record_field_type(param) {
   switch (param.tag | 0) {
     case 0 : 
@@ -1751,10 +1743,12 @@ function string_of_record_field_type(param) {
         return string_of_field_type(param[0][0]) + " option";
     case 2 : 
         var match = param[0];
-        return string_of_field_type(match[1]) + (" " + string_of_repeated_type(match[0]));
+        return string_of_field_type(match[1]) + (" " + (
+                  match[0] ? "Pbrt.Repeated_field.t" : "list"
+                ));
     case 3 : 
         var match$1 = param[0];
-        if (match$1[0] !== 0) {
+        if (match$1[0]) {
           return Curry._3(Printf.sprintf(/* Format */[
                           /* Char_literal */Block.__(12, [
                               /* "(" */40,
@@ -1851,10 +1845,10 @@ function string_of_payload_kind(capitalize, payload_kind, packed) {
   if (typeof payload_kind === "number") {
     switch (payload_kind) {
       case 0 : 
-          s = packed !== 0 ? "bytes" : "bits32";
+          s = packed ? "bytes" : "bits32";
           break;
       case 1 : 
-          s = packed !== 0 ? "bytes" : "bits64";
+          s = packed ? "bytes" : "bits64";
           break;
       case 2 : 
           s = "bytes";
@@ -1862,7 +1856,7 @@ function string_of_payload_kind(capitalize, payload_kind, packed) {
       
     }
   } else {
-    s = packed !== 0 ? "bytes" : "varint";
+    s = packed ? "bytes" : "varint";
   }
   if (capitalize) {
     return Caml_string.bytes_to_string(Bytes.capitalize(Caml_string.bytes_of_string(s)));
@@ -2010,7 +2004,7 @@ function runtime_function(param) {
               }
           
         }
-      } else if (match$1[0] !== 0) {
+      } else if (match$1[0]) {
         switch (param[2]) {
           case 2 : 
               return "Pbrt.Encoder.int_as_zigzag";
@@ -2105,7 +2099,7 @@ function runtime_function(param) {
             }
         
       }
-    } else if (match$3[0] !== 0) {
+    } else if (match$3[0]) {
       switch (param[2]) {
         case 2 : 
             return "Pbrt.Decoder.int_as_zigzag";
@@ -2185,7 +2179,7 @@ function gen_decode_record(and_, param, sc) {
               return acc;
           }
           if (exit === 1) {
-            if (rf_field_type[0][0] !== 0) {
+            if (rf_field_type[0][0]) {
               return acc;
             } else {
               return /* :: */[
@@ -2197,7 +2191,7 @@ function gen_decode_record(and_, param, sc) {
           
         }), /* [] */0, r_fields);
   var string_of_nonpacked_pk = function (pk) {
-    return string_of_payload_kind(/* Some */[/* () */0], pk, /* false */0);
+    return string_of_payload_kind(/* Some */[/* () */0], pk, false);
   };
   var process_field_common = function (sc, encoding_number, pk_as_string, f) {
     line$1(sc, Curry._2(Printf.sprintf(/* Format */[
@@ -2403,8 +2397,8 @@ function gen_decode_record(and_, param, sc) {
                                       var pk$2 = param$3[3];
                                       var encoding_number = param$3[2];
                                       var field_type$2 = param$3[1];
-                                      if (param$3[0] !== 0) {
-                                        if (is_packed !== 0) {
+                                      if (param$3[0]) {
+                                        if (is_packed) {
                                           return process_field_common(sc$3, encoding_number, "Bytes", (function (sc) {
                                                         line$1(sc, "Pbrt.Decoder.packed_fold (fun () d -> ");
                                                         scope(sc, (function (sc) {
@@ -2453,7 +2447,7 @@ function gen_decode_record(and_, param, sc) {
                                                                           ]), decode_field_f(field_type$2, pk$2), rf_label$3));
                                                       }));
                                         }
-                                      } else if (is_packed !== 0) {
+                                      } else if (is_packed) {
                                         return process_field_common(sc$3, encoding_number, "Bytes", (function (sc) {
                                                       return line$1(sc, Curry._2(Printf.sprintf(/* Format */[
                                                                           /* String_literal */Block.__(11, [
@@ -2533,7 +2527,7 @@ function gen_decode_record(and_, param, sc) {
                                                                 ]),
                                                               "(Pbrt.Decoder.map_entry d ~decode_key:%s ~decode_value)"
                                                             ]), decode_key_f);
-                                                    if (at !== 0) {
+                                                    if (at) {
                                                       line$1(sc, Curry._1(Printf.sprintf(/* Format */[
                                                                     /* String_literal */Block.__(11, [
                                                                         "let a, b = ",
@@ -2865,19 +2859,19 @@ function gen_struct(and_, t, sc) {
     case 0 : 
         tmp = /* tuple */[
           gen_decode_record(and_, match[0], sc),
-          /* true */1
+          true
         ];
         break;
     case 1 : 
         tmp = /* tuple */[
           gen_decode_variant(and_, match[0], sc),
-          /* true */1
+          true
         ];
         break;
     case 2 : 
         tmp = /* tuple */[
           gen_decode_const_variant(and_, match[0], sc),
-          /* true */1
+          true
         ];
         break;
     
@@ -2931,7 +2925,7 @@ function gen_sig(_, t, sc) {
     case 2 : 
         tmp = /* tuple */[
           f(match[0][/* cv_name */0]),
-          /* true */1
+          true
         ];
         break;
     
@@ -3104,7 +3098,7 @@ function gen_pp_record(and_, param, sc) {
                                   case 2 : 
                                       var match = rf_field_type[0];
                                       var field_string_of$2 = gen_pp_field(match[1]);
-                                      if (match[0] !== 0) {
+                                      if (match[0]) {
                                         return line$1(sc, Curry._3(Printf.sprintf(/* Format */[
                                                             /* String_literal */Block.__(11, [
                                                                 "Pbrt.Pp.pp_record_field \"",
@@ -3159,7 +3153,7 @@ function gen_pp_record(and_, param, sc) {
                                       }
                                   case 3 : 
                                       var match$1 = rf_field_type[0];
-                                      var pp_runtime_function = match$1[0] !== 0 ? "pp_hastable" : "pp_associative_list";
+                                      var pp_runtime_function = match$1[0] ? "pp_hastable" : "pp_associative_list";
                                       var pp_key = gen_pp_field(/* Ft_basic_type */Block.__(0, [match$1[2][0]]));
                                       var pp_value = gen_pp_field(match$1[3][0]);
                                       return line$1(sc, Curry._5(Printf.sprintf(/* Format */[
@@ -3401,7 +3395,7 @@ function gen_struct$1(and_, t, sc) {
         break;
     
   }
-  return /* true */1;
+  return true;
 }
 
 function gen_sig$1(_, t, sc) {
@@ -3448,7 +3442,7 @@ function gen_sig$1(_, t, sc) {
         break;
     
   }
-  return /* true */1;
+  return true;
 }
 
 var Codegen_pp = /* module */[
@@ -3680,7 +3674,7 @@ function reset(g) {
                         /* core */core,
                         /* index : None */0,
                         /* lowlink : None */0,
-                        /* on_stack : false */0
+                        /* on_stack */false
                       ];
               }), g);
 }
@@ -3715,7 +3709,7 @@ function strong_connect(g, sccs, stack, index, v) {
     v,
     stack
   ];
-  v[/* on_stack */3] = /* true */1;
+  v[/* on_stack */3] = true;
   var match = List.fold_left((function (param, id) {
           var index = param[2];
           var stack = param[1];
@@ -3841,7 +3835,7 @@ function strong_connect(g, sccs, stack, index, v) {
                       splitted
                     ];
             } else {
-              n[/* on_stack */3] = /* false */0;
+              n[/* on_stack */3] = false;
               if (n[/* core */0][/* id */0] === v[/* core */0][/* id */0]) {
                 return /* tuple */[
                         /* :: */[
@@ -3849,7 +3843,7 @@ function strong_connect(g, sccs, stack, index, v) {
                           scc
                         ],
                         stack,
-                        /* true */1
+                        true
                       ];
               } else {
                 return /* tuple */[
@@ -3858,14 +3852,14 @@ function strong_connect(g, sccs, stack, index, v) {
                           scc
                         ],
                         stack,
-                        /* false */0
+                        false
                       ];
               }
             }
           }), /* tuple */[
           /* [] */0,
           /* [] */0,
-          /* false */0
+          false
         ], stack$2);
     return /* tuple */[
             /* :: */[
@@ -3961,7 +3955,7 @@ function type_id_of_type(param) {
 
 function type_of_id(all_types, id) {
   return List.find((function (t) {
-                return +(type_id_of_type(t) === id);
+                return type_id_of_type(t) === id;
               }), all_types);
 }
 
@@ -4010,7 +4004,7 @@ function unresolved_of_string(s) {
     return /* record */[
             /* scope */List.rev(match[1]),
             /* type_name */match[0],
-            /* from_root */+(Caml_string.get(s, 0) === /* "." */46)
+            /* from_root */Caml_string.get(s, 0) === /* "." */46
           ];
   } else {
     throw [
@@ -4209,11 +4203,11 @@ function compile_oneof_p1(param) {
 function not_found(f) {
   try {
     Curry._1(f, /* () */0);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -4409,9 +4403,9 @@ function type_scope_of_type(param) {
 function is_empty_message(param) {
   var match = param[/* spec */4];
   if (match.tag) {
-    return +(0 === List.length(match[0][/* message_body */2]));
+    return 0 === List.length(match[0][/* message_body */2]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4542,7 +4536,7 @@ function compile_message_p2(types, param, message) {
               var types$2 = find_all_types_in_field_scope(types$1, scope$1);
               try {
                 var t = List.find((function (t) {
-                        return +(type_name$1 === type_name_of_type(t));
+                        return type_name$1 === type_name_of_type(t);
                       }), types$2);
                 return /* Some */[type_id_of_type(t)];
               }
@@ -4718,7 +4712,7 @@ function group(proto) {
                               return List.find((function (param) {
                                             var input_id = id;
                                             var param$1 = param;
-                                            return +(input_id === param$1[/* id */1]);
+                                            return input_id === param$1[/* id */1];
                                           }), proto);
                             }), l);
               }), sccs);
@@ -4735,18 +4729,18 @@ function type_decl_of_and(param) {
 function gen_type_record(mutable_, and_, param, sc) {
   var r_fields = param[/* r_fields */1];
   var r_name = param[/* r_name */0];
-  var mutable_$1 = mutable_ ? /* true */1 : /* false */0;
+  var mutable_$1 = mutable_ ? true : false;
   var is_imperative_type = function (param) {
     switch (param.tag | 0) {
       case 2 : 
       case 3 : 
-          if (param[0][0] !== 0) {
-            return /* true */1;
+          if (param[0][0]) {
+            return true;
           } else {
-            return /* false */0;
+            return false;
           }
       default:
-        return /* false */0;
+        return false;
     }
   };
   var field_prefix = function (field_type, field_mutable) {
@@ -4912,7 +4906,7 @@ function gen_struct$2(and_, t, scope) {
         break;
     
   }
-  return /* true */1;
+  return true;
 }
 
 function gen_sig$2(and_, t, scope) {
@@ -4929,7 +4923,7 @@ function gen_sig$2(and_, t, scope) {
         break;
     
   }
-  return /* true */1;
+  return true;
 }
 
 var Codegen_type = /* module */[
@@ -5102,7 +5096,7 @@ function gen_encode_record(and_, param, sc) {
                                           ]),
                                         "v.%s"
                                       ]), rf_label);
-                              return gen_encode_field_type(/* Some */[/* () */0], sc, var_name, match[1], match[2], /* false */0, match[0]);
+                              return gen_encode_field_type(/* Some */[/* () */0], sc, var_name, match[1], match[2], false, match[0]);
                           case 1 : 
                               var match$1 = rf_field_type[0];
                               var pk = match$1[2];
@@ -5131,7 +5125,7 @@ function gen_encode_record(and_, param, sc) {
                                                 "| Some x -> ("
                                               ]));
                                       scope(sc, (function (sc) {
-                                              return gen_encode_field_type(/* Some */[/* () */0], sc, "x", encoding_number, pk, /* false */0, field_type);
+                                              return gen_encode_field_type(/* Some */[/* () */0], sc, "x", encoding_number, pk, false, field_type);
                                             }));
                                       line$1(sc, ")");
                                       return line$1(sc, "| None -> ();");
@@ -5143,8 +5137,8 @@ function gen_encode_record(and_, param, sc) {
                               var pk$1 = match$2[3];
                               var encoding_number$1 = match$2[2];
                               var field_type$1 = match$2[1];
-                              if (match$2[0] !== 0) {
-                                if (is_packed !== 0) {
+                              if (match$2[0]) {
+                                if (is_packed) {
                                   gen_encode_field_key(sc, encoding_number$1, pk$1, is_packed);
                                   line$1(sc, "Pbrt.Encoder.nested (fun encoder ->");
                                   scope(sc, (function (sc) {
@@ -5186,7 +5180,7 @@ function gen_encode_record(and_, param, sc) {
                                                       ") v.%s;"
                                                     ]), rf_label));
                                 }
-                              } else if (is_packed !== 0) {
+                              } else if (is_packed) {
                                 gen_encode_field_key(sc, encoding_number$1, pk$1, is_packed);
                                 line$1(sc, "Pbrt.Encoder.nested (fun encoder ->");
                                 scope(sc, (function (sc) {
@@ -5251,16 +5245,16 @@ function gen_encode_record(and_, param, sc) {
                                           ]), encode_basic_type(match$5[0], key_pk)));
                               line$1(sc, "let encode_value = (fun x encoder ->");
                               scope(sc, (function (sc) {
-                                      return gen_encode_field_type(/* None */0, sc, "x", -1, value_pk, /* false */0, value_type);
+                                      return gen_encode_field_type(/* None */0, sc, "x", -1, value_pk, false, value_type);
                                     }));
                               line$1(sc, ") in");
-                              if (match$3[0] !== 0) {
+                              if (match$3[0]) {
                                 line$1(sc, "Hashtbl.iter (fun k v ->");
                               } else {
                                 line$1(sc, "List.iter (fun (k, v) ->");
                               }
                               scope(sc, (function (sc) {
-                                      gen_encode_field_key(sc, encoding_number$2, /* Pk_bytes */2, /* false */0);
+                                      gen_encode_field_key(sc, encoding_number$2, /* Pk_bytes */2, false);
                                       line$1(sc, Curry._2(Printf.sprintf(/* Format */[
                                                     /* String_literal */Block.__(11, [
                                                         "let map_entry = (k, Pbrt.",
@@ -5279,7 +5273,7 @@ function gen_encode_record(and_, param, sc) {
                                                           ])
                                                       ]),
                                                     "let map_entry = (k, Pbrt.%s), (v, Pbrt.%s) in"
-                                                  ]), string_of_payload_kind(/* Some */[/* () */0], key_pk, /* false */0), string_of_payload_kind(/* Some */[/* () */0], value_pk, /* false */0)));
+                                                  ]), string_of_payload_kind(/* Some */[/* () */0], key_pk, false), string_of_payload_kind(/* Some */[/* () */0], value_pk, false)));
                                       return line$1(sc, "Pbrt.Encoder.map_entry ~encode_key ~encode_value map_entry encoder");
                                     }));
                               return line$1(sc, Curry._1(Printf.sprintf(/* Format */[
@@ -5333,7 +5327,7 @@ function gen_encode_record(and_, param, sc) {
                                                                     "| %s x -> ("
                                                                   ]), vc_constructor));
                                                       scope(sc, (function (sc) {
-                                                              return gen_encode_field_type(/* Some */[/* () */0], sc, "x", vc_encoding_number, vc_payload_kind, /* false */0, field_type);
+                                                              return gen_encode_field_type(/* Some */[/* () */0], sc, "x", vc_encoding_number, vc_payload_kind, false, field_type);
                                                             }));
                                                       return line$1(sc, ")");
                                                     } else {
@@ -5351,7 +5345,7 @@ function gen_encode_record(and_, param, sc) {
                                                                     "| %s -> ("
                                                                   ]), vc_constructor));
                                                       scope(sc, (function (sc) {
-                                                              gen_encode_field_key(sc, vc_encoding_number, vc_payload_kind, /* false */0);
+                                                              gen_encode_field_key(sc, vc_encoding_number, vc_payload_kind, false);
                                                               return line$1(sc, "Pbrt.Encoder.empty_nested encoder");
                                                             }));
                                                       return line$1(sc, ")");
@@ -5414,7 +5408,7 @@ function gen_encode_variant(and_, variant, sc) {
                                               "| %s x -> ("
                                             ]), vc_constructor));
                                 scope(sc, (function (sc) {
-                                        return gen_encode_field_type(/* Some */[/* () */0], sc, "x", vc_encoding_number, vc_payload_kind, /* false */0, field_type);
+                                        return gen_encode_field_type(/* Some */[/* () */0], sc, "x", vc_encoding_number, vc_payload_kind, false, field_type);
                                       }));
                                 return line$1(sc, ")");
                               } else {
@@ -5432,7 +5426,7 @@ function gen_encode_variant(and_, variant, sc) {
                                               "| %s -> ("
                                             ]), vc_constructor));
                                 scope(sc, (function (sc) {
-                                        gen_encode_field_key(sc, vc_encoding_number, vc_payload_kind, /* false */0);
+                                        gen_encode_field_key(sc, vc_encoding_number, vc_payload_kind, false);
                                         return line$1(sc, "Pbrt.Encoder.empty_nested encoder");
                                       }));
                                 return line$1(sc, ")");
@@ -5523,19 +5517,19 @@ function gen_struct$3(and_, t, sc) {
     case 0 : 
         tmp = /* tuple */[
           gen_encode_record(and_, match[0], sc),
-          /* true */1
+          true
         ];
         break;
     case 1 : 
         tmp = /* tuple */[
           gen_encode_variant(and_, match[0], sc),
-          /* true */1
+          true
         ];
         break;
     case 2 : 
         tmp = /* tuple */[
           gen_encode_const_variant(and_, match[0], sc),
-          /* true */1
+          true
         ];
         break;
     
@@ -5586,7 +5580,7 @@ function gen_sig$3(_, t, sc) {
     case 2 : 
         tmp = /* tuple */[
           f(match[0][/* cv_name */0]),
-          /* true */1
+          true
         ];
         break;
     
@@ -5775,7 +5769,7 @@ function record_field_default_info(record_field) {
         break;
     case 2 : 
         var match$2 = rf_field_type[0];
-        default_value = match$2[0] !== 0 ? Curry._1(Printf.sprintf(/* Format */[
+        default_value = match$2[0] ? Curry._1(Printf.sprintf(/* Format */[
                     /* String_literal */Block.__(11, [
                         "Pbrt.Repeated_field.make (",
                         /* String */Block.__(2, [
@@ -5790,7 +5784,7 @@ function record_field_default_info(record_field) {
                   ]), dfvft(match$2[1], /* None */0)) : "[]";
         break;
     case 3 : 
-        default_value = rf_field_type[0][0] !== 0 ? "Hashtbl.create 128" : "[]";
+        default_value = rf_field_type[0][0] ? "Hashtbl.create 128" : "[]";
         break;
     case 4 : 
         var v_constructors = rf_field_type[0][/* v_constructors */1];
@@ -6094,19 +6088,19 @@ function gen_struct$4(and_, t, sc) {
         var r = match[0];
         tmp = /* tuple */[
           (gen_default_record(/* None */0, and_, r, sc), line$1(sc, ""), gen_default_record(/* Some */[/* () */0], /* Some */[/* () */0], r, sc)),
-          /* true */1
+          true
         ];
         break;
     case 1 : 
         tmp = /* tuple */[
           gen_default_variant(and_, match[0], sc),
-          /* true */1
+          true
         ];
         break;
     case 2 : 
         tmp = /* tuple */[
           gen_default_const_variant(/* None */0, match[0], sc),
-          /* true */1
+          true
         ];
         break;
     
@@ -6221,14 +6215,14 @@ function gen_sig$4(_, t, sc) {
     case 0 : 
         tmp = /* tuple */[
           gen_sig_record(sc, match[0]),
-          /* true */1
+          true
         ];
         break;
     case 1 : 
     case 2 : 
         tmp = /* tuple */[
           f(match[0][/* cv_name */0]),
-          /* true */1
+          true
         ];
         break;
     
@@ -6245,9 +6239,9 @@ var Codegen_default = /* module */[
 function rev_split_by_naming_convention(s) {
   var is_uppercase = function (c) {
     if (64 < c) {
-      return +(c < 91);
+      return c < 91;
     } else {
-      return /* false */0;
+      return false;
     }
   };
   var add_sub_string = function (start_i, end_i, l) {
@@ -6264,7 +6258,7 @@ function rev_split_by_naming_convention(s) {
           var start_i = param[1];
           var l = param[0];
           if (c !== 95) {
-            if (param[2] !== 0) {
+            if (param[2]) {
               return /* tuple */[
                       l,
                       start_i,
@@ -6274,7 +6268,7 @@ function rev_split_by_naming_convention(s) {
               return /* tuple */[
                       add_sub_string(start_i, i, l),
                       i,
-                      /* true */1
+                      true
                     ];
             } else {
               return /* tuple */[
@@ -6287,13 +6281,13 @@ function rev_split_by_naming_convention(s) {
             return /* tuple */[
                     add_sub_string(start_i, i, l),
                     i + 1 | 0,
-                    /* false */0
+                    false
                   ];
           }
         }), /* tuple */[
         /* [] */0,
         0,
-        /* false */0
+        false
       ], s);
   var len = s.length;
   return add_sub_string(match[1], len, match[0]);
@@ -6426,7 +6420,7 @@ function encoding_info_of_field_type(all_types, field_type) {
     switch (field_type) {
       case 6 : 
       case 7 : 
-          return /* Pk_varint */[/* true */1];
+          return /* Pk_varint */[true];
       case 1 : 
       case 8 : 
       case 10 : 
@@ -6440,7 +6434,7 @@ function encoding_info_of_field_type(all_types, field_type) {
       case 4 : 
       case 5 : 
       case 12 : 
-          return /* Pk_varint */[/* false */0];
+          return /* Pk_varint */[false];
       case 13 : 
       case 14 : 
           return /* Pk_bytes */2;
@@ -6451,7 +6445,7 @@ function encoding_info_of_field_type(all_types, field_type) {
     if (match[/* spec */4].tag) {
       return /* Pk_bytes */2;
     } else {
-      return /* Pk_varint */[/* false */0];
+      return /* Pk_varint */[false];
     }
   }
 }
@@ -6471,7 +6465,7 @@ function encoding_of_field(all_types, field) {
           ];
     }
   } else {
-    packed = /* false */0;
+    packed = false;
   }
   var pk = encoding_info_of_field_type(all_types, field_type(field));
   return /* tuple */[
@@ -6572,7 +6566,7 @@ function compile_field_type(field_name, all_types, file_options, field_options, 
         return /* Ft_unit */0;
       } else {
         var udt_nested;
-        udt_nested = t[/* spec */4].tag ? /* true */1 : /* false */0;
+        udt_nested = t[/* spec */4].tag ? true : false;
         var field_type_module = module_of_file_name(t[/* file_name */2]);
         var match$6 = type_scope_of_type(t);
         var udt_type_name = type_name(match$6[/* message_names */1], type_name_of_type(t));
@@ -6608,7 +6602,7 @@ function is_mutable(field_name, field_options) {
           ];
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -6849,7 +6843,7 @@ function compile(proto_definition) {
                                           var record_field$1 = /* record */[
                                             record_field_000$1,
                                             record_field_001,
-                                            /* rf_mutable : false */0
+                                            /* rf_mutable */false
                                           ];
                                           var variants_000 = /* record */[
                                             /* module_ */module_,
@@ -7009,11 +7003,11 @@ function compile(proto_definition) {
                                         var has_encoded = first ? Curry._3(f, /* None */0, type_, sc) : Curry._3(f, /* Some */[/* () */0], type_, sc);
                                         line$1(sc, "");
                                         if (first) {
-                                          return 1 - has_encoded;
+                                          return !has_encoded;
                                         } else {
-                                          return /* false */0;
+                                          return false;
                                         }
-                                      }), /* true */1, types);
+                                      }), true, types);
                                 return /* () */0;
                               }), otypes);
                 }), fs);

--- a/jscomp/test/ocaml_re_test.js
+++ b/jscomp/test/ocaml_re_test.js
@@ -250,13 +250,13 @@ function mem(c, _s) {
     if (s) {
       var match = s[0];
       if (c <= match[1]) {
-        return +(c >= match[0]);
+        return c >= match[0];
       } else {
         _s = s[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -412,14 +412,14 @@ var cany = /* :: */[
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
 function intersect(x, y) {
-  return +((x & y) !== 0);
+  return (x & y) !== 0;
 }
 
 function $plus$plus(x, y) {
@@ -712,9 +712,9 @@ function seq$1(ids, kind, x, y) {
 function is_eps(expr) {
   var match = expr[/* def */1];
   if (typeof match === "number") {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -778,15 +778,15 @@ function equal(_l1, _l2) {
                       _l1 = l1[1];
                       continue ;
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                 case 1 : 
                 case 2 : 
-                    return /* false */0;
+                    return false;
                 
               }
             } else {
-              return /* false */0;
+              return false;
             }
         case 1 : 
             if (l2) {
@@ -798,15 +798,15 @@ function equal(_l1, _l2) {
                       _l1 = l1[1];
                       continue ;
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                 case 0 : 
                 case 2 : 
-                    return /* false */0;
+                    return false;
                 
               }
             } else {
-              return /* false */0;
+              return false;
             }
         case 2 : 
             if (l2) {
@@ -814,26 +814,26 @@ function equal(_l1, _l2) {
               switch (match$3.tag | 0) {
                 case 0 : 
                 case 1 : 
-                    return /* false */0;
+                    return false;
                 case 2 : 
                     if (Caml_obj.caml_equal(match[0], match$3[0])) {
                       _l2 = l2[1];
                       _l1 = l1[1];
                       continue ;
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                 
               }
             } else {
-              return /* false */0;
+              return false;
             }
         
       }
     } else if (l2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -941,7 +941,7 @@ function equal$1(x, y) {
   if (x[/* hash */4] === y[/* hash */4] && x[/* idx */0] === y[/* idx */0] && x[/* category */1] === y[/* category */1]) {
     return equal(x[/* desc */2], y[/* desc */2]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -955,7 +955,7 @@ var Table = Hashtbl.Make(/* module */[
     ]);
 
 function reset_table(a) {
-  return $$Array.fill(a, 0, a.length, /* false */0);
+  return $$Array.fill(a, 0, a.length, false);
 }
 
 function mark_used_indices(tbl) {
@@ -975,7 +975,7 @@ function mark_used_indices(tbl) {
                       return List.iter((function (param) {
                                     var i = param[1];
                                     if (i >= 0) {
-                                      return Caml_array.caml_array_set(tbl, i, /* true */1);
+                                      return Caml_array.caml_array_set(tbl, i, true);
                                     } else {
                                       return 0;
                                     }
@@ -1005,7 +1005,7 @@ function free_index(tbl_ref, l) {
   var len = tbl.length;
   var idx = find_free(tbl, 0, len);
   if (idx === len) {
-    tbl_ref[0] = Caml_array.caml_make_vect((len << 1), /* false */0);
+    tbl_ref[0] = Caml_array.caml_make_vect((len << 1), false);
   }
   return idx;
 }
@@ -1014,9 +1014,9 @@ var remove_matches = List.filter((function (param) {
         switch (param.tag | 0) {
           case 0 : 
           case 1 : 
-              return /* true */1;
+              return true;
           case 2 : 
-              return /* false */0;
+              return false;
           
         }
       }));
@@ -1166,9 +1166,9 @@ function filter_marks(b, e, marks) {
           /* marks */List.filter((function (param) {
                     var i = param[0];
                     if (i < b) {
-                      return /* true */1;
+                      return true;
                     } else {
-                      return +(i > e);
+                      return i > e;
                     }
                   }))(marks[/* marks */0]),
           /* pmarks */marks[/* pmarks */1]
@@ -1455,7 +1455,7 @@ var unknown_state = /* record */[
 
 function mk_state(ncol, desc) {
   var match = status(desc);
-  var break_state = typeof match === "number" && match !== 0 ? /* false */0 : /* true */1;
+  var break_state = typeof match === "number" && match !== 0 ? false : true;
   return /* record */[
           /* idx */break_state ? -3 : desc[/* idx */0],
           /* real_idx */desc[/* idx */0],
@@ -1727,11 +1727,11 @@ function is_charset(_param) {
   while(true) {
     var param = _param;
     if (typeof param === "number") {
-      return /* false */0;
+      return false;
     } else {
       switch (param.tag | 0) {
         case 0 : 
-            return /* true */1;
+            return true;
         case 4 : 
         case 5 : 
             _param = param[1];
@@ -1750,10 +1750,10 @@ function is_charset(_param) {
               _param = param[1];
               continue ;
             } else {
-              return /* false */0;
+              return false;
             }
         default:
-          return /* false */0;
+          return false;
       }
     }
   };
@@ -1813,7 +1813,7 @@ var cword = union(/* :: */[
     ], calnum);
 
 function colorize(c, regexp) {
-  var lnl = [/* false */0];
+  var lnl = [false];
   var colorize$1 = function (_regexp) {
     while(true) {
       var regexp = _regexp;
@@ -1833,7 +1833,7 @@ function colorize(c, regexp) {
           case 4 : 
               return split(cword, c);
           case 7 : 
-              lnl[0] = /* true */1;
+              lnl[0] = true;
               return /* () */0;
           case 5 : 
           case 6 : 
@@ -1905,63 +1905,63 @@ function equal$2(_x1, _x2) {
       switch (x1) {
         case 0 : 
             if (typeof x2 === "number" && x2 === 0) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 1 : 
             if (typeof x2 === "number" && x2 === 1) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 2 : 
             if (typeof x2 === "number" && x2 === 2) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 3 : 
             if (typeof x2 === "number" && x2 === 3) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 4 : 
             if (typeof x2 === "number" && x2 === 4) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 5 : 
             if (typeof x2 === "number" && x2 === 5) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 6 : 
             if (typeof x2 === "number" && x2 === 6) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 7 : 
             if (typeof x2 === "number" && x2 === 7) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 8 : 
             if (typeof x2 === "number" && x2 === 8) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         case 9 : 
             if (typeof x2 === "number" && x2 >= 9) {
-              return /* true */1;
+              return true;
             } else {
-              return /* false */0;
+              return false;
             }
         
       }
@@ -1969,25 +1969,25 @@ function equal$2(_x1, _x2) {
       switch (x1.tag | 0) {
         case 0 : 
             if (typeof x2 === "number" || x2.tag) {
-              return /* false */0;
+              return false;
             } else {
               return Caml_obj.caml_equal(x1[0], x2[0]);
             }
         case 1 : 
             if (typeof x2 === "number" || x2.tag !== 1) {
-              return /* false */0;
+              return false;
             } else {
               return eq_list(x1[0], x2[0]);
             }
         case 2 : 
             if (typeof x2 === "number" || x2.tag !== 2) {
-              return /* false */0;
+              return false;
             } else {
               return eq_list(x1[0], x2[0]);
             }
         case 3 : 
             if (typeof x2 === "number" || !(x2.tag === 3 && x1[1] === x2[1] && Caml_obj.caml_equal(x1[2], x2[2]))) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[0];
               _x1 = x1[0];
@@ -1995,7 +1995,7 @@ function equal$2(_x1, _x2) {
             }
         case 4 : 
             if (typeof x2 === "number" || !(x2.tag === 4 && x1[0] === x2[0])) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[1];
               _x1 = x1[1];
@@ -2003,17 +2003,17 @@ function equal$2(_x1, _x2) {
             }
         case 5 : 
             if (typeof x2 === "number" || !(x2.tag === 5 && x1[0] === x2[0])) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[1];
               _x1 = x1[1];
               continue ;
             }
         case 6 : 
-            return /* false */0;
+            return false;
         case 7 : 
             if (typeof x2 === "number" || x2.tag !== 7) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[0];
               _x1 = x1[0];
@@ -2021,7 +2021,7 @@ function equal$2(_x1, _x2) {
             }
         case 8 : 
             if (typeof x2 === "number" || x2.tag !== 8) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[0];
               _x1 = x1[0];
@@ -2029,7 +2029,7 @@ function equal$2(_x1, _x2) {
             }
         case 9 : 
             if (typeof x2 === "number" || x2.tag !== 9) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[0];
               _x1 = x1[0];
@@ -2037,7 +2037,7 @@ function equal$2(_x1, _x2) {
             }
         case 10 : 
             if (typeof x2 === "number" || x2.tag !== 10) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[0];
               _x1 = x1[0];
@@ -2045,19 +2045,19 @@ function equal$2(_x1, _x2) {
             }
         case 11 : 
             if (typeof x2 === "number" || x2.tag !== 11) {
-              return /* false */0;
+              return false;
             } else {
               return eq_list(x1[0], x2[0]);
             }
         case 12 : 
             if (typeof x2 === "number" || x2.tag !== 12) {
-              return /* false */0;
+              return false;
             } else {
               return eq_list(x1[0], x2[0]);
             }
         case 13 : 
             if (typeof x2 === "number" || !(x2.tag === 13 && equal$2(x1[0], x2[0]))) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[1];
               _x1 = x1[1];
@@ -2065,7 +2065,7 @@ function equal$2(_x1, _x2) {
             }
         case 14 : 
             if (typeof x2 === "number" || !(x2.tag === 14 && x1[0] === x2[0])) {
-              return /* false */0;
+              return false;
             } else {
               _x2 = x2[1];
               _x1 = x1[1];
@@ -2087,12 +2087,12 @@ function eq_list(_l1, _l2) {
         _l1 = l1[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (l2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -2374,7 +2374,7 @@ function translate(ids, kind, _ign_group, ign_case, _greedy, pos, cache, c, _par
             }
         case 7 : 
             _param = param[0];
-            _ign_group = /* true */1;
+            _ign_group = true;
             continue ;
         case 8 : 
             var b = pos[0];
@@ -2539,11 +2539,11 @@ function handle_case(_ign_case, _r) {
             }
         case 9 : 
             _r = r[0];
-            _ign_case = /* false */0;
+            _ign_case = false;
             continue ;
         case 10 : 
             _r = r[0];
-            _ign_case = /* true */1;
+            _ign_case = true;
             continue ;
         case 11 : 
             var l$prime$1 = List.map((function(ign_case){
@@ -2583,9 +2583,9 @@ function anchored(_param) {
       switch (param) {
         case 5 : 
         case 8 : 
-            return /* true */1;
+            return true;
         default:
-          return /* false */0;
+          return false;
       }
     } else {
       switch (param.tag | 0) {
@@ -2598,7 +2598,7 @@ function anchored(_param) {
               _param = param[0];
               continue ;
             } else {
-              return /* false */0;
+              return false;
             }
         case 6 : 
         case 7 : 
@@ -2613,7 +2613,7 @@ function anchored(_param) {
             _param = param[1];
             continue ;
         default:
-          return /* false */0;
+          return false;
       }
     }
   };
@@ -2888,7 +2888,7 @@ function exec_internal(name, $staropt$star, $staropt$star$1, groups, re, s) {
         ];
   }
   var groups$1 = groups;
-  var partial = /* false */0;
+  var partial = false;
   var re$1 = re;
   var s$1 = s;
   var pos$1 = pos;
@@ -2911,7 +2911,7 @@ function exec_internal(name, $staropt$star, $staropt$star$1, groups, re, s) {
         0
       ] : Caml_array.caml_make_vect(n, 0);
   } else {
-    tmp = /* int array */[];
+    tmp = /* array */[];
   }
   var info = /* record */[
     /* re */re$1,
@@ -3019,9 +3019,9 @@ function parse(multiline, dollar_endonly, dotall, ungreedy, s) {
   var l = s.length;
   var test = function (c) {
     if (i[0] !== l) {
-      return +(Caml_string.get(s, i[0]) === c);
+      return Caml_string.get(s, i[0]) === c;
     } else {
-      return /* false */0;
+      return false;
     }
   };
   var accept = function (c) {
@@ -3046,11 +3046,11 @@ function parse(multiline, dollar_endonly, dotall, ungreedy, s) {
         }
       }
       i[0] = i[0] + len | 0;
-      return /* true */1;
+      return true;
     }
     catch (exn$1){
       if (exn$1 === Pervasives.Exit) {
-        return /* false */0;
+        return false;
       } else {
         throw exn$1;
       }
@@ -3063,7 +3063,7 @@ function parse(multiline, dollar_endonly, dotall, ungreedy, s) {
   };
   var greedy_mod = function (r) {
     var gr = accept(/* "?" */63);
-    var gr$1 = ungreedy ? 1 - gr : gr;
+    var gr$1 = ungreedy ? !gr : gr;
     if (gr$1) {
       return /* Sem_greedy */Block.__(5, [
                 /* Non_greedy */620821490,
@@ -3773,7 +3773,7 @@ function regexp(flags, pat) {
             /* [] */0
           ]
         ]);
-  var regexp$2 = handle_case(/* false */0, regexp$1);
+  var regexp$2 = handle_case(false, regexp$1);
   var c = Bytes.make(257, /* "\000" */0);
   var need_lnl = colorize(c, regexp$2);
   var match = flatten_cmap(c);
@@ -3783,7 +3783,7 @@ function regexp(flags, pat) {
   var ncol$1 = need_lnl ? ncol + 1 | 0 : ncol;
   var ids = [0];
   var pos = [0];
-  var match$1 = translate(ids, /* First */332064784, /* false */0, /* false */0, /* Greedy */-904640576, pos, [/* Empty */0], col, regexp$2);
+  var match$1 = translate(ids, /* First */332064784, false, false, /* Greedy */-904640576, pos, [/* Empty */0], col, regexp$2);
   var r$1 = enforce_kind(ids, /* First */332064784, match$1[1], match$1[0]);
   var init = r$1;
   var cols = col;
@@ -3798,7 +3798,7 @@ function regexp(flags, pat) {
           /* col_repr */col_repr,
           /* ncol */ncol$2,
           /* lnl */lnl$1,
-          /* tbl */[/* int array */[/* false */0]],
+          /* tbl */[/* array */[false]],
           /* states */Curry._1(Re_automata_022[/* Table */2][/* create */0], 97),
           /* group_count */group_count
         ];
@@ -3809,7 +3809,7 @@ function exec(rex, pos, s) {
   var len = /* None */0;
   var re = rex;
   var s$1 = s;
-  var match = exec_internal("Re.exec", pos$1, len, /* true */1, re, s$1);
+  var match = exec_internal("Re.exec", pos$1, len, true, re, s$1);
   if (typeof match === "number") {
     throw Caml_builtin_exceptions.not_found;
   } else {

--- a/jscomp/test/ocaml_typedtree_test.js
+++ b/jscomp/test/ocaml_typedtree_test.js
@@ -49,58 +49,58 @@ var load_path = [/* [] */0];
 
 var interface_suffix = [".mli"];
 
-var print_types = [/* false */0];
+var print_types = [false];
 
-var debug = /* false */0;
+var debug = false;
 
-var fast = [/* false */0];
+var fast = [false];
 
-var classic = [/* false */0];
+var classic = [false];
 
-var nopervasives = /* false */0;
+var nopervasives = false;
 
-var annotations = [/* false */0];
+var annotations = [false];
 
-var binary_annotations = [/* false */0];
+var binary_annotations = [false];
 
-var principal = [/* false */0];
+var principal = [false];
 
-var real_paths = [/* true */1];
+var real_paths = [true];
 
-var recursive_types = [/* false */0];
+var recursive_types = [false];
 
-var strict_sequence = [/* false */0];
+var strict_sequence = [false];
 
-var strict_formats = [/* false */0];
+var strict_formats = [false];
 
-var applicative_functors = [/* true */1];
+var applicative_functors = [true];
 
 var error_size = [500];
 
-var transparent_modules = [/* false */0];
+var transparent_modules = [false];
 
-var native_code = [/* false */0];
+var native_code = [false];
 
-var dont_write_files = [/* false */0];
+var dont_write_files = [false];
 
-var keep_docs = [/* false */0];
+var keep_docs = [false];
 
-var keep_locs = [/* false */0];
+var keep_locs = [false];
 
-var unsafe_string = /* true */1;
+var unsafe_string = true;
 
 var assume_no_mli = [/* Mli_na */0];
 
-var record_event_when_debug = /* true */1;
+var record_event_when_debug = true;
 
 var bs_vscode;
 
 try {
   Caml_sys.caml_sys_getenv("BS_VSCODE");
-  bs_vscode = /* true */1;
+  bs_vscode = true;
 }
 catch (exn){
-  bs_vscode = /* false */0;
+  bs_vscode = false;
 }
 
 var color = [/* Auto */0];
@@ -147,12 +147,12 @@ function for_all2(pred, _l1, _l2) {
         _l1 = l1[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (l2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -400,7 +400,7 @@ function style_of_tag(s) {
   }
 }
 
-var color_enabled = [/* true */1];
+var color_enabled = [true];
 
 function set_color_tag_handling(ppf) {
   var functions = Format.pp_get_formatter_tag_functions(ppf, /* () */0);
@@ -455,11 +455,11 @@ function set_color_tag_handling(ppf) {
     functions$prime_002,
     functions$prime_003
   ];
-  ppf[/* pp_mark_tags */21] = /* true */1;
+  ppf[/* pp_mark_tags */21] = true;
   return Format.pp_set_formatter_tag_functions(ppf, functions$prime);
 }
 
-var first = [/* true */1];
+var first = [true];
 
 var formatter_l_001 = /* :: */[
   Format.err_formatter,
@@ -476,17 +476,17 @@ var formatter_l = /* :: */[
 
 function setup(o) {
   if (first[0]) {
-    first[0] = /* false */0;
-    Format.set_mark_tags(/* true */1);
+    first[0] = false;
+    Format.set_mark_tags(true);
     List.iter(set_color_tag_handling, formatter_l);
     var tmp;
     switch (o) {
       case 1 : 
-          tmp = /* true */1;
+          tmp = true;
           break;
       case 0 : 
       case 2 : 
-          tmp = /* false */0;
+          tmp = false;
           break;
       
     }
@@ -796,8 +796,8 @@ function letter(param) {
 }
 
 var current = [/* record */[
-    /* active */Caml_array.caml_make_vect(51, /* true */1),
-    /* error */Caml_array.caml_make_vect(51, /* false */0)
+    /* active */Caml_array.caml_make_vect(51, true),
+    /* error */Caml_array.caml_make_vect(51, false)
   ]];
 
 function is_active(x) {
@@ -806,14 +806,14 @@ function is_active(x) {
 
 function parse_opt(error, active, flags, s) {
   var set = function (i) {
-    return Caml_array.caml_array_set(flags, i, /* true */1);
+    return Caml_array.caml_array_set(flags, i, true);
   };
   var clear = function (i) {
-    return Caml_array.caml_array_set(flags, i, /* false */0);
+    return Caml_array.caml_array_set(flags, i, false);
   };
   var set_all = function (i) {
-    Caml_array.caml_array_set(active, i, /* true */1);
-    return Caml_array.caml_array_set(error, i, /* true */1);
+    Caml_array.caml_array_set(active, i, true);
+    return Caml_array.caml_array_set(error, i, true);
   };
   var get_num = function (_n, _i) {
     while(true) {
@@ -981,9 +981,9 @@ function parse_options(errflag, s) {
   return /* () */0;
 }
 
-parse_options(/* false */0, "+a-4-6-7-9-27-29-32..39-41..42-44-45-48-50");
+parse_options(false, "+a-4-6-7-9-27-29-32..39-41..42-44-45-48-50");
 
-parse_options(/* true */1, "-a");
+parse_options(true, "-a");
 
 function message(param) {
   if (typeof param === "number") {
@@ -1182,18 +1182,18 @@ function message(param) {
           return "unused ancestor variable " + (param[0] + ".");
       case 21 : 
           var s$2 = param[0];
-          if (param[1] !== 0) {
+          if (param[1]) {
             return "constructor " + (s$2 + " is never used to build values.\n(However, this constructor appears in patterns.)");
-          } else if (param[2] !== 0) {
+          } else if (param[2]) {
             return "constructor " + (s$2 + " is never used to build values.\nIts type is exported as a private type.");
           } else {
             return "unused constructor " + (s$2 + ".");
           }
       case 22 : 
           var s$3 = param[0];
-          if (param[1] !== 0) {
+          if (param[1]) {
             return "extension constructor " + (s$3 + " is never used to build values.\n(However, this constructor appears in patterns.)");
-          } else if (param[2] !== 0) {
+          } else if (param[2]) {
             return "extension constructor " + (s$3 + " is never used to build values.\nIt is exported or rebound as a private extension.");
           } else {
             return "unused extension constructor " + (s$3 + ".");
@@ -1202,13 +1202,13 @@ function message(param) {
           var slist$2 = param[1];
           var ty = param[0];
           var exit = 0;
-          if (slist$2 && !(slist$2[1] || param[2] !== 0)) {
+          if (slist$2 && !(slist$2[1] || param[2])) {
             return slist$2[0] + (" was selected from type " + (ty + ".\nIt is not visible in the current scope, and will not \nbe selected if the type becomes unknown."));
           } else {
             exit = 1;
           }
           if (exit === 1) {
-            if (param[2] !== 0) {
+            if (param[2]) {
               return "this record of type " + (ty + (" contains fields that are \nnot visible in the current scope: " + ($$String.concat(" ", slist$2) + ".\nThey will not be selected if the type becomes unknown.")));
             } else {
               throw [
@@ -1225,13 +1225,13 @@ function message(param) {
       case 24 : 
           var slist$3 = param[0];
           var exit$1 = 0;
-          if (slist$3 && !(slist$3[1] || param[2] !== 0)) {
+          if (slist$3 && !(slist$3[1] || param[2])) {
             return slist$3[0] + (" belongs to several types: " + ($$String.concat(" ", param[1]) + "\nThe first one was selected. Please disambiguate if this is wrong."));
           } else {
             exit$1 = 1;
           }
           if (exit$1 === 1) {
-            if (param[2] !== 0) {
+            if (param[2]) {
               return "these field labels belong to several types: " + ($$String.concat(" ", param[1]) + "\nThe first one was selected. Please disambiguate if this is wrong.");
             } else {
               throw [
@@ -1385,7 +1385,7 @@ function print(ppf, w) {
 
 var Errors = Caml_exceptions.create("Ocaml_typedtree_test.Warnings.Errors");
 
-var absname = [/* false */0];
+var absname = [false];
 
 function in_file(name) {
   var loc = /* record */[
@@ -1397,7 +1397,7 @@ function in_file(name) {
   return /* record */[
           /* loc_start */loc,
           /* loc_end */loc,
-          /* loc_ghost : true */1
+          /* loc_ghost */true
         ];
 }
 
@@ -1407,7 +1407,7 @@ function curr(lexbuf) {
   return /* record */[
           /* loc_start */lexbuf[/* lex_start_p */10],
           /* loc_end */lexbuf[/* lex_curr_p */11],
-          /* loc_ghost : false */0
+          /* loc_ghost */false
         ];
 }
 
@@ -1415,7 +1415,7 @@ function symbol_rloc() {
   return /* record */[
           /* loc_start */Parsing.symbol_start_pos(/* () */0),
           /* loc_end */Parsing.symbol_end_pos(/* () */0),
-          /* loc_ghost : false */0
+          /* loc_ghost */false
         ];
 }
 
@@ -1423,7 +1423,7 @@ function symbol_gloc() {
   return /* record */[
           /* loc_start */Parsing.symbol_start_pos(/* () */0),
           /* loc_end */Parsing.symbol_end_pos(/* () */0),
-          /* loc_ghost : true */1
+          /* loc_ghost */true
         ];
 }
 
@@ -1431,7 +1431,7 @@ function rhs_loc(n) {
   return /* record */[
           /* loc_start */Parsing.rhs_start_pos(n),
           /* loc_end */Parsing.rhs_end_pos(n),
-          /* loc_ghost : false */0
+          /* loc_ghost */false
         ];
 }
 
@@ -1461,30 +1461,30 @@ function highlight_terminfo(ppf, num_lines, lb, locs) {
   }
   Caml_io.caml_ml_flush(Pervasives.stdout);
   Caml_missing_polyfill.not_implemented("caml_terminfo_backup not implemented by bucklescript yet\n");
-  var bol = /* false */0;
+  var bol = false;
   Pervasives.print_string("# ");
   for(var pos = 0 ,pos_finish = (lb[/* lex_buffer_len */2] - pos0 | 0) - 1 | 0; pos <= pos_finish; ++pos){
     if (bol) {
       Pervasives.print_string("  ");
-      bol = /* false */0;
+      bol = false;
     }
     if (List.exists((function(pos){
           return function (loc) {
-            return +(pos === loc[/* loc_start */0][/* pos_cnum */3]);
+            return pos === loc[/* loc_start */0][/* pos_cnum */3];
           }
           }(pos)), locs)) {
       Caml_missing_polyfill.not_implemented("caml_terminfo_standout not implemented by bucklescript yet\n");
     }
     if (List.exists((function(pos){
           return function (loc) {
-            return +(pos === loc[/* loc_end */1][/* pos_cnum */3]);
+            return pos === loc[/* loc_end */1][/* pos_cnum */3];
           }
           }(pos)), locs)) {
       Caml_missing_polyfill.not_implemented("caml_terminfo_standout not implemented by bucklescript yet\n");
     }
     var c = Caml_bytes.get(lb[/* lex_buffer */1], pos + pos0 | 0);
     Pervasives.print_char(c);
-    bol = +(c === /* "\n" */10);
+    bol = c === /* "\n" */10;
   }
   Caml_missing_polyfill.not_implemented("caml_terminfo_standout not implemented by bucklescript yet\n");
   Caml_missing_polyfill.not_implemented("caml_terminfo_resume not implemented by bucklescript yet\n");
@@ -1612,33 +1612,33 @@ function highlight_locations(ppf, locs) {
         if (match$1) {
           var norepeat;
           try {
-            norepeat = +(Caml_sys.caml_sys_getenv("TERM") === "norepeat");
+            norepeat = Caml_sys.caml_sys_getenv("TERM") === "norepeat";
           }
           catch (exn){
             if (exn === Caml_builtin_exceptions.not_found) {
-              norepeat = /* false */0;
+              norepeat = false;
             } else {
               throw exn;
             }
           }
           if (norepeat) {
-            return /* false */0;
+            return false;
           } else {
             var loc1 = List.hd(locs);
             try {
               highlight_dumb(ppf, match$1[0], loc1);
-              return /* true */1;
+              return true;
             }
             catch (exn$1){
               if (exn$1 === Pervasives.Exit) {
-                return /* false */0;
+                return false;
               } else {
                 throw exn$1;
               }
             }
           }
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
         status[0] = Caml_missing_polyfill.not_implemented("caml_terminfo_setup not implemented by bucklescript yet\n");
@@ -1649,17 +1649,17 @@ function highlight_locations(ppf, locs) {
       if (match$2) {
         try {
           highlight_terminfo(ppf, match[0], match$2[0], locs);
-          return /* true */1;
+          return true;
         }
         catch (exn$2){
           if (exn$2 === Pervasives.Exit) {
-            return /* false */0;
+            return false;
           } else {
             throw exn$2;
           }
         }
       } else {
-        return /* false */0;
+        return false;
       }
     }
   };
@@ -2090,7 +2090,7 @@ function unique_toplevel_name(i) {
 }
 
 function equal(i1, i2) {
-  return +(i1[/* name */1] === i2[/* name */1]);
+  return i1[/* name */1] === i2[/* name */1];
 }
 
 function set_current_time(t) {
@@ -2112,7 +2112,7 @@ function make_global(i) {
 }
 
 function $$global(i) {
-  return +((i[/* flags */2] & 1) !== 0);
+  return (i[/* flags */2] & 1) !== 0;
 }
 
 function print$2(ppf, i) {
@@ -2397,7 +2397,7 @@ function same(_p1, _p2) {
                 return Caml_obj.caml_equal(p1[0], p2[0]);
             case 1 : 
             case 2 : 
-                return /* false */0;
+                return false;
             
           }
       case 1 : 
@@ -2408,25 +2408,25 @@ function same(_p1, _p2) {
                   _p1 = p1[0];
                   continue ;
                 } else {
-                  return /* false */0;
+                  return false;
                 }
             case 0 : 
             case 2 : 
-                return /* false */0;
+                return false;
             
           }
       case 2 : 
           switch (p2.tag | 0) {
             case 0 : 
             case 1 : 
-                return /* false */0;
+                return false;
             case 2 : 
                 if (same(p1[0], p2[0])) {
                   _p2 = p2[1];
                   _p1 = p1[1];
                   continue ;
                 } else {
-                  return /* false */0;
+                  return false;
                 }
             
           }
@@ -2446,7 +2446,7 @@ function isfree(id, _param) {
           continue ;
       case 2 : 
           if (isfree(id, param[0])) {
-            return /* true */1;
+            return true;
           } else {
             _param = param[1];
             continue ;
@@ -2473,7 +2473,7 @@ function binding_time(_param) {
 }
 
 function kfalse() {
-  return /* false */0;
+  return false;
 }
 
 function name($staropt$star, param) {
@@ -2588,26 +2588,26 @@ function parse_declaration(arity, decl) {
               return /* record */[
                       /* prim_name */name,
                       /* prim_arity */arity,
-                      /* prim_alloc : false */0,
+                      /* prim_alloc */false,
                       /* prim_native_name */name2$1,
-                      /* prim_native_float : true */1
+                      /* prim_native_float */true
                     ];
             } else {
               return /* record */[
                       /* prim_name */name,
                       /* prim_arity */arity,
-                      /* prim_alloc : false */0,
+                      /* prim_alloc */false,
                       /* prim_native_name */name2$1,
-                      /* prim_native_float : false */0
+                      /* prim_native_float */false
                     ];
             }
           } else {
             return /* record */[
                     /* prim_name */name,
                     /* prim_arity */arity,
-                    /* prim_alloc : false */0,
+                    /* prim_alloc */false,
                     /* prim_native_name */name2$1,
-                    /* prim_native_float : false */0
+                    /* prim_native_float */false
                   ];
           }
         } else {
@@ -2619,9 +2619,9 @@ function parse_declaration(arity, decl) {
           return /* record */[
                   /* prim_name */name,
                   /* prim_arity */arity,
-                  /* prim_alloc : true */1,
+                  /* prim_alloc */true,
                   /* prim_native_name */name2,
-                  /* prim_native_float : true */1
+                  /* prim_native_float */true
                 ];
         } else {
           exit = 1;
@@ -2632,17 +2632,17 @@ function parse_declaration(arity, decl) {
           return /* record */[
                   /* prim_name */name,
                   /* prim_arity */arity,
-                  /* prim_alloc : false */0,
+                  /* prim_alloc */false,
                   /* prim_native_name */"",
-                  /* prim_native_float : false */0
+                  /* prim_native_float */false
                 ];
         } else {
           return /* record */[
                   /* prim_name */name,
                   /* prim_arity */arity,
-                  /* prim_alloc : true */1,
+                  /* prim_alloc */true,
                   /* prim_native_name */name2,
-                  /* prim_native_float : false */0
+                  /* prim_native_float */false
                 ];
         }
       }
@@ -2651,9 +2651,9 @@ function parse_declaration(arity, decl) {
       return /* record */[
               /* prim_name */name,
               /* prim_arity */arity,
-              /* prim_alloc : true */1,
+              /* prim_alloc */true,
               /* prim_native_name */"",
-              /* prim_native_float : false */0
+              /* prim_native_float */false
             ];
     }
   } else {
@@ -2690,7 +2690,7 @@ function hash(t) {
 }
 
 function equal$1(t1, t2) {
-  return +(t1 === t2);
+  return t1 === t2;
 }
 
 function height(param) {
@@ -2825,13 +2825,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -2910,7 +2910,7 @@ function inter(v1, v2) {
 }
 
 function subset(v1, v2) {
-  return +((v1 & v2) === v1);
+  return (v1 & v2) === v1;
 }
 
 function set(x, b, v) {
@@ -3155,7 +3155,7 @@ function split(x, param) {
     if (c === 0) {
       return /* tuple */[
               l,
-              /* true */1,
+              true,
               r
             ];
     } else if (c < 0) {
@@ -3176,7 +3176,7 @@ function split(x, param) {
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0,
+            false,
             /* Empty */0
           ];
   }
@@ -3188,13 +3188,13 @@ function mem$2(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -3234,7 +3234,7 @@ function inter$1(s1, s2) {
     var l1 = s1[0];
     var match = split(v1, s2);
     var l2 = match[0];
-    if (match[1] !== 0) {
+    if (match[1]) {
       return join(inter$1(l1, l2), v1, inter$1(r1, match[2]));
     } else {
       return concat(inter$1(l1, l2), inter$1(r1, match[2]));
@@ -3252,7 +3252,7 @@ function diff(s1, s2) {
       var l1 = s1[0];
       var match = split(v1, s2);
       var l2 = match[0];
-      if (match[1] !== 0) {
+      if (match[1]) {
         return concat(diff(l1, l2), diff(r1, match[2]));
       } else {
         return join(diff(l1, l2), v1, diff(r1, match[2]));
@@ -3311,7 +3311,7 @@ function compare$1(s1, s2) {
 }
 
 function equal$2(s1, s2) {
-  return +(compare$1(s1, s2) === 0);
+  return compare$1(s1, s2) === 0;
 }
 
 function fold$1(f, _s, _accu) {
@@ -3350,31 +3350,31 @@ function equal_tag(t1, t2) {
     case 0 : 
         switch (t2.tag | 0) {
           case 0 : 
-              return +(t2[0] === t1[0]);
+              return t2[0] === t1[0];
           case 1 : 
           case 2 : 
-              return /* false */0;
+              return false;
           
         }
     case 1 : 
         switch (t2.tag | 0) {
           case 1 : 
-              return +(t2[0] === t1[0]);
+              return t2[0] === t1[0];
           case 0 : 
           case 2 : 
-              return /* false */0;
+              return false;
           
         }
     case 2 : 
         switch (t2.tag | 0) {
           case 0 : 
           case 1 : 
-              return /* false */0;
+              return false;
           case 2 : 
               if (same(t1[0], t2[0])) {
-                return +(t1[1] === t2[1]);
+                return t1[1] === t2[1];
               } else {
-                return /* false */0;
+                return false;
               }
           
         }
@@ -3603,7 +3603,7 @@ function split$1(x, param) {
     if (c === 0) {
       return /* tuple */[
               l,
-              /* true */1,
+              true,
               r
             ];
     } else if (c < 0) {
@@ -3624,7 +3624,7 @@ function split$1(x, param) {
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0,
+            false,
             /* Empty */0
           ];
   }
@@ -3636,13 +3636,13 @@ function mem$3(x, _param) {
     if (param) {
       var c = Curry._2(funarg[/* compare */0], x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -3682,7 +3682,7 @@ function inter$2(s1, s2) {
     var l1 = s1[0];
     var match = split$1(v1, s2);
     var l2 = match[0];
-    if (match[1] !== 0) {
+    if (match[1]) {
       return join$1(inter$2(l1, l2), v1, inter$2(r1, match[2]));
     } else {
       return concat$1(inter$2(l1, l2), inter$2(r1, match[2]));
@@ -3700,7 +3700,7 @@ function diff$1(s1, s2) {
       var l1 = s1[0];
       var match = split$1(v1, s2);
       var l2 = match[0];
-      if (match[1] !== 0) {
+      if (match[1]) {
         return concat$1(diff$1(l1, l2), diff$1(r1, match[2]));
       } else {
         return join$1(diff$1(l1, l2), v1, diff$1(r1, match[2]));
@@ -3731,7 +3731,7 @@ function subset$1(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (c < 0) {
           if (subset$1(/* Node */[
@@ -3743,7 +3743,7 @@ function subset$1(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (subset$1(/* Node */[
                 /* Empty */0,
@@ -3754,13 +3754,13 @@ function subset$1(_s1, _s2) {
           _s1 = l1;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -3784,13 +3784,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._1(p, param[1]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -3990,18 +3990,18 @@ function newty2(level, desc) {
 function is_Tvar(param) {
   var match = param[/* desc */0];
   if (typeof match === "number" || match.tag) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
 function is_Tunivar(param) {
   var match = param[/* desc */0];
   if (typeof match === "number" || match.tag !== 9) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -4189,18 +4189,18 @@ function row_more(_row) {
 function row_fixed(row) {
   var row$1 = row_repr_aux(/* [] */0, row);
   if (row$1[/* row_fixed */4]) {
-    return /* true */1;
+    return true;
   } else {
     var match = repr(row$1[/* row_more */1])[/* desc */0];
     if (typeof match === "number") {
-      return /* false */0;
+      return false;
     } else {
       switch (match.tag | 0) {
         case 0 : 
-            return /* false */0;
+            return false;
         case 3 : 
         case 9 : 
-            return /* true */1;
+            return true;
         default:
           throw [
                 Caml_builtin_exceptions.assert_failure,
@@ -4221,13 +4221,13 @@ function static_row(row) {
     return List.for_all((function (param) {
                   var match = row_field_repr_aux(/* [] */0, param[1]);
                   if (typeof match === "number" || !match.tag) {
-                    return /* true */1;
+                    return true;
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }), row$1[/* row_fields */0]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4298,7 +4298,7 @@ function proxy(ty) {
 function has_constr_row(t) {
   var match = repr(t)[/* desc */0];
   if (typeof match === "number") {
-    return /* false */0;
+    return false;
   } else {
     switch (match.tag | 0) {
       case 4 : 
@@ -4307,16 +4307,16 @@ function has_constr_row(t) {
             var t$1 = _t;
             var match$1 = repr(t$1)[/* desc */0];
             if (typeof match$1 === "number") {
-              return /* false */0;
+              return false;
             } else {
               switch (match$1.tag | 0) {
                 case 3 : 
-                    return /* true */1;
+                    return true;
                 case 5 : 
                     _t = match$1[3];
                     continue ;
                 default:
-                  return /* false */0;
+                  return false;
               }
             }
           };
@@ -4324,12 +4324,12 @@ function has_constr_row(t) {
           var match$2 = row_more(match[0]);
           var match$3 = match$2[/* desc */0];
           if (typeof match$3 === "number" || match$3.tag !== 3) {
-            return /* false */0;
+            return false;
           } else {
-            return /* true */1;
+            return true;
           }
       default:
-        return /* false */0;
+        return false;
     }
   }
 }
@@ -4337,16 +4337,16 @@ function has_constr_row(t) {
 function is_row_name(s) {
   var l = s.length;
   if (l < 4) {
-    return /* false */0;
+    return false;
   } else {
-    return +($$String.sub(s, l - 4 | 0, 4) === "#row");
+    return $$String.sub(s, l - 4 | 0, 4) === "#row";
   }
 }
 
 function is_constr_row(t) {
   var match = t[/* desc */0];
   if (typeof match === "number" || match.tag !== 3) {
-    return /* false */0;
+    return false;
   } else {
     var match$1 = match[0];
     switch (match$1.tag | 0) {
@@ -4355,7 +4355,7 @@ function is_constr_row(t) {
       case 1 : 
           return is_row_name(match$1[1]);
       case 2 : 
-          return /* false */0;
+          return false;
       
     }
   }
@@ -4727,7 +4727,7 @@ function copy_type_desc(_$staropt$star, f, _ty) {
   while(true) {
     var ty = _ty;
     var $staropt$star = _$staropt$star;
-    var keep_names = $staropt$star ? $staropt$star[0] : /* false */0;
+    var keep_names = $staropt$star ? $staropt$star[0] : false;
     if (typeof ty === "number") {
       return /* Tnil */0;
     } else {
@@ -5078,9 +5078,9 @@ function forget_abbrev(mem, path) {
 
 function is_optional(l) {
   if (l.length !== 0) {
-    return +(Caml_string.get(l, 0) === /* "?" */63);
+    return Caml_string.get(l, 0) === /* "?" */63;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -5543,7 +5543,7 @@ function extension_descr(path_ext, ext) {
             ext[/* ext_type_params */1],
             [/* Mnil */0]
           ]));
-  var tag_001 = +(ext[/* ext_args */2] === /* [] */0);
+  var tag_001 = ext[/* ext_args */2] === /* [] */0;
   var tag = /* Cstr_extension */Block.__(2, [
       path_ext,
       tag_001
@@ -5567,7 +5567,7 @@ function extension_descr(path_ext, ext) {
           /* cstr_consts */-1,
           /* cstr_nonconsts */-1,
           /* cstr_normal */-1,
-          /* cstr_generalized */+(ext[/* ext_ret_type */3] !== /* None */0),
+          /* cstr_generalized */ext[/* ext_ret_type */3] !== /* None */0,
           /* cstr_private */ext[/* ext_private */4],
           /* cstr_loc */ext[/* ext_loc */5],
           /* cstr_attributes */ext[/* ext_attributes */6]
@@ -6080,18 +6080,18 @@ List.rev(builtin_idents[0]);
 var docstrings = [/* [] */0];
 
 function warn_bad_docstrings() {
-  if (is_active(/* Bad_docstring */Block.__(33, [/* true */1]))) {
+  if (is_active(/* Bad_docstring */Block.__(33, [true]))) {
     return List.iter((function (ds) {
                   var match = ds[/* ds_attached */2];
                   switch (match) {
                     case 0 : 
-                        return prerr_warning(ds[/* ds_loc */1], /* Bad_docstring */Block.__(33, [/* true */1]));
+                        return prerr_warning(ds[/* ds_loc */1], /* Bad_docstring */Block.__(33, [true]));
                     case 1 : 
                         return /* () */0;
                     case 2 : 
                         var match$1 = ds[/* ds_associated */3];
                         if (match$1 >= 2) {
-                          return prerr_warning(ds[/* ds_loc */1], /* Bad_docstring */Block.__(33, [/* false */0]));
+                          return prerr_warning(ds[/* ds_loc */1], /* Bad_docstring */Block.__(33, [false]));
                         } else {
                           return /* () */0;
                         }
@@ -6296,7 +6296,7 @@ function get_pre_docs(pos) {
   try {
     var dsl = Hashtbl.find(pre_table, pos);
     associate_docstrings(dsl);
-    return get_docstring(/* false */0, dsl);
+    return get_docstring(false, dsl);
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
@@ -6334,7 +6334,7 @@ function get_post_docs(pos) {
   try {
     var dsl = Hashtbl.find(post_table, pos);
     associate_docstrings(dsl);
-    return get_docstring(/* false */0, dsl);
+    return get_docstring(false, dsl);
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
@@ -6361,7 +6361,7 @@ function mark_post_docs(pos) {
 function get_info(pos) {
   try {
     var dsl = Hashtbl.find(post_table, pos);
-    return get_docstring(/* true */1, dsl);
+    return get_docstring(true, dsl);
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
@@ -8540,13 +8540,13 @@ function mem$4(x, _param) {
     if (param) {
       var c = Caml_obj.caml_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -8583,7 +8583,7 @@ var identity = /* record */[
   /* types : Empty */0,
   /* modules : Empty */0,
   /* modtypes : Empty */0,
-  /* for_saving : false */0
+  /* for_saving */false
 ];
 
 function add_type(id, p, s) {
@@ -8618,7 +8618,7 @@ function for_saving(s) {
           /* types */s[/* types */0],
           /* modules */s[/* modules */1],
           /* modtypes */s[/* modtypes */2],
-          /* for_saving : true */1
+          /* for_saving */true
         ];
 }
 
@@ -8642,9 +8642,9 @@ function is_not_doc(param) {
     case "ocaml.doc" : 
     case "ocaml.text" : 
     case "text" : 
-        return /* false */0;
+        return false;
     default:
-      return /* true */1;
+      return true;
   }
 }
 
@@ -8877,15 +8877,15 @@ function typexp(s, ty) {
                   }
                 }
                 if (exit$2 === 4) {
-                  var dup = /* true */1;
+                  var dup = true;
                   if (!s[/* for_saving */3]) {
-                    var tmp$2 = /* true */1;
+                    var tmp$2 = true;
                     if (more[/* level */1] !== 100000000) {
-                      var tmp$3 = /* true */1;
+                      var tmp$3 = true;
                       if (!static_row(row)) {
                         var match$6 = more[/* desc */0];
                         var tmp$4;
-                        tmp$4 = typeof match$6 === "number" || match$6.tag !== 3 ? /* false */0 : /* true */1;
+                        tmp$4 = typeof match$6 === "number" || match$6.tag !== 3 ? false : true;
                         tmp$3 = tmp$4;
                       }
                       tmp$2 = tmp$3;
@@ -8935,7 +8935,7 @@ function typexp(s, ty) {
                               ]]))]);
                   var row$1 = copy_row((function (param) {
                           return typexp(s, param);
-                        }), /* true */1, row, 1 - dup, more$prime);
+                        }), true, row, !dup, more$prime);
                   var match$8 = row$1[/* row_name */5];
                   if (match$8) {
                     var match$9 = match$8[0];
@@ -9353,13 +9353,13 @@ var type_declarations = Hashtbl.create(/* None */0, 16);
 function add_constructor_usage(cu, param) {
   switch (param) {
     case 0 : 
-        cu[/* cu_positive */0] = /* true */1;
+        cu[/* cu_positive */0] = true;
         return /* () */0;
     case 1 : 
-        cu[/* cu_pattern */1] = /* true */1;
+        cu[/* cu_pattern */1] = true;
         return /* () */0;
     case 2 : 
-        cu[/* cu_privatize */2] = /* true */1;
+        cu[/* cu_privatize */2] = true;
         return /* () */0;
     
   }
@@ -9412,11 +9412,11 @@ function nothing() {
 function already_defined(s, tbl) {
   try {
     find_name(s, tbl);
-    return /* true */1;
+    return true;
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -9504,7 +9504,7 @@ var empty = /* record */[
   /* cltypes : Empty */0,
   /* functor_args : Empty */0,
   /* summary : Env_empty */0,
-  /* local_constraints : false */0,
+  /* local_constraints */false,
   /* gadt_instances : [] */0,
   /* flags */0
 ];
@@ -9522,11 +9522,11 @@ function implicit_coercion(env) {
 }
 
 function is_in_signature(env) {
-  return +((env[/* flags */13] & 1) !== 0);
+  return (env[/* flags */13] & 1) !== 0;
 }
 
 function is_implicit_coercion(env) {
-  return +((env[/* flags */13] & 2) !== 0);
+  return (env[/* flags */13] & 2) !== 0;
 }
 
 var components_of_module$prime = [(function (_, _$1, _$2, _$3) {
@@ -9760,7 +9760,7 @@ function check_consistency(ps) {
                 return /* () */0;
               }
             }), ps[/* ps_crcs */3]);
-      ps[/* ps_crcs_checked */4] = /* true */1;
+      ps[/* ps_crcs_checked */4] = true;
       return /* () */0;
     }
     catch (raw_exn){
@@ -9804,7 +9804,7 @@ function read_pers_struct(modname, filename) {
     /* ps_sig */sign,
     /* ps_comps */comps,
     /* ps_crcs */crcs,
-    /* ps_crcs_checked : false */0,
+    /* ps_crcs_checked */false,
     /* ps_filename */filename,
     /* ps_flags */flags
   ];
@@ -9837,7 +9837,7 @@ function read_pers_struct(modname, filename) {
 }
 
 function find_pers_struct($staropt$star, name) {
-  var check = $staropt$star ? $staropt$star[0] : /* true */1;
+  var check = $staropt$star ? $staropt$star[0] : true;
   if (name === "*predef*") {
     throw Caml_builtin_exceptions.not_found;
   }
@@ -10061,13 +10061,13 @@ function normalize_path(lax, env, path) {
     case 2 : 
         path$1 = /* Papply */Block.__(2, [
             normalize_path(lax, env, path[0]),
-            normalize_path(/* true */1, env, path[1])
+            normalize_path(true, env, path[1])
           ]);
         break;
     
   }
   try {
-    var match = find_module(/* true */1, path$1, env);
+    var match = find_module(true, path$1, env);
     var match$1 = match[/* md_type */0];
     if (match$1.tag === 3) {
       var path$prime = normalize_path(lax, env, match$1[0]);
@@ -10086,16 +10086,16 @@ function normalize_path(lax, env, path) {
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
-      var tmp = /* true */1;
+      var tmp = true;
       if (!lax) {
         var tmp$1;
         switch (path$1.tag | 0) {
           case 0 : 
-              tmp$1 = +(path$1[0][/* stamp */0] !== 0);
+              tmp$1 = path$1[0][/* stamp */0] !== 0;
               break;
           case 1 : 
           case 2 : 
-              tmp$1 = /* true */1;
+              tmp$1 = true;
               break;
           
         }
@@ -10114,7 +10114,7 @@ function normalize_path(lax, env, path) {
 
 function normalize_path$1(oloc, env, path) {
   try {
-    return normalize_path(+(oloc === /* None */0), env, path);
+    return normalize_path(oloc === /* None */0, env, path);
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
@@ -10124,7 +10124,7 @@ function normalize_path$1(oloc, env, path) {
               /* Missing_module */Block.__(3, [
                   oloc[0],
                   path,
-                  normalize_path(/* true */1, env, path)
+                  normalize_path(true, env, path)
                 ])
             ];
       } else {
@@ -10231,11 +10231,11 @@ function is_functor_arg(_path, env) {
       case 0 : 
           try {
             find_same(path[0], env[/* functor_args */9]);
-            return /* true */1;
+            return true;
           }
           catch (exn){
             if (exn === Caml_builtin_exceptions.not_found) {
-              return /* false */0;
+              return false;
             } else {
               throw exn;
             }
@@ -10244,7 +10244,7 @@ function is_functor_arg(_path, env) {
           _path = path[0];
           continue ;
       case 2 : 
-          return /* true */1;
+          return true;
       
     }
   };
@@ -10297,8 +10297,8 @@ function lookup_module_descr(lid, env) {
     case 2 : 
         var match$3 = lookup_module_descr(lid[0], env);
         var p1 = match$3[0];
-        var p2 = lookup_module(/* true */1, lid[1], env);
-        var match$4 = find_module(/* false */0, p2, env);
+        var p2 = lookup_module(true, lid[1], env);
+        var match$4 = find_module(false, p2, env);
         var match$5 = force(components_of_module_maker$prime[0], match$3[1]);
         if (match$5.tag) {
           var f = match$5[0];
@@ -10347,7 +10347,7 @@ function lookup_module(load, lid, env) {
             }
             if (transparent_modules[0] && !load) {
               try {
-                find_pers_struct(/* Some */[/* false */0], s);
+                find_pers_struct(/* Some */[false], s);
               }
               catch (exn$1){
                 if (exn$1 === Caml_builtin_exceptions.not_found) {
@@ -10384,8 +10384,8 @@ function lookup_module(load, lid, env) {
         }
     case 2 : 
         var match$4 = lookup_module_descr(lid[0], env);
-        var p2 = lookup_module(/* true */1, lid[1], env);
-        var match$5 = find_module(/* false */0, p2, env);
+        var p2 = lookup_module(true, lid[1], env);
+        var match$5 = find_module(false, p2, env);
         var p_000 = match$4[0];
         var p = /* Papply */Block.__(2, [
             p_000,
@@ -10444,7 +10444,7 @@ function lookup_all_simple(proj1, proj2, shadow, lid, env) {
                       match[1]
                     ],
                     do_shadow(List.filter((function (param) {
-                                  return 1 - Curry._2(shadow, x, param[0]);
+                                  return !Curry._2(shadow, x, param[0]);
                                 }))(param[1]))
                   ];
           } else {
@@ -10490,14 +10490,14 @@ function cstr_shadow(cstr1, cstr2) {
   switch (match.tag | 0) {
     case 0 : 
     case 1 : 
-        return /* false */0;
+        return false;
     case 2 : 
         switch (match$1.tag | 0) {
           case 0 : 
           case 1 : 
-              return /* false */0;
+              return false;
           case 2 : 
-              return /* true */1;
+              return true;
           
         }
     
@@ -10505,7 +10505,7 @@ function cstr_shadow(cstr1, cstr2) {
 }
 
 function lbl_shadow(_, _$1) {
-  return /* false */0;
+  return false;
 }
 
 function lookup_value(param, param$1) {
@@ -10752,10 +10752,10 @@ function lookup_constructor(lid, env) {
 function is_lident(param) {
   switch (param.tag | 0) {
     case 0 : 
-        return /* true */1;
+        return true;
     case 1 : 
     case 2 : 
-        return /* false */0;
+        return false;
     
   }
 }
@@ -10911,7 +10911,7 @@ function scrape_alias_safe(env, _mty) {
       switch (path.tag | 0) {
         case 0 : 
             if (path[0][/* stamp */0] === 0) {
-              return /* false */0;
+              return false;
             } else {
               exit = 1;
             }
@@ -10923,12 +10923,12 @@ function scrape_alias_safe(env, _mty) {
         
       }
       if (exit === 1) {
-        _mty = find_module(/* false */0, path, env)[/* md_type */0];
+        _mty = find_module(false, path, env)[/* md_type */0];
         continue ;
       }
       
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -10967,13 +10967,13 @@ function iter_types(f) {
             }
             catch (exn){
               if (exn === Caml_builtin_exceptions.not_found) {
-                safe = /* false */0;
+                safe = false;
               } else {
                 throw exn;
               }
             }
           } else {
-            safe = /* true */1;
+            safe = true;
           }
           if (safe) {
             var match$2 = force(components_of_module_maker$prime[0], mcomps);
@@ -11043,9 +11043,9 @@ function iter_types(f) {
 
 function same_types(env1, env2) {
   if (env1[/* types */3] === env2[/* types */3]) {
-    return +(env1[/* components */6] === env2[/* components */6]);
+    return env1[/* components */6] === env2[/* components */6];
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -11155,9 +11155,9 @@ function add_gadt_instance_level(lv, env) {
 function is_Tlink(param) {
   var match = param[/* desc */0];
   if (typeof match === "number" || match.tag !== 6) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -11267,7 +11267,7 @@ function scrape_alias(env, path, mty) {
     case 3 : 
         var path$1 = mty[0];
         try {
-          return scrape_alias(env, /* Some */[path$1], find_module(/* false */0, path$1, env)[/* md_type */0]);
+          return scrape_alias(env, /* Some */[path$1], find_module(false, path$1, env)[/* md_type */0]);
         }
         catch (exn$1){
           if (exn$1 === Caml_builtin_exceptions.not_found) {
@@ -11346,7 +11346,7 @@ function constructors_of_type(ty_path, decl) {
         var cstr_006 = /* cstr_consts */num_consts[0];
         var cstr_007 = /* cstr_nonconsts */num_nonconsts[0];
         var cstr_008 = /* cstr_normal */num_normal[0];
-        var cstr_009 = /* cstr_generalized */+(cd_res !== /* None */0);
+        var cstr_009 = /* cstr_generalized */cd_res !== /* None */0;
         var cstr_011 = /* cstr_loc */match[/* cd_loc */3];
         var cstr_012 = /* cstr_attributes */match[/* cd_attributes */4];
         var cstr = /* record */[
@@ -11739,9 +11739,9 @@ function check_usage(loc, id, warn, tbl) {
     if (Hashtbl.mem(tbl, key)) {
       return /* () */0;
     } else {
-      var used = [/* false */0];
+      var used = [false];
       Hashtbl.add(tbl, key, (function () {
-              used[0] = /* true */1;
+              used[0] = true;
               return /* () */0;
             }));
       if (name === "" || Caml_string.get(name, 0) === /* "_" */95 || Caml_string.get(name, 0) === /* "#" */35) {
@@ -11987,8 +11987,8 @@ function store_type(check, slot, id, path, info, env, renv) {
   ];
   if (check && !loc[/* loc_ghost */2] && is_active(/* Unused_constructor */Block.__(21, [
             "",
-            /* false */0,
-            /* false */0
+            false,
+            false
           ]))) {
     var ty = id[/* name */1];
     List.iter((function (param) {
@@ -12002,9 +12002,9 @@ function store_type(check, slot, id, path, info, env, renv) {
               return 0;
             } else {
               var used = /* record */[
-                /* cu_positive : false */0,
-                /* cu_pattern : false */0,
-                /* cu_privatize : false */0
+                /* cu_positive */false,
+                /* cu_pattern */false,
+                /* cu_privatize */false
               ];
               Hashtbl.add(used_constructors, k, (function (param) {
                       return add_constructor_usage(used, param);
@@ -12053,8 +12053,8 @@ function store_extension(check, slot, id, path, ext, env, renv) {
   var loc = ext[/* ext_loc */5];
   if (check && !loc[/* loc_ghost */2] && is_active(/* Unused_extension */Block.__(22, [
             "",
-            /* false */0,
-            /* false */0
+            false,
+            false
           ]))) {
     var ty = last(ext[/* ext_type_path */0]);
     var n = id[/* name */1];
@@ -12065,9 +12065,9 @@ function store_extension(check, slot, id, path, ext, env, renv) {
     ];
     if (!Hashtbl.mem(used_constructors, k)) {
       var used = /* record */[
-        /* cu_positive : false */0,
-        /* cu_pattern : false */0,
-        /* cu_privatize : false */0
+        /* cu_positive */false,
+        /* cu_pattern */false,
+        /* cu_privatize */false
       ];
       Hashtbl.add(used_constructors, k, (function (param) {
               return add_constructor_usage(used, param);
@@ -12168,7 +12168,7 @@ function add_module_declaration(arg, id, md, env) {
   var $staropt$star = arg;
   var id$1 = id;
   var env$2 = env$1;
-  var arg$1 = $staropt$star ? $staropt$star[0] : /* false */0;
+  var arg$1 = $staropt$star ? $staropt$star[0] : false;
   if (arg$1) {
     var newrecord = env$2.slice();
     newrecord[/* functor_args */9] = add(id$1, /* () */0, env$2[/* functor_args */9]);
@@ -12203,12 +12203,12 @@ function add_local_constraint(id, info, elv, env) {
     var match = info[/* type_newtype_level */6];
     if (match) {
       var newrecord = info.slice();
-      var env$1 = add_type$1(/* false */0, id, (newrecord[/* type_newtype_level */6] = /* Some */[/* tuple */[
+      var env$1 = add_type$1(false, id, (newrecord[/* type_newtype_level */6] = /* Some */[/* tuple */[
                 match[0][0],
                 elv
               ]], newrecord), env);
       var newrecord$1 = env$1.slice();
-      newrecord$1[/* local_constraints */11] = /* true */1;
+      newrecord$1[/* local_constraints */11] = true;
       return newrecord$1;
     } else {
       throw [
@@ -12242,7 +12242,7 @@ function enter(store_fun, name, data, env) {
 
 function enter_type(param, param$1, param$2) {
   return enter((function (param, param$1, param$2, param$3, param$4, param$5) {
-                return store_type(/* true */1, param, param$1, param$2, param$3, param$4, param$5);
+                return store_type(true, param, param$1, param$2, param$3, param$4, param$5);
               }), param, param$1, param$2);
 }
 
@@ -12267,9 +12267,9 @@ function add_item(comp, env) {
     case 0 : 
         return add_value(/* None */0, comp[0], comp[1], env);
     case 1 : 
-        return add_type$1(/* false */0, comp[0], comp[1], env);
+        return add_type$1(false, comp[0], comp[1], env);
     case 2 : 
-        return add_extension(/* false */0, comp[0], comp[1], env);
+        return add_extension(false, comp[0], comp[1], env);
     case 3 : 
         return add_module_declaration(/* None */0, comp[0], comp[1], env);
     case 4 : 
@@ -12308,9 +12308,9 @@ function open_signature(slot, root, sg, env0) {
             case 0 : 
                 return store_value(/* None */0, slot, hide(item[0]), p, item[1], env, env0);
             case 1 : 
-                return store_type(/* false */0, slot, hide(item[0]), p, item[1], env, env0);
+                return store_type(false, slot, hide(item[0]), p, item[1], env, env0);
             case 2 : 
-                return store_extension(/* false */0, slot, hide(item[0]), p, item[1], env, env0);
+                return store_extension(false, slot, hide(item[0]), p, item[1], env, env0);
             case 3 : 
                 return store_module(slot, hide(item[0]), p, item[1], env, env0);
             case 4 : 
@@ -12332,7 +12332,7 @@ function open_signature(slot, root, sg, env0) {
 
 function open_signature$1($staropt$star, $staropt$star$1, ovf, root, sg, env) {
   var loc = $staropt$star ? $staropt$star[0] : none;
-  var toplevel = $staropt$star$1 ? $staropt$star$1[0] : /* false */0;
+  var toplevel = $staropt$star$1 ? $staropt$star$1[0] : false;
   if (!toplevel && ovf === /* Fresh */1 && !loc[/* loc_ghost */2] && (is_active(/* Unused_open */Block.__(17, [""])) || is_active(/* Open_shadow_identifier */Block.__(27, [
               "",
               ""
@@ -12340,7 +12340,7 @@ function open_signature$1($staropt$star, $staropt$star$1, ovf, root, sg, env) {
               "",
               ""
             ])))) {
-    var used = [/* false */0];
+    var used = [false];
     Curry._1(add_delayed_check_forward[0], (function () {
             if (used[0]) {
               return 0;
@@ -12378,7 +12378,7 @@ function open_signature$1($staropt$star, $staropt$star$1, ovf, root, sg, env) {
         }
         prerr_warning(loc, w);
       }
-      used[0] = /* true */1;
+      used[0] = true;
       return /* () */0;
     };
     return open_signature(/* Some */[slot], root, sg, env);
@@ -12463,7 +12463,7 @@ function save_signature(sg, modname, filename) {
         ],
         imports$1
       ],
-      /* ps_crcs_checked : false */0,
+      /* ps_crcs_checked */false,
       /* ps_filename */filename$1,
       cmi_003
     ];
@@ -12628,9 +12628,9 @@ function fold_cltypes(f) {
 }
 
 var match = build_initial_env((function (param, param$1, param$2) {
-        return add_type$1(/* false */0, param, param$1, param$2);
+        return add_type$1(false, param, param$1, param$2);
       }), (function (param, param$1, param$2) {
-        return add_extension(/* false */0, param, param$1, param$2);
+        return add_extension(false, param, param$1, param$2);
       }), empty);
 
 var initial_safe_string = match[0];
@@ -12994,21 +12994,21 @@ function is_mocha() {
     if (match$1) {
       var exec = Path.basename(match$1[0]);
       if (exec === "mocha") {
-        return /* true */1;
+        return true;
       } else {
-        return +(exec === "_mocha");
+        return exec === "_mocha";
       }
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function close_enough($staropt$star, a, b) {
   var threshold = $staropt$star ? $staropt$star[0] : 0.0000001;
-  return +(Math.abs(a - b) < threshold);
+  return Math.abs(a - b) < threshold;
 }
 
 function from_pair_suites(name, suites) {
@@ -13034,25 +13034,24 @@ function from_pair_suites(name, suites) {
                                           Assert.notStrictEqual(match[0], match[1]);
                                           return /* () */0;
                                       case 4 : 
-                                          var b = match[0];
-                                          Assert.ok(b ? true : false);
+                                          Assert.ok(match[0]);
                                           return /* () */0;
                                       case 5 : 
-                                          var b$1 = match[1];
+                                          var b = match[1];
                                           var a = match[0];
-                                          if (close_enough(/* None */0, a, b$1)) {
+                                          if (close_enough(/* None */0, a, b)) {
                                             return 0;
                                           } else {
-                                            Assert.deepEqual(a, b$1);
+                                            Assert.deepEqual(a, b);
                                             return /* () */0;
                                           }
                                       case 6 : 
-                                          var b$2 = match[2];
+                                          var b$1 = match[2];
                                           var a$1 = match[1];
-                                          if (close_enough(/* Some */[match[0]], a$1, b$2)) {
+                                          if (close_enough(/* Some */[match[0]], a$1, b$1)) {
                                             return 0;
                                           } else {
-                                            Assert.deepEqual(a$1, b$2);
+                                            Assert.deepEqual(a$1, b$1);
                                             return /* () */0;
                                           }
                                       case 7 : 
@@ -13366,7 +13365,7 @@ function mkoption(d) {
   var loc = /* record */[
     loc_000,
     loc_001,
-    /* loc_ghost : true */1
+    /* loc_ghost */true
   ];
   return mk(/* Some */[loc], /* None */0, /* Ptyp_constr */Block.__(3, [
                 /* record */[
@@ -13486,7 +13485,7 @@ function mktailexp(nilloc, param) {
     var loc = /* record */[
       loc_000,
       loc_001,
-      /* loc_ghost : true */1
+      /* loc_ghost */true
     ];
     var arg = Curry._3(Ast_helper_004[/* mk */0], /* Some */[loc], /* None */0, /* Pexp_tuple */Block.__(8, [/* :: */[
               e1,
@@ -13498,7 +13497,7 @@ function mktailexp(nilloc, param) {
     return mkexp_cons(/* record */[
                 loc_000,
                 loc_001,
-                /* loc_ghost : true */1
+                /* loc_ghost */true
               ], arg, loc);
   } else {
     var loc_000$1 = /* loc_start */nilloc[/* loc_start */0];
@@ -13506,7 +13505,7 @@ function mktailexp(nilloc, param) {
     var loc$1 = /* record */[
       loc_000$1,
       loc_001$1,
-      /* loc_ghost : true */1
+      /* loc_ghost */true
     ];
     var nil_000 = /* txt : Lident */Block.__(0, ["[]"]);
     var nil = /* record */[
@@ -13529,7 +13528,7 @@ function mktailpat(nilloc, param) {
     var loc = /* record */[
       loc_000,
       loc_001,
-      /* loc_ghost : true */1
+      /* loc_ghost */true
     ];
     var arg = mk$1(/* Some */[loc], /* None */0, /* Ppat_tuple */Block.__(4, [/* :: */[
               p1,
@@ -13541,7 +13540,7 @@ function mktailpat(nilloc, param) {
     return mkpat_cons(/* record */[
                 loc_000,
                 loc_001,
-                /* loc_ghost : true */1
+                /* loc_ghost */true
               ], arg, loc);
   } else {
     var loc_000$1 = /* loc_start */nilloc[/* loc_start */0];
@@ -13549,7 +13548,7 @@ function mktailpat(nilloc, param) {
     var loc$1 = /* record */[
       loc_000$1,
       loc_001$1,
-      /* loc_ghost : true */1
+      /* loc_ghost */true
     ];
     var nil_000 = /* txt : Lident */Block.__(0, ["[]"]);
     var nil = /* record */[
@@ -13919,7 +13918,7 @@ function extra_csig(pos, items) {
 }
 
 function add_nonrec(rf, attrs, pos) {
-  if (rf !== 0) {
+  if (rf) {
     return attrs;
   } else {
     var name_001 = /* loc */rhs_loc(pos);
@@ -18272,15 +18271,15 @@ var yyact = /* array */[
       return /* Rtag */Block.__(0, [
                 _1,
                 _2,
-                /* true */1,
+                true,
                 /* [] */0
               ]);
     }),
   (function () {
-      return /* true */1;
+      return true;
     }),
   (function () {
-      return /* false */0;
+      return false;
     }),
   (function (__caml_parser_env) {
       var _1 = Parsing.peek_val(__caml_parser_env, 0);
@@ -18771,14 +18770,14 @@ var yyact = /* array */[
       var _2 = Parsing.peek_val(__caml_parser_env, 1);
       return /* Ptop_dir */Block.__(1, [
                 _2,
-                /* Pdir_bool */Block.__(3, [/* false */0])
+                /* Pdir_bool */Block.__(3, [false])
               ]);
     }),
   (function (__caml_parser_env) {
       var _2 = Parsing.peek_val(__caml_parser_env, 1);
       return /* Ptop_dir */Block.__(1, [
                 _2,
-                /* Pdir_bool */Block.__(3, [/* true */1])
+                /* Pdir_bool */Block.__(3, [true])
               ]);
     }),
   (function (__caml_parser_env) {
@@ -19369,17 +19368,17 @@ function defined(str) {
   catch (exn){
     try {
       Caml_sys.caml_sys_getenv(str);
-      return /* true */1;
+      return true;
     }
     catch (exn$1){
-      return /* false */0;
+      return false;
     }
   }
   if (exit === 1) {
     if (typeof val === "number") {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   }
   
@@ -19402,7 +19401,7 @@ function query(_, str) {
       }
       catch (exn$1){
         if (exn$1 === Caml_builtin_exceptions.not_found) {
-          return /* Dir_bool */Block.__(0, [/* false */0]);
+          return /* Dir_bool */Block.__(0, [false]);
         } else {
           throw exn$1;
         }
@@ -19432,7 +19431,7 @@ function query(_, str) {
   }
   if (exit === 1) {
     if (typeof v === "number") {
-      return /* Dir_bool */Block.__(0, [/* false */0]);
+      return /* Dir_bool */Block.__(0, [false]);
     } else {
       return v;
     }
@@ -19444,9 +19443,9 @@ function value_of_token(loc, t) {
   if (typeof t === "number") {
     switch (t) {
       case 29 : 
-          return /* Dir_bool */Block.__(0, [/* false */0]);
+          return /* Dir_bool */Block.__(0, [false]);
       case 91 : 
-          return /* Dir_bool */Block.__(0, [/* true */1]);
+          return /* Dir_bool */Block.__(0, [true]);
       default:
         throw [
               $$Error$4,
@@ -19642,7 +19641,7 @@ function directive_parse(token_with_comments, lexbuf) {
                     if (pred >= 17049) {
                       if (pred >= 172069535) {
                         if (pred >= 785637236) {
-                          return +(major === l_major);
+                          return major === l_major;
                         } else {
                           return Caml_obj.caml_equal(lversion, version);
                         }
@@ -19655,9 +19654,9 @@ function directive_parse(token_with_comments, lexbuf) {
                       if (pred >= 15949) {
                         return Caml_obj.caml_greaterthan(lversion, version);
                       } else if (major === l_major) {
-                        return +(version[1] === lversion[1]);
+                        return version[1] === lversion[1];
                       } else {
-                        return /* false */0;
+                        return false;
                       }
                     } else {
                       return Caml_obj.caml_greaterequal(lversion, version);
@@ -19688,7 +19687,7 @@ function directive_parse(token_with_comments, lexbuf) {
               }
               
             } else {
-              return /* true */1;
+              return true;
             }
             break;
         case "<=" : 
@@ -19748,7 +19747,7 @@ function directive_parse(token_with_comments, lexbuf) {
       if (calc) {
         return Curry._2(f, lhs, assert_same_type(lexbuf, lhs, rhs$1));
       } else {
-        return /* true */1;
+        return true;
       }
     }
     
@@ -19760,10 +19759,10 @@ function directive_parse(token_with_comments, lexbuf) {
         push(e);
         return v;
       } else {
-        var calc$1 = calc && 1 - v;
+        var calc$1 = calc && !v;
         var b = parse_or_aux(calc$1, parse_and_aux(calc$1, parse_relation(calc$1)));
         if (v) {
-          return /* true */1;
+          return true;
         } else {
           return b;
         }
@@ -19779,7 +19778,7 @@ function directive_parse(token_with_comments, lexbuf) {
     if (typeof curr_token === "number") {
       switch (curr_token) {
         case 29 : 
-            return /* false */0;
+            return false;
         case 54 : 
             var v = parse_or_aux(calc, parse_and_aux(calc, parse_relation(calc)));
             var match = token(/* () */0);
@@ -19801,7 +19800,7 @@ function directive_parse(token_with_comments, lexbuf) {
                   ];
             }
         case 91 : 
-            return /* true */1;
+            return true;
         default:
           throw [
                 $$Error$4,
@@ -19861,12 +19860,12 @@ function directive_parse(token_with_comments, lexbuf) {
                 var s = t[0];
                 if (calc) {
                   if (Caml_string.get(r, 0) === /* "u" */117) {
-                    return 1 - defined(s);
+                    return !defined(s);
                   } else {
                     return defined(s);
                   }
                 } else {
-                  return /* true */1;
+                  return true;
                 }
               } else {
                 throw [
@@ -19932,7 +19931,7 @@ function directive_parse(token_with_comments, lexbuf) {
         if (v) {
           return b;
         } else {
-          return /* false */0;
+          return false;
         }
       }
     } else {
@@ -19940,7 +19939,7 @@ function directive_parse(token_with_comments, lexbuf) {
       return v;
     }
   };
-  var v = parse_or_aux(/* true */1, parse_and_aux(/* true */1, parse_relation(/* true */1)));
+  var v = parse_or_aux(true, parse_and_aux(true, parse_relation(true)));
   var match = token(/* () */0);
   if (typeof match === "number") {
     if (match !== 88) {
@@ -19963,9 +19962,9 @@ function directive_parse(token_with_comments, lexbuf) {
 
 function is_elif(i) {
   if (typeof i === "number" || !(i.tag === 11 && i[0] === "elif")) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -20347,9 +20346,9 @@ var string_start_loc = [none];
 
 var comment_start_loc = [/* [] */0];
 
-var is_in_string = [/* false */0];
+var is_in_string = [false];
 
-var print_warnings = [/* true */1];
+var print_warnings = [true];
 
 var if_then_else = [/* Dir_out */2];
 
@@ -20507,7 +20506,7 @@ function update_loc(lexbuf, file, line, absolute, chars) {
 
 var preprocessor = [/* None */0];
 
-var escaped_newlines = [/* false */0];
+var escaped_newlines = [false];
 
 function warn_latin1(lexbuf) {
   return prerr_warning(curr(lexbuf), /* Deprecated */Block.__(0, ["ISO-Latin1 characters in identifiers"]));
@@ -20747,10 +20746,10 @@ function token(lexbuf) {
                     curr(lexbuf$1)
                   ];
             }
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf$1, /* None */0, 1, false, 0);
             return token(lexbuf$1);
         case 1 : 
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf$1, /* None */0, 1, false, 0);
             return /* EOL */100;
         case 2 : 
             return token(lexbuf$1);
@@ -20858,11 +20857,11 @@ function token(lexbuf) {
             }
         case 19 : 
             reset_string_buffer(/* () */0);
-            is_in_string[0] = /* true */1;
+            is_in_string[0] = true;
             var string_start = lexbuf$1[/* lex_start_p */10];
             string_start_loc[0] = curr(lexbuf$1);
             string(lexbuf$1);
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             lexbuf$1[/* lex_start_p */10] = string_start;
             return /* STRING */Block.__(16, [/* tuple */[
                         get_stored_string(/* () */0),
@@ -20872,18 +20871,18 @@ function token(lexbuf) {
             reset_string_buffer(/* () */0);
             var delim = Lexing.lexeme(lexbuf$1);
             var delim$1 = $$String.sub(delim, 1, delim.length - 2 | 0);
-            is_in_string[0] = /* true */1;
+            is_in_string[0] = true;
             var string_start$1 = lexbuf$1[/* lex_start_p */10];
             string_start_loc[0] = curr(lexbuf$1);
             __ocaml_lex_quoted_string_rec(delim$1, lexbuf$1, 183);
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             lexbuf$1[/* lex_start_p */10] = string_start$1;
             return /* STRING */Block.__(16, [/* tuple */[
                         get_stored_string(/* () */0),
                         /* Some */[delim$1]
                       ]]);
         case 21 : 
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, 1);
+            update_loc(lexbuf$1, /* None */0, 1, false, 1);
             return /* CHAR */Block.__(0, [Lexing.lexeme_char(lexbuf$1, 1)]);
         case 22 : 
             return /* CHAR */Block.__(0, [Lexing.lexeme_char(lexbuf$1, 1)]);
@@ -20952,7 +20951,7 @@ function token(lexbuf) {
         case 33 : 
             var num = Lexing.sub_lexeme(lexbuf$1, Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 0), Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 1));
             var name = Lexing.sub_lexeme_opt(lexbuf$1, Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 3), Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 2));
-            update_loc(lexbuf$1, name, Caml_format.caml_int_of_string(num), /* true */1, 0);
+            update_loc(lexbuf$1, name, Caml_format.caml_int_of_string(num), true, 0);
             return token(lexbuf$1);
         case 34 : 
             return /* SHARP */84;
@@ -21106,12 +21105,12 @@ function __ocaml_lex_quoted_string_rec(delim, lexbuf, ___ocaml_lex_state) {
     } else {
       switch (__ocaml_lex_state$1) {
         case 0 : 
-            update_loc(lexbuf, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf, /* None */0, 1, false, 0);
             store_string(Lexing.lexeme(lexbuf));
             ___ocaml_lex_state = 183;
             continue ;
         case 1 : 
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             throw [
                   $$Error$4,
                   /* Unterminated_string */0,
@@ -21154,7 +21153,7 @@ function string(lexbuf) {
             return /* () */0;
         case 1 : 
             var space = Lexing.sub_lexeme(lexbuf$1, Caml_array.caml_array_get(lexbuf$1[/* lex_mem */9], 0), lexbuf$1[/* lex_curr_pos */5]);
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, space.length);
+            update_loc(lexbuf$1, /* None */0, 1, false, space.length);
             return string(lexbuf$1);
         case 2 : 
             store_string_char(char_for_backslash(Lexing.lexeme_char(lexbuf$1, 1)));
@@ -21179,11 +21178,11 @@ function string(lexbuf) {
             if (comment_start_loc[0] === /* [] */0) {
               prerr_warning(curr(lexbuf$1), /* Eol_in_string */14);
             }
-            update_loc(lexbuf$1, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf$1, /* None */0, 1, false, 0);
             store_string(Lexing.lexeme(lexbuf$1));
             return string(lexbuf$1);
         case 7 : 
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             throw [
                   $$Error$4,
                   /* Unterminated_string */0,
@@ -21246,7 +21245,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
         case 2 : 
             string_start_loc[0] = curr(lexbuf);
             store_string_char(/* "\"" */34);
-            is_in_string[0] = /* true */1;
+            is_in_string[0] = true;
             try {
               string(lexbuf);
             }
@@ -21288,7 +21287,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
                 throw exn;
               }
             }
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             store_string_char(/* "\"" */34);
             ___ocaml_lex_state = 132;
             continue ;
@@ -21297,7 +21296,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
             var delim$1 = $$String.sub(delim, 1, delim.length - 2 | 0);
             string_start_loc[0] = curr(lexbuf);
             store_string(Lexing.lexeme(lexbuf));
-            is_in_string[0] = /* true */1;
+            is_in_string[0] = true;
             try {
               __ocaml_lex_quoted_string_rec(delim$1, lexbuf, 183);
             }
@@ -21339,14 +21338,14 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
                 throw exn$1;
               }
             }
-            is_in_string[0] = /* false */0;
+            is_in_string[0] = false;
             store_string_char(/* "|" */124);
             store_string(delim$1);
             store_string_char(/* "}" */125);
             ___ocaml_lex_state = 132;
             continue ;
         case 5 : 
-            update_loc(lexbuf, /* None */0, 1, /* false */0, 1);
+            update_loc(lexbuf, /* None */0, 1, false, 1);
             store_string(Lexing.lexeme(lexbuf));
             ___ocaml_lex_state = 132;
             continue ;
@@ -21371,7 +21370,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
                   ];
             }
         case 11 : 
-            update_loc(lexbuf, /* None */0, 1, /* false */0, 0);
+            update_loc(lexbuf, /* None */0, 1, false, 0);
             store_string(Lexing.lexeme(lexbuf));
             ___ocaml_lex_state = 132;
             continue ;
@@ -21392,7 +21391,7 @@ function __ocaml_lex_comment_rec(lexbuf, ___ocaml_lex_state) {
 
 function at_bol(lexbuf) {
   var pos = lexbuf[/* lex_start_p */10];
-  return +(pos[/* pos_cnum */3] === pos[/* pos_bol */2]);
+  return pos[/* pos_cnum */3] === pos[/* pos_bol */2];
 }
 
 function token_with_comments(lexbuf) {
@@ -21566,7 +21565,7 @@ function token$1(lexbuf) {
                   if (if_then_else$1 !== 0) {
                     return Curry._1(look_ahead, match);
                   } else {
-                    var _else_seen = +(match === /* ELSE */23);
+                    var _else_seen = match === /* ELSE */23;
                     while(true) {
                       var else_seen = _else_seen;
                       var token$2 = token_with_comments(lexbuf$1);
@@ -21592,7 +21591,7 @@ function token$1(lexbuf) {
                                     curr(lexbuf$1)
                                   ];
                             } else {
-                              _else_seen = /* true */1;
+                              _else_seen = true;
                               continue ;
                             }
                           } else if (switcher$1 !== 14) {
@@ -21723,7 +21722,7 @@ function token$1(lexbuf) {
 function init$1() {
   sharp_look_ahead[0] = /* None */0;
   if_then_else[0] = /* Dir_out */2;
-  is_in_string[0] = /* false */0;
+  is_in_string[0] = false;
   comment_start_loc[0] = /* [] */0;
   comment_list[0] = /* [] */0;
   var match = preprocessor[0];
@@ -23342,11 +23341,11 @@ var need_to_clear_env;
 
 try {
   Caml_sys.caml_sys_getenv("OCAML_BINANNOT_WITHENV");
-  need_to_clear_env = /* false */0;
+  need_to_clear_env = false;
 }
 catch (exn$2){
   if (exn$2 === Caml_builtin_exceptions.not_found) {
-    need_to_clear_env = /* true */1;
+    need_to_clear_env = true;
   } else {
     throw exn$2;
   }
@@ -23817,24 +23816,24 @@ function is_object_type(path) {
             ];
     
   }
-  return +(Caml_string.get(name, 0) === /* "#" */35);
+  return Caml_string.get(name, 0) === /* "#" */35;
 }
 
-var trace_gadt_instances = [/* false */0];
+var trace_gadt_instances = [false];
 
 function check_trace_gadt_instances(env) {
   if (!trace_gadt_instances[0] && env[/* local_constraints */11]) {
-    trace_gadt_instances[0] = /* true */1;
+    trace_gadt_instances[0] = true;
     cleanup_abbrev(/* () */0);
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function reset_trace_gadt_instances(b) {
   if (b) {
-    trace_gadt_instances[0] = /* false */0;
+    trace_gadt_instances[0] = false;
     return /* () */0;
   } else {
     return 0;
@@ -23881,9 +23880,9 @@ var none$2 = newty2(current_level[0], /* Ttuple */Block.__(2, [/* [] */0]));
 
 function equal$3(param, param$1) {
   if (param[0] === param$1[0]) {
-    return +(param[1] === param$1[1]);
+    return param[1] === param$1[1];
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -23898,9 +23897,9 @@ var TypePairs = Hashtbl.Make(/* module */[
 
 var umode = [/* Expression */0];
 
-var generate_equations = [/* false */0];
+var generate_equations = [false];
 
-var assume_injective = [/* false */0];
+var assume_injective = [false];
 
 function set_mode_pattern(generate, injective, f) {
   var old_unification_mode = umode[0];
@@ -23927,10 +23926,10 @@ function set_mode_pattern(generate, injective, f) {
 function in_current_module(param) {
   switch (param.tag | 0) {
     case 0 : 
-        return /* true */1;
+        return true;
     case 1 : 
     case 2 : 
-        return /* false */0;
+        return false;
     
   }
 }
@@ -23939,26 +23938,26 @@ function in_pervasives(p) {
   if (in_current_module(p)) {
     try {
       find_type_full(p, initial_safe_string)[0];
-      return /* true */1;
+      return true;
     }
     catch (exn){
       if (exn === Caml_builtin_exceptions.not_found) {
-        return /* false */0;
+        return false;
       } else {
         throw exn;
       }
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function is_datatype(decl) {
   var match = decl[/* type_kind */2];
   if (typeof match === "number" && match === 0) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -24154,15 +24153,15 @@ function object_row(_ty) {
 function opened_object(ty) {
   var match = object_row(ty)[/* desc */0];
   if (typeof match === "number") {
-    return /* false */0;
+    return false;
   } else {
     switch (match.tag | 0) {
       case 0 : 
       case 3 : 
       case 9 : 
-          return /* true */1;
+          return true;
       default:
-        return /* false */0;
+        return false;
     }
   }
 }
@@ -24170,9 +24169,9 @@ function opened_object(ty) {
 function concrete_object(ty) {
   var match = object_row(ty)[/* desc */0];
   if (typeof match === "number" || match.tag) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -24505,7 +24504,7 @@ function filter_row_fields(erase, param) {
     if (typeof match === "number") {
       return fi;
     } else if (match.tag) {
-      if (match[2] !== 0) {
+      if (match[2]) {
         return /* :: */[
                 p,
                 fi
@@ -24579,12 +24578,12 @@ function closed_schema(ty) {
   try {
     closed_schema_rec(ty);
     unmark_type(ty);
-    return /* true */1;
+    return true;
   }
   catch (exn){
     if (exn === Non_closed0) {
       unmark_type(ty);
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -24642,7 +24641,7 @@ function free_vars_rec(_real, _ty) {
                   
                 }
                 return List.iter((function (param) {
-                              return free_vars_rec(/* true */1, param);
+                              return free_vars_rec(true, param);
                             }), match[1]);
               } else {
                 exit = 1;
@@ -24650,23 +24649,23 @@ function free_vars_rec(_real, _ty) {
               break;
           case 4 : 
               _ty = match[0];
-              _real = /* false */0;
+              _real = false;
               continue ;
           case 5 : 
-              free_vars_rec(/* true */1, match[2]);
+              free_vars_rec(true, match[2]);
               _ty = match[3];
-              _real = /* false */0;
+              _real = false;
               continue ;
           case 8 : 
               var row = row_repr_aux(/* [] */0, match[0]);
               iter_row((function (param) {
-                      return free_vars_rec(/* true */1, param);
+                      return free_vars_rec(true, param);
                     }), row);
               if (static_row(row)) {
                 return 0;
               } else {
                 _ty = row[/* row_more */1];
-                _real = /* false */0;
+                _real = false;
                 continue ;
               }
           default:
@@ -24675,7 +24674,7 @@ function free_vars_rec(_real, _ty) {
       }
       if (exit === 1) {
         return iter_type_expr((function (param) {
-                      return free_vars_rec(/* true */1, param);
+                      return free_vars_rec(true, param);
                     }), ty$1);
       }
       
@@ -24688,7 +24687,7 @@ function free_vars_rec(_real, _ty) {
 function free_vars$1(env, ty) {
   free_variables[0] = /* [] */0;
   really_closed[0] = env;
-  free_vars_rec(/* true */1, ty);
+  free_vars_rec(true, ty);
   var res = free_variables[0];
   free_variables[0] = /* [] */0;
   really_closed[0] = /* None */0;
@@ -24722,12 +24721,12 @@ function closed_parameterized_type(params, ty) {
   var ok;
   try {
     closed_type(ty);
-    ok = /* true */1;
+    ok = true;
   }
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn[0] === Non_closed) {
-      ok = /* false */0;
+      ok = false;
     } else {
       throw exn;
     }
@@ -24742,7 +24741,7 @@ function closed_type_decl(decl) {
     List.iter(mark_type, decl[/* type_params */0]);
     var match = decl[/* type_kind */2];
     if (typeof match === "number") {
-      +(match === 0);
+      match === 0;
     } else if (match.tag) {
       List.iter((function (param) {
               if (param[/* cd_res */2]) {
@@ -24908,11 +24907,11 @@ function generalize_structure(var_level, ty) {
     if (is_Tvar(ty$1) && ty$1[/* level */1] > var_level) {
       return set_level(ty$1, var_level);
     } else {
-      var tmp = /* false */0;
+      var tmp = false;
       if (ty$1[/* level */1] > current_level[0]) {
         var match = ty$1[/* desc */0];
         var tmp$1;
-        tmp$1 = typeof match === "number" || match.tag !== 3 ? /* true */1 : 1 - is_object_type(match[0]) && (match[2][0] = /* Mnil */0, /* true */1);
+        tmp$1 = typeof match === "number" || match.tag !== 3 ? true : !is_object_type(match[0]) && (match[2][0] = /* Mnil */0, true);
         tmp = tmp$1;
       }
       if (tmp) {
@@ -25443,7 +25442,7 @@ function find_repr(p1, _param) {
       var rem = param[0][/* contents */0];
       _param = rem;
       continue ;
-    } else if (param[0] !== 0) {
+    } else if (param[0]) {
       if (same(p1, param[1])) {
         return /* Some */[param[2]];
       } else {
@@ -25482,7 +25481,7 @@ function copy(env, partial, keep_names, ty) {
         var match$1 = partial[0];
         var param = Curry._1(match$1[0], ty$1);
         forget = (
-          param ? /* false */0 : /* true */1
+          param ? false : true
         ) ? (
             match$1[1] ? ty$1[/* level */1] : current_level[0]
           ) : 100000000;
@@ -25592,7 +25591,7 @@ function copy(env, partial, keep_names, ty) {
                   }
                 }
                 if (exit$2 === 2) {
-                  var keep = +(more[/* level */1] !== 100000000);
+                  var keep = more[/* level */1] !== 100000000;
                   var match$9 = more[/* desc */0];
                   var more$prime;
                   var exit$3 = 0;
@@ -25641,13 +25640,13 @@ function copy(env, partial, keep_names, ty) {
                     row$1 = row;
                   } else {
                     var newrecord = row.slice();
-                    newrecord[/* row_fixed */4] = /* true */1;
+                    newrecord[/* row_fixed */4] = true;
                     row$1 = newrecord;
                   }
                   var match$12;
                   if (partial) {
                     var match$13 = partial[0];
-                    if (match$13[1] !== 0) {
+                    if (match$13[1]) {
                       match$12 = /* tuple */[
                         more$prime,
                         row$1
@@ -25663,19 +25662,19 @@ function copy(env, partial, keep_names, ty) {
                       var not_reither = function (param) {
                         var match = row_field_repr_aux(/* [] */0, param[1]);
                         if (typeof match === "number" || !match.tag) {
-                          return /* true */1;
+                          return true;
                         } else {
-                          return /* false */0;
+                          return false;
                         }
                       };
-                      var tmp$2 = /* false */0;
+                      var tmp$2 = false;
                       if (row$1[/* row_closed */3]) {
-                        var tmp$3 = /* false */0;
+                        var tmp$3 = false;
                         if (!row$1[/* row_fixed */4]) {
                           var param$1 = Curry._1(match$13[0], ty$1);
                           tmp$3 = (
-                            param$1 ? /* false */0 : /* true */1
-                          ) && 1 - List.for_all(not_reither, row$1[/* row_fields */0]);
+                            param$1 ? false : true
+                          ) && !List.for_all(not_reither, row$1[/* row_fields */0]);
                         }
                         tmp$2 = tmp$3;
                       }
@@ -25685,8 +25684,8 @@ function copy(env, partial, keep_names, ty) {
                             /* row_fields */List.filter(not_reither)(row$1[/* row_fields */0]),
                             /* row_more */more$prime$1,
                             /* row_bound : () */0,
-                            /* row_closed : false */0,
-                            /* row_fixed : false */0,
+                            /* row_closed */false,
+                            /* row_fixed */false,
                             /* row_name : None */0
                           ]
                         ] : /* tuple */[
@@ -25708,7 +25707,7 @@ function copy(env, partial, keep_names, ty) {
                                   /* [] */0
                                 ]
                               ]]))]);
-                  tmp = /* Tvariant */Block.__(8, [copy_row(copy$1, /* true */1, match$12[1], keep, more$prime$2)]);
+                  tmp = /* Tvariant */Block.__(8, [copy_row(copy$1, true, match$12[1], keep, more$prime$2)]);
                 }
                 break;
             default:
@@ -25993,7 +25992,7 @@ var delayed_copy = [/* [] */0];
 function copy_sep(fixed, free, bound, visited, ty) {
   var ty$1 = repr(ty);
   var univars = Curry._1(free, ty$1);
-  if (univars ? /* false */0 : /* true */1) {
+  if (univars ? false : true) {
     if (ty$1[/* level */1] !== 100000000) {
       return ty$1;
     } else {
@@ -26062,7 +26061,7 @@ function copy_sep(fixed, free, bound, visited, ty) {
             case 8 : 
                 var row = row_repr_aux(/* [] */0, match$2[0]);
                 var more = repr(row[/* row_more */1]);
-                var keep = is_Tvar(more) && +(more[/* level */1] !== 100000000);
+                var keep = is_Tvar(more) && more[/* level */1] !== 100000000;
                 var more$prime = copy_rec(more);
                 var fixed$prime = fixed && is_Tvar(repr(more$prime));
                 var row$1 = copy_row(copy_rec, fixed$prime, row, keep, more$prime);
@@ -26102,7 +26101,7 @@ function copy_sep(fixed, free, bound, visited, ty) {
 }
 
 function instance_poly($staropt$star, fixed, univars, sch) {
-  var keep_names = $staropt$star ? $staropt$star[0] : /* false */0;
+  var keep_names = $staropt$star ? $staropt$star[0] : false;
   var univars$1 = List.map(repr, univars);
   var copy_var = function (ty) {
     var match = ty[/* desc */0];
@@ -26397,16 +26396,16 @@ function safe_abbrev(env, ty) {
   var snap = snapshot(/* () */0);
   try {
     expand_abbrev(env)(ty);
-    return /* true */1;
+    return true;
   }
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn === Cannot_expand) {
       backtrack(snap);
-      return /* false */0;
+      return false;
     } else if (exn[0] === Unify) {
       backtrack(snap);
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -26642,11 +26641,11 @@ function full_expand(env, ty) {
 function generic_abbrev(env, path) {
   try {
     var match = find_type_expansion(path, env);
-    return +(repr(match[1])[/* level */1] === 100000000);
+    return repr(match[1])[/* level */1] === 100000000;
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -26657,20 +26656,20 @@ function generic_private_abbrev(env, path) {
   try {
     var match = find_type_full(path, env)[0];
     var match$1 = match[/* type_kind */2];
-    if (typeof match$1 === "number" && !(match$1 !== 0 || match[/* type_private */3] !== 0)) {
+    if (typeof match$1 === "number" && !(match$1 !== 0 || match[/* type_private */3])) {
       var match$2 = match[/* type_manifest */4];
       if (match$2) {
-        return +(repr(match$2[0])[/* level */1] === 100000000);
+        return repr(match$2[0])[/* level */1] === 100000000;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -26680,18 +26679,18 @@ function generic_private_abbrev(env, path) {
 function is_contractive(env, ty) {
   var match = repr(ty)[/* desc */0];
   if (typeof match === "number" || match.tag !== 3) {
-    return /* true */1;
+    return true;
   } else {
     var p = match[0];
     if (in_pervasives(p)) {
-      return /* true */1;
+      return true;
     } else {
       try {
         return is_datatype(find_type_full(p, env)[0]);
       }
       catch (exn){
         if (exn === Caml_builtin_exceptions.not_found) {
-          return /* false */0;
+          return false;
         } else {
           throw exn;
         }
@@ -26796,11 +26795,11 @@ function occur_rec(env, visited, ty0, ty) {
   
 }
 
-var type_changed = [/* false */0];
+var type_changed = [false];
 
 function merge(r, b) {
   if (b) {
-    r[0] = /* true */1;
+    r[0] = true;
     return /* () */0;
   } else {
     return 0;
@@ -26810,7 +26809,7 @@ function merge(r, b) {
 function occur(env, ty0, ty) {
   var old = type_changed[0];
   try {
-    while(type_changed[0] = /* false */0, occur_rec(env, /* [] */0, ty0, ty), type_changed[0]) {
+    while(type_changed[0] = false, occur_rec(env, /* [] */0, ty0, ty), type_changed[0]) {
       
     };
     return merge(type_changed, old);
@@ -26828,12 +26827,12 @@ function occur(env, ty0, ty) {
 function occur_in(env, ty0, t) {
   try {
     occur(env, ty0, t);
-    return /* false */0;
+    return false;
   }
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn[0] === Unify) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -26848,7 +26847,7 @@ function unify_univar(t1, t2, _param) {
       var find_univ = function (t, cl) {
         try {
           var match = List.find((function (param) {
-                  return +(t === repr(param[0]));
+                  return t === repr(param[0]);
                 }), cl);
           return /* Some */[match[1]];
         }
@@ -26924,30 +26923,30 @@ function occur_univar(env, ty) {
       var ty = _ty;
       var bound = _bound;
       var ty$1 = repr(ty);
-      var tmp = /* false */0;
+      var tmp = false;
       if (ty$1[/* level */1] >= 0) {
         var tmp$1;
-        if (bound ? /* false */0 : /* true */1) {
+        if (bound ? false : true) {
           ty$1[/* level */1] = pivot_level - ty$1[/* level */1] | 0;
-          tmp$1 = /* true */1;
+          tmp$1 = true;
         } else {
           try {
             var bound$prime = find$1(ty$1, visited[0]);
             if (exists((function(bound){
                   return function (x) {
-                    return 1 - mem$3(x, bound);
+                    return !mem$3(x, bound);
                   }
                   }(bound)), bound$prime)) {
               visited[0] = add$4(ty$1, inter$2(bound, bound$prime), visited[0]);
-              tmp$1 = /* true */1;
+              tmp$1 = true;
             } else {
-              tmp$1 = /* false */0;
+              tmp$1 = false;
             }
           }
           catch (exn){
             if (exn === Caml_builtin_exceptions.not_found) {
               visited[0] = add$4(ty$1, bound, visited[0]);
-              tmp$1 = /* true */1;
+              tmp$1 = true;
             } else {
               throw exn;
             }
@@ -27125,11 +27124,11 @@ function univars_escape(env, univar_pairs, vl, ty) {
   };
   try {
     occur(ty);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Occur) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -27201,12 +27200,12 @@ function has_cached_expansion(p, _abbrev) {
   while(true) {
     var abbrev = _abbrev;
     if (typeof abbrev === "number") {
-      return /* false */0;
+      return false;
     } else if (abbrev.tag) {
       _abbrev = abbrev[0][0];
       continue ;
     } else if (same(p, abbrev[1])) {
-      return /* true */1;
+      return true;
     } else {
       _abbrev = abbrev[4];
       continue ;
@@ -27240,12 +27239,12 @@ function mkvariant(fields, closed) {
                   /* row_more */newvar(/* None */0, /* () */0),
                   /* row_bound : () */0,
                   /* row_closed */closed,
-                  /* row_fixed : false */0,
+                  /* row_fixed */false,
                   /* row_name : None */0
                 ]]));
 }
 
-var rigid_variants = [/* false */0];
+var rigid_variants = [false];
 
 function deep_occur(t0, ty) {
   var occur_rec = function (ty) {
@@ -27263,12 +27262,12 @@ function deep_occur(t0, ty) {
   try {
     occur_rec(ty);
     unmark_type(ty);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Occur) {
       unmark_type(ty);
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -27371,7 +27370,7 @@ function reify(env, t) {
                       /* row_more */t$1,
                       row_002,
                       row_003,
-                      /* row_fixed : true */1,
+                      /* row_fixed */true,
                       row_005
                     ];
                     link_type(m, newty2(m[/* level */1], /* Tvariant */Block.__(8, [row])));
@@ -27392,14 +27391,14 @@ function is_newtype(env, p) {
   try {
     var decl = find_type_full(p, env)[0];
     if (decl[/* type_newtype_level */6] !== /* None */0 && decl[/* type_kind */2] === /* Type_abstract */0) {
-      return +(decl[/* type_private */3] === /* Public */1);
+      return decl[/* type_private */3] === /* Public */1;
     } else {
-      return /* false */0;
+      return false;
     }
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -27408,9 +27407,9 @@ function is_newtype(env, p) {
 
 function non_aliasable(p, decl) {
   if (in_current_module(p)) {
-    return +(decl[/* type_newtype_level */6] === /* None */0);
+    return decl[/* type_newtype_level */6] === /* None */0;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -27418,18 +27417,18 @@ function expands_to_datatype(env, ty) {
   var ty$1 = repr(ty);
   var match = ty$1[/* desc */0];
   if (typeof match === "number" || match.tag !== 3) {
-    return /* false */0;
+    return false;
   } else {
     try {
       if (is_datatype(find_type_full(match[0], env)[0])) {
-        return /* true */1;
+        return true;
       } else {
         return expands_to_datatype(env, try_expand_once(env, ty$1));
       }
     }
     catch (exn){
       if (exn === Caml_builtin_exceptions.not_found || exn === Cannot_expand) {
-        return /* false */0;
+        return false;
       } else {
         throw exn;
       }
@@ -27635,7 +27634,7 @@ function mcomp(type_pairs, env, _t1, _t2) {
                               catch (exn$1){
                                 if (exn$1 === Caml_builtin_exceptions.not_found) {
                                   inj = List.map((function () {
-                                          return /* false */0;
+                                          return false;
                                         }), tl1);
                                 } else {
                                   throw exn$1;
@@ -27873,9 +27872,9 @@ function mcomp(type_pairs, env, _t1, _t2) {
                                 var cannot_erase = function (param) {
                                   var match = row_field_repr_aux(/* [] */0, param[1]);
                                   if (typeof match === "number" || match.tag) {
-                                    return /* false */0;
+                                    return false;
                                   } else {
-                                    return /* true */1;
+                                    return true;
                                   }
                                 };
                                 if (row1$1[/* row_closed */3] && List.exists(cannot_erase, match$6[1]) || row2$1[/* row_closed */3] && List.exists(cannot_erase, match$6[0])) {
@@ -27894,7 +27893,7 @@ function mcomp(type_pairs, env, _t1, _t2) {
                                               exit$1 = 2;
                                             } else if (match.tag) {
                                               var exit$2 = 0;
-                                              if (match[0] !== 0 || typeof match$1 === "number" || match$1.tag) {
+                                              if (match[0] || typeof match$1 === "number" || match$1.tag) {
                                                 exit$2 = 3;
                                               } else {
                                                 var match$2 = match$1[0];
@@ -27925,7 +27924,7 @@ function mcomp(type_pairs, env, _t1, _t2) {
                                                         /* [] */0
                                                       ];
                                                 } else if (match$1.tag) {
-                                                  if (match$1[0] !== 0) {
+                                                  if (match$1[0]) {
                                                     throw [
                                                           Unify,
                                                           /* [] */0
@@ -27983,7 +27982,7 @@ function mcomp(type_pairs, env, _t1, _t2) {
                                             }
                                             if (exit === 1) {
                                               var exit$3 = 0;
-                                              if (typeof match === "number" || match[0] !== 0) {
+                                              if (typeof match === "number" || match[0]) {
                                                 exit$3 = 2;
                                               } else {
                                                 return /* () */0;
@@ -28379,7 +28378,7 @@ function add_type_equality(t1, t2) {
 
 function eq_package_path(env, p1, p2) {
   if (same(p1, p2)) {
-    return /* true */1;
+    return true;
   } else {
     return same(normalize_package_path(env, p1), normalize_package_path(env, p2));
   }
@@ -28442,7 +28441,7 @@ function nondep_instance(env, level, id, ty) {
 }
 
 function complete_type_list($staropt$star, env, nl1, lv2, mty2, nl2, tl2) {
-  var allow_absent = $staropt$star ? $staropt$star[0] : /* false */0;
+  var allow_absent = $staropt$star ? $staropt$star[0] : false;
   var id2 = create("Pkg");
   var env$prime = add_module$1(/* None */0, id2, mty2, env);
   var complete = function (_nl1, ntl2) {
@@ -28477,7 +28476,7 @@ function complete_type_list($staropt$star, env, nl1, lv2, mty2, nl2, tl2) {
               if (typeof match$1 === "number") {
                 if (match$1 !== 0) {
                   throw Pervasives.Exit;
-                } else if (decl[/* type_private */3] !== 0) {
+                } else if (decl[/* type_private */3]) {
                   var match$2 = decl[/* type_manifest */4];
                   if (match$2) {
                     return /* :: */[
@@ -28543,23 +28542,23 @@ function unify_package(env, unify_list, _, p1, n1, tl1, lv2, p2, n2, tl2) {
 
 function unify_eq(_, t1, t2) {
   if (t1 === t2) {
-    return /* true */1;
+    return true;
   } else {
     var match = umode[0];
-    if (match !== 0) {
+    if (match) {
       try {
         Curry._2(TypePairs[/* find */6], unify_eq_set, order_type_pair(t1, t2));
-        return /* true */1;
+        return true;
       }
       catch (exn){
         if (exn === Caml_builtin_exceptions.not_found) {
-          return /* false */0;
+          return false;
         } else {
           throw exn;
         }
       }
     } else {
-      return /* false */0;
+      return false;
     }
   }
 }
@@ -28575,7 +28574,7 @@ function unify(env, t1, t2) {
     } else {
       var reset_tracing = check_trace_gadt_instances(env[0]);
       try {
-        type_changed[0] = /* true */1;
+        type_changed[0] = true;
         var match = t1$1[/* desc */0];
         var match$1 = t2$1[/* desc */0];
         var exit = 0;
@@ -28702,7 +28701,7 @@ function unify(env, t1, t2) {
 function unify3(env, t1, t1$prime, t2, t2$prime) {
   var d1 = t1$prime[/* desc */0];
   var d2 = t2$prime[/* desc */0];
-  var create_recursion = +(t2 !== t2$prime) && deep_occur(t1$prime, t2);
+  var create_recursion = t2 !== t2$prime && deep_occur(t1$prime, t2);
   var exit = 0;
   var exit$1 = 0;
   if (typeof d1 === "number") {
@@ -28759,7 +28758,7 @@ function unify3(env, t1, t1$prime, t2, t2$prime) {
   }
   if (exit === 1) {
     var match = umode[0];
-    if (match !== 0) {
+    if (match) {
       add_type_equality(t1$prime, t2$prime);
     } else {
       occur(env[0], t1$prime, t2$prime);
@@ -28871,11 +28870,11 @@ function unify3(env, t1, t1$prime, t2, t2$prime) {
                   if (umode[0] === /* Expression */0 || !generate_equations[0]) {
                     unify_list(env, tl1, tl2);
                   } else if (assume_injective[0]) {
-                    set_mode_pattern(/* true */1, /* false */0, (function () {
+                    set_mode_pattern(true, false, (function () {
                             return unify_list(env, tl1, tl2);
                           }));
                   } else {
-                    var tmp = /* true */1;
+                    var tmp = true;
                     if (!in_current_module(p1)) {
                       var partial_arg = env[0];
                       tmp = List.exists((function (param) {
@@ -28901,7 +28900,7 @@ function unify3(env, t1, t1$prime, t2, t2$prime) {
                       catch (exn){
                         if (exn === Caml_builtin_exceptions.not_found) {
                           inj = List.map((function () {
-                                  return /* false */0;
+                                  return false;
                                 }), tl1);
                         } else {
                           throw exn;
@@ -28913,7 +28912,7 @@ function unify3(env, t1, t1$prime, t2, t2$prime) {
                               if (i) {
                                 return unify(env, t1, t2);
                               } else {
-                                return set_mode_pattern(/* false */0, /* false */0, (function () {
+                                return set_mode_pattern(false, false, (function () {
                                               var snap = snapshot(/* () */0);
                                               try {
                                                 return unify(env, t1, t2);
@@ -29015,15 +29014,15 @@ function unify3(env, t1, t1$prime, t2, t2$prime) {
                               var match$7 = repr(match$6[0])[/* desc */0];
                               var tmp$1;
                               if (typeof match$7 === "number") {
-                                tmp$1 = /* true */1;
+                                tmp$1 = true;
                               } else {
                                 switch (match$7.tag | 0) {
                                   case 0 : 
                                   case 9 : 
-                                      tmp$1 = /* true */1;
+                                      tmp$1 = true;
                                       break;
                                   default:
-                                    tmp$1 = /* false */0;
+                                    tmp$1 = false;
                                 }
                               }
                               if (!tmp$1) {
@@ -29530,7 +29529,7 @@ function unify_fields(env, ty1, ty2) {
   var miss1 = match$2[1];
   var l1 = repr(ty1)[/* level */1];
   var l2 = repr(ty2)[/* level */1];
-  var va = make_rowvar(l1 < l2 ? l1 : l2, +(miss2 === /* [] */0), rest1, +(miss1 === /* [] */0), rest2);
+  var va = make_rowvar(l1 < l2 ? l1 : l2, miss2 === /* [] */0, rest1, miss1 === /* [] */0, rest2);
   var d1 = rest1[/* desc */0];
   var d2 = rest2[/* desc */0];
   try {
@@ -29638,30 +29637,30 @@ function unify_row(env, row1, row2) {
       return List.for_all((function (param) {
                     var match = Curry._2($$switch, param[1], param[2]);
                     if (row_field_repr_aux(/* [] */0, match[0]) === /* Rabsent */0) {
-                      return /* true */1;
+                      return true;
                     } else {
-                      return +(row_field_repr_aux(/* [] */0, match[1]) !== /* Rabsent */0);
+                      return row_field_repr_aux(/* [] */0, match[1]) !== /* Rabsent */0;
                     }
                   }), pairs);
     };
     var empty = function (fields) {
       return List.for_all((function (param) {
-                    return +(row_field_repr_aux(/* [] */0, param[1]) === /* Rabsent */0);
+                    return row_field_repr_aux(/* [] */0, param[1]) === /* Rabsent */0;
                   }), fields);
     };
     if (closed && (empty(r1) || row2$1[/* row_closed */3]) && (empty(r2) || row1$1[/* row_closed */3]) && List.for_all((function (param) {
               if (row_field_repr_aux(/* [] */0, param[1]) === /* Rabsent */0) {
-                return /* true */1;
+                return true;
               } else {
-                return +(row_field_repr_aux(/* [] */0, param[2]) === /* Rabsent */0);
+                return row_field_repr_aux(/* [] */0, param[2]) === /* Rabsent */0;
               }
             }), pairs)) {
       throw [
             Unify,
             /* :: */[
               /* tuple */[
-                mkvariant(/* [] */0, /* true */1),
-                mkvariant(/* [] */0, /* true */1)
+                mkvariant(/* [] */0, true),
+                mkvariant(/* [] */0, true)
               ],
               /* [] */0
             ]
@@ -29691,8 +29690,8 @@ function unify_row(env, row1, row2) {
     var set_more = function (row, rest) {
       var rest$1 = closed ? filter_row_fields(row[/* row_closed */3], rest) : rest;
       if (rest$1 !== /* [] */0 && (row[/* row_closed */3] || row_fixed(row)) || closed && row_fixed(row) && !row[/* row_closed */3]) {
-        var t1 = mkvariant(/* [] */0, /* true */1);
-        var t2 = mkvariant(rest$1, /* false */0);
+        var t1 = mkvariant(/* [] */0, true);
+        var t2 = mkvariant(rest$1, false);
         throw [
               Unify,
               /* :: */[
@@ -29756,7 +29755,7 @@ function unify_row(env, row1, row2) {
                           if (typeof f2$2 === "number") {
                             return /* () */0;
                           } else if (f2$2.tag) {
-                            if (f2$2[2] !== 0) {
+                            if (f2$2[2]) {
                               throw [
                                     Unify,
                                     /* [] */0
@@ -29781,7 +29780,7 @@ function unify_row(env, row1, row2) {
                           var tl1 = f1$2[1];
                           var e1 = f1$2[3];
                           if (typeof f2$2 === "number") {
-                            if (m1 !== 0) {
+                            if (m1) {
                               throw [
                                     Unify,
                                     /* [] */0
@@ -29802,7 +29801,7 @@ function unify_row(env, row1, row2) {
                               var m2 = f2$2[2];
                               var tl2 = f2$2[1];
                               var c2 = f2$2[0];
-                              var redo = /* false */0;
+                              var redo = false;
                               if (m1 || m2 || fixed1$1 || fixed2$1 || rigid_variants[0] && (List.length(tl1) === 1 || List.length(tl2) === 1)) {
                                 var match = Pervasives.$at(tl1, tl2);
                                 var tmp;
@@ -29819,9 +29818,9 @@ function unify_row(env, row1, row2) {
                                         return unify(env$1, t1, param);
                                       }
                                       }(t1)), match[1]);
-                                  tmp = +(e1[0] !== /* None */0 || e2[0] !== /* None */0);
+                                  tmp = e1[0] !== /* None */0 || e2[0] !== /* None */0;
                                 } else {
-                                  tmp = /* false */0;
+                                  tmp = false;
                                 }
                                 redo = tmp;
                               }
@@ -29882,7 +29881,7 @@ function unify_row(env, row1, row2) {
                                 return set_row_field(e2, f2$prime);
                               }
                             }
-                          } else if (c1 !== 0) {
+                          } else if (c1) {
                             if (f1$2[1]) {
                               throw [
                                     Unify,
@@ -29943,7 +29942,7 @@ function unify_row(env, row1, row2) {
                                     /* [] */0
                                   ];
                             } else if (f2$2.tag) {
-                              if (f2$2[0] !== 0) {
+                              if (f2$2[0]) {
                                 throw [
                                       Unify,
                                       /* [] */0
@@ -29986,7 +29985,7 @@ function unify_row(env, row1, row2) {
                                   /* [] */0
                                 ];
                           } else if (f2$2.tag) {
-                            if (f2$2[0] !== 0) {
+                            if (f2$2[0]) {
                               if (f2$2[1]) {
                                 throw [
                                       Unify,
@@ -30030,14 +30029,14 @@ function unify_row(env, row1, row2) {
                                           f1
                                         ],
                                         /* [] */0
-                                      ], /* true */1),
+                                      ], true),
                                   mkvariant(/* :: */[
                                         /* tuple */[
                                           l,
                                           f2
                                         ],
                                         /* [] */0
-                                      ], /* true */1)
+                                      ], true)
                                 ],
                                 exn$2[1]
                               ]
@@ -30223,7 +30222,7 @@ function filter_method_field(env, name, priv, _ty) {
             var ty2 = newty2(level, /* Tvar */Block.__(0, [/* None */0]));
             var ty$prime = newty2(level, /* Tfield */Block.__(5, [
                     name,
-                    priv !== 0 ? /* Fpresent */0 : /* Fvar */[[/* None */0]],
+                    priv ? /* Fpresent */0 : /* Fvar */[[/* None */0]],
                     ty1,
                     ty2
                   ]));
@@ -30341,9 +30340,9 @@ function moregen_occur(env, level, ty) {
 
 function may_instantiate(inst_nongen, t1) {
   if (inst_nongen) {
-    return +(t1[/* level */1] !== 99999999);
+    return t1[/* level */1] !== 99999999;
   } else {
-    return +(t1[/* level */1] === 100000000);
+    return t1[/* level */1] === 100000000;
   }
 }
 
@@ -30539,13 +30538,13 @@ function moregen(inst_nongen, type_pairs, env, t1, t2) {
                           if (rm1 === rm2) {
                             return /* () */0;
                           } else {
-                            var may_inst = is_Tvar(rm1) && may_instantiate(inst_nongen$1, rm1) || +(rm1[/* desc */0] === /* Tnil */0);
+                            var may_inst = is_Tvar(rm1) && may_instantiate(inst_nongen$1, rm1) || rm1[/* desc */0] === /* Tnil */0;
                             var match$4 = merge_row_fields(row1$1[/* row_fields */0], row2$1[/* row_fields */0]);
                             var r2 = match$4[1];
                             var r1 = match$4[0];
                             var match$5 = row2$1[/* row_closed */3] ? /* tuple */[
                                 filter_row_fields(may_inst, r1),
-                                filter_row_fields(/* false */0, r2)
+                                filter_row_fields(false, r2)
                               ] : /* tuple */[
                                 r1,
                                 r2
@@ -30638,7 +30637,7 @@ function moregen(inst_nongen, type_pairs, env, t1, t2) {
                                           } else if (f1.tag) {
                                             var c1 = f1[0];
                                             var exit = 0;
-                                            if (c1 !== 0) {
+                                            if (c1) {
                                               if (f1[1] || typeof f2 === "number" || f2.tag) {
                                                 exit = 1;
                                               } else if (f2[0]) {
@@ -31018,12 +31017,12 @@ function moregeneral(env, inst_nongen, pat_sch, subj_sch) {
   var res;
   try {
     moregen$1(inst_nongen, Curry._1(TypePairs[/* create */0], 13), env, patt, subj);
-    res = /* true */1;
+    res = true;
   }
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn[0] === Unify) {
-      res = /* false */0;
+      res = false;
     } else {
       throw exn;
     }
@@ -31068,7 +31067,7 @@ function rigidify_rec(vars, _ty) {
                   /* row_more */more$prime,
                   row$prime_002,
                   row$prime_003,
-                  /* row_fixed : true */1,
+                  /* row_fixed */true,
                   row$prime_005
                 ];
                 link_type(more, newty2(ty$1[/* level */1], /* Tvariant */Block.__(8, [row$prime])));
@@ -31106,7 +31105,7 @@ function all_distinct_vars(env, vars) {
   return List.for_all((function (ty) {
                 var ty$1 = expand_head(env, ty);
                 if (List.memq(ty$1, tyl[0])) {
-                  return /* false */0;
+                  return false;
                 } else {
                   tyl[0] = /* :: */[
                     ty$1,
@@ -31129,7 +31128,7 @@ function matches(env, ty, ty$prime) {
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn[0] === Unify) {
-      ok = /* false */0;
+      ok = false;
     } else {
       throw exn;
     }
@@ -31140,7 +31139,7 @@ function matches(env, ty, ty$prime) {
 
 function expand_head_rigid(env, ty) {
   var old = rigid_variants[0];
-  rigid_variants[0] = /* true */1;
+  rigid_variants[0] = true;
   var ty$prime = expand_head(env, ty);
   rigid_variants[0] = old;
   return ty$prime;
@@ -31153,11 +31152,11 @@ function normalize_subst(subst) {
             if (typeof match === "number" || match.tag !== 6) {
               exit = 1;
             } else {
-              return /* true */1;
+              return true;
             }
             if (exit === 1) {
               var match$1 = param[1][/* desc */0];
-              return typeof match$1 === "number" || match$1.tag !== 6 ? /* false */0 : /* true */1;
+              return typeof match$1 === "number" || match$1.tag !== 6 ? false : true;
             }
             
           }), subst[0])) {
@@ -31208,7 +31207,7 @@ function eqtype(rename, type_pairs, subst, env, t1, t2) {
                   catch (exn){
                     if (exn === Caml_builtin_exceptions.not_found) {
                       if (List.exists((function (param) {
-                                return +(param[1] === t2$1);
+                                return param[1] === t2$1;
                               }), subst[0])) {
                         throw [
                               Unify,
@@ -31299,7 +31298,7 @@ function eqtype(rename, type_pairs, subst, env, t1, t2) {
                           catch (exn$2){
                             if (exn$2 === Caml_builtin_exceptions.not_found) {
                               if (List.exists((function (param) {
-                                        return +(param[1] === t2$prime$1);
+                                        return param[1] === t2$prime$1;
                                       }), subst[0])) {
                                 throw [
                                       Unify,
@@ -31447,7 +31446,7 @@ function eqtype(rename, type_pairs, subst, env, t1, t2) {
                               var match$6 = merge_row_fields(row1$1[/* row_fields */0], row2$1[/* row_fields */0]);
                               var r2 = match$6[1];
                               var r1 = match$6[0];
-                              if (row1$1[/* row_closed */3] !== row2$1[/* row_closed */3] || !row1$1[/* row_closed */3] && (r1 !== /* [] */0 || r2 !== /* [] */0) || filter_row_fields(/* false */0, Pervasives.$at(r1, r2)) !== /* [] */0) {
+                              if (row1$1[/* row_closed */3] !== row2$1[/* row_closed */3] || !row1$1[/* row_closed */3] && (r1 !== /* [] */0 || r2 !== /* [] */0) || filter_row_fields(false, Pervasives.$at(r1, r2)) !== /* [] */0) {
                                 throw [
                                       Unify,
                                       /* [] */0
@@ -31469,7 +31468,7 @@ function eqtype(rename, type_pairs, subst, env, t1, t2) {
                                                     ];
                                               }
                                             } else if (match.tag) {
-                                              if (match[0] !== 0) {
+                                              if (match[0]) {
                                                 if (match[1]) {
                                                   throw [
                                                         Unify,
@@ -31481,7 +31480,7 @@ function eqtype(rename, type_pairs, subst, env, t1, t2) {
                                                         /* [] */0
                                                       ];
                                                 } else if (match$1.tag) {
-                                                  if (match$1[0] !== 0) {
+                                                  if (match$1[0]) {
                                                     if (match$1[1]) {
                                                       throw [
                                                             Unify,
@@ -31513,7 +31512,7 @@ function eqtype(rename, type_pairs, subst, env, t1, t2) {
                                                           /* [] */0
                                                         ];
                                                   } else if (match$1.tag) {
-                                                    if (match$1[0] !== 0) {
+                                                    if (match$1[0]) {
                                                       throw [
                                                             Unify,
                                                             /* [] */0
@@ -31743,7 +31742,7 @@ function eqtype_fields(rename, type_pairs, subst, env, ty1, _ty2) {
     var rest1 = match[1];
     var match$1 = flatten_fields(ty2);
     var rest2 = match$1[1];
-    var same_row = +(rest1 === rest2) || Curry._2(TypePairs[/* mem */9], type_pairs, /* tuple */[
+    var same_row = rest1 === rest2 || Curry._2(TypePairs[/* mem */9], type_pairs, /* tuple */[
           rest1,
           rest2
         ]) || rename && List.mem(/* tuple */[
@@ -31855,12 +31854,12 @@ function equal$4(env, rename, tyl1, tyl2) {
   try {
     univar_pairs[0] = /* [] */0;
     eqtype_list(rename, Curry._1(TypePairs[/* create */0], 11), [/* [] */0], env, tyl1, tyl2);
-    return /* true */1;
+    return true;
   }
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn[0] === Unify) {
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -31879,7 +31878,7 @@ function moregen_clty(trace, type_pairs, env, cty1, cty2) {
     var exit = 0;
     switch (cty1.tag | 0) {
       case 0 : 
-          return moregen_clty(/* true */1, type_pairs, env, cty1[2], cty2);
+          return moregen_clty(true, type_pairs, env, cty1[2], cty2);
       case 1 : 
           var sign1 = cty1[0];
           switch (cty2.tag | 0) {
@@ -31895,7 +31894,7 @@ function moregen_clty(trace, type_pairs, env, cty1, cty2) {
                 var match$2 = associate_fields(match[0], match$1[0]);
                 List.iter((function (param) {
                         try {
-                          return moregen$1(/* true */1, type_pairs, env, param[2], param[4]);
+                          return moregen$1(true, type_pairs, env, param[2], param[4]);
                         }
                         catch (raw_exn){
                           var exn = Js_exn.internalToOCamlException(raw_exn);
@@ -31919,7 +31918,7 @@ function moregen_clty(trace, type_pairs, env, cty1, cty2) {
                 return iter$1((function (lab, param) {
                               var match = find(lab, sign1[/* csig_vars */1]);
                               try {
-                                return moregen$1(/* true */1, type_pairs, env, match[2], param[2]);
+                                return moregen$1(true, type_pairs, env, match[2], param[2]);
                               }
                               catch (raw_exn){
                                 var exn = Js_exn.internalToOCamlException(raw_exn);
@@ -31961,7 +31960,7 @@ function moregen_clty(trace, type_pairs, env, cty1, cty2) {
             case 2 : 
                 if (cty1[0] === cty2[0]) {
                   try {
-                    moregen$1(/* true */1, type_pairs, env, cty1[1], cty2[1]);
+                    moregen$1(true, type_pairs, env, cty1[1], cty2[1]);
                   }
                   catch (raw_exn){
                     var exn = Js_exn.internalToOCamlException(raw_exn);
@@ -31980,7 +31979,7 @@ function moregen_clty(trace, type_pairs, env, cty1, cty2) {
                       throw exn;
                     }
                   }
-                  return moregen_clty(/* false */0, type_pairs, env, cty1[2], cty2[2]);
+                  return moregen_clty(false, type_pairs, env, cty1[2], cty2[2]);
                 } else {
                   throw [
                         Failure,
@@ -31993,7 +31992,7 @@ function moregen_clty(trace, type_pairs, env, cty1, cty2) {
       
     }
     if (exit === 1) {
-      return moregen_clty(/* true */1, type_pairs, env, cty1, cty2[2]);
+      return moregen_clty(true, type_pairs, env, cty1, cty2[2]);
     }
     
   }
@@ -32023,7 +32022,7 @@ function moregen_clty(trace, type_pairs, env, cty1, cty2) {
 }
 
 function match_class_types($staropt$star, env, pat_sch, subj_sch) {
-  var trace = $staropt$star ? $staropt$star[0] : /* true */1;
+  var trace = $staropt$star ? $staropt$star[0] : true;
   var type_pairs = Curry._1(TypePairs[/* create */0], 53);
   var old_level = current_level[0];
   current_level[0] = 99999999;
@@ -32068,7 +32067,7 @@ function match_class_types($staropt$star, env, pat_sch, subj_sch) {
   var error$1 = Pervasives.$at(List.map((function (m) {
               return /* CM_Missing_method */Block.__(9, [m]);
             }), missing_method), error);
-  moregen$1(/* true */1, type_pairs, env, match$2[1], match$3[1]);
+  moregen$1(true, type_pairs, env, match$2[1], match$3[1]);
   var error$2 = List.fold_right((function (param, err) {
           try {
             moregen_kind(param[1], param[3]);
@@ -32174,7 +32173,7 @@ function equal_clty(trace, type_pairs, subst, env, cty1, cty2) {
           var exit$1 = 0;
           switch (cty2.tag | 0) {
             case 0 : 
-                return equal_clty(/* true */1, type_pairs, subst, env, cty1$1, cty2[2]);
+                return equal_clty(true, type_pairs, subst, env, cty1$1, cty2[2]);
             case 1 : 
             case 2 : 
                 exit$1 = 3;
@@ -32182,7 +32181,7 @@ function equal_clty(trace, type_pairs, subst, env, cty1, cty2) {
             
           }
           if (exit$1 === 3) {
-            return equal_clty(/* true */1, type_pairs, subst, env, cty1$1, cty2);
+            return equal_clty(true, type_pairs, subst, env, cty1$1, cty2);
           }
           break;
       case 1 : 
@@ -32200,7 +32199,7 @@ function equal_clty(trace, type_pairs, subst, env, cty1, cty2) {
                 var match$2 = associate_fields(match[0], match$1[0]);
                 List.iter((function (param) {
                         try {
-                          return eqtype$1(/* true */1, type_pairs, subst, env, param[2], param[4]);
+                          return eqtype$1(true, type_pairs, subst, env, param[2], param[4]);
                         }
                         catch (raw_exn){
                           var exn = Js_exn.internalToOCamlException(raw_exn);
@@ -32224,7 +32223,7 @@ function equal_clty(trace, type_pairs, subst, env, cty1, cty2) {
                 return iter$1((function (lab, param) {
                               var match = find(lab, sign1[/* csig_vars */1]);
                               try {
-                                return eqtype$1(/* true */1, type_pairs, subst, env, match[2], param[2]);
+                                return eqtype$1(true, type_pairs, subst, env, match[2], param[2]);
                               }
                               catch (raw_exn){
                                 var exn = Js_exn.internalToOCamlException(raw_exn);
@@ -32262,7 +32261,7 @@ function equal_clty(trace, type_pairs, subst, env, cty1, cty2) {
             case 2 : 
                 if (cty1[0] === cty2[0]) {
                   try {
-                    eqtype$1(/* true */1, type_pairs, subst, env, cty1[1], cty2[1]);
+                    eqtype$1(true, type_pairs, subst, env, cty1[1], cty2[1]);
                   }
                   catch (raw_exn){
                     var exn = Js_exn.internalToOCamlException(raw_exn);
@@ -32281,7 +32280,7 @@ function equal_clty(trace, type_pairs, subst, env, cty1, cty2) {
                       throw exn;
                     }
                   }
-                  return equal_clty(/* false */0, type_pairs, subst, env, cty1[2], cty2[2]);
+                  return equal_clty(false, type_pairs, subst, env, cty1[2], cty2[2]);
                 } else {
                   exit = 2;
                 }
@@ -32293,7 +32292,7 @@ function equal_clty(trace, type_pairs, subst, env, cty1, cty2) {
     }
     switch (exit) {
       case 1 : 
-          return equal_clty(/* true */1, type_pairs, subst, env, cty1, cty2[2]);
+          return equal_clty(true, type_pairs, subst, env, cty1, cty2[2]);
       case 2 : 
           throw [
                 Failure,
@@ -32372,7 +32371,7 @@ function match_class_declarations(env, patt_params, patt_type, subj_params, subj
   var error$1 = Pervasives.$at(List.map((function (m) {
               return /* CM_Missing_method */Block.__(9, [m]);
             }), missing_method), error);
-  eqtype$1(/* true */1, type_pairs, subst, env, match[1], match$1[1]);
+  eqtype$1(true, type_pairs, subst, env, match[1], match$1[1]);
   var error$2 = List.fold_right((function (param, err) {
           var lab = param[0];
           var k1 = field_kind_repr(param[1]);
@@ -32488,7 +32487,7 @@ function match_class_declarations(env, patt_params, patt_type, subj_params, subj
       }
       List.iter2((function (p, s) {
               try {
-                return eqtype$1(/* true */1, type_pairs, subst, env, p, s);
+                return eqtype$1(true, type_pairs, subst, env, p, s);
               }
               catch (raw_exn){
                 var exn = Js_exn.internalToOCamlException(raw_exn);
@@ -32508,7 +32507,7 @@ function match_class_declarations(env, patt_params, patt_type, subj_params, subj
                 }
               }
             }), patt_params, subj_params);
-      equal_clty(/* false */0, type_pairs, subst, env, /* Cty_signature */Block.__(1, [sign1]), /* Cty_signature */Block.__(1, [sign2]));
+      equal_clty(false, type_pairs, subst, env, /* Cty_signature */Block.__(1, [sign1]), /* Cty_signature */Block.__(1, [sign2]));
       var clty_params = function (param, param$1) {
         return List.fold_right((function (ty, cty) {
                       return /* Cty_arrow */Block.__(2, [
@@ -32518,7 +32517,7 @@ function match_class_declarations(env, patt_params, patt_type, subj_params, subj
                               ]);
                     }), param, param$1);
       };
-      return match_class_types(/* Some */[/* false */0], env, clty_params(patt_params, patt_type), clty_params(subj_params, subj_type));
+      return match_class_types(/* Some */[false], env, clty_params(patt_params, patt_type), clty_params(subj_params, subj_type));
     }
     catch (raw_exn){
       var exn = Js_exn.internalToOCamlException(raw_exn);
@@ -32531,7 +32530,7 @@ function match_class_declarations(env, patt_params, patt_type, subj_params, subj
   }
 }
 
-var warn = [/* false */0];
+var warn = [false];
 
 function pred_expand(n) {
   if (n % 2 === 0 && n > 0) {
@@ -32581,10 +32580,10 @@ function filter_visited(_l) {
 
 function memq_warn(t, visited) {
   if (List.memq(t, visited)) {
-    warn[0] = /* true */1;
-    return /* true */1;
+    warn[0] = true;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -32660,7 +32659,7 @@ function build_subtype(env, visited, loops, posi, level, t) {
               /* Changed */2
             ];
     } else {
-      warn[0] = /* true */1;
+      warn[0] = true;
       return /* tuple */[
               t$1,
               /* Unchanged */0
@@ -32672,7 +32671,7 @@ function build_subtype(env, visited, loops, posi, level, t) {
           if (posi) {
             try {
               var t$prime = List.assq(t$1, loops);
-              warn[0] = /* true */1;
+              warn[0] = true;
               return /* tuple */[
                       t$prime,
                       /* Equiv */1
@@ -32705,7 +32704,7 @@ function build_subtype(env, visited, loops, posi, level, t) {
               t$1,
               visited
             ];
-            var match$1 = build_subtype(env, visited$1, loops, 1 - posi, level, match[1]);
+            var match$1 = build_subtype(env, visited$1, loops, !posi, level, match[1]);
             var match$2 = build_subtype(env, visited$1, loops, posi, level, match[2]);
             var c = Caml_primitive.caml_int_max(match$1[1], match$2[1]);
             if (c > /* Unchanged */0) {
@@ -32892,7 +32891,7 @@ function build_subtype(env, visited, loops, posi, level, t) {
             try {
               var decl = find_type_full(p, env)[0];
               if (level === 0 && generic_abbrev(env, p) && safe_abbrev(env, t$1) && !has_constr_row$prime(env, t$1)) {
-                warn[0] = /* true */1;
+                warn[0] = true;
               }
               var tl$prime = List.map2((function (v, t) {
                       var match = Curry._1(Types_003[/* get_upper */10], v);
@@ -32904,7 +32903,7 @@ function build_subtype(env, visited, loops, posi, level, t) {
                                   /* Unchanged */0
                                 ];
                         } else {
-                          return build_subtype(env, visited$3, loops, 1 - posi, level, t);
+                          return build_subtype(env, visited$3, loops, !posi, level, t);
                         }
                       } else if (co) {
                         return build_subtype(env, visited$3, loops, posi, level, t);
@@ -33016,7 +33015,7 @@ function build_subtype(env, visited, loops, posi, level, t) {
               t$1,
               visited_001$1
             ];
-            var fields = filter_row_fields(/* false */0, row[/* row_fields */0]);
+            var fields = filter_row_fields(false, row[/* row_fields */0]);
             var fields$1 = List.map((function (orig) {
                     var l = orig[0];
                     var match = row_field_repr_aux(/* [] */0, orig[1]);
@@ -33044,12 +33043,12 @@ function build_subtype(env, visited, loops, posi, level, t) {
                         var match$2 = build_subtype(env, visited$5, loops, posi, level$prime$2, match$1[0]);
                         var t$prime = match$2[0];
                         var f = posi && level > 0 ? /* Reither */Block.__(1, [
-                              /* false */0,
+                              false,
                               /* :: */[
                                 t$prime,
                                 /* [] */0
                               ],
-                              /* false */0,
+                              false,
                               [/* None */0]
                             ]) : /* Rpresent */Block.__(0, [/* Some */[t$prime]]);
                         return /* tuple */[
@@ -33064,9 +33063,9 @@ function build_subtype(env, visited, loops, posi, level, t) {
                                 /* tuple */[
                                   l,
                                   /* Reither */Block.__(1, [
-                                      /* true */1,
+                                      true,
                                       /* [] */0,
-                                      /* false */0,
+                                      false,
                                       [/* None */0]
                                     ])
                                 ],
@@ -33091,7 +33090,7 @@ function build_subtype(env, visited, loops, posi, level, t) {
               row_001,
               /* row_bound : () */0,
               /* row_closed */posi,
-              /* row_fixed : false */0,
+              /* row_fixed */false,
               row_005
             ];
             return /* tuple */[
@@ -33128,8 +33127,8 @@ function build_subtype(env, visited, loops, posi, level, t) {
 }
 
 function enlarge_type(env, ty) {
-  warn[0] = /* false */0;
-  var match = build_subtype(env, /* [] */0, /* [] */0, /* true */1, 4, ty);
+  warn[0] = false;
+  var match = build_subtype(env, /* [] */0, /* [] */0, true, 4, ty);
   return /* tuple */[
           match[0],
           warn[0]
@@ -33444,13 +33443,13 @@ function subtype_rec(env, _trace, _t1, _t2, _cstrs) {
                                                         throw Pervasives.Exit;
                                                       }
                                                     } else if (match.tag) {
-                                                      if (match[0] !== 0) {
+                                                      if (match[0]) {
                                                         if (match[1]) {
                                                           throw Pervasives.Exit;
                                                         } else if (typeof match$1 === "number") {
                                                           throw Pervasives.Exit;
                                                         } else if (match$1.tag) {
-                                                          if (match$1[0] !== 0) {
+                                                          if (match$1[0]) {
                                                             if (match$1[1]) {
                                                               throw Pervasives.Exit;
                                                             } else {
@@ -33470,7 +33469,7 @@ function subtype_rec(env, _trace, _t1, _t2, _cstrs) {
                                                           } else if (typeof match$1 === "number") {
                                                             throw Pervasives.Exit;
                                                           } else if (match$1.tag) {
-                                                            if (match$1[0] !== 0) {
+                                                            if (match$1[0]) {
                                                               throw Pervasives.Exit;
                                                             } else {
                                                               var match$3 = match$1[1];
@@ -33566,7 +33565,7 @@ function subtype_rec(env, _trace, _t1, _t2, _cstrs) {
                                               if (typeof match === "number") {
                                                 return cstrs;
                                               } else if (match.tag) {
-                                                if (match[0] !== 0) {
+                                                if (match[0]) {
                                                   exit = 1;
                                                 } else {
                                                   var match$2 = match[1];
@@ -33732,7 +33731,7 @@ function subtype_rec(env, _trace, _t1, _t2, _cstrs) {
                                 }
                               }
                             } else {
-                              var match$8 = instance_poly(/* None */0, /* false */0, tl1$1, u1$1);
+                              var match$8 = instance_poly(/* None */0, false, tl1$1, u1$1);
                               _t2 = u2$1;
                               _t1 = match$8[1];
                               continue ;
@@ -33763,7 +33762,7 @@ function subtype_rec(env, _trace, _t1, _t2, _cstrs) {
                           var p2 = match$1[0];
                           try {
                             var ntl1 = complete_type_list(/* None */0, env, nl2, t1$1[/* level */1], /* Mty_ident */Block.__(0, [p1]), nl1, tl1$2);
-                            var ntl2 = complete_type_list(/* Some */[/* true */1], env, nl1, t2$1[/* level */1], /* Mty_ident */Block.__(0, [p2]), nl2, tl2$2);
+                            var ntl2 = complete_type_list(/* Some */[true], env, nl1, t2$1[/* level */1], /* Mty_ident */Block.__(0, [p2]), nl2, tl2$2);
                             var cstrs$prime = List.map((function(trace,ntl1){
                                 return function (param) {
                                   return /* tuple */[
@@ -34065,9 +34064,9 @@ function cyclic_abbrev(env, id, ty) {
     var ty$1 = repr(ty);
     var match = ty$1[/* desc */0];
     if (typeof match === "number" || match.tag !== 3) {
-      return /* false */0;
+      return false;
     } else if (Caml_obj.caml_equal(match[0], /* Pident */Block.__(0, [id])) || List.memq(ty$1, seen)) {
-      return /* true */1;
+      return true;
     } else {
       try {
         return check_cycle(/* :: */[
@@ -34078,9 +34077,9 @@ function cyclic_abbrev(env, id, ty) {
       catch (raw_exn){
         var exn = Js_exn.internalToOCamlException(raw_exn);
         if (exn === Cannot_expand) {
-          return /* false */0;
+          return false;
         } else if (exn[0] === Unify) {
-          return /* true */1;
+          return true;
         } else {
           throw exn;
         }
@@ -34173,7 +34172,7 @@ function normalize_type_rec(env, visited, ty) {
                         if (tyl) {
                           var tyl$prime = List.fold_left((function (tyl, ty) {
                                   if (List.exists((function (ty$prime) {
-                                            return equal$4(env, /* false */0, /* :: */[
+                                            return equal$4(env, false, /* :: */[
                                                         ty,
                                                         /* [] */0
                                                       ], /* :: */[
@@ -34213,7 +34212,7 @@ function normalize_type_rec(env, visited, ty) {
             var fields$1 = List.sort((function (param, param$1) {
                     return Caml_primitive.caml_string_compare(param[0], param$1[0]);
                   }), List.filter((function (param) {
-                          return +(param[1] !== /* Rabsent */0);
+                          return param[1] !== /* Rabsent */0;
                         }))(fields));
             log_type(ty$1);
             var newrecord = row.slice();
@@ -34337,7 +34336,7 @@ function nondep_type_rec(env, id, _ty) {
                       var more$prime = $$static ? newty2(100000000, /* Tnil */0) : more;
                       var row$1 = copy_row((function (param) {
                               return nondep_type_rec(env, id, param);
-                            }), /* true */1, row, /* true */1, more$prime);
+                            }), true, row, true, more$prime);
                       var match$4 = row$1[/* row_name */5];
                       if (match$4) {
                         if (isfree(id, match$4[0][0])) {
@@ -34797,31 +34796,31 @@ function parenthesized_ident(name) {
             ]
           ]
         ])) {
-    return /* true */1;
+    return true;
   } else {
     var match = Caml_string.get(name, 0);
     if (match >= 97) {
       if (match >= 223) {
         if (match !== 247) {
-          return /* false */0;
+          return false;
         } else {
-          return /* true */1;
+          return true;
         }
       } else if (match >= 123) {
-        return /* true */1;
+        return true;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (match >= 91) {
       if (match !== 95) {
-        return /* true */1;
+        return true;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (match >= 65) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   }
 }
@@ -35576,9 +35575,9 @@ function print_simple_out_type(ppf, ty) {
                       ]),
                     "@[<1>(module %s"
                   ]), ty[0]);
-          var first = [/* true */1];
+          var first = [true];
           List.iter2((function (s, t) {
-                  var sep = first[0] ? (first[0] = /* false */0, "with") : "and";
+                  var sep = first[0] ? (first[0] = false, "with") : "and";
                   return Curry._4(Format.fprintf(ppf, /* Format */[
                                   /* Char_literal */Block.__(12, [
                                       /* " " */32,
@@ -37199,7 +37198,7 @@ function print_out_sig_item(ppf, param) {
         var ty;
         ty = typeof match === "number" || match.tag !== 4 ? td[/* otype_type */2] : match[1];
         var print_private = function (ppf, param) {
-          if (param !== 0) {
+          if (param) {
             return /* () */0;
           } else {
             return Format.fprintf(ppf, /* Format */[
@@ -38901,9 +38900,9 @@ print_raw = raw_type_expr;
 
 function is_nth(param) {
   if (typeof param === "number" || param.tag) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -39115,7 +39114,7 @@ function find$4(x, _param) {
 var printing_map = [/* Empty */0];
 
 function same_type(t, t$prime) {
-  return +(repr(t) === repr(t$prime));
+  return repr(t) === repr(t$prime);
 }
 
 function index(l, x) {
@@ -39136,19 +39135,19 @@ function uniq(_param) {
     if (param) {
       var l = param[1];
       if (List.memq(param[0], l)) {
-        return /* false */0;
+        return false;
       } else {
         _param = l;
         continue ;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
 
 function normalize_type_path($staropt$star, env, p) {
-  var cache = $staropt$star ? $staropt$star[0] : /* false */0;
+  var cache = $staropt$star ? $staropt$star[0] : false;
   try {
     var match = find_type_expansion(p, env);
     var params = List.map(repr, match[0]);
@@ -39163,7 +39162,7 @@ function normalize_type_path($staropt$star, env, p) {
       var p1 = match$1[0];
       var tyl = List.map(repr, match$1[1]);
       if (List.length(params) === List.length(tyl) && List.for_all2((function (prim, prim$1) {
-                return +(prim === prim$1);
+                return prim === prim$1;
               }), params, tyl)) {
         return normalize_type_path(/* Some */[cache], env, p1);
       } else if (cache || List.length(params) <= List.length(tyl) || !uniq(tyl)) {
@@ -39230,7 +39229,7 @@ function same_printing_env(env) {
   if (same_types(printing_old[0], env)) {
     return equal$2(printing_pers[0], used_pers);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -39244,7 +39243,7 @@ function set_printing_env(env) {
     printing_map[0] = /* Empty */0;
     printing_depth[0] = 0;
     var partial_arg = iter_types((function (p, param) {
-            var match = normalize_type_path(/* Some */[/* true */1], env, param[0]);
+            var match = normalize_type_path(/* Some */[true], env, param[0]);
             if (match[1] === /* Id */0) {
               var p1 = match[0];
               try {
@@ -39305,18 +39304,18 @@ function is_unambiguous(path, env) {
   if (List.exists((function (param) {
             return same(path, param);
           }), l) || !l) {
-    return /* true */1;
+    return true;
   } else {
     var rem = l[1];
     var p = l[0];
     var normalize = function (p) {
-      return normalize_type_path(/* Some */[/* true */1], env, p)[0];
+      return normalize_type_path(/* Some */[true], env, p)[0];
     };
     var p$prime = normalize(p);
     if (List.for_all((function (p) {
               return same(normalize(p), p$prime);
             }), rem)) {
-      return /* true */1;
+      return true;
     } else {
       var id = lid_of_path(/* None */0, p);
       if (List.for_all((function (p) {
@@ -39324,7 +39323,7 @@ function is_unambiguous(path, env) {
               }), rem)) {
         return same(p, lookup_type$1(id, env)[0]);
       } else {
-        return /* false */0;
+        return false;
       }
     }
   }
@@ -39375,16 +39374,16 @@ function best_type_path(p) {
       };
     };
     while((function () {
-            var tmp = /* false */0;
+            var tmp = false;
             if (printing_cont[0] !== /* [] */0) {
               var tmp$1;
               try {
                 get_path(/* () */0);
-                tmp$1 = /* false */0;
+                tmp$1 = false;
               }
               catch (exn){
                 if (exn === Caml_builtin_exceptions.not_found) {
-                  tmp$1 = /* true */1;
+                  tmp$1 = true;
                 } else {
                   throw exn;
                 }
@@ -39477,7 +39476,7 @@ function new_name(_param) {
     name_counter[0] = name_counter[0] + 1 | 0;
     if (List.mem(name, named_vars[0]) || List.exists((function(name){
           return function (param) {
-            return +(name === param[1]);
+            return name === param[1];
           }
           }(name)), names[0])) {
       _param = /* () */0;
@@ -39516,7 +39515,7 @@ function name_of_type(t) {
           var current_name = [name$1];
           var i = 0;
           while(List.exists((function (param) {
-                    return +(current_name[0] === param[1]);
+                    return current_name[0] === param[1];
                   }), names[0])) {
             current_name[0] = name$1 + String(i);
             i = i + 1 | 0;
@@ -39550,7 +39549,7 @@ function check_name_of_type(t) {
 function remove_names(tyl) {
   var tyl$1 = List.map(repr, tyl);
   names[0] = List.filter((function (param) {
-            return 1 - List.memq(param[0], tyl$1);
+            return !List.memq(param[0], tyl$1);
           }))(names[0]);
   return /* () */0;
 }
@@ -39593,17 +39592,17 @@ function add_alias(ty) {
 function aliasable(ty) {
   var match = ty[/* desc */0];
   if (typeof match === "number") {
-    return /* true */1;
+    return true;
   } else {
     switch (match.tag | 0) {
       case 3 : 
-          return 1 - is_nth(best_type_path(match[0])[1]);
+          return !is_nth(best_type_path(match[0])[1]);
       case 0 : 
       case 9 : 
       case 10 : 
-          return /* false */0;
+          return false;
       default:
-        return /* true */1;
+        return true;
     }
   }
 }
@@ -39613,22 +39612,22 @@ function namable_row(row) {
     return List.for_all((function (param) {
                   var match = row_field_repr_aux(/* [] */0, param[1]);
                   if (typeof match === "number" || !match.tag) {
-                    return /* true */1;
+                    return true;
                   } else {
                     var l = match[1];
                     if (row[/* row_closed */3]) {
                       if (match[0]) {
-                        return +(l === /* [] */0);
+                        return l === /* [] */0;
                       } else {
-                        return +(List.length(l) === 1);
+                        return List.length(l) === 1;
                       }
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                   }
                 }), row[/* row_fields */0]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -39790,7 +39789,7 @@ function reset_and_mark_loops_list(tyl) {
   return List.iter(mark_loops, tyl);
 }
 
-var print_labels = [/* true */1];
+var print_labels = [true];
 
 function tree_of_typexp(sch, ty) {
   var ty$1 = repr(ty);
@@ -39870,17 +39869,17 @@ function tree_of_typexp(sch, ty) {
           case 8 : 
               var row = row_repr_aux(/* [] */0, match[0]);
               var fields = row[/* row_closed */3] ? List.filter((function (param) {
-                          return +(row_field_repr_aux(/* [] */0, param[1]) !== /* Rabsent */0);
+                          return row_field_repr_aux(/* [] */0, param[1]) !== /* Rabsent */0;
                         }))(row[/* row_fields */0]) : row[/* row_fields */0];
               var present = List.filter((function (param) {
                         var match = row_field_repr_aux(/* [] */0, param[1]);
                         if (typeof match === "number" || match.tag) {
-                          return /* false */0;
+                          return false;
                         } else {
-                          return /* true */1;
+                          return true;
                         }
                       }))(fields);
-              var all_present = +(List.length(present) === List.length(fields));
+              var all_present = List.length(present) === List.length(fields);
               var match$4 = row[/* row_name */5];
               var exit = 0;
               if (match$4) {
@@ -39946,7 +39945,7 @@ function tree_of_typexp(sch, ty) {
                 exit = 1;
               }
               if (exit === 1) {
-                var non_gen$1 = 1 - (row[/* row_closed */3] && all_present) && is_non_gen(sch, px);
+                var non_gen$1 = !(row[/* row_closed */3] && all_present) && is_non_gen(sch, px);
                 var fields$1 = List.map((function (param) {
                         var sch$1 = sch;
                         var param$1 = param;
@@ -39955,16 +39954,16 @@ function tree_of_typexp(sch, ty) {
                         if (typeof match === "number") {
                           return /* tuple */[
                                   l,
-                                  /* false */0,
+                                  false,
                                   /* [] */0
                                 ];
                         } else if (match.tag) {
                           var c = match[0];
                           var exit = 0;
-                          if (c !== 0 && !match[1]) {
+                          if (c && !match[1]) {
                             return /* tuple */[
                                     l,
-                                    /* false */0,
+                                    false,
                                     /* [] */0
                                   ];
                           } else {
@@ -39975,7 +39974,7 @@ function tree_of_typexp(sch, ty) {
                             if (c) {
                               return /* tuple */[
                                       l,
-                                      /* true */1,
+                                      true,
                                       List.map((function (param) {
                                               return tree_of_typexp(sch$1, param);
                                             }), tyl)
@@ -39983,7 +39982,7 @@ function tree_of_typexp(sch, ty) {
                             } else {
                               return /* tuple */[
                                       l,
-                                      /* false */0,
+                                      false,
                                       List.map((function (param) {
                                               return tree_of_typexp(sch$1, param);
                                             }), tyl)
@@ -39996,7 +39995,7 @@ function tree_of_typexp(sch, ty) {
                           if (match$1) {
                             return /* tuple */[
                                     l,
-                                    /* false */0,
+                                    false,
                                     /* :: */[
                                       tree_of_typexp(sch$1, match$1[0]),
                                       /* [] */0
@@ -40005,7 +40004,7 @@ function tree_of_typexp(sch, ty) {
                           } else {
                             return /* tuple */[
                                     l,
-                                    /* false */0,
+                                    false,
                                     /* [] */0
                                   ];
                           }
@@ -40024,7 +40023,7 @@ function tree_of_typexp(sch, ty) {
               break;
           case 9 : 
               return /* Otyp_var */Block.__(10, [
-                        /* false */0,
+                        false,
                         name_of_type(ty$1)
                       ]);
           case 10 : 
@@ -40067,7 +40066,7 @@ function tree_of_typexp(sch, ty) {
     };
     if (List.memq(px, delayed[0])) {
       delayed[0] = List.filter((function (param) {
-                return +(px !== param);
+                return px !== param;
               }))(delayed[0]);
     }
     if (is_aliased(px) && aliasable(ty$1)) {
@@ -40142,9 +40141,9 @@ function tree_of_typobject(sch, fi, nm) {
 
 function is_non_gen(sch, ty) {
   if (sch && is_Tvar(ty)) {
-    return +(ty[/* level */1] !== 100000000);
+    return ty[/* level */1] !== 100000000;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -40173,7 +40172,7 @@ function tree_of_typfields(sch, rest, param) {
     } else {
       switch (match$2.tag | 0) {
         case 3 : 
-            rest$1 = /* Some */[/* false */0];
+            rest$1 = /* Some */[false];
             break;
         case 0 : 
         case 9 : 
@@ -40195,30 +40194,30 @@ function typexp$1(sch, _, ppf, ty) {
 }
 
 function type_expr$1(ppf, ty) {
-  return typexp$1(/* false */0, 0, ppf, ty);
+  return typexp$1(false, 0, ppf, ty);
 }
 
 function type_scheme(ppf, ty) {
   reset(/* () */0);
   mark_loops(ty);
-  return typexp$1(/* true */1, 0, ppf, ty);
+  return typexp$1(true, 0, ppf, ty);
 }
 
 function tree_of_type_scheme(ty) {
   reset(/* () */0);
   mark_loops(ty);
-  return tree_of_typexp(/* true */1, ty);
+  return tree_of_typexp(true, ty);
 }
 
 function tree_of_constraints(params) {
   return List.fold_right((function (ty, list) {
                 var ty$prime = unalias(ty);
                 if (proxy(ty) !== proxy(ty$prime)) {
-                  var tr = tree_of_typexp(/* true */1, ty);
+                  var tr = tree_of_typexp(true, ty);
                   return /* :: */[
                           /* tuple */[
                             tr,
-                            tree_of_typexp(/* true */1, ty$prime)
+                            tree_of_typexp(true, ty$prime)
                           ],
                           list
                         ];
@@ -40251,9 +40250,9 @@ function tree_of_constructor(cd) {
   if (match) {
     var nm = names[0];
     names[0] = /* [] */0;
-    var ret = tree_of_typexp(/* false */0, match[0]);
+    var ret = tree_of_typexp(false, match[0]);
     var args = List.map((function (param) {
-            return tree_of_typexp(/* false */0, param);
+            return tree_of_typexp(false, param);
           }), cd[/* cd_args */1]);
     names[0] = nm;
     return /* tuple */[
@@ -40265,7 +40264,7 @@ function tree_of_constructor(cd) {
     return /* tuple */[
             name,
             List.map((function (param) {
-                    return tree_of_typexp(/* false */0, param);
+                    return tree_of_typexp(false, param);
                   }), cd[/* cd_args */1]),
             /* None */0
           ];
@@ -40275,8 +40274,8 @@ function tree_of_constructor(cd) {
 function tree_of_label(l) {
   return /* tuple */[
           l[/* ld_id */0][/* name */1],
-          +(l[/* ld_mutable */1] === /* Mutable */1),
-          tree_of_typexp(/* false */0, l[/* ld_type */2])
+          l[/* ld_mutable */1] === /* Mutable */1,
+          tree_of_typexp(false, l[/* ld_type */2])
         ];
 }
 
@@ -40344,7 +40343,7 @@ function tree_of_type_decl(id, decl) {
   }
   var match$6 = decl[/* type_kind */2];
   if (typeof match$6 === "number") {
-    +(match$6 === 0);
+    match$6 === 0;
   } else if (match$6.tag) {
     List.iter((function (c) {
             List.iter(mark_loops, c[/* cd_args */1]);
@@ -40366,19 +40365,19 @@ function tree_of_type_decl(id, decl) {
     var match = decl[/* type_kind */2];
     var abstr;
     abstr = typeof match === "number" ? (
-        match === 0 ? +(decl[/* type_manifest */4] === /* None */0 || decl[/* type_private */3] === /* Private */0) : +(decl[/* type_manifest */4] === /* None */0)
+        match === 0 ? decl[/* type_manifest */4] === /* None */0 || decl[/* type_private */3] === /* Private */0 : decl[/* type_manifest */4] === /* None */0
       ) : (
-        match.tag ? +(decl[/* type_private */3] === /* Private */0) || List.exists((function (cd) {
-                  return +(cd[/* cd_res */2] !== /* None */0);
-                }), match[0]) : +(decl[/* type_private */3] === /* Private */0)
+        match.tag ? decl[/* type_private */3] === /* Private */0 || List.exists((function (cd) {
+                  return cd[/* cd_res */2] !== /* None */0;
+                }), match[0]) : decl[/* type_private */3] === /* Private */0
       );
     var vari = List.map2((function (ty, v) {
             if (abstr || !is_Tvar(repr(ty))) {
               return Curry._1(Types_003[/* get_upper */10], v);
             } else {
               return /* tuple */[
-                      /* true */1,
-                      /* true */1
+                      true,
+                      true
                     ];
             }
           }), decl[/* type_params */0], decl[/* type_variance */5]);
@@ -40386,7 +40385,7 @@ function tree_of_type_decl(id, decl) {
             id[/* name */1],
             List.map2((function (ty, cocn) {
                     return /* tuple */[
-                            type_param(tree_of_typexp(/* false */0, ty)),
+                            type_param(tree_of_typexp(false, ty)),
                             cocn
                           ];
                   }), params, vari)
@@ -40395,7 +40394,7 @@ function tree_of_type_decl(id, decl) {
   var tree_of_manifest = function (ty1) {
     if (ty_manifest) {
       return /* Otyp_manifest */Block.__(4, [
-                tree_of_typexp(/* false */0, ty_manifest[0]),
+                tree_of_typexp(false, ty_manifest[0]),
                 ty1
               ]);
     } else {
@@ -40409,7 +40408,7 @@ function tree_of_type_decl(id, decl) {
   match$9 = typeof match$8 === "number" ? (
       match$8 === 0 ? (
           ty_manifest ? /* tuple */[
-              tree_of_typexp(/* false */0, ty_manifest[0]),
+              tree_of_typexp(false, ty_manifest[0]),
               decl[/* type_private */3]
             ] : /* tuple */[
               /* Otyp_abstract */0,
@@ -40458,7 +40457,7 @@ function tree_of_extension_constructor(id, ext, es) {
   List.iter(mark_loops, ext[/* ext_args */2]);
   may(mark_loops, ext[/* ext_ret_type */3]);
   var ty_params$1 = List.map((function (ty) {
-          var param = tree_of_typexp(/* false */0, ty);
+          var param = tree_of_typexp(false, ty);
           if (typeof param === "number" || param.tag !== 10) {
             return "?";
           } else {
@@ -40471,9 +40470,9 @@ function tree_of_extension_constructor(id, ext, es) {
   if (match) {
     var nm = names[0];
     names[0] = /* [] */0;
-    var ret = tree_of_typexp(/* false */0, match[0]);
+    var ret = tree_of_typexp(false, match[0]);
     var args = List.map((function (param) {
-            return tree_of_typexp(/* false */0, param);
+            return tree_of_typexp(false, param);
           }), ext[/* ext_args */2]);
     names[0] = nm;
     match$1 = /* tuple */[
@@ -40483,7 +40482,7 @@ function tree_of_extension_constructor(id, ext, es) {
   } else {
     match$1 = /* tuple */[
       List.map((function (param) {
-              return tree_of_typexp(/* false */0, param);
+              return tree_of_typexp(false, param);
             }), ext[/* ext_args */2]),
       /* None */0
     ];
@@ -40622,7 +40621,7 @@ function tree_of_class_type(sch, params, _param) {
             return /* Octy_constr */Block.__(0, [
                       tree_of_path(param[0]),
                       List.map((function (param) {
-                              return tree_of_typexp(/* true */1, param);
+                              return tree_of_typexp(true, param);
                             }), param[1])
                     ]);
           }
@@ -40630,7 +40629,7 @@ function tree_of_class_type(sch, params, _param) {
           var sign = param[0];
           var sty$1 = repr(sign[/* csig_self */0]);
           var self_ty = is_aliased(sty$1) ? /* Some */[/* Otyp_var */Block.__(10, [
-                  /* false */0,
+                  false,
                   name_of_type(proxy(sty$1))
                 ])] : /* None */0;
           var match = flatten_fields(object_fields(sign[/* csig_self */0]));
@@ -40659,8 +40658,8 @@ function tree_of_class_type(sch, params, _param) {
                   return /* :: */[
                           /* Ocsg_value */Block.__(2, [
                               param[0],
-                              +(param[1] === /* Mutable */1),
-                              +(param[2] === /* Virtual */0),
+                              param[1] === /* Mutable */1,
+                              param[2] === /* Virtual */0,
                               tree_of_typexp(sch, param[3])
                             ]),
                           csil
@@ -40676,8 +40675,8 @@ function tree_of_class_type(sch, params, _param) {
                 var lab = param$2[0];
                 if (lab !== dummy_method) {
                   var kind = field_kind_repr(param$2[1]);
-                  var priv = +(kind !== /* Fpresent */0);
-                  var virt = 1 - mem$2(lab, concrete);
+                  var priv = kind !== /* Fpresent */0;
+                  var virt = !mem$2(lab, concrete);
                   var match = method_type(/* tuple */[
                         lab,
                         kind,
@@ -40742,18 +40741,18 @@ function tree_of_class_type(sch, params, _param) {
 function class_type$1(ppf, cty) {
   reset(/* () */0);
   prepare_class_type(/* [] */0, cty);
-  return Curry._2(out_class_type[0], ppf, tree_of_class_type(/* false */0, /* [] */0, cty));
+  return Curry._2(out_class_type[0], ppf, tree_of_class_type(false, /* [] */0, cty));
 }
 
 function tree_of_class_param(param, variance) {
-  var match = tree_of_typexp(/* true */1, param);
+  var match = tree_of_typexp(true, param);
   var tmp;
   tmp = typeof match === "number" || match.tag !== 10 ? "?" : match[1];
   return /* tuple */[
           tmp,
           is_Tvar(repr(param)) ? /* tuple */[
-              /* true */1,
-              /* true */1
+              true,
+              true
             ] : variance
         ];
 }
@@ -40779,12 +40778,12 @@ function tree_of_class_declaration(id, cl, rs) {
     var t = proxy(sty);
     name_of_type(t);
   }
-  var vir_flag = +(cl[/* cty_new */3] === /* None */0);
+  var vir_flag = cl[/* cty_new */3] === /* None */0;
   return /* Osig_class */Block.__(0, [
             vir_flag,
             id[/* name */1],
             List.map2(tree_of_class_param, params, class_variance(cl[/* cty_variance */4])),
-            tree_of_class_type(/* true */1, params, cl[/* cty_type */1]),
+            tree_of_class_type(true, params, cl[/* cty_type */1]),
             rs
           ]);
 }
@@ -40809,19 +40808,19 @@ function tree_of_cltype_declaration(id, cl, rs) {
   var match = flatten_fields(object_fields(sign[/* csig_self */0]));
   var virt = List.exists((function (param) {
           var lab = param[0];
-          return 1 - (+(lab === dummy_method) || mem$2(lab, sign[/* csig_concr */2]));
+          return !(lab === dummy_method || mem$2(lab, sign[/* csig_concr */2]));
         }), match[0]) || fold((function (_, param, b) {
           if (param[1] === /* Virtual */0) {
-            return /* true */1;
+            return true;
           } else {
             return b;
           }
-        }), sign[/* csig_vars */1], /* false */0);
+        }), sign[/* csig_vars */1], false);
   return /* Osig_class_type */Block.__(1, [
             virt,
             id[/* name */1],
             List.map2(tree_of_class_param, params, class_variance(cl[/* clty_variance */3])),
-            tree_of_class_type(/* true */1, params, cl[/* clty_type */1]),
+            tree_of_class_type(true, params, cl[/* clty_type */1]),
             rs
           ]);
 }
@@ -40951,7 +40950,7 @@ function hide_rec_items(param) {
       return set_printing_env(List.fold_right((function (id) {
                         var partial_arg = rename(id);
                         return (function (param) {
-                            return add_type$1(/* false */0, partial_arg, dummy, param);
+                            return add_type$1(false, partial_arg, dummy, param);
                           });
                       }), ids, printing_env[0]));
     } else {
@@ -40975,7 +40974,7 @@ function tree_of_modtype(param) {
         var res;
         if (ty_arg) {
           var mty = ty_arg[0];
-          var partial_arg = /* Some */[/* true */1];
+          var partial_arg = /* Some */[true];
           res = wrap_env((function (param$2) {
                   return add_module$1(partial_arg, param$1, mty, param$2);
                 }), tree_of_modtype, ty_res);
@@ -40998,7 +40997,7 @@ function tree_of_signature(sg) {
   return wrap_env((function (env) {
                 return env;
               }), (function (param) {
-                return tree_of_signature_rec(partial_arg, /* false */0, param);
+                return tree_of_signature_rec(partial_arg, false, param);
               }), sg);
 }
 
@@ -41007,23 +41006,23 @@ function tree_of_signature_rec(env$prime, in_type_group, param) {
     var item = param[0];
     var in_type_group$1;
     var exit = 0;
-    if (in_type_group !== 0) {
+    if (in_type_group) {
       if (item.tag === 1) {
         if (item[2] >= 2) {
-          in_type_group$1 = /* true */1;
+          in_type_group$1 = true;
         } else {
           exit = 1;
         }
       } else {
         set_printing_env(env$prime);
-        in_type_group$1 = /* false */0;
+        in_type_group$1 = false;
       }
     } else {
       exit = 1;
     }
     if (exit === 1) {
       set_printing_env(env$prime);
-      in_type_group$1 = item.tag === 1 && item[2] < 2 ? /* true */1 : /* false */0;
+      in_type_group$1 = item.tag === 1 && item[2] < 2 ? true : false;
     }
     var match = filter_rem_sig(item, param[1]);
     var rem = match[1];
@@ -41146,12 +41145,12 @@ function same_path(t, t$prime) {
   var t$1 = repr(t);
   var t$prime$1 = repr(t$prime);
   if (t$1 === t$prime$1) {
-    return /* true */1;
+    return true;
   } else {
     var match = t$1[/* desc */0];
     var match$1 = t$prime$1[/* desc */0];
     if (typeof match === "number" || !(match.tag === 3 && !(typeof match$1 === "number" || match$1.tag !== 3))) {
-      return /* false */0;
+      return false;
     } else {
       var match$2 = best_type_path(match[0]);
       var s1 = match$2[1];
@@ -41161,16 +41160,16 @@ function same_path(t, t$prime) {
       if (typeof s1 === "number" || s1.tag) {
         exit = 1;
       } else if (typeof s2 === "number" || !(!s2.tag && s1[0] === s2[0])) {
-        return /* false */0;
+        return false;
       } else {
-        return /* true */1;
+        return true;
       }
       if (exit === 1) {
         var exit$1 = 0;
         if (typeof s2 === "number" || s2.tag) {
           exit$1 = 2;
         } else {
-          return /* false */0;
+          return false;
         }
         if (exit$1 === 2) {
           if (same(match$2[0], match$3[0])) {
@@ -41179,10 +41178,10 @@ function same_path(t, t$prime) {
             if (List.length(tl) === List.length(tl$prime)) {
               return List.for_all2(same_type, tl, tl$prime);
             } else {
-              return /* false */0;
+              return false;
             }
           } else {
-            return /* false */0;
+            return false;
           }
         }
         
@@ -41341,7 +41340,7 @@ function trace(fst, txt, ppf, param) {
                   }), match$2[1], txt, (function (param, param$1) {
                     return type_expansion(t2, param, param$1);
                   }), match$1[1], (function (param, param$1) {
-                    return trace(/* false */0, txt, param, param$1);
+                    return trace(false, txt, param, param$1);
                   }), match[1]);
     } else {
       return /* () */0;
@@ -41556,7 +41555,7 @@ function has_explanation(_, t3, t4) {
             exit$2 = 3;
             break;
         case 3 : 
-            return /* true */1;
+            return true;
         default:
           exit$1 = 2;
       }
@@ -41564,10 +41563,10 @@ function has_explanation(_, t3, t4) {
   } else {
     switch (match.tag | 0) {
       case 0 : 
-          return /* true */1;
+          return true;
       case 3 : 
           if (typeof match$1 === "number") {
-            return /* true */1;
+            return true;
           } else if (match$1.tag) {
             exit$1 = 2;
           } else {
@@ -41588,44 +41587,44 @@ function has_explanation(_, t3, t4) {
               case 5 : 
                   var match$3 = match$1[3][/* desc */0];
                   if (typeof match$3 === "number") {
-                    return +(match[0] === match$1[0]);
+                    return match[0] === match$1[0];
                   } else {
-                    return /* false */0;
+                    return false;
                   }
               default:
-                return /* false */0;
+                return false;
             }
           } else {
             exit$3 = 4;
           }
           if (exit$3 === 4) {
             if (typeof match$1 === "number") {
-              return /* true */1;
+              return true;
             } else {
               switch (match$1.tag | 0) {
                 case 0 : 
                     exit$2 = 3;
                     break;
                 case 3 : 
-                    return /* true */1;
+                    return true;
                 default:
-                  return /* false */0;
+                  return false;
               }
             }
           }
           break;
       case 8 : 
           if (typeof match$1 === "number") {
-            return /* false */0;
+            return false;
           } else {
             switch (match$1.tag | 0) {
               case 0 : 
                   exit$2 = 3;
                   break;
               case 8 : 
-                  return /* true */1;
+                  return true;
               default:
-                return /* false */0;
+                return false;
             }
           }
           break;
@@ -41637,21 +41636,21 @@ function has_explanation(_, t3, t4) {
     if (typeof match$1 === "number" || match$1.tag) {
       exit$1 = 2;
     } else {
-      return /* true */1;
+      return true;
     }
   }
   if (exit$1 === 2) {
     if (typeof match === "number" || match.tag === 3) {
       exit = 1;
     } else {
-      return /* false */0;
+      return false;
     }
   }
   if (exit === 1) {
     if (typeof match$1 === "number" || match$1.tag !== 5) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   }
   
@@ -41885,9 +41884,9 @@ function explanation(unif, mis, ppf) {
                     var match$6 = row2[/* row_closed */3];
                     var exit$5 = 0;
                     if (match$3) {
-                      if (match$3[1] || !(match$4 !== 0 && match$5)) {
+                      if (match$3[1] || !(match$4 && match$5)) {
                         exit$5 = 10;
-                      } else if (match$5[1] || match$6 === 0) {
+                      } else if (match$5[1] || !match$6) {
                         return /* () */0;
                       } else {
                         var l1 = match$3[0][0];
@@ -41916,9 +41915,9 @@ function explanation(unif, mis, ppf) {
                           return /* () */0;
                         }
                       }
-                    } else if (match$4 !== 0) {
+                    } else if (match$4) {
                       var exit$6 = 0;
-                      if (match$5 || match$6 === 0) {
+                      if (match$5 || !match$6) {
                         exit$6 = 11;
                       } else {
                         return Format.fprintf(ppf$1, /* Format */[
@@ -41985,7 +41984,7 @@ function explanation(unif, mis, ppf) {
                       exit$5 = 10;
                     }
                     if (exit$5 === 10) {
-                      if (match$5 || match$6 === 0) {
+                      if (match$5 || !match$6) {
                         return /* () */0;
                       } else {
                         return Curry._2(Format.fprintf(ppf$1, /* Format */[
@@ -42473,7 +42472,7 @@ function trace_same_names(_param) {
 }
 
 function report_unification_error(ppf, env, $staropt$star, tr, txt1, txt2) {
-  var unif = $staropt$star ? $staropt$star[0] : /* true */1;
+  var unif = $staropt$star ? $staropt$star[0] : true;
   return wrap_printing_env(env, (function () {
                 var unif$1 = unif;
                 var tr$1 = tr;
@@ -42493,12 +42492,12 @@ function report_unification_error(ppf, env, $staropt$star, tr, txt1, txt2) {
                   var match = tr$2[1];
                   if (match) {
                     try {
-                      var tr$3 = filter_trace(+(mis === /* None */0), match[1]);
-                      var match$1 = may_prepare_expansion(+(tr$3 === /* [] */0), tr$2[0]);
+                      var tr$3 = filter_trace(mis === /* None */0, match[1]);
+                      var match$1 = may_prepare_expansion(tr$3 === /* [] */0, tr$2[0]);
                       var t1 = match$1[0];
-                      var match$2 = may_prepare_expansion(+(tr$3 === /* [] */0), match[0]);
+                      var match$2 = may_prepare_expansion(tr$3 === /* [] */0, match[0]);
                       var t2 = match$2[0];
-                      print_labels[0] = 1 - classic[0];
+                      print_labels[0] = !classic[0];
                       var tr$4 = List.map(prepare_expansion, tr$3);
                       Curry.app(Format.fprintf(ppf$1, /* Format */[
                                 /* Formatting_gen */Block.__(18, [
@@ -42557,18 +42556,18 @@ function report_unification_error(ppf, env, $staropt$star, tr, txt1, txt2) {
                               }),
                             match$2[1],
                             (function (param, param$1) {
-                                return trace(/* false */0, "is not compatible with type", param, param$1);
+                                return trace(false, "is not compatible with type", param, param$1);
                               }),
                             tr$4,
                             (function (param) {
                                 return explanation(unif$1, mis, param);
                               })
                           ]);
-                      print_labels[0] = /* true */1;
+                      print_labels[0] = true;
                       return /* () */0;
                     }
                     catch (exn){
-                      print_labels[0] = /* true */1;
+                      print_labels[0] = true;
                       throw exn;
                     }
                   } else {
@@ -42595,7 +42594,7 @@ function report_unification_error(ppf, env, $staropt$star, tr, txt1, txt2) {
 }
 
 function trace$1(fst, keep_last, txt, ppf, tr) {
-  print_labels[0] = 1 - classic[0];
+  print_labels[0] = !classic[0];
   trace_same_names(tr);
   try {
     if (tr) {
@@ -42612,7 +42611,7 @@ function trace$1(fst, keep_last, txt, ppf, tr) {
         } else {
           trace(fst, txt, ppf, filter_trace(keep_last, tr));
         }
-        print_labels[0] = /* true */1;
+        print_labels[0] = true;
         return /* () */0;
       } else {
         return /* () */0;
@@ -42622,7 +42621,7 @@ function trace$1(fst, keep_last, txt, ppf, tr) {
     }
   }
   catch (exn){
-    print_labels[0] = /* true */1;
+    print_labels[0] = true;
     throw exn;
   }
 }
@@ -42673,7 +42672,7 @@ function include_err(ppf, param) {
                       "The classes do not have the same number of type parameters"
                     ]);
       case 1 : 
-          return report_unification_error(ppf, param[0], /* Some */[/* false */0], param[1], (function (ppf) {
+          return report_unification_error(ppf, param[0], /* Some */[false], param[1], (function (ppf) {
                         return Format.fprintf(ppf, /* Format */[
                                     /* String_literal */Block.__(11, [
                                         "A type parameter has type",
@@ -42736,7 +42735,7 @@ function include_err(ppf, param) {
                                       ]), class_type$1, cty1, "is not matched by the class type", class_type$1, cty2);
                       }));
       case 3 : 
-          return report_unification_error(ppf, param[0], /* Some */[/* false */0], param[1], (function (ppf) {
+          return report_unification_error(ppf, param[0], /* Some */[false], param[1], (function (ppf) {
                         return Format.fprintf(ppf, /* Format */[
                                     /* String_literal */Block.__(11, [
                                         "A parameter has type",
@@ -42755,7 +42754,7 @@ function include_err(ppf, param) {
                       }));
       case 4 : 
           var lab = param[0];
-          return report_unification_error(ppf, param[1], /* Some */[/* false */0], param[2], (function (ppf) {
+          return report_unification_error(ppf, param[1], /* Some */[false], param[2], (function (ppf) {
                         return Curry._1(Format.fprintf(ppf, /* Format */[
                                         /* String_literal */Block.__(11, [
                                             "The instance variable ",
@@ -42787,7 +42786,7 @@ function include_err(ppf, param) {
                       }));
       case 5 : 
           var lab$1 = param[0];
-          return report_unification_error(ppf, param[1], /* Some */[/* false */0], param[2], (function (ppf) {
+          return report_unification_error(ppf, param[1], /* Some */[false], param[2], (function (ppf) {
                         return Curry._1(Format.fprintf(ppf, /* Format */[
                                         /* String_literal */Block.__(11, [
                                             "The method ",
@@ -43057,42 +43056,42 @@ var Dont_match = Caml_exceptions.create("Ocaml_typedtree_test.Includecore.Dont_m
 function private_flags(decl1, decl2) {
   var match = decl1[/* type_private */3];
   var match$1 = decl2[/* type_private */3];
-  if (match !== 0 || match$1 === 0) {
-    return /* true */1;
+  if (match || !match$1) {
+    return true;
   } else if (decl2[/* type_kind */2] === /* Type_abstract */0) {
     if (decl2[/* type_manifest */4] === /* None */0) {
-      return /* true */1;
+      return true;
     } else {
-      return +(decl1[/* type_kind */2] !== /* Type_abstract */0);
+      return decl1[/* type_kind */2] !== /* Type_abstract */0;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function is_absrow(env, ty) {
   var match = ty[/* desc */0];
   if (typeof match === "number" || match.tag !== 3) {
-    return /* false */0;
+    return false;
   } else {
     switch (match[0].tag | 0) {
       case 0 : 
           var match$1 = expand_head(env, ty);
           var match$2 = match$1[/* desc */0];
           if (typeof match$2 === "number") {
-            return /* false */0;
+            return false;
           } else {
             switch (match$2.tag | 0) {
               case 4 : 
               case 8 : 
-                  return /* true */1;
+                  return true;
               default:
-                return /* false */0;
+                return false;
             }
           }
       case 1 : 
       case 2 : 
-          return /* false */0;
+          return false;
       
     }
   }
@@ -43115,7 +43114,7 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
             var fi2 = match$1[0];
             if (is_absrow(env, flatten_fields(fi2)[1])) {
               var match$2 = flatten_fields(fi2);
-              if (equal$4(env, /* true */1, /* :: */[
+              if (equal$4(env, true, /* :: */[
                       ty1,
                       params1
                     ], /* :: */[
@@ -43126,15 +43125,15 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
                 var match$4 = match$3[1][/* desc */0];
                 var tmp;
                 if (typeof match$4 === "number") {
-                  tmp = /* true */1;
+                  tmp = true;
                 } else {
                   switch (match$4.tag | 0) {
                     case 0 : 
                     case 3 : 
-                        tmp = /* true */1;
+                        tmp = true;
                         break;
                     default:
-                      tmp = /* false */0;
+                      tmp = false;
                   }
                 }
                 if (tmp) {
@@ -43146,15 +43145,15 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
                                         param[4]
                                       ];
                               }), match$5[0]));
-                    return equal$4(env, /* true */1, Pervasives.$at(params1, match$6[0]), Pervasives.$at(params2, match$6[1]));
+                    return equal$4(env, true, Pervasives.$at(params1, match$6[0]), Pervasives.$at(params2, match$6[1]));
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 } else {
-                  return /* false */0;
+                  return false;
                 }
               } else {
-                return /* false */0;
+                return false;
               }
             } else {
               exit = 1;
@@ -43169,7 +43168,7 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
             if (is_absrow(env, row_more(row2))) {
               var row1 = row_repr_aux(/* [] */0, match[0]);
               var row2$1 = row_repr_aux(/* [] */0, row2);
-              if (equal$4(env, /* true */1, /* :: */[
+              if (equal$4(env, true, /* :: */[
                       ty1,
                       params1
                     ], /* :: */[
@@ -43180,25 +43179,25 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
                 var match$8 = match$7[/* desc */0];
                 var tmp$1;
                 if (typeof match$8 === "number") {
-                  tmp$1 = /* true */1;
+                  tmp$1 = true;
                 } else {
                   switch (match$8.tag | 0) {
                     case 0 : 
                     case 3 : 
-                        tmp$1 = /* true */1;
+                        tmp$1 = true;
                         break;
                     default:
-                      tmp$1 = /* false */0;
+                      tmp$1 = false;
                   }
                 }
                 if (tmp$1) {
                   var match$9 = merge_row_fields(row1[/* row_fields */0], row2$1[/* row_fields */0]);
-                  if ((!row2$1[/* row_closed */3] || row1[/* row_closed */3] && filter_row_fields(/* false */0, match$9[0]) === /* [] */0) && List.for_all((function (param) {
+                  if ((!row2$1[/* row_closed */3] || row1[/* row_closed */3] && filter_row_fields(false, match$9[0]) === /* [] */0) && List.for_all((function (param) {
                             var match = row_field_repr_aux(/* [] */0, param[1]);
                             if (typeof match === "number" || match.tag) {
-                              return /* true */1;
+                              return true;
                             } else {
-                              return /* false */0;
+                              return false;
                             }
                           }), match$9[1])) {
                     var to_equal = [List.combine(params1, params2)];
@@ -43207,21 +43206,21 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
                               var match$1 = row_field_repr_aux(/* [] */0, param[2]);
                               if (typeof match === "number") {
                                 if (typeof match$1 === "number" || match$1.tag) {
-                                  return /* true */1;
+                                  return true;
                                 } else {
-                                  return /* false */0;
+                                  return false;
                                 }
                               } else if (match.tag) {
                                 var tl1 = match[1];
                                 if (typeof match$1 === "number" || !match$1.tag) {
-                                  return /* false */0;
+                                  return false;
                                 } else {
                                   var tl2 = match$1[1];
                                   if (List.length(tl1) === List.length(tl2) && match[0] === match$1[0]) {
                                     to_equal[0] = Pervasives.$at(List.combine(tl1, tl2), to_equal[0]);
-                                    return /* true */1;
+                                    return true;
                                   } else {
-                                    return /* false */0;
+                                    return false;
                                   }
                                 }
                               } else {
@@ -43230,17 +43229,17 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
                                   var exit = 0;
                                   var t2;
                                   if (typeof match$1 === "number") {
-                                    return /* false */0;
+                                    return false;
                                   } else if (match$1.tag) {
-                                    if (match$1[0] !== 0) {
-                                      return /* false */0;
+                                    if (match$1[0]) {
+                                      return false;
                                     } else {
                                       var match$3 = match$1[1];
                                       if (match$3 && !match$3[1]) {
                                         t2 = match$3[0];
                                         exit = 1;
                                       } else {
-                                        return /* false */0;
+                                        return false;
                                       }
                                     }
                                   } else {
@@ -43249,7 +43248,7 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
                                       t2 = match$4[0];
                                       exit = 1;
                                     } else {
-                                      return /* false */0;
+                                      return false;
                                     }
                                   }
                                   if (exit === 1) {
@@ -43260,37 +43259,37 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
                                       ],
                                       to_equal[0]
                                     ];
-                                    return /* true */1;
+                                    return true;
                                   }
                                   
                                 } else if (typeof match$1 === "number") {
-                                  return /* false */0;
+                                  return false;
                                 } else if (match$1.tag) {
-                                  if (match$1[0] !== 0 && !match$1[1]) {
-                                    return /* true */1;
+                                  if (match$1[0] && !match$1[1]) {
+                                    return true;
                                   } else {
-                                    return /* false */0;
+                                    return false;
                                   }
                                 } else if (match$1[0]) {
-                                  return /* false */0;
+                                  return false;
                                 } else {
-                                  return /* true */1;
+                                  return true;
                                 }
                               }
                             }), match$9[2])) {
                       var match$10 = List.split(to_equal[0]);
-                      return equal$4(env, /* true */1, match$10[0], match$10[1]);
+                      return equal$4(env, true, match$10[0], match$10[1]);
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 } else {
-                  return /* false */0;
+                  return false;
                 }
               } else {
-                return /* false */0;
+                return false;
               }
             } else {
               exit = 1;
@@ -43303,27 +43302,27 @@ function type_manifest(env, ty1, params1, ty2, params2, priv2) {
   }
   if (exit === 1) {
     var check_super = function (ty1) {
-      if (equal$4(env, /* true */1, /* :: */[
+      if (equal$4(env, true, /* :: */[
               ty1,
               params1
             ], /* :: */[
               ty2,
               params2
             ])) {
-        return /* true */1;
+        return true;
       } else if (priv2 === /* Private */0) {
         try {
           return check_super(try_expand_once_opt(env, expand_head(env, ty1)));
         }
         catch (exn){
           if (exn === Cannot_expand) {
-            return /* false */0;
+            return false;
           } else {
             throw exn;
           }
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
     return check_super(ty1);
@@ -43566,7 +43565,7 @@ function compare_variants(env, decl1, decl2, _n, _cstrs1, _cstrs2) {
           var exit = 0;
           if (ret1) {
             if (ret2) {
-              if (equal$4(env, /* true */1, /* :: */[
+              if (equal$4(env, true, /* :: */[
                       ret1[0],
                       /* [] */0
                     ], /* :: */[
@@ -43596,7 +43595,7 @@ function compare_variants(env, decl1, decl2, _n, _cstrs1, _cstrs2) {
           }
           if (exit === 1) {
             if (for_all2((function (ty1, ty2) {
-                      return equal$4(env, /* true */1, /* :: */[
+                      return equal$4(env, true, /* :: */[
                                   ty1,
                                   decl1[/* type_params */0]
                                 ], /* :: */[
@@ -43620,7 +43619,7 @@ function compare_variants(env, decl1, decl2, _n, _cstrs1, _cstrs2) {
       } else {
         return /* :: */[
                 /* Field_missing */Block.__(4, [
-                    /* false */0,
+                    false,
                     c[/* cd_id */0]
                   ]),
                 /* [] */0
@@ -43629,7 +43628,7 @@ function compare_variants(env, decl1, decl2, _n, _cstrs1, _cstrs2) {
     } else if (cstrs2) {
       return /* :: */[
               /* Field_missing */Block.__(4, [
-                  /* true */1,
+                  true,
                   cstrs2[0][/* cd_id */0]
                 ]),
               /* [] */0
@@ -43665,7 +43664,7 @@ function compare_records(env, decl1, decl2, _n, _labels1, _labels2) {
                   /* Field_mutable */Block.__(1, [lab1]),
                   /* [] */0
                 ];
-        } else if (equal$4(env, /* true */1, /* :: */[
+        } else if (equal$4(env, true, /* :: */[
                 l[/* ld_type */2],
                 decl1[/* type_params */0]
               ], /* :: */[
@@ -43685,7 +43684,7 @@ function compare_records(env, decl1, decl2, _n, _labels1, _labels2) {
       } else {
         return /* :: */[
                 /* Field_missing */Block.__(4, [
-                    /* false */0,
+                    false,
                     l[/* ld_id */0]
                   ]),
                 /* [] */0
@@ -43694,7 +43693,7 @@ function compare_records(env, decl1, decl2, _n, _labels1, _labels2) {
     } else if (labels2) {
       return /* :: */[
               /* Field_missing */Block.__(4, [
-                  /* true */1,
+                  true,
                   labels2[0][/* ld_id */0]
                 ]),
               /* [] */0
@@ -43706,7 +43705,7 @@ function compare_records(env, decl1, decl2, _n, _labels1, _labels2) {
 }
 
 function type_declarations$1($staropt$star, env, name, decl1, id, decl2) {
-  var equality = $staropt$star ? $staropt$star[0] : /* false */0;
+  var equality = $staropt$star ? $staropt$star[0] : false;
   if (decl1[/* type_arity */1] !== decl2[/* type_arity */1]) {
     return /* :: */[
             /* Arity */0,
@@ -43773,7 +43772,7 @@ function type_declarations$1($staropt$star, env, name, decl1, id, decl2) {
         var rep2 = match$1[1];
         var err$1 = compare_records(env, decl1, decl2, 1, match[0], match$1[0]);
         err = err$1 !== /* [] */0 || match[1] === rep2 ? err$1 : /* :: */[
-            /* Record_representation */Block.__(5, [+(rep2 === /* Record_float */1)]),
+            /* Record_representation */Block.__(5, [rep2 === /* Record_float */1]),
             /* [] */0
           ];
       }
@@ -43796,8 +43795,8 @@ function type_declarations$1($staropt$star, env, name, decl1, id, decl2) {
                   decl2[/* type_params */0],
                   [/* Mnil */0]
                 ]));
-          err$2 = equal$4(env, /* true */1, decl1[/* type_params */0], decl2[/* type_params */0]) ? (
-              equal$4(env, /* false */0, /* :: */[
+          err$2 = equal$4(env, true, decl1[/* type_params */0], decl2[/* type_params */0]) ? (
+              equal$4(env, false, /* :: */[
                     ty1,
                     /* [] */0
                   ], /* :: */[
@@ -43813,7 +43812,7 @@ function type_declarations$1($staropt$star, env, name, decl1, id, decl2) {
             ];
         }
       } else {
-        err$2 = equal$4(env, /* true */1, decl1[/* type_params */0], decl2[/* type_params */0]) ? /* [] */0 : /* :: */[
+        err$2 = equal$4(env, true, decl1[/* type_params */0], decl2[/* type_params */0]) ? /* [] */0 : /* :: */[
             /* Constraint */3,
             /* [] */0
           ];
@@ -43821,10 +43820,10 @@ function type_declarations$1($staropt$star, env, name, decl1, id, decl2) {
       if (err$2 !== /* [] */0) {
         return err$2;
       } else {
-        var abstr = +(decl2[/* type_private */3] === /* Private */0 || decl2[/* type_kind */2] === /* Type_abstract */0 && decl2[/* type_manifest */4] === /* None */0);
-        var opn = +(decl2[/* type_kind */2] === /* Type_open */1 && decl2[/* type_manifest */4] === /* None */0);
+        var abstr = decl2[/* type_private */3] === /* Private */0 || decl2[/* type_kind */2] === /* Type_abstract */0 && decl2[/* type_manifest */4] === /* None */0;
+        var opn = decl2[/* type_kind */2] === /* Type_open */1 && decl2[/* type_manifest */4] === /* None */0;
         var constrained = function (ty) {
-          return 1 - is_Tvar(repr(ty));
+          return !is_Tvar(repr(ty));
         };
         if (List.for_all2((function (ty, param) {
                   var v2 = param[1];
@@ -43835,15 +43834,15 @@ function type_declarations$1($staropt$star, env, name, decl1, id, decl2) {
                   var match$1 = Curry._1(Types_003[/* get_upper */10], v2);
                   var cn2 = match$1[1];
                   var co2 = match$1[0];
-                  if (abstr ? (1 - co1 || co2) && (1 - cn1 || cn2) : (
-                        opn || constrained(ty) ? +(co1 === co2 && cn1 === cn2) : /* true */1
+                  if (abstr ? (!co1 || co2) && (!cn1 || cn2) : (
+                        opn || constrained(ty) ? co1 === co2 && cn1 === cn2 : true
                       )) {
                     var match$2 = Curry._1(Types_003[/* get_lower */11], v1);
                     var match$3 = Curry._1(Types_003[/* get_lower */11], v2);
-                    var b = (1 - match$3[0] || match$2[0]) && (1 - match$3[1] || match$2[1]) && (1 - match$3[2] || match$2[2]) && (1 - match$3[3] || match$2[3]);
-                    return abstr ? b : /* true */1;
+                    var b = (!match$3[0] || match$2[0]) && (!match$3[1] || match$2[1]) && (!match$3[2] || match$2[2]) && (!match$3[3] || match$2[3]);
+                    return abstr ? b : true;
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }), decl2[/* type_params */0], List.combine(decl1[/* type_variance */5], decl2[/* type_variance */5]))) {
           return /* [] */0;
@@ -43876,7 +43875,7 @@ function extension_constructors(env, id, ext1, ext2) {
           ext2[/* ext_type_params */1],
           [/* Mnil */0]
         ]));
-  if (equal$4(env, /* true */1, /* :: */[
+  if (equal$4(env, true, /* :: */[
           ty1,
           ext1[/* ext_type_params */1]
         ], /* :: */[
@@ -43888,7 +43887,7 @@ function extension_constructors(env, id, ext1, ext2) {
     var tmp;
     var exit = 0;
     if (match) {
-      if (match$1 && equal$4(env, /* true */1, /* :: */[
+      if (match$1 && equal$4(env, true, /* :: */[
               match[0],
               /* [] */0
             ], /* :: */[
@@ -43897,16 +43896,16 @@ function extension_constructors(env, id, ext1, ext2) {
             ])) {
         exit = 1;
       } else {
-        tmp = /* false */0;
+        tmp = false;
       }
     } else if (match$1) {
-      tmp = /* false */0;
+      tmp = false;
     } else {
       exit = 1;
     }
     if (exit === 1) {
       tmp = for_all2((function (ty1, ty2) {
-              return equal$4(env, /* true */1, /* :: */[
+              return equal$4(env, true, /* :: */[
                           ty1,
                           ext1[/* ext_type_params */1]
                         ], /* :: */[
@@ -43918,16 +43917,16 @@ function extension_constructors(env, id, ext1, ext2) {
     if (tmp) {
       var match$2 = ext1[/* ext_private */4];
       var match$3 = ext2[/* ext_private */4];
-      if (match$2 !== 0 || match$3 === 0) {
-        return /* true */1;
+      if (match$2 || !match$3) {
+        return true;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -43990,7 +43989,7 @@ function strengthen_sig(env, sg, p) {
           var match$2 = decl[/* type_kind */2];
           var newdecl;
           var exit = 0;
-          if (match && (match$1 !== 0 || typeof match$2 !== "number")) {
+          if (match && (match$1 || typeof match$2 !== "number")) {
             newdecl = decl;
           } else {
             exit = 1;
@@ -44119,12 +44118,12 @@ function nondep_supertype(env, mid, mty) {
                             return nondep_mty(env, var_inv, param);
                           }
                           }(var_inv)), arg),
-                      nondep_mty(add_module$1(/* Some */[/* true */1], param, default_mty(arg), env), va, mty[2])
+                      nondep_mty(add_module$1(/* Some */[true], param, default_mty(arg), env), va, mty[2])
                     ]);
         case 3 : 
             var p$1 = mty[0];
             if (isfree(mid, p$1)) {
-              _mty = find_module(/* false */0, p$1, env)[/* md_type */0];
+              _mty = find_module(false, p$1, env)[/* md_type */0];
               continue ;
             } else {
               return mty;
@@ -44157,7 +44156,7 @@ function nondep_supertype(env, mid, mty) {
             return /* :: */[
                     /* Sig_type */Block.__(1, [
                         id,
-                        nondep_type_decl(env, mid, id, +(va === /* Co */0), item[1]),
+                        nondep_type_decl(env, mid, id, va === /* Co */0, item[1]),
                         item[2]
                       ]),
                     rem$prime
@@ -44421,7 +44420,7 @@ function contains_type(env, _param) {
                               var match = param$1[1];
                               var match$1 = match[/* type_kind */2];
                               if (match[/* type_manifest */4]) {
-                                if (typeof match$1 === "number" && !(match$1 !== 0 || match[/* type_private */3] !== 0)) {
+                                if (typeof match$1 === "number" && !(match$1 !== 0 || match[/* type_private */3])) {
                                   throw Pervasives.Exit;
                                 } else {
                                   return /* () */0;
@@ -44450,11 +44449,11 @@ function contains_type(env, _param) {
 function contains_type$1(env, mty) {
   try {
     contains_type(env, mty);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Pervasives.Exit) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -44620,7 +44619,7 @@ function split$2(x, param) {
     if (c === 0) {
       return /* tuple */[
               l,
-              /* true */1,
+              true,
               r
             ];
     } else if (c < 0) {
@@ -44641,7 +44640,7 @@ function split$2(x, param) {
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0,
+            false,
             /* Empty */0
           ];
   }
@@ -44966,7 +44965,7 @@ function split$3(x, param) {
     if (c === 0) {
       return /* tuple */[
               l,
-              /* true */1,
+              true,
               r
             ];
     } else if (c < 0) {
@@ -44987,7 +44986,7 @@ function split$3(x, param) {
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0,
+            false,
             /* Empty */0
           ];
   }
@@ -44999,13 +44998,13 @@ function mem$5(x, _param) {
     if (param) {
       var c = Caml_obj.caml_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -45265,7 +45264,7 @@ function value_descriptions(env, cxt, subst, id, vd1, vd2) {
     var id$1 = id;
     var vd1$1 = vd1;
     var vd2$2 = vd2$1;
-    if (moregeneral(env$1, /* true */1, vd1$1[/* val_type */0], vd2$2[/* val_type */0])) {
+    if (moregeneral(env$1, true, vd1$1[/* val_type */0], vd2$2[/* val_type */0])) {
       var match = vd1$1[/* val_kind */1];
       var match$1 = vd2$2[/* val_kind */1];
       var exit = 0;
@@ -45429,11 +45428,11 @@ var Dont_match$1 = Caml_exceptions.create("Ocaml_typedtree_test.Includemod.Dont_
 function may_expand_module_path(env, path) {
   try {
     find_modtype_expansion(path, env);
-    return /* true */1;
+    return true;
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -45465,7 +45464,7 @@ function expand_module_path(env, cxt, path) {
 
 function expand_module_alias(env, cxt, path) {
   try {
-    return find_module(/* false */0, path, env)[/* md_type */0];
+    return find_module(false, path, env)[/* md_type */0];
   }
   catch (exn){
     if (exn === Caml_builtin_exceptions.not_found) {
@@ -45566,16 +45565,16 @@ function is_runtime_component(param) {
     case 0 : 
         var tmp = param[1][/* val_kind */1];
         if (typeof tmp === "number" || tmp.tag) {
-          return /* true */1;
+          return true;
         } else {
-          return /* false */0;
+          return false;
         }
     case 1 : 
     case 4 : 
     case 6 : 
-        return /* false */0;
+        return false;
     default:
-      return /* true */1;
+      return true;
   }
 }
 
@@ -45914,28 +45913,28 @@ function signatures(env, cxt, subst, sig1, sig2) {
           if (item2[1][/* type_manifest */4]) {
             match$1 = /* tuple */[
               name2,
-              /* true */1
+              true
             ];
           } else if (name2.tag === 1) {
             var s = name2[0];
             var l = s.length;
             match$1 = l >= 4 && $$String.sub(s, l - 4 | 0, 4) === "#row" ? /* tuple */[
                 /* Field_type */Block.__(1, [$$String.sub(s, 0, s.length - 4 | 0)]),
-                /* false */0
+                false
               ] : /* tuple */[
                 name2,
-                /* true */1
+                true
               ];
           } else {
             match$1 = /* tuple */[
               name2,
-              /* true */1
+              true
             ];
           }
         } else {
           match$1 = /* tuple */[
             name2,
-            /* true */1
+            true
           ];
         }
         var name2$1 = match$1[0];
@@ -46007,10 +46006,10 @@ function signatures(env, cxt, subst, sig1, sig2) {
                   _pos = pos + 1 | 0;
                   continue ;
                 } else {
-                  return /* false */0;
+                  return false;
                 }
               } else {
-                return /* true */1;
+                return true;
               }
             };
           };
@@ -47131,7 +47130,7 @@ function context$1(ppf, cxt) {
   if (cxt === /* [] */0) {
     return /* () */0;
   } else if (List.for_all((function (param) {
-            return param.tag ? /* false */0 : /* true */1;
+            return param.tag ? false : true;
           }), cxt)) {
     return Curry._2(Format.fprintf(ppf, /* Format */[
                     /* String_literal */Block.__(11, [
@@ -47220,13 +47219,13 @@ function is_big(obj) {
     }
     try {
       Marshal.to_buffer(buffer[0], 0, size, obj, /* [] */0);
-      return /* false */0;
+      return false;
     }
     catch (exn){
-      return /* true */1;
+      return true;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -47235,7 +47234,7 @@ function report_error$4(ppf, errs) {
     return /* () */0;
   } else {
     var match = split_last(errs);
-    var pe = [/* true */1];
+    var pe = [true];
     var print_errs = function (ppf) {
       return (function (param) {
           return List.iter((function (param) {
@@ -47257,7 +47256,7 @@ function report_error$4(ppf, errs) {
                                     ]),
                                   "...@ "
                                 ]);
-                            pe[0] = /* false */0;
+                            pe[0] = false;
                             return /* () */0;
                           } else {
                             return 0;
@@ -47370,13 +47369,13 @@ function omegas(i) {
 var zero = make_pat(/* Tpat_constant */Block.__(2, [/* Const_int */Block.__(0, [0])]), none$2, empty);
 
 function is_absent(tag, row) {
-  return +(row_field(tag, row[0]) === /* Rabsent */0);
+  return row_field(tag, row[0]) === /* Rabsent */0;
 }
 
 function is_absent_pat(p) {
   var match = p[/* pat_desc */0];
   if (typeof match === "number" || match.tag !== 5) {
-    return /* false */0;
+    return false;
   } else {
     return is_absent(match[0], match[2]);
   }
@@ -47515,7 +47514,7 @@ function compat(_p, _q) {
                     exit = 1;
                     break;
                 case 2 : 
-                    return +(const_compare(match[0], match$1[0]) === 0);
+                    return const_compare(match[0], match$1[0]) === 0;
                 case 8 : 
                     exit = 2;
                     break;
@@ -47556,7 +47555,7 @@ function compat(_p, _q) {
                     if (equal_tag(match[1][/* cstr_tag */5], match$1[1][/* cstr_tag */5])) {
                       return compats(match[2], match$1[2]);
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                 case 8 : 
                     exit = 2;
@@ -47585,7 +47584,7 @@ function compat(_p, _q) {
                         _p = match$2[0];
                         continue ;
                       } else {
-                        return /* false */0;
+                        return false;
                       }
                   case 8 : 
                       exit = 2;
@@ -47604,9 +47603,9 @@ function compat(_p, _q) {
                     break;
                 case 5 : 
                     if (match$1[1]) {
-                      return /* false */0;
+                      return false;
                     } else {
-                      return +(l1 === match$1[0]);
+                      return l1 === match$1[0];
                     }
                 case 8 : 
                     exit = 2;
@@ -47651,7 +47650,7 @@ function compat(_p, _q) {
                     if (List.length(ps) === List.length(qs)) {
                       return compats(ps, qs);
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                 case 8 : 
                     exit = 2;
@@ -47689,17 +47688,17 @@ function compat(_p, _q) {
     switch (exit) {
       case 1 : 
           if (typeof match$1 === "number") {
-            return /* true */1;
+            return true;
           } else {
             switch (match$1.tag | 0) {
               case 0 : 
-                  return /* true */1;
+                  return true;
               case 1 : 
                   _q = match$1[0];
                   continue ;
               default:
                 if (typeof match === "number" || !(match.tag && !compat(match[0], q))) {
-                  return /* true */1;
+                  return true;
                 } else {
                   _p = match[1];
                   continue ;
@@ -47708,7 +47707,7 @@ function compat(_p, _q) {
           }
       case 2 : 
           if (compat(p, match$1[0])) {
-            return /* true */1;
+            return true;
           } else {
             _q = match$1[1];
             continue ;
@@ -47738,7 +47737,7 @@ function compats(_ps, _qs) {
           _ps = ps[1];
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
         throw [
@@ -47760,7 +47759,7 @@ function compats(_ps, _qs) {
             ]
           ];
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -47787,9 +47786,9 @@ function get_type_path(ty, tenv) {
 
 function is_cons(param) {
   if (param[/* cstr_name */0] === "::") {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -48201,9 +48200,9 @@ function pretty_val(ppf, v) {
                             "@[{%a}@]"
                           ]), pretty_lvals, List.filter((function (param) {
                                 if (typeof param[2][/* pat_desc */0] === "number") {
-                                  return /* false */0;
+                                  return false;
                                 } else {
-                                  return /* true */1;
+                                  return true;
                                 }
                               }))(match$1[0]));
         case 7 : 
@@ -48522,9 +48521,9 @@ function simple_match(p1, p2) {
                   exit = 1;
                   break;
               case 2 : 
-                  return +(const_compare(match[0], match$1[0]) === 0);
+                  return const_compare(match[0], match$1[0]) === 0;
               default:
-                return /* false */0;
+                return false;
             }
           }
           break;
@@ -48537,9 +48536,9 @@ function simple_match(p1, p2) {
                   exit = 1;
                   break;
               case 3 : 
-                  return /* true */1;
+                  return true;
               default:
-                return /* false */0;
+                return false;
             }
           }
           break;
@@ -48554,7 +48553,7 @@ function simple_match(p1, p2) {
               case 4 : 
                   return equal_tag(match[1][/* cstr_tag */5], match$1[1][/* cstr_tag */5]);
               default:
-                return /* false */0;
+                return false;
             }
           }
           break;
@@ -48567,9 +48566,9 @@ function simple_match(p1, p2) {
                   exit = 1;
                   break;
               case 5 : 
-                  return +(match[0] === match$1[0]);
+                  return match[0] === match$1[0];
               default:
-                return /* false */0;
+                return false;
             }
           }
           break;
@@ -48582,9 +48581,9 @@ function simple_match(p1, p2) {
                   exit = 1;
                   break;
               case 6 : 
-                  return /* true */1;
+                  return true;
               default:
-                return /* false */0;
+                return false;
             }
           }
           break;
@@ -48597,9 +48596,9 @@ function simple_match(p1, p2) {
                   exit = 1;
                   break;
               case 7 : 
-                  return +(List.length(match[0]) === List.length(match$1[0]));
+                  return List.length(match[0]) === List.length(match$1[0]);
               default:
-                return /* false */0;
+                return false;
             }
           }
           break;
@@ -48612,9 +48611,9 @@ function simple_match(p1, p2) {
                   exit = 1;
                   break;
               case 9 : 
-                  return /* true */1;
+                  return true;
               default:
-                return /* false */0;
+                return false;
             }
           }
           break;
@@ -48624,9 +48623,9 @@ function simple_match(p1, p2) {
   }
   if (exit === 1) {
     if (typeof match$1 === "number" || !match$1.tag) {
-      return /* true */1;
+      return true;
     } else {
-      return /* false */0;
+      return false;
     }
   }
   
@@ -48645,7 +48644,7 @@ function record_arg(p) {
 
 function get_field(pos, arg) {
   return List.find((function (param) {
-                  return +(pos === param[1][/* lbl_pos */4]);
+                  return pos === param[1][/* lbl_pos */4];
                 }), arg)[2];
 }
 
@@ -48998,10 +48997,10 @@ function do_set_args(erase_mutable, q, r) {
                           List.map2((function (param, arg) {
                                   var lbl = param[1];
                                   var lid = param[0];
-                                  var tmp = /* false */0;
+                                  var tmp = false;
                                   if (erase_mutable) {
                                     var match = lbl[/* lbl_mut */3];
-                                    tmp = match !== 0 ? /* true */1 : /* false */0;
+                                    tmp = match ? true : false;
                                   }
                                   if (tmp) {
                                     return /* tuple */[
@@ -49452,7 +49451,7 @@ function close_variant(env, row) {
   var row$1 = row_repr_aux(/* [] */0, row);
   var nm = List.fold_left((function (nm, param) {
           var match = row_field_repr_aux(/* [] */0, param[1]);
-          if (typeof match === "number" || !match.tag || match[2] !== 0) {
+          if (typeof match === "number" || !match.tag || match[2]) {
             return nm;
           } else {
             set_row_field(match[3], /* Rabsent */0);
@@ -49464,7 +49463,7 @@ function close_variant(env, row) {
                         /* row_fields : [] */0,
                         /* row_more */newty2(100000000, /* Tvar */Block.__(0, [/* None */0])),
                         /* row_bound */row$1[/* row_bound */2],
-                        /* row_closed : true */1,
+                        /* row_closed */true,
                         /* row_fixed */row$1[/* row_fixed */4],
                         /* row_name */nm
                       ]])));
@@ -49558,19 +49557,19 @@ function full_match(ignore_generalized, closing, env) {
       switch (match.tag | 0) {
         case 2 : 
             if (match[0].tag === 1) {
-              return +(List.length(env) === 256);
+              return List.length(env) === 256;
             } else {
-              return /* false */0;
+              return false;
             }
         case 4 : 
             var c = match[1];
             if (c[/* cstr_consts */6] < 0) {
-              return /* false */0;
+              return false;
             } else if (ignore_generalized) {
               var env$1 = clean_env(env);
-              return +(List.length(env$1) === c[/* cstr_normal */8]);
+              return List.length(env$1) === c[/* cstr_normal */8];
             } else {
-              return +(List.length(env) === (c[/* cstr_consts */6] + c[/* cstr_nonconsts */7] | 0));
+              return List.length(env) === (c[/* cstr_consts */6] + c[/* cstr_nonconsts */7] | 0);
             }
         case 5 : 
             var fields = List.map((function (param) {
@@ -49602,8 +49601,8 @@ function full_match(ignore_generalized, closing, env) {
               return List.for_all((function (param) {
                             var tag = param[0];
                             var match = row_field_repr_aux(/* [] */0, param[1]);
-                            if (typeof match === "number" || !(!match.tag || match[2] !== 0)) {
-                              return /* true */1;
+                            if (typeof match === "number" || !(!match.tag || match[2])) {
+                              return true;
                             } else {
                               return List.mem(tag, fields);
                             }
@@ -49611,20 +49610,20 @@ function full_match(ignore_generalized, closing, env) {
             } else if (row[/* row_closed */3]) {
               return List.for_all((function (param) {
                             if (row_field_repr_aux(/* [] */0, param[1]) === /* Rabsent */0) {
-                              return /* true */1;
+                              return true;
                             } else {
                               return List.mem(param[0], fields);
                             }
                           }), row[/* row_fields */0]);
             } else {
-              return /* false */0;
+              return false;
             }
         case 7 : 
-            return /* false */0;
+            return false;
         case 3 : 
         case 6 : 
         case 9 : 
-            return /* true */1;
+            return true;
         default:
           return fatal_error("Parmatch.full_match");
       }
@@ -49638,13 +49637,13 @@ function full_match_gadt(env) {
   if (env) {
     var match = env[0][0][/* pat_desc */0];
     if (typeof match === "number" || match.tag !== 4) {
-      return /* true */1;
+      return true;
     } else {
       var c = match[1];
-      return +(List.length(env) === (c[/* cstr_consts */6] + c[/* cstr_nonconsts */7] | 0));
+      return List.length(env) === (c[/* cstr_consts */6] + c[/* cstr_nonconsts */7] | 0);
     }
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -49653,7 +49652,7 @@ function should_extend(ext, env) {
     var p = env[0][0];
     var match = p[/* pat_desc */0];
     if (typeof match === "number" || match.tag !== 4) {
-      return /* false */0;
+      return false;
     } else {
       var exit = 0;
       switch (match[1][/* cstr_tag */5].tag | 0) {
@@ -49662,7 +49661,7 @@ function should_extend(ext, env) {
             exit = 1;
             break;
         case 2 : 
-            return /* false */0;
+            return false;
         
       }
       if (exit === 1) {
@@ -49672,19 +49671,19 @@ function should_extend(ext, env) {
       
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function complete_tags(nconsts, nconstrs, tags) {
-  var seen_const = Caml_array.caml_make_vect(nconsts, /* false */0);
-  var seen_constr = Caml_array.caml_make_vect(nconstrs, /* false */0);
+  var seen_const = Caml_array.caml_make_vect(nconsts, false);
+  var seen_constr = Caml_array.caml_make_vect(nconstrs, false);
   List.iter((function (param) {
           switch (param.tag | 0) {
             case 0 : 
-                return Caml_array.caml_array_set(seen_const, param[0], /* true */1);
+                return Caml_array.caml_array_set(seen_const, param[0], true);
             case 1 : 
-                return Caml_array.caml_array_set(seen_constr, param[0], /* true */1);
+                return Caml_array.caml_array_set(seen_constr, param[0], true);
             case 2 : 
                 throw [
                       Caml_builtin_exceptions.assert_failure,
@@ -50205,7 +50204,7 @@ function build_other(ext, env) {
                               ];
                       } else {
                         return /* :: */[
-                                make_other_pat(tag, +(match[0] === /* None */0)),
+                                make_other_pat(tag, match[0] === /* None */0),
                                 others
                               ];
                       }
@@ -50220,7 +50219,7 @@ function build_other(ext, env) {
                                         ]), p[/* pat_type */3], p[/* pat_env */4]);
                           }), match$2[0], match$2[1]);
             } else {
-              return make_other_pat("AnyExtraTag", /* true */1);
+              return make_other_pat("AnyExtraTag", true);
             }
         case 7 : 
             var all_lengths = List.map((function (param) {
@@ -50309,7 +50308,7 @@ function has_instance(_p) {
     var p = _p;
     var match = p[/* pat_desc */0];
     if (typeof match === "number") {
-      return /* true */1;
+      return true;
     } else {
       switch (match.tag | 0) {
         case 4 : 
@@ -50317,12 +50316,12 @@ function has_instance(_p) {
         case 5 : 
             var match$1 = match[1];
             if (is_absent(match[0], match[2])) {
-              return /* false */0;
+              return false;
             } else if (match$1) {
               _p = match$1[0];
               continue ;
             } else {
-              return /* true */1;
+              return true;
             }
         case 6 : 
             return has_instances(List.map((function (param) {
@@ -50333,7 +50332,7 @@ function has_instance(_p) {
             return has_instances(match[0]);
         case 8 : 
             if (has_instance(match[0])) {
-              return /* true */1;
+              return true;
             } else {
               _p = match[1];
               continue ;
@@ -50343,7 +50342,7 @@ function has_instance(_p) {
             _p = match[0];
             continue ;
         default:
-          return /* true */1;
+          return true;
       }
     }
   };
@@ -50357,10 +50356,10 @@ function has_instances(_param) {
         _param = param[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -50389,7 +50388,7 @@ function satisfiable(_pss, _qs) {
                 continue ;
             case 5 : 
                 if (is_absent(match[0], match[2])) {
-                  return /* false */0;
+                  return false;
                 } else {
                   exit = 2;
                 }
@@ -50400,7 +50399,7 @@ function satisfiable(_pss, _qs) {
                         match[0],
                         qs$1
                       ])) {
-                  return /* true */1;
+                  return true;
                 } else {
                   _qs = /* :: */[
                     match[1],
@@ -50418,12 +50417,12 @@ function satisfiable(_pss, _qs) {
               var q0 = discr_pat(omega, pss);
               var constrs = filter_all(q0, pss);
               if (constrs) {
-                if (full_match(/* false */0, /* false */0, constrs)) {
+                if (full_match(false, false, constrs)) {
                   return List.exists((function(qs$2){
                             return function (param) {
                               var p = param[0];
                               if (is_absent_pat(p)) {
-                                return /* false */0;
+                                return false;
                               } else {
                                 return satisfiable(param[1], Pervasives.$at(simple_match_args(p, omega), qs$2));
                               }
@@ -50447,7 +50446,7 @@ function satisfiable(_pss, _qs) {
           
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
       return has_instances(qs);
@@ -50517,13 +50516,13 @@ function exhaust(ext, pss, n) {
           } else {
             var r = exhaust(ext, param[1], (List.length(simple_match_args(p, omega)) + n | 0) - 1 | 0);
             if (r) {
-              return /* Rsome */[do_set_args(/* false */0, p, r[0])];
+              return /* Rsome */[do_set_args(false, p, r[0])];
             } else {
               return r;
             }
           }
         };
-        if (full_match(/* true */1, /* false */0, constrs) && !should_extend(ext, constrs)) {
+        if (full_match(true, false, constrs) && !should_extend(ext, constrs)) {
           var f = try_non_omega;
           var _param = constrs;
           while(true) {
@@ -50618,7 +50617,7 @@ function exhaust_gadt(ext, pss, n) {
             var r = exhaust_gadt(ext, param[1], (List.length(simple_match_args(p, omega)) + n | 0) - 1 | 0);
             if (r) {
               return /* Rsome */[List.map((function (row) {
-                              return do_set_args(/* false */0, p, row);
+                              return do_set_args(false, p, row);
                             }), r[0])];
             } else {
               return r;
@@ -50738,21 +50737,21 @@ function pressure_variants(_tdefs, _pss) {
               if (try_non_omega(param[1])) {
                 return ok;
               } else {
-                return /* false */0;
+                return false;
               }
             } else {
-              return /* true */1;
+              return true;
             }
           }
           }(tdefs));
-          if (full_match(/* true */1, +(tdefs === /* None */0), constrs)) {
+          if (full_match(true, tdefs === /* None */0, constrs)) {
             return try_non_omega(constrs);
           } else if (tdefs === /* None */0) {
             _pss = filter_extra(pss);
             _tdefs = /* None */0;
             continue ;
           } else {
-            var full = full_match(/* true */1, /* true */1, constrs);
+            var full = full_match(true, true, constrs);
             var ok = full ? try_non_omega(constrs) : try_non_omega(filter_all(q0, mark_partial(pss)));
             if (constrs) {
               var p = constrs[0][0];
@@ -50779,10 +50778,10 @@ function pressure_variants(_tdefs, _pss) {
           continue ;
         }
       } else {
-        return /* true */1;
+        return true;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -50815,9 +50814,9 @@ function is_var_column(rs) {
                   var p = match[0];
                   var match$1 = unalias$1(p)[/* pat_desc */0];
                   if (typeof match$1 === "number" || !match$1.tag) {
-                    return /* true */1;
+                    return true;
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 } else {
                   throw [
@@ -51310,11 +51309,11 @@ function le_pat(_p, _q) {
     var exit = 0;
     var exit$1 = 0;
     if (typeof match === "number") {
-      return /* true */1;
+      return true;
     } else {
       switch (match.tag | 0) {
         case 0 : 
-            return /* true */1;
+            return true;
         case 1 : 
             _p = match[0];
             continue ;
@@ -51327,7 +51326,7 @@ function le_pat(_p, _q) {
                     exit$1 = 2;
                     break;
                 case 2 : 
-                    return +(const_compare(match[0], match$1[0]) === 0);
+                    return const_compare(match[0], match$1[0]) === 0;
                 default:
                   exit = 1;
               }
@@ -51360,7 +51359,7 @@ function le_pat(_p, _q) {
                     if (equal_tag(match[1][/* cstr_tag */5], match$1[1][/* cstr_tag */5])) {
                       return le_pats(match[2], match$1[2]);
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                 default:
                   exit = 1;
@@ -51385,7 +51384,7 @@ function le_pat(_p, _q) {
                         _p = match$2[0];
                         continue ;
                       } else {
-                        return /* false */0;
+                        return false;
                       }
                   default:
                     exit = 1;
@@ -51400,9 +51399,9 @@ function le_pat(_p, _q) {
                     break;
                 case 5 : 
                     if (match$1[1]) {
-                      return /* false */0;
+                      return false;
                     } else {
-                      return +(l1 === match$1[0]);
+                      return l1 === match$1[0];
                     }
                 default:
                   exit = 1;
@@ -51439,7 +51438,7 @@ function le_pat(_p, _q) {
                     if (List.length(ps) === List.length(qs)) {
                       return le_pats(ps, qs);
                     } else {
-                      return /* false */0;
+                      return false;
                     }
                 default:
                   exit = 1;
@@ -51478,7 +51477,7 @@ function le_pat(_p, _q) {
       }
     }
     if (exit === 1) {
-      return 1 - satisfiable(/* :: */[
+      return !satisfiable(/* :: */[
                   /* :: */[
                     p,
                     /* [] */0
@@ -51503,10 +51502,10 @@ function le_pats(_ps, _qs) {
         _ps = ps[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -51593,7 +51592,7 @@ function initial_all(no_guard, param) {
               ],
               pat[/* pat_loc */1]
             ],
-            initial_all(no_guard && +(match[/* c_guard */1] === /* None */0), param[1])
+            initial_all(no_guard && match[/* c_guard */1] === /* None */0, param[1])
           ];
   } else if (no_guard) {
     throw NoGuard;
@@ -51750,7 +51749,7 @@ function do_match(_pss, _qs) {
 
 function check_partial_all(v, casel) {
   try {
-    var pss = initial_all(/* true */1, casel);
+    var pss = initial_all(true, casel);
     return do_match(pss, /* :: */[
                 v,
                 /* [] */0
@@ -52052,7 +52051,7 @@ function add_path(path, paths) {
 }
 
 function extendable_path(path) {
-  return 1 - (same(path, path_bool) || same(path, path_list) || same(path, path_unit) || same(path, path_option));
+  return !(same(path, path_bool) || same(path, path_list) || same(path, path_unit) || same(path, path_option));
 }
 
 function collect_paths_from_pat(_r, _p) {
@@ -52471,9 +52470,9 @@ function warning_attribute(attrs) {
                 }
                 switch (exit) {
                   case 1 : 
-                      return $$process(match[/* loc */1], txt, /* false */0, param[1]);
+                      return $$process(match[/* loc */1], txt, false, param[1]);
                   case 2 : 
-                      return $$process(match[/* loc */1], txt, /* true */1, param[1]);
+                      return $$process(match[/* loc */1], txt, true, param[1]);
                   
                 }
               }), attrs);
@@ -52482,7 +52481,7 @@ function warning_attribute(attrs) {
 function narrow_unbound_lid_error(env, loc, lid, make_error) {
   var check_module = function (mlid) {
     try {
-      lookup_module(/* true */1, mlid, env);
+      lookup_module(true, mlid, env);
       return /* () */0;
     }
     catch (exn){
@@ -52508,7 +52507,7 @@ function narrow_unbound_lid_error(env, loc, lid, make_error) {
     case 1 : 
         var mlid = lid[0];
         check_module(mlid);
-        var md = find_module(/* false */0, lookup_module(/* true */1, mlid, env), env);
+        var md = find_module(false, lookup_module(true, mlid, env), env);
         var match = scrape_alias(env, /* None */0, md[/* md_type */0]);
         if (match.tag === 2) {
           throw [
@@ -52621,7 +52620,7 @@ function find_value$1(env, loc, lid) {
 }
 
 function lookup_module$1($staropt$star, env, loc, lid) {
-  var load = $staropt$star ? $staropt$star[0] : /* false */0;
+  var load = $staropt$star ? $staropt$star[0] : false;
   return find_component((function (lid, env) {
                   return /* tuple */[
                           lookup_module(load, lid, env),
@@ -52633,8 +52632,8 @@ function lookup_module$1($staropt$star, env, loc, lid) {
 }
 
 function find_module$1(env, loc, lid) {
-  var path = lookup_module$1(/* Some */[/* true */1], env, loc, lid);
-  var decl = find_module(/* false */0, path, env);
+  var path = lookup_module$1(/* Some */[true], env, loc, lid);
+  var decl = find_module(false, path, env);
   check_deprecated(loc, decl[/* md_attributes */1], name(/* None */0, path));
   return /* tuple */[
           path,
@@ -52771,11 +52770,11 @@ function widen(param) {
 
 function strict_lowercase(c) {
   if (c === /* "_" */95) {
-    return /* true */1;
+    return true;
   } else if (c >= /* "a" */97) {
-    return +(c <= /* "z" */122);
+    return c <= /* "z" */122;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -53106,7 +53105,7 @@ function transl_type(env, policy, styp) {
             match$3 = /* tuple */[
               match$4[0],
               decl$1,
-              /* true */1
+              true
             ];
           }
           catch (exn$3){
@@ -53133,7 +53132,7 @@ function transl_type(env, policy, styp) {
                 match$3 = /* tuple */[
                   match$6[0],
                   match$6[1],
-                  /* false */0
+                  false
                 ];
               }
               catch (exn$4){
@@ -53245,17 +53244,17 @@ function transl_type(env, policy, styp) {
                           } else {
                             var match$1 = match[0];
                             tmp = match$1 ? /* Reither */Block.__(1, [
-                                  /* false */0,
+                                  false,
                                   /* :: */[
                                     match$1[0],
                                     /* [] */0
                                   ],
-                                  /* false */0,
+                                  false,
                                   [/* None */0]
                                 ]) : /* Reither */Block.__(1, [
-                                  /* true */1,
+                                  true,
                                   /* [] */0,
-                                  /* false */0,
+                                  false,
                                   [/* None */0]
                                 ]);
                           }
@@ -53273,8 +53272,8 @@ function transl_type(env, policy, styp) {
                     /* row_fields */fields$1,
                     row_001,
                     /* row_bound : () */0,
-                    /* row_closed : true */1,
-                    /* row_fixed : false */0,
+                    /* row_closed */true,
+                    /* row_fixed */false,
                     row_005
                   ];
                   var $$static = static_row(row$1);
@@ -53427,8 +53426,8 @@ function transl_type(env, policy, styp) {
                   ],
                   /* row_more */newvar$1(/* None */0, /* () */0),
                   /* row_bound : () */0,
-                  /* row_closed : true */1,
-                  /* row_fixed : false */0,
+                  /* row_closed */true,
+                  /* row_fixed */false,
                   /* row_name : None */0
                 ]]);
             return newty2(current_level[0], desc);
@@ -53452,7 +53451,7 @@ function transl_type(env, policy, styp) {
               }
               var ty = mkfield(l, f);
               var ty$prime = mkfield(l, match[1]);
-              if (equal$4(env, /* false */0, /* :: */[
+              if (equal$4(env, false, /* :: */[
                       ty,
                       /* [] */0
                     ], /* :: */[
@@ -53584,17 +53583,17 @@ function transl_type(env, policy, styp) {
                         } else {
                           var match = f[0];
                           f$1 = match ? /* Reither */Block.__(1, [
-                                /* false */0,
+                                false,
                                 /* :: */[
                                   match[0],
                                   /* [] */0
                                 ],
-                                /* false */0,
+                                false,
                                 [/* None */0]
                               ]) : /* Reither */Block.__(1, [
-                                /* true */1,
+                                true,
                                 /* [] */0,
-                                /* false */0,
+                                false,
                                 [/* None */0]
                               ]);
                         }
@@ -53621,7 +53620,7 @@ function transl_type(env, policy, styp) {
                 f = /* Reither */Block.__(1, [
                     c,
                     ty_tl,
-                    /* false */0,
+                    false,
                     [/* None */0]
                   ]);
               } else {
@@ -53670,14 +53669,14 @@ function transl_type(env, policy, styp) {
           }
           var row_000 = /* row_fields */List.rev(fields$2);
           var row_001$1 = /* row_more */newvar$1(/* None */0, /* () */0);
-          var row_003 = /* row_closed */+(closed === /* Closed */0);
+          var row_003 = /* row_closed */closed === /* Closed */0;
           var row_005$1 = /* row_name */name$1[0];
           var row$3 = /* record */[
             row_000,
             row_001$1,
             /* row_bound : () */0,
             row_003,
-            /* row_fixed : false */0,
+            /* row_fixed */false,
             row_005$1
           ];
           var $$static$1 = static_row(row$3);
@@ -53757,7 +53756,7 @@ function transl_type(env, policy, styp) {
       case 9 : 
           var match$10 = match[0];
           var p = match$10[0];
-          var match$11 = create_package_mty(/* true */1, styp[/* ptyp_loc */1], env, /* tuple */[
+          var match$11 = create_package_mty(true, styp[/* ptyp_loc */1], env, /* tuple */[
                 p,
                 match$10[1]
               ]);
@@ -53826,7 +53825,7 @@ function transl_fields(loc, env, policy, seen, o, param) {
                   match[2][/* ctyp_type */1],
                   ty2
                 ]));
-  } else if (o !== 0) {
+  } else if (o) {
     if (policy >= 2) {
       return new_pre_univar(/* None */0, /* () */0);
     } else {
@@ -53858,7 +53857,7 @@ function make_fixed_univars(ty) {
                                 /* Reither */Block.__(1, [
                                     match[0],
                                     match[1],
-                                    /* true */1,
+                                    true,
                                     match[3]
                                   ])
                               ];
@@ -53867,7 +53866,7 @@ function make_fixed_univars(ty) {
               /* row_more */row[/* row_more */1],
               /* row_bound */row[/* row_bound */2],
               /* row_closed */row[/* row_closed */3],
-              /* row_fixed : true */1,
+              /* row_fixed */true,
               /* row_name */row[/* row_name */5]
             ]]);
       }
@@ -53893,11 +53892,11 @@ function globalize_used_variables(env, fixed) {
           var tmp;
           try {
             unify$2(env, v, ty);
-            tmp = /* true */1;
+            tmp = true;
           }
           catch (exn){
             backtrack(snap);
-            tmp = /* false */0;
+            tmp = false;
           }
           if (tmp) {
             try {
@@ -53988,7 +53987,7 @@ function transl_simple_type_univars(env, styp) {
             return 0;
           }
         }), new_variables);
-  globalize_used_variables(env, /* false */0)(/* () */0);
+  globalize_used_variables(env, false)(/* () */0);
   end_def(/* () */0);
   iter_generalize$1([/* [] */0], typ[/* ctyp_type */1]);
   var univs = List.fold_left((function (acc, v) {
@@ -54024,14 +54023,14 @@ function transl_simple_type_delayed(env, styp) {
   make_fixed_univars$1(typ[/* ctyp_type */1]);
   return /* tuple */[
           typ,
-          globalize_used_variables(env, /* false */0)
+          globalize_used_variables(env, false)
         ];
 }
 
 function transl_type_scheme(env, styp) {
   reset_type_variables(/* () */0);
   begin_def(/* () */0);
-  var typ = transl_simple_type(env, /* false */0, styp);
+  var typ = transl_simple_type(env, false, styp);
   end_def(/* () */0);
   iter_generalize$1([/* [] */0], typ[/* ctyp_type */1]);
   return typ;
@@ -55159,9 +55158,9 @@ function explicit_arity(param) {
                 switch (param[0][/* txt */0]) {
                   case "explicit_arity" : 
                   case "ocaml.explicit_arity" : 
-                      return /* true */1;
+                      return true;
                   default:
-                    return /* false */0;
+                    return false;
                 }
               }), param);
 }
@@ -55265,7 +55264,7 @@ function unify_pat_types_gadt(loc, env, ty, ty$prime) {
     try {
       univar_pairs[0] = /* [] */0;
       newtype_level[0] = /* Some */[lev];
-      set_mode_pattern(/* true */1, /* true */1, (function () {
+      set_mode_pattern(true, true, (function () {
               return unify$1(env$1, ty1, ty2);
             }));
       newtype_level[0] = /* None */0;
@@ -55359,7 +55358,7 @@ function finalize_variant(pat) {
     } else {
       var c = match$3[0];
       var exit = 0;
-      if (c !== 0) {
+      if (c) {
         if (match$3[1] || row[/* row_closed */3]) {
           exit = 1;
         } else {
@@ -55394,11 +55393,11 @@ function finalize_variant(pat) {
         }
       }
       if (exit === 1) {
-        if (match$3[2] !== 0 && !row_fixed(row)) {
+        if (match$3[2] && !row_fixed(row)) {
           return set_row_field(match$3[3], /* Reither */Block.__(1, [
                         c,
                         /* [] */0,
-                        /* false */0,
+                        false,
                         [/* None */0]
                       ]));
         } else {
@@ -55427,11 +55426,11 @@ function has_variants(p) {
               throw Pervasives.Exit;
             }
           }), p);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Pervasives.Exit) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -55444,7 +55443,7 @@ var pattern_force = [/* [] */0];
 
 var pattern_scope = [/* None */0];
 
-var allow_modules = [/* false */0];
+var allow_modules = [false];
 
 var module_variables = [/* [] */0];
 
@@ -55458,10 +55457,10 @@ function reset_pattern(scope, allow) {
 }
 
 function enter_variable($staropt$star, $staropt$star$1, loc, name, ty) {
-  var is_module = $staropt$star ? $staropt$star[0] : /* false */0;
-  var is_as_variable = $staropt$star$1 ? $staropt$star$1[0] : /* false */0;
+  var is_module = $staropt$star ? $staropt$star[0] : false;
+  var is_as_variable = $staropt$star$1 ? $staropt$star$1[0] : false;
   if (List.exists((function (param) {
-            return +(param[0][/* name */1] === name[/* txt */0]);
+            return param[0][/* name */1] === name[/* txt */0];
           }), pattern_variables[0])) {
     throw [
           $$Error$7,
@@ -55614,7 +55613,7 @@ function build_as_type(env, _p) {
         case 4 : 
             var pl = match[2];
             var cstr = match[1];
-            var keep = +(cstr[/* cstr_private */10] === /* Private */0 || cstr[/* cstr_existentials */2] !== /* [] */0);
+            var keep = cstr[/* cstr_private */10] === /* Private */0 || cstr[/* cstr_existentials */2] !== /* [] */0;
             if (keep) {
               return p[/* pat_type */3];
             } else {
@@ -55646,8 +55645,8 @@ function build_as_type(env, _p) {
                   ],
                   /* row_more */newvar(/* None */0, /* () */0),
                   /* row_bound : () */0,
-                  /* row_closed : false */0,
-                  /* row_fixed : false */0,
+                  /* row_closed */false,
+                  /* row_fixed */false,
                   /* row_name : None */0
                 ]]);
             return newty2(current_level[0], desc);
@@ -55666,17 +55665,17 @@ function build_as_type(env, _p) {
                     }), lpl);
               var do_label = (function(p,ty$1,ppl){
               return function do_label(lbl) {
-                var match = instance_label(/* false */0, lbl);
+                var match = instance_label(false, lbl);
                 var ty_arg = match[1];
                 var newrecord = p.slice();
                 unify_pat(env, (newrecord[/* pat_type */3] = ty$1, newrecord), match[2]);
-                var refinable = /* false */0;
+                var refinable = false;
                 if (lbl[/* lbl_mut */3] === /* Immutable */0) {
-                  var tmp = /* false */0;
+                  var tmp = false;
                   if (List.mem_assoc(lbl[/* lbl_pos */4], ppl)) {
                     var match$1 = repr(lbl[/* lbl_arg */2])[/* desc */0];
                     var tmp$1;
-                    tmp$1 = typeof match$1 === "number" || match$1.tag !== 10 ? /* true */1 : /* false */0;
+                    tmp$1 = typeof match$1 === "number" || match$1.tag !== 10 ? true : false;
                     tmp = tmp$1;
                   }
                   refinable = tmp;
@@ -55686,7 +55685,7 @@ function build_as_type(env, _p) {
                   var newrecord$1 = arg.slice();
                   return unify_pat(env, (newrecord$1[/* pat_type */3] = build_as_type(env, arg), newrecord$1), ty_arg);
                 } else {
-                  var match$2 = instance_label(/* false */0, lbl);
+                  var match$2 = instance_label(false, lbl);
                   unify$2(env, ty_arg, match$2[1]);
                   return unify_pat(env, p, match$2[2]);
                 }
@@ -55704,7 +55703,7 @@ function build_as_type(env, _p) {
                     /* row_fields */row$1[/* row_fields */0],
                     /* row_more */newvar(/* None */0, /* () */0),
                     /* row_bound */row$1[/* row_bound */2],
-                    /* row_closed : false */0,
+                    /* row_closed */false,
                     /* row_fixed */row$1[/* row_fixed */4],
                     /* row_name */row$1[/* row_name */5]
                   ]]);
@@ -55793,12 +55792,12 @@ function build_or_pat(env, loc, lid) {
                         /* tuple */[
                           l,
                           /* Reither */Block.__(1, [
-                              /* false */0,
+                              false,
                               /* :: */[
                                 ty,
                                 /* [] */0
                               ],
-                              /* true */1,
+                              true,
                               [/* None */0]
                             ])
                         ],
@@ -55818,9 +55817,9 @@ function build_or_pat(env, loc, lid) {
                         /* tuple */[
                           l,
                           /* Reither */Block.__(1, [
-                              /* true */1,
+                              true,
                               /* [] */0,
-                              /* true */1,
+                              true,
                               [/* None */0]
                             ])
                         ],
@@ -55843,8 +55842,8 @@ function build_or_pat(env, loc, lid) {
     row_000,
     row_001,
     /* row_bound : () */0,
-    /* row_closed : false */0,
-    /* row_fixed : false */0,
+    /* row_closed */false,
+    /* row_fixed */false,
     row_005
   ];
   var ty$1 = newty2(current_level[0], /* Tvariant */Block.__(8, [row$1]));
@@ -55853,7 +55852,7 @@ function build_or_pat(env, loc, lid) {
   var gloc = /* record */[
     gloc_000,
     gloc_001,
-    /* loc_ghost : true */1
+    /* loc_ghost */true
   ];
   var newrecord = row$1.slice();
   var row$prime = [(newrecord[/* row_more */1] = newvar(/* None */0, /* () */0), newrecord)];
@@ -56015,7 +56014,7 @@ function lookup_from_type(env, tpath, lid) {
         var s = match[0];
         try {
           return List.find((function (nd) {
-                        return +(nd[/* lbl_name */0] === s);
+                        return nd[/* lbl_name */0] === s;
                       }), descrs);
         }
         catch (exn){
@@ -56124,7 +56123,7 @@ function disambiguate($staropt$star, $staropt$star$1, scope, lid, env, opath, lb
                         /* [] */0
                       ],
                       paths,
-                      /* false */0
+                      false
                     ]));
             }
             
@@ -56149,7 +56148,7 @@ function disambiguate($staropt$star, $staropt$star$1, scope, lid, env, opath, lb
                     last$1(lid[/* txt */0]),
                     /* [] */0
                   ],
-                  /* false */0
+                  false
                 ]));
           if (!pr) {
             warn_pr(/* () */0);
@@ -56207,7 +56206,7 @@ function disambiguate($staropt$star, $staropt$star$1, scope, lid, env, opath, lb
                 /* [] */0
               ],
               paths$1,
-              /* false */0
+              false
             ]));
     }
     lbl = lbl$3;
@@ -56241,27 +56240,27 @@ function disambiguate_label_by_ids(keep, _, closed, ids, labels) {
   };
   var check_closed = function (param) {
     if (closed) {
-      return +(List.length(ids) === param[0][/* lbl_all */5].length);
+      return List.length(ids) === param[0][/* lbl_all */5].length;
     } else {
-      return /* true */1;
+      return true;
     }
   };
   var labels$prime = List.filter(check_ids)(labels);
   if (keep && labels$prime === /* [] */0) {
     return /* tuple */[
-            /* false */0,
+            false,
             labels
           ];
   } else {
     var labels$prime$prime = List.filter(check_closed)(labels$prime);
     if (keep && labels$prime$prime === /* [] */0) {
       return /* tuple */[
-              /* false */0,
+              false,
               labels$prime
             ];
     } else {
       return /* tuple */[
-              /* true */1,
+              true,
               labels$prime$prime
             ];
     }
@@ -56272,7 +56271,7 @@ function disambiguate_lid_a_list(loc, closed, env, opath, lid_a_list) {
   var ids = List.map((function (param) {
           return last$1(param[0][/* txt */0]);
         }), lid_a_list);
-  var w_pr = [/* false */0];
+  var w_pr = [false];
   var w_amb = [/* [] */0];
   var w_scope = [/* [] */0];
   var w_scope_ty = [""];
@@ -56282,7 +56281,7 @@ function disambiguate_lid_a_list(loc, closed, env, opath, lid_a_list) {
     } else {
       switch (msg.tag | 0) {
         case 8 : 
-            w_pr[0] = /* true */1;
+            w_pr[0] = true;
             return /* () */0;
         case 23 : 
             var match = msg[1];
@@ -56322,16 +56321,16 @@ function disambiguate_lid_a_list(loc, closed, env, opath, lid_a_list) {
     }
     var match;
     var exit = 0;
-    if (opath && opath[0][2] !== 0) {
+    if (opath && opath[0][2]) {
       match = /* tuple */[
-        /* true */1,
+        true,
         scope
       ];
     } else {
       exit = 1;
     }
     if (exit === 1) {
-      match = disambiguate_label_by_ids(+(opath === /* None */0), env, closed, ids, scope);
+      match = disambiguate_label_by_ids(opath === /* None */0, env, closed, ids, scope);
     }
     var labels = match[1];
     if (match[0]) {
@@ -56365,7 +56364,7 @@ function disambiguate_lid_a_list(loc, closed, env, opath, lid_a_list) {
                         return prim[0];
                       }), amb),
                 amb[0][1],
-                /* true */1
+                true
               ]));
       } else {
         List.iter((function (param) {
@@ -56375,7 +56374,7 @@ function disambiguate_lid_a_list(loc, closed, env, opath, lid_a_list) {
                                 /* [] */0
                               ],
                               param[1],
-                              /* false */0
+                              false
                             ]));
               }), amb);
       }
@@ -56386,7 +56385,7 @@ function disambiguate_lid_a_list(loc, closed, env, opath, lid_a_list) {
     prerr_warning(loc, /* Name_out_of_scope */Block.__(23, [
             w_scope_ty[0],
             List.rev(w_scope[0]),
-            /* true */1
+            true
           ]));
   }
   return lbl_a_list;
@@ -56501,7 +56500,7 @@ function type_label_a_list(labels, loc, closed, env, type_lbl_a, opath, lid_a_li
 function check_recordpat_labels(loc, lbl_pat_list, closed) {
   if (lbl_pat_list) {
     var all = lbl_pat_list[0][1][/* lbl_all */5];
-    var defined = Caml_array.caml_make_vect(all.length, /* false */0);
+    var defined = Caml_array.caml_make_vect(all.length, false);
     var check_defined = function (param) {
       var label = param[1];
       if (Caml_array.caml_array_get(defined, label[/* lbl_pos */4])) {
@@ -56512,7 +56511,7 @@ function check_recordpat_labels(loc, lbl_pat_list, closed) {
               /* Label_multiply_defined */Block.__(10, [label[/* lbl_name */0]])
             ];
       } else {
-        return Caml_array.caml_array_set(defined, label[/* lbl_pos */4], /* true */1);
+        return Caml_array.caml_array_set(defined, label[/* lbl_pos */4], true);
       }
     };
     List.iter(check_defined, lbl_pat_list);
@@ -56573,7 +56572,7 @@ function lookup_from_type$1(env, tpath, lid) {
         var s = match[0];
         try {
           return List.find((function (nd) {
-                        return +(nd[/* cstr_name */0] === s);
+                        return nd[/* cstr_name */0] === s;
                       }), descrs);
         }
         catch (exn){
@@ -56682,7 +56681,7 @@ function disambiguate$1($staropt$star, $staropt$star$1, scope, lid, env, opath, 
                         /* [] */0
                       ],
                       paths,
-                      /* false */0
+                      false
                     ]));
             }
             
@@ -56707,7 +56706,7 @@ function disambiguate$1($staropt$star, $staropt$star$1, scope, lid, env, opath, 
                     last$1(lid[/* txt */0]),
                     /* [] */0
                   ],
-                  /* false */0
+                  false
                 ]));
           if (!pr) {
             warn_pr(/* () */0);
@@ -56765,7 +56764,7 @@ function disambiguate$1($staropt$star, $staropt$star$1, scope, lid, env, opath, 
                 /* [] */0
               ],
               paths$1,
-              /* false */0
+              false
             ]));
     }
     lbl = lbl$3;
@@ -56864,7 +56863,7 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
           var ty_var = build_as_type(env[0], q);
           end_def(/* () */0);
           iter_generalize$1([/* [] */0], ty_var);
-          var id$1 = enter_variable(/* None */0, /* Some */[/* true */1], loc, name$1, ty_var);
+          var id$1 = enter_variable(/* None */0, /* Some */[true], loc, name$1, ty_var);
           return rp(/* record */[
                       /* pat_desc : Tpat_alias */Block.__(1, [
                           q,
@@ -56900,7 +56899,7 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
               var gloc = /* record */[
                 gloc_000,
                 gloc_001,
-                /* loc_ghost : true */1
+                /* loc_ghost */true
               ];
               var loop = function (c1, c2) {
                 if (c1 === c2) {
@@ -56970,7 +56969,7 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
             opath = /* Some */[/* tuple */[
                 match$3[0],
                 match$3[1],
-                /* true */1
+                true
               ]];
           }
           catch (exn){
@@ -57125,9 +57124,9 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
             /* tuple */[
               l,
               /* Reither */Block.__(1, [
-                  +(sarg$1 === /* None */0),
+                  sarg$1 === /* None */0,
                   arg_type,
-                  /* true */1,
+                  true,
                   [/* None */0]
                 ])
             ],
@@ -57138,8 +57137,8 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
             row_000,
             row_001,
             /* row_bound : () */0,
-            /* row_closed : false */0,
-            /* row_fixed : false */0,
+            /* row_closed */false,
+            /* row_fixed */false,
             /* row_name : None */0
           ];
           unify_pat_types(loc, env[0], newty2(current_level[0], /* Tvariant */Block.__(8, [row])), expected_ty);
@@ -57170,7 +57169,7 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
               /* Some */[/* tuple */[
                   match$8[0],
                   match$8[1],
-                  /* true */1
+                  true
                 ]],
               expected_ty
             ];
@@ -57191,7 +57190,7 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
             var label = param[1];
             var label_lid = param[0];
             begin_def(/* () */0);
-            var match = instance_label(/* false */0, label);
+            var match = instance_label(false, label);
             var ty_arg = match[1];
             var vars = match[0];
             if (vars === /* [] */0) {
@@ -57224,9 +57223,9 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
               var instantiated = function (tv) {
                 var tv$1 = expand_head(env[0], tv);
                 if (is_Tvar(tv$1)) {
-                  return +(tv$1[/* level */1] !== 100000000);
+                  return tv$1[/* level */1] !== 100000000;
                 } else {
-                  return /* true */1;
+                  return true;
                 }
               };
               if (List.exists(instantiated, vars)) {
@@ -57247,7 +57246,7 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
           };
           var partial_arg$2 = env[0];
           var lbl_pat_list = wrap_disambiguate("This record pattern is expected to have", expected_ty, (function (param) {
-                  return type_label_a_list(labels, loc, /* false */0, partial_arg$2, type_label_pat, opath$1, param);
+                  return type_label_a_list(labels, loc, false, partial_arg$2, type_label_pat, opath$1, param);
                 }), lid_sp_list);
           check_recordpat_labels(loc, lbl_pat_list, closed);
           unify_pat_types(loc, env[0], record_ty, expected_ty);
@@ -57337,7 +57336,7 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
                     ];
               } else if (match$11.tag === 10) {
                 begin_def(/* () */0);
-                var match$12 = instance_poly(/* Some */[/* true */1], /* false */0, match$11[1], match$11[0]);
+                var match$12 = instance_poly(/* Some */[true], false, match$11[1], match$11[0]);
                 var ty$prime = match$12[1];
                 end_def(/* () */0);
                 iter_generalize$1([/* [] */0], ty$prime);
@@ -57471,7 +57470,7 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
                     ]);
       case 13 : 
           var name$3 = match[0];
-          var id$3 = enter_variable(/* Some */[/* true */1], /* None */0, loc, name$3, expected_ty);
+          var id$3 = enter_variable(/* Some */[true], /* None */0, loc, name$3, expected_ty);
           return rp(/* record */[
                       /* pat_desc : Tpat_var */Block.__(0, [
                           id$3,
@@ -57508,11 +57507,11 @@ function type_pat(constrs, labels, no_existentials, mode, env, sp, expected_ty) 
 }
 
 function type_pat$1($staropt$star, constrs, labels, $staropt$star$1, env, sp, expected_ty) {
-  var allow_existentials = $staropt$star ? $staropt$star[0] : /* false */0;
+  var allow_existentials = $staropt$star ? $staropt$star[0] : false;
   var lev = $staropt$star$1 ? $staropt$star$1[0] : current_level[0];
   newtype_level$1[0] = /* Some */[lev];
   try {
-    var r = type_pat(constrs, labels, 1 - allow_existentials, /* Normal */0, env, sp, expected_ty);
+    var r = type_pat(constrs, labels, !allow_existentials, /* Normal */0, env, sp, expected_ty);
     iter_pattern((function (p) {
             p[/* pat_env */4] = env[0];
             return /* () */0;
@@ -57529,8 +57528,8 @@ function type_pat$1($staropt$star, constrs, labels, $staropt$star$1, env, sp, ex
 function partial_pred(lev, env, expected_ty, constrs, labels, p) {
   var snap = snapshot(/* () */0);
   try {
-    reset_pattern(/* None */0, /* true */1);
-    var typed_p = type_pat$1(/* Some */[/* true */1], /* Some */[constrs], /* Some */[labels], /* Some */[lev], [env], p, expected_ty);
+    reset_pattern(/* None */0, true);
+    var typed_p = type_pat$1(/* Some */[true], /* Some */[constrs], /* Some */[labels], /* Some */[lev], [env], p, expected_ty);
     backtrack(snap);
     return /* Some */[typed_p];
   }
@@ -57549,7 +57548,7 @@ function check_partial$1($staropt$star, env, expected_ty) {
       var loc = param;
       var casel = param$1;
       var first_check = check_partial(loc, casel);
-      if (first_check !== 0) {
+      if (first_check) {
         return check_partial_param((function (param, param$1, param$2) {
                       var pred$1 = pred;
                       var loc = param;
@@ -57580,9 +57579,9 @@ function add_pattern_variables(check, check_as, env) {
 }
 
 function type_pattern(lev, env, spat, scope, expected_ty) {
-  reset_pattern(scope, /* true */1);
+  reset_pattern(scope, true);
   var new_env = [env];
-  var pat = type_pat$1(/* Some */[/* true */1], /* None */0, /* None */0, /* Some */[lev], new_env, spat, expected_ty);
+  var pat = type_pat$1(/* Some */[true], /* None */0, /* None */0, /* Some */[lev], new_env, spat, expected_ty);
   var match = add_pattern_variables(/* Some */[(function (s) {
             return /* Unused_var_strict */Block.__(13, [s]);
           })], /* Some */[(function (s) {
@@ -57612,7 +57611,7 @@ function type_pattern_list(env, spatl, scope, expected_tys, allow) {
 }
 
 function type_class_arg_pattern(cl_num, val_env, met_env, l, spat) {
-  reset_pattern(/* None */0, /* false */0);
+  reset_pattern(/* None */0, false);
   var nv = newvar(/* None */0, /* () */0);
   var pat = type_pat$1(/* None */0, /* None */0, /* None */0, /* None */0, [val_env], spat, nv);
   if (has_variants(pat)) {
@@ -57687,7 +57686,7 @@ function type_self_pattern(cl_num, privty, val_env, met_env, par_env, spat) {
             /* loc */none
           ]
         ]));
-  reset_pattern(/* None */0, /* false */0);
+  reset_pattern(/* None */0, false);
   var nv = newvar(/* None */0, /* () */0);
   var pat = type_pat$1(/* None */0, /* None */0, /* None */0, /* None */0, [val_env], spat$1, nv);
   List.iter((function (f) {
@@ -57814,28 +57813,28 @@ function is_nonexpansive(_exp) {
             _exp = match[2];
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
       case 0 : 
       case 1 : 
       case 3 : 
-          return /* true */1;
+          return true;
       case 4 : 
           var match$1 = match[1];
           if (match$1 && !(match$1[0][1] || !is_nonexpansive(match[0]))) {
             return List.for_all(is_nonexpansive_opt, List.map(snd3, match$1[1]));
           } else {
-            return /* false */0;
+            return false;
           }
       case 5 : 
           if (match[2] || !is_nonexpansive(match[0])) {
-            return /* false */0;
+            return false;
           } else {
             return List.for_all((function (param) {
                           if (is_nonexpansive_opt(param[/* c_guard */1])) {
                             return is_nonexpansive(param[/* c_rhs */2]);
                           } else {
-                            return /* false */0;
+                            return false;
                           }
                         }), match[1]);
           }
@@ -57847,39 +57846,39 @@ function is_nonexpansive(_exp) {
           return is_nonexpansive_opt(match[1]);
       case 10 : 
           if (List.for_all((function (param) {
-                    return param[1][/* lbl_mut */3] === /* Immutable */0 ? is_nonexpansive(param[2]) : /* false */0;
+                    return param[1][/* lbl_mut */3] === /* Immutable */0 ? is_nonexpansive(param[2]) : false;
                   }), match[0])) {
             return is_nonexpansive_opt(match[1]);
           } else {
-            return /* false */0;
+            return false;
           }
       case 13 : 
           if (match[0]) {
-            return /* false */0;
+            return false;
           } else {
-            return /* true */1;
+            return true;
           }
       case 14 : 
           if (is_nonexpansive(match[1])) {
             return is_nonexpansive_opt(match[2]);
           } else {
-            return /* false */0;
+            return false;
           }
       case 15 : 
           _exp = match[1];
           continue ;
       case 19 : 
           if (class_type_arity(match[2][/* cty_type */1]) > 0) {
-            return /* true */1;
+            return true;
           } else {
-            return /* false */0;
+            return false;
           }
       case 23 : 
           if (is_nonexpansive_mod(match[2])) {
             _exp = match[3];
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
       case 11 : 
       case 25 : 
@@ -57893,31 +57892,31 @@ function is_nonexpansive(_exp) {
                   var match = field[/* cf_desc */0];
                   switch (match.tag | 0) {
                     case 0 : 
-                        return /* false */0;
+                        return false;
                     case 1 : 
                         var match$1 = match[3];
                         count[0] = count[0] + 1 | 0;
-                        return match$1.tag ? is_nonexpansive(match$1[1]) : /* true */1;
+                        return match$1.tag ? is_nonexpansive(match$1[1]) : true;
                     case 4 : 
                         return is_nonexpansive(match[0]);
                     default:
-                      return /* true */1;
+                      return true;
                   }
                 }
                 }(count)), match$2[/* cstr_fields */1]) && fold((function(count){
                 return function (_, param, b) {
                   count[0] = count[0] - 1 | 0;
-                  return b ? +(param[0] === /* Immutable */0) : /* false */0;
+                  return b ? param[0] === /* Immutable */0 : false;
                 }
-                }(count)), match$2[/* cstr_type */2][/* csig_vars */1], /* true */1)) {
-            return +(count[0] === 0);
+                }(count)), match$2[/* cstr_type */2][/* csig_vars */1], true)) {
+            return count[0] === 0;
           } else {
-            return /* false */0;
+            return false;
           }
       case 27 : 
           return is_nonexpansive_mod(match[0]);
       default:
-        return /* false */0;
+        return false;
     }
   };
 }
@@ -57938,16 +57937,16 @@ function is_nonexpansive_mod(_mexp) {
                           case 4 : 
                               return List.for_all((function (param) {
                                             if (param[/* ext_kind */3].tag) {
-                                              return /* true */1;
+                                              return true;
                                             } else {
-                                              return /* false */0;
+                                              return false;
                                             }
                                           }), match[0][/* tyext_constructors */3]);
                           case 5 : 
                               if (match[0][/* ext_kind */3].tag) {
-                                return /* true */1;
+                                return true;
                               } else {
-                                return /* false */0;
+                                return false;
                               }
                           case 6 : 
                               return is_nonexpansive_mod(match[0][/* mb_expr */2]);
@@ -57956,20 +57955,20 @@ function is_nonexpansive_mod(_mexp) {
                                             return is_nonexpansive_mod(param[/* mb_expr */2]);
                                           }), match[0]);
                           case 10 : 
-                              return /* false */0;
+                              return false;
                           case 12 : 
                               return is_nonexpansive_mod(match[0][/* incl_mod */0]);
                           case 13 : 
-                              return /* true */1;
+                              return true;
                           default:
-                            return /* true */1;
+                            return true;
                         }
                       }), match[0][/* str_items */0]);
       case 0 : 
       case 2 : 
-          return /* true */1;
+          return true;
       case 3 : 
-          return /* false */0;
+          return false;
       case 4 : 
           _mexp = match[0];
           continue ;
@@ -57984,7 +57983,7 @@ function is_nonexpansive_opt(param) {
   if (param) {
     return is_nonexpansive(param[0]);
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -58176,7 +58175,7 @@ function list_labels(env, ty) {
                   if (List.memq(ty, visited)) {
                     return /* tuple */[
                             List.rev(ls),
-                            /* false */0
+                            false
                           ];
                   } else {
                     var match = ty[/* desc */0];
@@ -58222,11 +58221,11 @@ function check_univars(env, expans, kind, exp, ty_expected, vars) {
             iter_generalize$1([/* [] */0], t$1);
             var match = t$1[/* desc */0];
             if (typeof match === "number" || !(!match.tag && t$1[/* level */1] === 100000000)) {
-              return /* false */0;
+              return false;
             } else {
               log_type(t$1);
               t$1[/* desc */0] = /* Tunivar */Block.__(9, [match[0]]);
-              return /* true */1;
+              return true;
             }
           }))(vars$2);
   if (List.length(vars$2) === List.length(vars$prime)) {
@@ -58309,12 +58308,12 @@ function generalizable(level, ty) {
   try {
     check(ty);
     unmark_type(ty);
-    return /* true */1;
+    return true;
   }
   catch (exn){
     if (exn === Pervasives.Exit) {
       unmark_type(ty);
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -58362,12 +58361,12 @@ function contains_variant_either(ty) {
   try {
     loop(ty);
     unmark_type(ty);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Pervasives.Exit) {
       unmark_type(ty);
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -58421,11 +58420,11 @@ function contains_polymorphic_variant(p) {
   };
   try {
     loop(p);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Pervasives.Exit) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -58459,11 +58458,11 @@ function contains_gadt(env, p) {
   };
   try {
     loop(p);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Pervasives.Exit) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -58482,9 +58481,9 @@ function check_absent_variant(env) {
                       var row = row_repr_aux(/* [] */0, match[2][0]);
                       if (List.exists((function (param) {
                                 if (s === param[0]) {
-                                  return +(row_field_repr_aux(/* [] */0, param[1]) !== /* Rabsent */0);
+                                  return row_field_repr_aux(/* [] */0, param[1]) !== /* Rabsent */0;
                                 } else {
-                                  return /* false */0;
+                                  return false;
                                 }
                               }), row[/* row_fields */0]) || !row[/* row_fixed */4] && !static_row(row)) {
                         return /* () */0;
@@ -58497,9 +58496,9 @@ function check_absent_variant(env) {
                           /* tuple */[
                             s,
                             /* Reither */Block.__(1, [
-                                +(arg === /* None */0),
+                                arg === /* None */0,
                                 ty_arg,
-                                /* true */1,
+                                true,
                                 [/* None */0]
                               ])
                           ],
@@ -58510,8 +58509,8 @@ function check_absent_variant(env) {
                           row$prime_000,
                           row$prime_001,
                           /* row_bound : () */0,
-                          /* row_closed : false */0,
-                          /* row_fixed : false */0,
+                          /* row_closed */false,
+                          /* row_fixed */false,
                           /* row_name : None */0
                         ];
                         var newrecord = pat.slice();
@@ -58694,12 +58693,12 @@ function type_expect_(in_function, env, sexp, ty_expected) {
           var match$6 = ty_exp[/* desc */0];
           var is_format;
           if (typeof match$6 === "number" || !(match$6.tag === 3 && same(match$6[0], fmt6_path))) {
-            is_format = /* false */0;
+            is_format = false;
           } else {
             if (principal[0] && ty_exp[/* level */1] !== 100000000) {
               prerr_warning(loc, /* Not_principal */Block.__(8, ["this coercion to format6"]));
             }
-            is_format = /* true */1;
+            is_format = true;
           }
           if (is_format) {
             var init = type_format(loc, cst[0], env);
@@ -58735,7 +58734,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
     case 2 : 
         var rec_flag = match[0];
         var exit = 0;
-        if (rec_flag !== 0) {
+        if (rec_flag) {
           exit = 1;
         } else {
           var match$7 = match[1];
@@ -58776,9 +58775,9 @@ function type_expect_(in_function, env, sexp, ty_expected) {
             exit$1 = 2;
           }
           if (exit$1 === 2) {
-            scp = rec_flag !== 0 ? /* Some */[/* Idef */Block.__(1, [loc])] : /* Some */[/* Idef */Block.__(1, [sbody[/* pexp_loc */1]])];
+            scp = rec_flag ? /* Some */[/* Idef */Block.__(1, [loc])] : /* Some */[/* Idef */Block.__(1, [sbody[/* pexp_loc */1]])];
           }
-          var match$10 = type_let(/* None */0, /* None */0, env, rec_flag, match[1], scp, /* true */1);
+          var match$10 = type_let(/* None */0, /* None */0, env, rec_flag, match[1], scp, true);
           var body = type_expect(/* None */0, match$10[1], wrap_unpacks(sbody, match$10[2]), ty_expected);
           return re(/* record */[
                       /* exp_desc : Texp_let */Block.__(2, [
@@ -59004,8 +59003,8 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                 /* No_value_clauses */7
               ];
         }
-        var match$14 = type_cases(/* None */0, env, arg[/* exp_type */3], ty_expected, /* true */1, loc, val_caselist);
-        var match$15 = type_cases(/* None */0, env, type_exn, ty_expected, /* false */0, loc, exn_caselist);
+        var match$14 = type_cases(/* None */0, env, arg[/* exp_type */3], ty_expected, true, loc, val_caselist);
+        var match$15 = type_cases(/* None */0, env, type_exn, ty_expected, false, loc, exn_caselist);
         return re(/* record */[
                     /* exp_desc : Texp_match */Block.__(5, [
                         arg,
@@ -59021,7 +59020,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                   ]);
     case 7 : 
         var body$1 = type_expect(/* None */0, env, match[0], ty_expected);
-        var match$16 = type_cases(/* None */0, env, type_exn, ty_expected, /* false */0, loc, match[1]);
+        var match$16 = type_cases(/* None */0, env, type_exn, ty_expected, false, loc, match[1]);
         return re(/* record */[
                     /* exp_desc : Texp_try */Block.__(6, [
                         body$1,
@@ -59070,7 +59069,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
           opath = /* Some */[/* tuple */[
               match$17[0],
               match$17[1],
-              +(ty_expected$1[/* level */1] === 100000000) || 1 - principal[0]
+              ty_expected$1[/* level */1] === 100000000 || !principal[0]
             ]];
         }
         catch (exn){
@@ -59268,8 +59267,8 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                   ],
                   /* row_more */newvar(/* None */0, /* () */0),
                   /* row_bound : () */0,
-                  /* row_closed : false */0,
-                  /* row_fixed : false */0,
+                  /* row_closed */false,
+                  /* row_fixed */false,
                   /* row_name : None */0
                 ]]);
             return rue(/* record */[
@@ -59313,7 +59312,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
             return /* Some */[/* tuple */[
                       match[0],
                       match[1],
-                      +(ty[/* level */1] === 100000000) || 1 - principal[0]
+                      ty[/* level */1] === 100000000 || !principal[0]
                     ]];
           }
           catch (exn){
@@ -59358,10 +59357,10 @@ function type_expect_(in_function, env, sexp, ty_expected) {
         }
         var opath$1 = match$30[1];
         var ty_record = match$30[0];
-        var closed = +(opt_sexp === /* None */0);
+        var closed = opt_sexp === /* None */0;
         var lbl_exp_list = wrap_disambiguate("This record expression is expected to have", ty_record, (function (param) {
                 return type_label_a_list(/* None */0, loc, closed, env, (function (param) {
-                              return type_label_exp(/* true */1, env, loc, ty_record, param);
+                              return type_label_exp(true, env, loc, ty_record, param);
                             }), opath$1, param);
               }), lid_sexp_list);
         unify_exp_types(loc, env, ty_record, instance(/* None */0, env, ty_expected));
@@ -59400,10 +59399,10 @@ function type_expect_(in_function, env, sexp, ty_expected) {
             var ty_exp$1 = instance(/* None */0, env, exp$1[/* exp_type */3]);
             var unify_kept = function (lbl) {
               if (List.for_all((function (param) {
-                        return +(param[1][/* lbl_pos */4] !== lbl[/* lbl_pos */4]);
+                        return param[1][/* lbl_pos */4] !== lbl[/* lbl_pos */4];
                       }), lbl_exp_list)) {
-                var match = instance_label(/* false */0, lbl);
-                var match$1 = instance_label(/* false */0, lbl);
+                var match = instance_label(false, lbl);
+                var match$1 = instance_label(false, lbl);
                 unify$2(env, match[1], match$1[1]);
                 unify$2(env, instance(/* None */0, env, ty_expected), match$1[2]);
                 return unify_exp_types(exp$1[/* exp_loc */1], env, ty_exp$1, match[2]);
@@ -59492,7 +59491,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
         var match$31 = type_label_access(env, loc, match[0], lid$2);
         var label = match$31[1];
         var record$3 = match$31[0];
-        var match$32 = instance_label(/* false */0, label);
+        var match$32 = instance_label(false, label);
         unify_exp(env, record$3, match$32[2]);
         return rue(/* record */[
                     /* exp_desc : Texp_field */Block.__(11, [
@@ -59511,7 +59510,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
         var match$33 = type_label_access(env, loc, match[0], lid$3);
         var record$4 = match$33[0];
         var ty_record$1 = match$33[2] === /* None */0 ? newvar(/* None */0, /* () */0) : record$4[/* exp_type */3];
-        var match$34 = type_label_exp(/* false */0, env, loc, ty_record$1, /* tuple */[
+        var match$34 = type_label_exp(false, env, loc, ty_record$1, /* tuple */[
               lid$3,
               match$33[1],
               match[2]
@@ -59670,7 +59669,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
     case 19 : 
         var sarg$2 = match[0];
         begin_def(/* () */0);
-        var cty = transl_simple_type(env, /* false */0, match[1]);
+        var cty = transl_simple_type(env, false, match[1]);
         var ty$3 = cty[/* ctyp_type */1];
         end_def(/* () */0);
         generalize_structure$1(current_level[0], ty$3);
@@ -59774,7 +59773,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
           }
           if (exit$2 === 1) {
             if (free_variables$1(/* Some */[env], arg$4[/* exp_type */3]) === /* [] */0 && free_variables$1(/* Some */[env], ty$prime$1) === /* [] */0) {
-              var tmp$3 = /* false */0;
+              var tmp$3 = false;
               if (!gen$1) {
                 var snap = snapshot(/* () */0);
                 var match$45 = enlarge_type(env, ty$prime$1);
@@ -59782,13 +59781,13 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                 try {
                   Curry._1(force, /* () */0);
                   unify$2(env, arg$4[/* exp_type */3], match$45[0]);
-                  tmp$4 = /* true */1;
+                  tmp$4 = true;
                 }
                 catch (raw_exn$1){
                   var exn$3 = Js_exn.internalToOCamlException(raw_exn$1);
                   if (exn$3[0] === Unify) {
                     backtrack(snap);
-                    tmp$4 = /* false */0;
+                    tmp$4 = false;
                   } else {
                     throw exn$3;
                   }
@@ -60055,7 +60054,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                     if (principal[0] && l$2 !== 100000000) {
                       prerr_warning(loc, /* Not_principal */Block.__(8, ["this use of a polymorphic method"]));
                     }
-                    typ$3 = instance_poly(/* None */0, /* false */0, tl, ty$6)[1];
+                    typ$3 = instance_poly(/* None */0, false, tl, ty$6)[1];
                   } else {
                     typ$3 = instance(/* None */0, env, ty$6);
                   }
@@ -60136,7 +60135,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
           var exit$4 = 0;
           if (typeof match$60 === "number" || match$60.tag !== 1) {
             exit$4 = 1;
-          } else if (match$60[0] !== 0) {
+          } else if (match$60[0]) {
             var newval = type_expect(/* None */0, env, match[1], instance(/* None */0, env, desc$4[/* val_type */0]));
             var match$61 = lookup_value$1(/* Lident */Block.__(0, ["self-" + match$60[1]]), env);
             return rue(/* record */[
@@ -60158,7 +60157,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                   loc,
                   env,
                   /* Instance_variable_not_mutable */Block.__(22, [
-                      /* true */1,
+                      true,
                       lab[/* txt */0]
                     ])
                 ];
@@ -60169,7 +60168,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                   loc,
                   env,
                   /* Instance_variable_not_mutable */Block.__(22, [
-                      /* false */0,
+                      false,
                       lab[/* txt */0]
                     ])
                 ];
@@ -60194,7 +60193,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
         List.fold_right((function (param, l) {
                 var lab = param[0];
                 if (List.exists((function (l) {
-                          return +(l[/* txt */0] === lab[/* txt */0]);
+                          return l[/* txt */0] === lab[/* txt */0];
                         }), l)) {
                   throw [
                         $$Error$7,
@@ -60365,7 +60364,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
         var match$67;
         if (sty$1) {
           var sty$2 = force_poly(sty$1[0]);
-          var cty$2 = transl_simple_type(env, /* false */0, sty$2);
+          var cty$2 = transl_simple_type(env, false, sty$2);
           match$67 = /* tuple */[
             repr(cty$2[/* ctyp_type */1]),
             /* Some */[cty$2]
@@ -60415,7 +60414,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                   if (principal[0]) {
                     begin_def(/* () */0);
                   }
-                  var match$69 = instance_poly(/* None */0, /* true */1, tl$1, ty$prime$3);
+                  var match$69 = instance_poly(/* None */0, true, tl$1, ty$prime$3);
                   var ty$prime$prime = match$69[1];
                   if (principal[0]) {
                     end_def(/* () */0);
@@ -60423,7 +60422,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                   }
                   var exp$5 = type_expect(/* None */0, env, sbody$1, ty$prime$prime);
                   end_def(/* () */0);
-                  check_univars(env, /* false */0, "method", exp$5, ty_expected, match$69[0]);
+                  check_univars(env, false, "method", exp$5, ty_expected, match$69[0]);
                   var newrecord$5 = exp$5.slice();
                   newrecord$5[/* exp_type */3] = instance(/* None */0, env, ty$9);
                   exp$3 = newrecord$5;
@@ -60660,7 +60659,7 @@ function type_function(in_function, loc, attrs, env, ty_expected, l, caselist) {
               loc_fun,
               env,
               /* Too_many_arguments */Block.__(26, [
-                  +(in_function !== /* None */0),
+                  in_function !== /* None */0,
                   ty_fun
                 ])
             ];
@@ -60705,14 +60704,14 @@ function type_function(in_function, loc, attrs, env, ty_expected, l, caselist) {
   var match$3 = type_cases(/* Some */[/* tuple */[
           loc_fun,
           ty_fun
-        ]], env, ty_arg$1, ty_res, /* true */1, loc, caselist);
+        ]], env, ty_arg$1, ty_res, true, loc, caselist);
   var cases = match$3[0];
   var not_function = function (ty) {
     var match = list_labels(env, ty);
     if (match[0] === /* [] */0) {
-      return 1 - match[1];
+      return !match[1];
     } else {
-      return /* false */0;
+      return false;
     }
   };
   if (is_optional(l) && not_function(ty_res)) {
@@ -60753,7 +60752,7 @@ function type_label_access(env, _, srecord, lid) {
     opath = /* Some */[/* tuple */[
         match[0],
         match[1],
-        +(ty_exp[/* level */1] === 100000000) || 1 - principal[0]
+        ty_exp[/* level */1] === 100000000 || !principal[0]
       ]];
   }
   catch (exn){
@@ -60780,7 +60779,7 @@ function type_format(loc, str, env) {
   var loc$1 = /* record */[
     loc_000,
     loc_001,
-    /* loc_ghost : true */1
+    /* loc_ghost */true
   ];
   try {
     var mk_constr = function (name, args) {
@@ -61526,7 +61525,7 @@ function type_format(loc, str, env) {
         }
       }
     };
-    var legacy_behavior = 1 - strict_formats[0];
+    var legacy_behavior = !strict_formats[0];
     var match = CamlinternalFormat.fmt_ebb_of_string(/* Some */[legacy_behavior], str);
     return mk_constr("Format", /* :: */[
                 mk_fmt(match[0]),
@@ -61568,7 +61567,7 @@ function type_label_exp(create, env, loc, ty_expected, param) {
     begin_def(/* () */0);
     begin_def(/* () */0);
   }
-  var match = instance_label(/* true */1, label);
+  var match = instance_label(true, label);
   var ty_res = match[2];
   var ty_arg = match[1];
   var vars = match[0];
@@ -61626,7 +61625,7 @@ function type_label_exp(create, env, loc, ty_expected, param) {
   end_def(/* () */0);
   var arg$1;
   try {
-    check_univars(env, +(vars !== /* [] */0), "field value", arg, label[/* lbl_arg */2], vars);
+    check_univars(env, vars !== /* [] */0, "field value", arg, label[/* lbl_arg */2], vars);
     arg$1 = arg;
   }
   catch (exn$1){
@@ -61640,7 +61639,7 @@ function type_label_exp(create, env, loc, ty_expected, param) {
         end_def(/* () */0);
         generalize_expansive$1(env, arg$2[/* exp_type */3]);
         unify_exp(env, arg$2, ty_arg$1);
-        check_univars(env, /* false */0, "field value", arg$2, label[/* lbl_arg */2], vars);
+        check_univars(env, false, "field value", arg$2, label[/* lbl_arg */2], vars);
         arg$1 = arg$2;
       }
       catch (raw_e){
@@ -61672,7 +61671,7 @@ function type_argument(env, sarg, ty_expected$prime, ty_expected) {
   var no_labels = function (ty) {
     var match = list_labels(env, ty);
     if (match[1]) {
-      return /* false */0;
+      return false;
     } else {
       return List.for_all((function (param) {
                     return Caml_obj.caml_equal("", param);
@@ -61690,7 +61689,7 @@ function type_argument(env, sarg, ty_expected$prime, ty_expected) {
               _sexp = match$1[0];
               continue ;
             } else {
-              return /* false */0;
+              return false;
             }
         case 16 : 
             _sexp = match[1];
@@ -61702,12 +61701,12 @@ function type_argument(env, sarg, ty_expected$prime, ty_expected) {
         case 20 : 
         case 21 : 
         case 22 : 
-            return /* true */1;
+            return true;
         case 32 : 
             _sexp = match[2];
             continue ;
         default:
-          return /* false */0;
+          return false;
       }
     };
   };
@@ -61742,7 +61741,7 @@ function type_argument(env, sarg, ty_expected$prime, ty_expected) {
                   return /* tuple */[
                           List.rev(args),
                           ty_fun,
-                          /* false */0
+                          false
                         ];
               case 1 : 
                   var ty_fun$1 = match[2];
@@ -61777,7 +61776,7 @@ function type_argument(env, sarg, ty_expected$prime, ty_expected) {
             return /* tuple */[
                     /* [] */0,
                     texp[/* exp_type */3],
-                    /* false */0
+                    false
                   ];
           }
           
@@ -61786,7 +61785,7 @@ function type_argument(env, sarg, ty_expected$prime, ty_expected) {
       var match$2 = make_args(/* [] */0, texp[/* exp_type */3]);
       var ty_fun$prime = match$2[1];
       var args = match$2[0];
-      var warn = principal[0] && +(lv !== 100000000 || repr(ty_fun$prime)[/* level */1] !== 100000000);
+      var warn = principal[0] && (lv !== 100000000 || repr(ty_fun$prime)[/* level */1] !== 100000000);
       var newrecord = texp.slice();
       newrecord[/* exp_type */3] = instance(/* None */0, env, texp[/* exp_type */3]);
       var ty_fun = instance(/* None */0, env, ty_fun$prime);
@@ -61944,29 +61943,29 @@ function type_application(env, funct, sargs) {
   var has_label = function (l, ty_fun) {
     var match = list_labels(env, ty_fun);
     if (match[1]) {
-      return /* true */1;
+      return true;
     } else {
       return List.mem(l, match[0]);
     }
   };
   var ignored = [/* [] */0];
-  var ignore_labels = /* true */1;
+  var ignore_labels = true;
   if (!classic[0]) {
     var match = list_labels(env, funct[/* exp_type */3]);
-    var tmp = /* false */0;
+    var tmp = false;
     if (!match[1]) {
       var labels = List.filter((function (l) {
-                return 1 - is_optional(l);
+                return !is_optional(l);
               }))(match[0]);
-      tmp = +(List.length(labels) === List.length(sargs)) && List.for_all((function (param) {
-              return +(param[0] === "");
+      tmp = List.length(labels) === List.length(sargs) && List.for_all((function (param) {
+              return param[0] === "";
             }), sargs) && List.exists((function (l) {
-              return +(l !== "");
-            }), labels) && (prerr_warning(funct[/* exp_loc */1], /* Labels_omitted */3), /* true */1);
+              return l !== "";
+            }), labels) && (prerr_warning(funct[/* exp_loc */1], /* Labels_omitted */3), true);
     }
     ignore_labels = tmp;
   }
-  var warned = [/* false */0];
+  var warned = [false];
   var type_args = function (_args, _omitted, _ty_fun, _ty_fun0, _ty_old, _sargs, _more_sargs) {
     while(true) {
       var more_sargs = _more_sargs;
@@ -61996,7 +61995,7 @@ function type_application(env, funct, sargs) {
             var may_warn = (function(lv){
             return function may_warn(loc, w) {
               if (!warned[0] && principal[0] && lv !== 100000000) {
-                warned[0] = /* true */1;
+                warned[0] = true;
                 return prerr_warning(loc, w);
               } else {
                 return 0;
@@ -62203,13 +62202,13 @@ function type_application(env, funct, sargs) {
                       var t2 = newvar(/* None */0, /* () */0);
                       var not_identity = function (param) {
                         if (param.tag) {
-                          return /* true */1;
+                          return true;
                         } else {
                           var match = param[2][/* val_kind */1];
                           if (typeof match === "number" || !(!match.tag && match[0][/* prim_name */0] === "%identity")) {
-                            return /* true */1;
+                            return true;
                           } else {
-                            return /* false */0;
+                            return false;
                           }
                         }
                       };
@@ -62347,7 +62346,7 @@ function type_application(env, funct, sargs) {
           switch (match$5.tag | 0) {
             case 0 : 
                 add_delayed_check((function () {
-                        return check_application_result(env, /* false */0, exp);
+                        return check_application_result(env, false, exp);
                       }));
                 break;
             case 1 : 
@@ -62406,7 +62405,7 @@ function type_statement(env, sexp) {
               prerr_warning(loc, /* Nonreturning_statement */10);
             } else {
               add_delayed_check((function () {
-                      return check_application_result(env, /* true */1, exp);
+                      return check_application_result(env, true, exp);
                     }));
             }
             break;
@@ -62484,7 +62483,7 @@ function type_cases(in_function, env, ty_arg, ty_res, partial_flag, loc, caselis
             begin_def(/* () */0);
           }
           var scope = /* Some */[/* Idef */Block.__(1, [loc])];
-          var partial = principal[0] || erase_either ? /* Some */[/* false */0] : /* None */0;
+          var partial = principal[0] || erase_either ? /* Some */[false] : /* None */0;
           var ty_arg$2 = instance(partial, env$2, ty_arg$1);
           var match = type_pattern(lev$1, env$2, param[/* pc_lhs */0], scope, ty_arg$2);
           var pat = match[0];
@@ -62548,7 +62547,7 @@ function type_cases(in_function, env, ty_arg, ty_res, partial_flag, loc, caselis
           var ty_res$prime;
           if (principal[0]) {
             begin_def(/* () */0);
-            var ty = instance(/* Some */[/* true */1], env$2, ty_res$1);
+            var ty = instance(/* Some */[true], env$2, ty_res$1);
             end_def(/* () */0);
             generalize_structure$1(current_level[0], ty);
             ty_res$prime = ty;
@@ -62679,25 +62678,25 @@ function type_let($staropt$star, $staropt$star$1, env, rec_flag, spat_sexp_list,
     if (match.tag === 6) {
       var match$1 = match[0][/* pexp_desc */0];
       if (match$1.tag) {
-        is_fake_let = /* false */0;
+        is_fake_let = false;
       } else {
         var match$2 = match$1[0][/* txt */0];
         switch (match$2.tag | 0) {
           case 0 : 
-              is_fake_let = match$2[0] === "*opt*" && !spat_sexp_list[1] ? /* true */1 : /* false */0;
+              is_fake_let = match$2[0] === "*opt*" && !spat_sexp_list[1] ? true : false;
               break;
           case 1 : 
           case 2 : 
-              is_fake_let = /* false */0;
+              is_fake_let = false;
               break;
           
         }
       }
     } else {
-      is_fake_let = /* false */0;
+      is_fake_let = false;
     }
   } else {
-    is_fake_let = /* false */0;
+    is_fake_let = false;
   }
   var check$1 = is_fake_let ? check_strict : check;
   var spatl = List.map((function (param) {
@@ -62728,7 +62727,7 @@ function type_let($staropt$star, $staropt$star$1, env, rec_flag, spat_sexp_list,
               return constraint_(/* Some */[/* record */[
                             /* loc_start */init[/* loc_start */0],
                             /* loc_end */init[/* loc_end */1],
-                            /* loc_ghost : true */1
+                            /* loc_ghost */true
                           ]], /* None */0, spat, sty);
             } else {
               return spat;
@@ -62743,7 +62742,7 @@ function type_let($staropt$star, $staropt$star$1, env, rec_flag, spat_sexp_list,
   var unpacks = match$3[3];
   var new_env = match$3[1];
   var pat_list = match$3[0];
-  var is_recursive = +(rec_flag === /* Recursive */1);
+  var is_recursive = rec_flag === /* Recursive */1;
   if (is_recursive) {
     List.iter2((function (pat, binding) {
             var match = pat[/* pat_type */3][/* desc */0];
@@ -62752,7 +62751,7 @@ function type_let($staropt$star, $staropt$star$1, env, rec_flag, spat_sexp_list,
               pat$1 = pat;
             } else {
               var newrecord = pat.slice();
-              newrecord[/* pat_type */3] = instance_poly(/* Some */[/* true */1], /* false */0, match[1], match[0])[1];
+              newrecord[/* pat_type */3] = instance_poly(/* Some */[true], false, match[1], match[0])[1];
               pat$1 = newrecord;
             }
             return unify_pat(env, pat$1, type_approx(env, binding[/* pvb_expr */1]));
@@ -62782,17 +62781,17 @@ function type_let($staropt$star, $staropt$star$1, env, rec_flag, spat_sexp_list,
         }), match$3[2]);
   var exp_env = is_recursive ? new_env : env;
   var current_slot = [/* None */0];
-  var rec_needed = [/* false */0];
+  var rec_needed = [false];
   var warn_unused = is_active(Curry._1(check$1, "")) || is_active(Curry._1(check_strict, "")) || is_recursive && is_active(/* Unused_rec_flag */15);
   var pat_slot_list = List.map((function (pat) {
           if (warn_unused) {
-            var some_used = [/* false */0];
+            var some_used = [false];
             var slot = [/* [] */0];
             List.iter((function (param) {
                     var id = param[0];
                     var vd = find_value(/* Pident */Block.__(0, [id]), new_env);
                     var name = id[/* name */1];
-                    var used = [/* false */0];
+                    var used = [false];
                     if (!(name === "" || Caml_string.get(name, 0) === /* "_" */95 || Caml_string.get(name, 0) === /* "#" */35)) {
                       add_delayed_check((function () {
                               if (used[0]) {
@@ -62815,14 +62814,14 @@ function type_let($staropt$star, $staropt$star$1, env, rec_flag, spat_sexp_list,
                           ],
                           slot$1[0]
                         ];
-                        rec_needed[0] = /* true */1;
+                        rec_needed[0] = true;
                         return /* () */0;
                       } else {
                         List.iter((function (param) {
                                 return mark_value_used(env, param[0], param[1]);
                               }), get_ref(slot));
-                        used[0] = /* true */1;
-                        some_used[0] = /* true */1;
+                        used[0] = true;
+                        some_used[0] = true;
                         return /* () */0;
                       }
                     };
@@ -62872,7 +62871,7 @@ function type_let($staropt$star, $staropt$star$1, env, rec_flag, spat_sexp_list,
             if (principal[0]) {
               begin_def(/* () */0);
             }
-            var match$1 = instance_poly(/* Some */[/* true */1], /* true */1, match[1], match[0]);
+            var match$1 = instance_poly(/* Some */[true], true, match[1], match[0]);
             var ty$prime = match$1[1];
             if (principal[0]) {
               end_def(/* () */0);
@@ -62880,7 +62879,7 @@ function type_let($staropt$star, $staropt$star$1, env, rec_flag, spat_sexp_list,
             }
             var exp = type_expect(/* None */0, exp_env, sexp$1, ty$prime);
             end_def(/* () */0);
-            check_univars(env, /* true */1, "definition", exp, pat[/* pat_type */3], match$1[0]);
+            check_univars(env, true, "definition", exp, pat[/* pat_type */3], match$1[0]);
             var newrecord = exp.slice();
             newrecord[/* exp_type */3] = instance(/* None */0, env, exp[/* exp_type */3]);
             return newrecord;
@@ -62938,7 +62937,7 @@ function type_binding(env, rec_flag, spat_sexp_list, scope) {
             return /* Unused_value_declaration */Block.__(16, [s]);
           })], /* Some */[(function (s) {
             return /* Unused_value_declaration */Block.__(16, [s]);
-          })], env, rec_flag, spat_sexp_list, scope, /* false */0);
+          })], env, rec_flag, spat_sexp_list, scope, false);
   return /* tuple */[
           match[0],
           match[1]
@@ -62946,7 +62945,7 @@ function type_binding(env, rec_flag, spat_sexp_list, scope) {
 }
 
 function type_let$1(env, rec_flag, spat_sexp_list, scope) {
-  var match = type_let(/* None */0, /* None */0, env, rec_flag, spat_sexp_list, scope, /* false */0);
+  var match = type_let(/* None */0, /* None */0, env, rec_flag, spat_sexp_list, scope, false);
   return /* tuple */[
           match[0],
           match[1]
@@ -64031,7 +64030,7 @@ register_error_of_exn((function (param) {
                                                               reset(/* () */0);
                                                               var tr1$1 = List.map(prepare_expansion, tr1);
                                                               var tr2$1 = List.map(prepare_expansion, tr2);
-                                                              var partial_arg = +(tr2$1 === /* [] */0);
+                                                              var partial_arg = tr2$1 === /* [] */0;
                                                               Curry._2(Format.fprintf(ppf$5, /* Format */[
                                                                         /* Formatting_gen */Block.__(18, [
                                                                             /* Open_box */Block.__(1, [/* Format */[
@@ -64045,7 +64044,7 @@ register_error_of_exn((function (param) {
                                                                           ]),
                                                                         "@[<v>%a"
                                                                       ]), (function (param, param$1) {
-                                                                      return trace$1(/* true */1, partial_arg, txt1$1, param, param$1);
+                                                                      return trace$1(true, partial_arg, txt1$1, param, param$1);
                                                                     }), tr1$1);
                                                               if (tr2$1 === /* [] */0) {
                                                                 return Format.fprintf(ppf$5, /* Format */[
@@ -64056,8 +64055,8 @@ register_error_of_exn((function (param) {
                                                                             "@]"
                                                                           ]);
                                                               } else {
-                                                                var mis = mismatch(/* true */1, tr2$1);
-                                                                var partial_arg$1 = +(mis === /* None */0);
+                                                                var mis = mismatch(true, tr2$1);
+                                                                var partial_arg$1 = mis === /* None */0;
                                                                 return Curry._3(Format.fprintf(ppf$5, /* Format */[
                                                                                 /* Alpha */Block.__(15, [/* Theta */Block.__(16, [/* Formatting_lit */Block.__(17, [
                                                                                             /* Close_box */0,
@@ -64065,9 +64064,9 @@ register_error_of_exn((function (param) {
                                                                                           ])])]),
                                                                                 "%a%t@]"
                                                                               ]), (function (param, param$1) {
-                                                                              return trace$1(/* false */0, partial_arg$1, "is not compatible with type", param, param$1);
+                                                                              return trace$1(false, partial_arg$1, "is not compatible with type", param, param$1);
                                                                             }), tr2$1, (function (param) {
-                                                                              return explanation(/* true */1, mis, param);
+                                                                              return explanation(true, mis, param);
                                                                             }));
                                                               }
                                                             }));
@@ -64510,7 +64509,7 @@ function enter_type$1(env, sdecl, id) {
     decl_007,
     decl_008
   ];
-  return add_type$1(/* true */1, id, decl, env);
+  return add_type$1(true, id, decl, env);
 }
 
 function is_fixed_type(sd) {
@@ -64521,33 +64520,33 @@ function is_fixed_type(sd) {
       var sty = _sty;
       var match$1 = sty[/* ptyp_desc */0];
       if (typeof match$1 === "number") {
-        return /* false */0;
+        return false;
       } else {
         switch (match$1.tag | 0) {
           case 4 : 
-              if (match$1[1] !== 0) {
-                return /* true */1;
+              if (match$1[1]) {
+                return true;
               } else {
-                return /* false */0;
+                return false;
               }
           case 5 : 
-              return /* true */1;
+              return true;
           case 6 : 
               _sty = match$1[0];
               continue ;
           case 7 : 
-              if (match$1[1] !== 0 || match$1[2]) {
-                return /* true */1;
+              if (match$1[1] || match$1[2]) {
+                return true;
               } else {
-                return /* false */0;
+                return false;
               }
           default:
-            return /* false */0;
+            return false;
         }
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -64582,7 +64581,7 @@ function set_fixed_row(env, loc, p, decl) {
       case 8 : 
           var row = row_repr_aux(/* [] */0, match$1[0]);
           var newrecord = row.slice();
-          tm[/* desc */0] = /* Tvariant */Block.__(8, [(newrecord[/* row_fixed */4] = /* true */1, newrecord)]);
+          tm[/* desc */0] = /* Tvariant */Block.__(8, [(newrecord[/* row_fixed */4] = true, newrecord)]);
           rv = static_row(row) ? newty2(100000000, /* Tnil */0) : row[/* row_more */1];
           break;
       default:
@@ -64711,13 +64710,13 @@ function mem$6(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -64752,12 +64751,12 @@ function make_constructor(env, type_path, type_params, sargs, sret_type) {
     var z = narrow(/* () */0);
     reset_type_variables(/* () */0);
     var targs = List.map((function (param) {
-            return transl_simple_type(env, /* false */0, param);
+            return transl_simple_type(env, false, param);
           }), sargs);
     var args = List.map((function (cty) {
             return cty[/* ctyp_type */1];
           }), targs);
-    var tret_type = transl_simple_type(env, /* false */0, sret_type$1);
+    var tret_type = transl_simple_type(env, false, sret_type$1);
     var ret_type = tret_type[/* ctyp_type */1];
     var match = repr(ret_type)[/* desc */0];
     var exit = 0;
@@ -64785,7 +64784,7 @@ function make_constructor(env, type_path, type_params, sargs, sret_type) {
           ];
   } else {
     var targs$1 = List.map((function (param) {
-            return transl_simple_type(env, /* true */1, param);
+            return transl_simple_type(env, true, param);
           }), sargs);
     var args$1 = List.map((function (cty) {
             return cty[/* ctyp_type */1];
@@ -64803,7 +64802,7 @@ function generalize_decl(decl) {
   List.iter(generalize, decl[/* type_params */0]);
   var match = decl[/* type_kind */2];
   if (typeof match === "number") {
-    +(match === 0);
+    match === 0;
   } else if (match.tag) {
     List.iter((function (c) {
             List.iter(generalize, c[/* cd_args */1]);
@@ -64881,7 +64880,7 @@ function check_constraints_rec(env, loc, visited, _ty) {
                             return check_constraints_rec(env, loc, visited, param);
                           }), args);
           case 10 : 
-              var match$1 = instance_poly(/* None */0, /* false */0, match[1], match[0]);
+              var match$1 = instance_poly(/* None */0, false, match[1], match[0]);
               _ty = match$1[1];
               continue ;
           default:
@@ -65055,7 +65054,7 @@ function check_coherence(env, loc, id, decl) {
               /* Arity */0,
               /* [] */0
             ] : (
-              equal$4(env, /* false */0, args, decl[/* type_params */0]) ? type_declarations$1(/* Some */[/* true */1], env, last(path), decl$prime, id, type_declaration(add_type(id, path, identity), decl)) : /* :: */[
+              equal$4(env, false, args, decl[/* type_params */0]) ? type_declarations$1(/* Some */[true], env, last(path), decl$prime, id, type_declaration(add_type(id, path, identity), decl)) : /* :: */[
                   /* Constraint */3,
                   /* [] */0
                 ]
@@ -65108,7 +65107,7 @@ function check_well_founded(env, loc, path, to_check, ty) {
     if (mem$3(ty$1, exp_nodes)) {
       var match = ty0[/* desc */0];
       var tmp;
-      tmp = typeof match === "number" || match.tag !== 3 ? /* false */0 : same(match[0], path);
+      tmp = typeof match === "number" || match.tag !== 3 ? false : same(match[0], path);
       if (tmp) {
         throw [
               $$Error$8,
@@ -65130,17 +65129,17 @@ function check_well_founded(env, loc, path, to_check, ty) {
     try {
       var prev = find$1(ty$1, visited[0]);
       match$1 = subset$1(exp_nodes, prev) ? /* tuple */[
-          /* true */1,
+          true,
           exp_nodes
         ] : /* tuple */[
-          /* false */0,
+          false,
           union$2(exp_nodes, prev)
         ];
     }
     catch (exn){
       if (exn === Caml_builtin_exceptions.not_found) {
         match$1 = /* tuple */[
-          /* false */0,
+          false,
           exp_nodes
         ];
       } else {
@@ -65159,11 +65158,11 @@ function check_well_founded(env, loc, path, to_check, ty) {
           throw Cannot_expand;
         } else if (match$2.tag === 3) {
           if (!(
-              exp_nodes$1 ? /* false */0 : /* true */1
+              exp_nodes$1 ? false : true
             ) || Curry._1(to_check, match$2[0])) {
             var ty$prime = try_expand_once_opt(env, ty$1);
             var ty0$1 = (
-              exp_nodes$1 ? /* false */0 : /* true */1
+              exp_nodes$1 ? false : true
             ) ? ty$1 : ty0;
             return check(ty0$1, add$3(ty$1, exp_nodes$1), ty$prime);
           } else {
@@ -65176,20 +65175,20 @@ function check_well_founded(env, loc, path, to_check, ty) {
       catch (raw_exn){
         var exn$1 = Js_exn.internalToOCamlException(raw_exn);
         if (exn$1 === Cannot_expand) {
-          var tmp$1 = /* true */1;
+          var tmp$1 = true;
           if (!(recursive_types[0] && is_contractive(env, ty$1))) {
             var match$3 = ty$1[/* desc */0];
             var tmp$2;
             if (typeof match$3 === "number") {
-              tmp$2 = /* false */0;
+              tmp$2 = false;
             } else {
               switch (match$3.tag | 0) {
                 case 4 : 
                 case 8 : 
-                    tmp$2 = /* true */1;
+                    tmp$2 = true;
                     break;
                 default:
-                  tmp$2 = /* false */0;
+                  tmp$2 = false;
               }
             }
             tmp$1 = tmp$2;
@@ -65247,7 +65246,7 @@ function check_recursion(env, loc, path, decl, to_check) {
                   var args$prime = match[1];
                   var path$prime = match[0];
                   if (same(path, path$prime)) {
-                    if (!equal$4(env, /* false */0, args, args$prime)) {
+                    if (!equal$4(env, false, args, args$prime)) {
                       throw [
                             $$Error$8,
                             loc,
@@ -65300,7 +65299,7 @@ function check_recursion(env, loc, path, decl, to_check) {
                                 return check_regular(cpath, args, prev_exp, param);
                               }), args$prime);
               case 10 : 
-                  var match$3 = instance_poly(/* Some */[/* true */1], /* false */0, match[1], match[0]);
+                  var match$3 = instance_poly(/* Some */[true], false, match[1], match[0]);
                   _ty = match$3[1];
                   continue ;
               default:
@@ -65317,7 +65316,7 @@ function check_recursion(env, loc, path, decl, to_check) {
       };
     };
     return may((function (body) {
-                  var match = instance_parameterized_type(/* Some */[/* true */1], decl[/* type_params */0], body);
+                  var match = instance_parameterized_type(/* Some */[true], decl[/* type_params */0], body);
                   return check_regular(path, match[0], /* [] */0, match[1]);
                 }), decl[/* type_manifest */4]);
   }
@@ -65360,7 +65359,7 @@ function compute_variance(env, visited, vari, ty) {
           switch (match.tag | 0) {
             case 1 : 
                 var v = Curry._1(Types_003[/* conjugate */9], vari$1);
-                var v1 = Curry._2(Types_003[/* mem */8], /* May_pos */0, v) || Curry._2(Types_003[/* mem */8], /* May_neg */1, v) ? Curry._3(Types_003[/* set */7], /* May_weak */2, /* true */1, v) : v;
+                var v1 = Curry._2(Types_003[/* mem */8], /* May_pos */0, v) || Curry._2(Types_003[/* mem */8], /* May_neg */1, v) ? Curry._3(Types_003[/* set */7], /* May_weak */2, true, v) : v;
                 compute_variance_rec(v1, match[1]);
                 _ty = match[2];
                 _vari = vari$1;
@@ -65425,7 +65424,7 @@ function compute_variance(env, visited, vari, ty) {
                         return /* () */0;
                       } else if (match.tag) {
                         var upper = List.fold_left((function (s, f) {
-                                return Curry._3(Types_003[/* set */7], f, /* true */1, s);
+                                return Curry._3(Types_003[/* set */7], f, true, s);
                               }), Types_003[/* null */0], /* :: */[
                               /* May_pos */0,
                               /* :: */[
@@ -65494,8 +65493,8 @@ function compute_variance_type(env, check, param, decl, tyl) {
                   ];
           } else {
             return /* tuple */[
-                    /* true */1,
-                    /* true */1,
+                    true,
+                    true,
                     i
                   ];
           }
@@ -65542,7 +65541,7 @@ function compute_variance_type(env, check, param, decl, tyl) {
     var args = newty2(100000000, /* Ttuple */Block.__(2, [params]));
     var fvl = free_variables$1(/* None */0, args);
     var fvl$1 = List.filter((function (v) {
-              return 1 - List.memq(v, params);
+              return !List.memq(v, params);
             }))(fvl);
     if (fvl$1 !== /* [] */0) {
       var tvl2 = [/* Empty */0];
@@ -65567,7 +65566,7 @@ function compute_variance_type(env, check, param, decl, tyl) {
           var v1 = get_variance(ty$1, tvl);
           var snap = snapshot(/* () */0);
           var v2 = fold$3((function (t, vt, v) {
-                  if (equal$4(env, /* false */0, /* :: */[
+                  if (equal$4(env, false, /* :: */[
                           ty$1,
                           /* [] */0
                         ], /* :: */[
@@ -65599,12 +65598,12 @@ function compute_variance_type(env, check, param, decl, tyl) {
                         /* tuple */[
                           c1,
                           n1,
-                          /* false */0
+                          false
                         ],
                         /* tuple */[
                           c2,
                           n2,
-                          /* false */0
+                          false
                         ]
                       ])
                   ];
@@ -65625,17 +65624,17 @@ function compute_variance_type(env, check, param, decl, tyl) {
   return List.map2((function (ty, param) {
                 var v = get_variance(ty, tvl);
                 var tr = decl[/* type_private */3];
-                var concr = +(decl[/* type_kind */2] !== /* Type_abstract */0);
+                var concr = decl[/* type_kind */2] !== /* Type_abstract */0;
                 var match = tr === /* Private */0 || !is_Tvar(ty) ? /* tuple */[
                     param[0],
                     param[1]
                   ] : /* tuple */[
-                    /* false */0,
-                    /* false */0
+                    false,
+                    false
                   ];
                 var n = match[1];
                 var p = match[0];
-                var i = concr || param[2] && +(tr === /* Private */0);
+                var i = concr || param[2] && tr === /* Private */0;
                 var v$1 = Curry._2(Types_003[/* union */4], v, make(p, n, i));
                 var v$2 = concr ? (
                     Curry._2(Types_003[/* mem */8], /* Pos */4, v$1) && Curry._2(Types_003[/* mem */8], /* Neg */5, v$1) ? Types_003[/* full */1] : (
@@ -65655,7 +65654,7 @@ function compute_variance_type(env, check, param, decl, tyl) {
 function add_false(param) {
   return List.map((function (ty) {
                 return /* tuple */[
-                        /* false */0,
+                        false,
                         ty
                       ];
               }), param);
@@ -65664,7 +65663,7 @@ function add_false(param) {
 function constrained(_, vars, ty) {
   var match = ty[/* desc */0];
   if (typeof match === "number" || match.tag) {
-    return /* true */1;
+    return true;
   } else {
     return List.exists((function (tl) {
                   return List.memq(ty, tl);
@@ -65755,13 +65754,13 @@ function compute_variance_extension(env, check, decl, ext, rloc) {
 function compute_variance_decl(env, check, decl, rloc) {
   if ((decl[/* type_kind */2] === /* Type_abstract */0 || decl[/* type_kind */2] === /* Type_open */1) && decl[/* type_manifest */4] === /* None */0) {
     return List.map((function (param) {
-                  return make(1 - param[1], 1 - param[0], +(decl[/* type_kind */2] !== /* Type_abstract */0) || param[2]);
+                  return make(!param[1], !param[0], decl[/* type_kind */2] !== /* Type_abstract */0 || param[2]);
                 }), rloc[0]);
   } else {
     var match = decl[/* type_manifest */4];
     var mn = match ? /* :: */[
         /* tuple */[
-          /* false */0,
+          false,
           match[0]
         ],
         /* [] */0
@@ -65772,7 +65771,7 @@ function compute_variance_decl(env, check, decl, rloc) {
     } else if (match$1.tag) {
       var tll = match$1[0];
       if (List.for_all((function (c) {
-                return +(c[/* cd_res */2] === /* None */0);
+                return c[/* cd_res */2] === /* None */0;
               }), tll)) {
         return compute_variance_type(env, check, rloc, decl, Pervasives.$at(mn, add_false(List.flatten(List.map((function (c) {
                                       return c[/* cd_args */1];
@@ -65822,7 +65821,7 @@ function compute_variance_decl(env, check, decl, rloc) {
     } else {
       return compute_variance_type(env, check, rloc, decl, Pervasives.$at(mn, List.map((function (param) {
                             return /* tuple */[
-                                    +(param[/* ld_mutable */1] === /* Mutable */1),
+                                    param[/* ld_mutable */1] === /* Mutable */1,
                                     param[/* ld_type */2]
                                   ];
                           }), match$1[0])));
@@ -65833,9 +65832,9 @@ function compute_variance_decl(env, check, decl, rloc) {
 function is_sharp(id) {
   var s = id[/* name */1];
   if (s.length !== 0) {
-    return +(Caml_string.get(s, 0) === /* "#" */35);
+    return Caml_string.get(s, 0) === /* "#" */35;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -65850,13 +65849,13 @@ function compute_variance_fixpoint(env, decls, required, _variances) {
                   ];
           }), decls, variances);
     var new_env = List.fold_right((function (param, env) {
-            return add_type$1(/* true */1, param[0], param[1], env);
+            return add_type$1(true, param[0], param[1], env);
           }), new_decls, env);
     var new_variances = List.map2((function(new_env){
         return function (param) {
           var decl = param[1];
           return (function (param) {
-              return compute_variance_decl(new_env, /* false */0, decl, param);
+              return compute_variance_decl(new_env, false, decl, param);
             });
         }
         }(new_env)), new_decls, required);
@@ -65875,7 +65874,7 @@ function compute_variance_fixpoint(env, decls, required, _variances) {
             if (is_sharp(param[0])) {
               return 0;
             } else {
-              compute_variance_decl(new_env, /* true */1, param[1], req);
+              compute_variance_decl(new_env, true, param[1], req);
               return /* () */0;
             }
           }
@@ -65899,21 +65898,21 @@ function add_injectivity(param) {
                 switch (param) {
                   case 0 : 
                       return /* tuple */[
-                              /* true */1,
-                              /* false */0,
-                              /* false */0
+                              true,
+                              false,
+                              false
                             ];
                   case 1 : 
                       return /* tuple */[
-                              /* false */0,
-                              /* true */1,
-                              /* false */0
+                              false,
+                              true,
+                              false
                             ];
                   case 2 : 
                       return /* tuple */[
-                              /* false */0,
-                              /* false */0,
-                              /* false */0
+                              false,
+                              false,
+                              false
                             ];
                   
                 }
@@ -66016,7 +66015,7 @@ function check_duplicates(sdecl_list) {
 
 function name_recursion(sdecl, id, decl) {
   var match = decl[/* type_kind */2];
-  if (typeof match === "number" && !(match !== 0 || decl[/* type_private */3] !== 0)) {
+  if (typeof match === "number" && !(match !== 0 || decl[/* type_private */3])) {
     var match$1 = decl[/* type_manifest */4];
     if (match$1 && is_fixed_type(sdecl)) {
       var ty = repr(match$1[0]);
@@ -66070,11 +66069,11 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
         }), sdecl_list$1);
   init_def(currentstamp[0]);
   begin_def(/* () */0);
-  var temp_env = rec_flag !== 0 ? List.fold_left2(enter_type$1, env, sdecl_list$1, id_list) : env;
+  var temp_env = rec_flag ? List.fold_left2(enter_type$1, env, sdecl_list$1, id_list) : env;
   var current_slot = [/* None */0];
   var warn_unused = is_active(/* Unused_type_declaration */Block.__(18, [""]));
   var id_slots = function (id) {
-    if (rec_flag !== 0) {
+    if (rec_flag) {
       if (warn_unused) {
         var slot = [/* [] */0];
         var td = find_type_full(/* Pident */Block.__(0, [id]), temp_env)[0];
@@ -66128,8 +66127,8 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
           }), tparams);
     var cstrs = List.map((function (param) {
             return /* tuple */[
-                    transl_simple_type(env, /* false */0, param[0]),
-                    transl_simple_type(env, /* false */0, param[1]),
+                    transl_simple_type(env, false, param[0]),
+                    transl_simple_type(env, false, param[1]),
                     param[2]
                   ];
           }), sdecl[/* ptype_cstrs */2]);
@@ -66164,7 +66163,7 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
       var lbls$1 = List.map((function (param) {
               var name = param[/* pld_name */0];
               var arg = force_poly(param[/* pld_type */2]);
-              var cty = transl_simple_type(env, /* true */1, arg);
+              var cty = transl_simple_type(env, true, arg);
               return /* record */[
                       /* ld_id */create(name[/* txt */0]),
                       /* ld_name */name,
@@ -66193,7 +66192,7 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
               var match = repr(expand_head_opt(env$1, ty));
               var match$1 = match[/* desc */0];
               if (typeof match$1 === "number" || match$1.tag !== 3) {
-                return /* false */0;
+                return false;
               } else {
                 return same(match$1[0], path_float);
               }
@@ -66224,7 +66223,7 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
               return /* () */0;
             }), scstrs);
       if (List.length(List.filter((function (cd) {
-                      return +(cd[/* pcd_args */1] !== /* [] */0);
+                      return cd[/* pcd_args */1] !== /* [] */0;
                     }))(scstrs)) > 246) {
         throw [
               $$Error$8,
@@ -66273,7 +66272,7 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
     var match$3 = sdecl[/* ptype_manifest */5];
     var match$4;
     if (match$3) {
-      var no_row = 1 - is_fixed_type(sdecl);
+      var no_row = !is_fixed_type(sdecl);
       var cty = transl_simple_type(env, no_row, match$3[0]);
       match$4 = /* tuple */[
         /* Some */[cty],
@@ -66382,9 +66381,9 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
   current_slot[0] = /* None */0;
   check_duplicates(sdecl_list$1);
   var newenv = List.fold_right((function (param, env) {
-          return add_type$1(/* true */1, param[0], param[1], env);
+          return add_type$1(true, param[0], param[1], env);
         }), decls, env);
-  if (rec_flag !== 0) {
+  if (rec_flag) {
     List.iter2((function (id, sdecl) {
             var temp_env$1 = temp_env;
             var env = newenv;
@@ -66453,7 +66452,7 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
           return List.mem_assoc(param[0], id_loc_list);
       case 1 : 
       case 2 : 
-          return /* false */0;
+          return false;
       
     }
   };
@@ -66494,7 +66493,7 @@ function transl_type_decl(env, rec_flag, sdecl_list) {
           var visited = [/* Empty */0];
           var match = decl[/* type_kind */2];
           if (typeof match === "number") {
-            +(match === 0);
+            match === 0;
           } else if (match.tag) {
             var find_pl = function (param) {
               if (typeof param === "number") {
@@ -66772,7 +66771,7 @@ function transl_extension_constructor(env, _, type_path, type_params, typext_par
       ext_types_000,
       type_params
     ];
-    if (!equal$4(env, /* true */1, cstr_types, ext_types)) {
+    if (!equal$4(env, true, cstr_types, ext_types)) {
       throw [
             $$Error$8,
             lid[/* loc */1],
@@ -66784,8 +66783,8 @@ function transl_extension_constructor(env, _, type_path, type_params, typext_par
           ];
     }
     var match$6 = cdescr[/* cstr_private */10];
-    if (match$6 === 0) {
-      if (priv !== 0) {
+    if (!match$6) {
+      if (priv) {
         throw [
               $$Error$8,
               lid[/* loc */1],
@@ -66867,9 +66866,9 @@ function transl_type_extension(check_open, env, loc, styext) {
         try {
           var match$2 = List.find((function (param) {
                   if (param[/* pext_kind */1].tag) {
-                    return /* false */0;
+                    return false;
                   } else {
-                    return /* true */1;
+                    return true;
                   }
                 }), styext[/* ptyext_constructors */2]);
           throw [
@@ -66898,9 +66897,9 @@ function transl_type_extension(check_open, env, loc, styext) {
   var type_variance = List.map((function (v) {
           var match = Curry._1(Types_003[/* get_upper */10], v);
           return /* tuple */[
-                  1 - match[1],
-                  1 - match[0],
-                  /* false */0
+                  !match[1],
+                  !match[0],
+                  false
                 ];
         }), type_decl[/* type_variance */5]);
   var err = type_decl[/* type_arity */1] !== List.length(styext[/* ptyext_params */1]) ? /* :: */[
@@ -66912,10 +66911,10 @@ function transl_type_extension(check_open, env, loc, styext) {
                 if (param$1[1]) {
                   return param[1];
                 } else {
-                  return /* true */1;
+                  return true;
                 }
               } else {
-                return /* false */0;
+                return false;
               }
             }), type_variance, add_injectivity(List.map((function (prim) {
                       return prim[1];
@@ -66968,14 +66967,14 @@ function transl_type_extension(check_open, env, loc, styext) {
           }
         }), constructors);
   List.iter((function (ext) {
-          compute_variance_extension(env, /* true */1, type_decl, ext[/* ext_type */2], /* tuple */[
+          compute_variance_extension(env, true, type_decl, ext[/* ext_type */2], /* tuple */[
                 type_variance,
                 loc
               ]);
           return /* () */0;
         }), constructors);
   var newenv = List.fold_left((function (env, ext) {
-          return add_extension(/* true */1, ext[/* ext_id */0], ext[/* ext_type */2], env);
+          return add_extension(true, ext[/* ext_id */0], ext[/* ext_type */2], env);
         }), env, constructors);
   var tyext_001 = /* tyext_txt */styext[/* ptyext_path */0];
   var tyext_004 = /* tyext_private */styext[/* ptyext_private */3];
@@ -66997,7 +66996,7 @@ function transl_type_extension(check_open, env, loc, styext) {
 function transl_exception(env, sext) {
   reset_type_variables(/* () */0);
   begin_def(/* () */0);
-  var ext = transl_extension_constructor(env, /* false */0, path_exn, /* [] */0, /* [] */0, /* Public */1, sext);
+  var ext = transl_extension_constructor(env, false, path_exn, /* [] */0, /* [] */0, /* Public */1, sext);
   end_def(/* () */0);
   List.iter(generalize, ext[/* ext_type */2][/* ext_args */2]);
   may(generalize, ext[/* ext_type */2][/* ext_ret_type */3]);
@@ -67012,7 +67011,7 @@ function transl_exception(env, sext) {
             ])
         ];
   }
-  var newenv = add_extension(/* true */1, ext[/* ext_id */0], ext[/* ext_type */2], env);
+  var newenv = add_extension(true, ext[/* ext_id */0], ext[/* ext_type */2], env);
   return /* tuple */[
           ext,
           newenv
@@ -67094,7 +67093,7 @@ function transl_with_constraint(env, id, row_path, orig_decl, sdecl) {
           return param[0][/* ctyp_type */1];
         }), tparams);
   var orig_decl$1 = instance_declaration(orig_decl);
-  var arity_ok = +(List.length(params) === orig_decl$1[/* type_arity */1]);
+  var arity_ok = List.length(params) === orig_decl$1[/* type_arity */1];
   if (arity_ok) {
     List.iter2((function (param, param$1) {
             return unify_var(env, param, param$1);
@@ -67103,8 +67102,8 @@ function transl_with_constraint(env, id, row_path, orig_decl, sdecl) {
   var constraints = List.map((function (param) {
           var loc = param[2];
           try {
-            var cty = transl_simple_type(env, /* false */0, param[0]);
-            var cty$prime = transl_simple_type(env, /* false */0, param[1]);
+            var cty = transl_simple_type(env, false, param[0]);
+            var cty$prime = transl_simple_type(env, false, param[1]);
             var ty = cty[/* ctyp_type */1];
             var ty$prime = cty$prime[/* ctyp_type */1];
             unify$2(env, ty, ty$prime);
@@ -67130,7 +67129,7 @@ function transl_with_constraint(env, id, row_path, orig_decl, sdecl) {
             }
           }
         }), sdecl[/* ptype_cstrs */2]);
-  var no_row = 1 - is_fixed_type(sdecl);
+  var no_row = !is_fixed_type(sdecl);
   var match = sdecl[/* ptype_manifest */5];
   var match$1;
   if (match) {
@@ -67183,7 +67182,7 @@ function transl_with_constraint(env, id, row_path, orig_decl, sdecl) {
   }
   var decl$1 = name_recursion(sdecl, id, decl);
   var newrecord = decl$1.slice();
-  newrecord[/* type_variance */5] = compute_variance_decl(env, /* false */0, decl$1, /* tuple */[
+  newrecord[/* type_variance */5] = compute_variance_decl(env, false, decl$1, /* tuple */[
         add_injectivity(List.map((function (prim) {
                     return prim[1];
                   }), sdecl[/* ptype_params */1])),
@@ -68093,13 +68092,13 @@ function report_error$5(ppf, param) {
           var variance = function (param) {
             var n = param[1];
             var inj = param[2] ? "injective " : "";
-            if (param[0] !== 0) {
-              if (n !== 0) {
+            if (param[0]) {
+              if (n) {
                 return inj + "invariant";
               } else {
                 return inj + "covariant";
               }
-            } else if (n !== 0) {
+            } else if (n) {
               return inj + "contravariant";
             } else if (inj === "") {
               return "unrestricted";
@@ -68108,7 +68107,7 @@ function report_error$5(ppf, param) {
             }
           };
           var suffix = function (n) {
-            var teen = +((n % 100 / 10 | 0) === 1);
+            var teen = (n % 100 / 10 | 0) === 1;
             var match = n % 10;
             var switcher = match - 1 | 0;
             if (switcher > 2 || switcher < 0) {
@@ -68545,24 +68544,24 @@ function closed_class$1(cty) {
                             if (closed_schema(param[2])) {
                               return cc;
                             } else {
-                              return /* false */0;
+                              return false;
                             }
-                          }), sign[/* csig_vars */1], /* true */1);
+                          }), sign[/* csig_vars */1], true);
             } else {
-              return /* false */0;
+              return false;
             }
         case 2 : 
             if (closed_schema(param[1])) {
               _param = param[2];
               continue ;
             } else {
-              return /* false */0;
+              return false;
             }
         
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -68770,7 +68769,7 @@ function inheritance(self_type, env, ovf, concr_meths, warn_vals, loc, parent) {
         var concr_vals$1 = concr_vals(cl_sig[/* csig_vars */1]);
         var over_vals = inter$1(concr_vals$1, warn_vals);
         if (ovf) {
-          if (ovf[0] !== 0) {
+          if (ovf[0]) {
             var cname;
             switch (parent.tag | 0) {
               case 0 : 
@@ -68783,7 +68782,7 @@ function inheritance(self_type, env, ovf, concr_meths, warn_vals, loc, parent) {
               
             }
             if (!(
-                over_meths ? /* false */0 : /* true */1
+                over_meths ? false : true
               )) {
               prerr_warning(loc, /* Method_override */Block.__(2, [/* :: */[
                         cname,
@@ -68791,7 +68790,7 @@ function inheritance(self_type, env, ovf, concr_meths, warn_vals, loc, parent) {
                       ]]));
             }
             if (!(
-                over_vals ? /* false */0 : /* true */1
+                over_vals ? false : true
               )) {
               prerr_warning(loc, /* Instance_variable_override */Block.__(5, [/* :: */[
                         cname,
@@ -68800,9 +68799,9 @@ function inheritance(self_type, env, ovf, concr_meths, warn_vals, loc, parent) {
             }
             
           } else if ((
-              over_meths ? /* false */0 : /* true */1
+              over_meths ? false : true
             ) && (
-              over_vals ? /* false */0 : /* true */1
+              over_vals ? false : true
             )) {
             throw [
                   $$Error$9,
@@ -68838,7 +68837,7 @@ function inheritance(self_type, env, ovf, concr_meths, warn_vals, loc, parent) {
 function virtual_method(val_env, meths, self_type, lab, priv, sty, loc) {
   var match = filter_self_method(val_env, lab, priv, meths, self_type);
   var sty$1 = force_poly(sty);
-  var cty = transl_simple_type(val_env, /* false */0, sty$1);
+  var cty = transl_simple_type(val_env, false, sty$1);
   var ty = cty[/* ctyp_type */1];
   try {
     unify$2(val_env, ty, match[1]);
@@ -68893,7 +68892,7 @@ function declare_method(val_env, meths, self_type, lab, priv, sty, loc) {
   var sty$1 = force_poly(sty);
   var match$1 = sty$1[/* ptyp_desc */0];
   var exit = 0;
-  if (typeof match$1 === "number" || !(match$1.tag === 8 && !(match$1[0] || priv === 0))) {
+  if (typeof match$1 === "number" || !(match$1.tag === 8 && !(match$1[0] || !priv))) {
     exit = 1;
   } else {
     var sty$prime = match$1[1];
@@ -68915,7 +68914,7 @@ function declare_method(val_env, meths, self_type, lab, priv, sty, loc) {
     return returned_cty;
   }
   if (exit === 1) {
-    var cty = transl_simple_type(val_env, /* false */0, sty$1);
+    var cty = transl_simple_type(val_env, false, sty$1);
     var ty = cty[/* ctyp_type */1];
     unif(ty);
     return cty;
@@ -68924,9 +68923,9 @@ function declare_method(val_env, meths, self_type, lab, priv, sty, loc) {
 }
 
 function type_constraint(val_env, sty, sty$prime, loc) {
-  var cty = transl_simple_type(val_env, /* false */0, sty);
+  var cty = transl_simple_type(val_env, false, sty);
   var ty = cty[/* ctyp_type */1];
-  var cty$prime = transl_simple_type(val_env, /* false */0, sty$prime);
+  var cty$prime = transl_simple_type(val_env, false, sty$prime);
   var ty$prime = cty$prime[/* ctyp_type */1];
   try {
     unify$2(val_env, ty, ty$prime);
@@ -68985,7 +68984,7 @@ function add_val(_, _$1, lab, param, val_sig) {
 function class_signature$1(env, param) {
   var sty = param[/* pcsig_self */0];
   var meths = [/* Empty */0];
-  var self_cty = transl_simple_type(env, /* false */0, sty);
+  var self_cty = transl_simple_type(env, false, sty);
   var self_cty$1 = /* record */[
     /* ctyp_desc */self_cty[/* ctyp_desc */0],
     /* ctyp_type */expand_head(env, self_cty[/* ctyp_type */1]),
@@ -69073,7 +69072,7 @@ function class_signature$1(env, param) {
                 var virt = match$3[2];
                 var mut = match$3[1];
                 var lab = match$3[0];
-                var cty = transl_simple_type(env$1, /* false */0, match$3[3]);
+                var cty = transl_simple_type(env$1, false, match$3[3]);
                 var ty = cty[/* ctyp_type */1];
                 return /* tuple */[
                         /* :: */[
@@ -69099,7 +69098,7 @@ function class_signature$1(env, param) {
                 var priv = match$4[1];
                 var lab$1 = match$4[0];
                 var cty$1 = declare_method(env$1, meths$1, self_type$1, lab$1, priv, match$4[3], ctf[/* pctf_loc */1]);
-                var concr_meths$1 = virt$1 !== 0 ? add$2(lab$1, concr_meths) : concr_meths;
+                var concr_meths$1 = virt$1 ? add$2(lab$1, concr_meths) : concr_meths;
                 return /* tuple */[
                         /* :: */[
                           mkctf(/* Tctf_method */Block.__(2, [/* tuple */[
@@ -69215,7 +69214,7 @@ function class_type$2(env, scty) {
               ];
         }
         var ctys = List.map2((function (sty, ty) {
-                var cty$prime = transl_simple_type(env, /* false */0, sty);
+                var cty$prime = transl_simple_type(env, false, sty);
                 var ty$prime = cty$prime[/* ctyp_type */1];
                 try {
                   unify$2(env, ty$prime, ty);
@@ -69252,7 +69251,7 @@ function class_type$2(env, scty) {
         return cltyp(/* Tcty_signature */Block.__(1, [clsig]), typ$1);
     case 2 : 
         var l = match[0];
-        var cty = transl_simple_type(env, /* false */0, match[1]);
+        var cty = transl_simple_type(env, false, match[1]);
         var ty = cty[/* ctyp_type */1];
         var clty = class_type$2(env, match[2]);
         var typ_002$1 = clty[/* cltyp_type */1];
@@ -69300,7 +69299,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
   var self_loc = /* record */[
     self_loc_000,
     self_loc_001,
-    /* loc_ghost : true */1
+    /* loc_ghost */true
   ];
   var self_type = newvar(/* None */0, /* () */0);
   unify$2(val_env, filter_method(val_env, dummy_method, /* Private */0, self_type), newty2(current_level[0], /* Ttuple */Block.__(2, [/* [] */0])));
@@ -69414,7 +69413,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
                 var match$2 = inheritance(self_type$1, val_env, /* Some */[ovf], concr_meths, warn_vals, sparent[/* pcl_loc */1], parent[/* cl_type */2]);
                 var cl_sig = match$2[0];
                 var match$3 = fold((function (lab, info, param) {
-                        var match = enter_val(cl_num$1, vars$1, /* true */1, lab, info[0], info[1], info[2], param[0], param[1], param[2], sparent[/* pcl_loc */1]);
+                        var match = enter_val(cl_num$1, vars$1, true, lab, info[0], info[1], info[2], param[0], param[1], param[2], sparent[/* pcl_loc */1]);
                         return /* tuple */[
                                 match[1],
                                 match[2],
@@ -69558,7 +69557,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
                     end_def(/* () */0);
                     generalize_structure$1(current_level[0], exp[/* exp_type */3]);
                   }
-                  var match$9 = enter_val(cl_num$1, vars$1, /* false */0, lab[/* txt */0], mut, /* Concrete */1, exp[/* exp_type */3], val_env, met_env, par_env, loc);
+                  var match$9 = enter_val(cl_num$1, vars$1, false, lab[/* txt */0], mut, /* Concrete */1, exp[/* exp_type */3], val_env, met_env, par_env, loc);
                   var met_env$prime = match$9[2];
                   var id = match$9[0];
                   return /* tuple */[
@@ -69575,7 +69574,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
                                                       ovf$1,
                                                       exp
                                                     ]),
-                                                  +(met_env === met_env$prime)
+                                                  met_env === met_env$prime
                                                 ]));
                                   })]),
                             fields
@@ -69590,13 +69589,13 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
                   if (principal[0]) {
                     begin_def(/* () */0);
                   }
-                  var cty = transl_simple_type(val_env, /* false */0, match$7[0]);
+                  var cty = transl_simple_type(val_env, false, match$7[0]);
                   var ty = cty[/* ctyp_type */1];
                   if (principal[0]) {
                     end_def(/* () */0);
                     generalize_structure$1(current_level[0], ty);
                   }
-                  var match$10 = enter_val(cl_num$1, vars$1, /* false */0, lab[/* txt */0], mut, /* Virtual */0, ty, val_env, met_env, par_env, loc);
+                  var match$10 = enter_val(cl_num$1, vars$1, false, lab[/* txt */0], mut, /* Virtual */0, ty, val_env, met_env, par_env, loc);
                   var met_env$prime$1 = match$10[2];
                   var id$1 = match$10[0];
                   return /* tuple */[
@@ -69610,7 +69609,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
                                                   mut,
                                                   id$1,
                                                   /* Tcfk_virtual */Block.__(0, [cty]),
-                                                  +(met_env === met_env$prime$1)
+                                                  met_env === met_env$prime$1
                                                 ]));
                                   })]),
                             fields
@@ -69672,7 +69671,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
                       var sbody = match$15[0];
                       if (sty) {
                         var sty$1 = force_poly(sty[0]);
-                        var cty$prime = transl_simple_type(val_env, /* false */0, sty$1);
+                        var cty$prime = transl_simple_type(val_env, false, sty$1);
                         var ty$prime = cty$prime[/* ctyp_type */1];
                         unify$2(val_env, ty$prime, ty$1);
                       }
@@ -69697,7 +69696,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
                               unify$2(val_env, type_approx(val_env, sbody), ty$prime$1);
                               break;
                           case 10 : 
-                              var match$17 = instance_poly(/* None */0, /* false */0, match$16[1], match$16[0]);
+                              var match$17 = instance_poly(/* None */0, false, match$16[1], match$16[0]);
                               var ty2 = type_approx(val_env, sbody);
                               unify$2(val_env, ty2, match$17[1]);
                               break;
@@ -69914,7 +69913,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
   ];
   var methods = get_methods(self_type);
   var priv_meths = List.filter((function (param) {
-            return +(field_kind_repr(param[1]) !== /* Fpresent */0);
+            return field_kind_repr(param[1]) !== /* Fpresent */0;
           }))(methods);
   if ($$final) {
     close_object(self_type);
@@ -69940,7 +69939,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
             loc,
             val_env$1,
             /* Virtual_class */Block.__(10, [
-                /* true */1,
+                true,
                 $$final,
                 mets,
                 vals
@@ -70015,7 +70014,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
           return param[0];
         }), meths[0]);
   var pub_meths$prime = List.filter((function (param) {
-            return +(field_kind_repr(param[1]) === /* Fpresent */0);
+            return field_kind_repr(param[1]) === /* Fpresent */0;
           }))(get_methods(public_self));
   var names = function (param) {
     return List.map((function (param) {
@@ -70066,7 +70065,7 @@ function class_expr(cl_num, val_env, met_env, _scl) {
                 ];
           }
           var tyl = List.map((function (sty) {
-                  return transl_simple_type(val_env, /* false */0, sty);
+                  return transl_simple_type(val_env, false, sty);
                 }), match[1]);
           var match$2 = instance_class(decl[/* cty_params */0], decl[/* cty_type */1]);
           var clty = match$2[1];
@@ -70129,7 +70128,7 @@ function class_expr(cl_num, val_env, met_env, _scl) {
                       /* cl_attributes : [] */0
                     ]);
       case 1 : 
-          var match$4 = class_structure(cl_num, /* false */0, val_env, met_env, scl[/* pcl_loc */1], match[0]);
+          var match$4 = class_structure(cl_num, false, val_env, met_env, scl[/* pcl_loc */1], match[0]);
           return rc(/* record */[
                       /* cl_desc : Tcl_structure */Block.__(1, [match$4[0]]),
                       /* cl_loc */scl[/* pcl_loc */1],
@@ -70226,9 +70225,9 @@ function class_expr(cl_num, val_env, met_env, _scl) {
               switch (param.tag | 0) {
                 case 0 : 
                 case 1 : 
-                    return /* true */1;
+                    return true;
                 case 2 : 
-                    return /* false */0;
+                    return false;
                 
               }
             };
@@ -70282,7 +70281,7 @@ function class_expr(cl_num, val_env, met_env, _scl) {
           var cl$2 = class_expr(cl_num, val_env, met_env, match[0]);
           if (principal[0]) {
             end_def(/* () */0);
-            generalize_class_type(/* false */0)(cl$2[/* cl_type */2]);
+            generalize_class_type(false)(cl$2[/* cl_type */2]);
           }
           var nonopt_labels = function (_ls, _ty_fun) {
             while(true) {
@@ -70310,14 +70309,14 @@ function class_expr(cl_num, val_env, met_env, _scl) {
               }
             };
           };
-          var ignore_labels = /* true */1;
+          var ignore_labels = true;
           if (!classic[0]) {
             var labels = nonopt_labels(/* [] */0, cl$2[/* cl_type */2]);
-            ignore_labels = +(List.length(labels) === List.length(sargs)) && List.for_all((function (param) {
-                    return +(param[0] === "");
+            ignore_labels = List.length(labels) === List.length(sargs) && List.for_all((function (param) {
+                    return param[0] === "";
                   }), sargs) && List.exists((function (l) {
-                    return +(l !== "");
-                  }), labels) && (prerr_warning(cl$2[/* cl_loc */1], /* Labels_omitted */3), /* true */1);
+                    return l !== "";
+                  }), labels) && (prerr_warning(cl$2[/* cl_loc */1], /* Labels_omitted */3), true);
           }
           var type_args = (function(cl$2,ignore_labels){
           return function type_args(_args, _omitted, _ty_fun, _ty_fun0, _sargs, _more_sargs) {
@@ -70720,7 +70719,7 @@ function temp_abbrev(loc, env, id, arity) {
     ];
   }
   var ty = newobj(newvar(/* None */0, /* () */0));
-  var env$1 = add_type$1(/* true */1, id, /* record */[
+  var env$1 = add_type$1(true, id, /* record */[
         /* type_params */params,
         /* type_arity */arity,
         /* type_kind : Type_abstract */0,
@@ -70812,7 +70811,7 @@ function type_classes(define_class, approx, kind, env, cls) {
             /* cty_params : [] */0,
             /* cty_type */dummy_cty,
             /* cty_path */unbound_class,
-            /* cty_new */match$2 !== 0 ? /* Some */[constr_type] : /* None */0,
+            /* cty_new */match$2 ? /* Some */[constr_type] : /* None */0,
             /* cty_variance : [] */0,
             /* cty_loc */none,
             /* cty_attributes : [] */0
@@ -71061,7 +71060,7 @@ function type_classes(define_class, approx, kind, env, cls) {
             /* cty_params */params,
             /* cty_type */typ,
             /* cty_path : Pident */Block.__(0, [obj_id]),
-            /* cty_new */match$4 !== 0 ? /* Some */[constr_type] : /* None */0,
+            /* cty_new */match$4 ? /* Some */[constr_type] : /* None */0,
             /* cty_variance */cty_variance,
             /* cty_loc */cl[/* pci_loc */4],
             /* cty_attributes */cl[/* pci_attributes */5]
@@ -71088,7 +71087,7 @@ function type_classes(define_class, approx, kind, env, cls) {
                     env$1,
                     /* Virtual_class */Block.__(10, [
                         define_class$1,
-                        /* false */0,
+                        false,
                         mets,
                         vals
                       ])
@@ -71121,7 +71120,7 @@ function type_classes(define_class, approx, kind, env, cls) {
             /* cty_params */params$prime,
             /* cty_type */typ$prime,
             /* cty_path : Pident */Block.__(0, [obj_id]),
-            /* cty_new */match$7 !== 0 ? /* Some */[instance(/* None */0, env$1, constr_type)] : /* None */0,
+            /* cty_new */match$7 ? /* Some */[instance(/* None */0, env$1, constr_type)] : /* None */0,
             /* cty_variance */cty_variance,
             /* cty_loc */cl[/* pci_loc */4],
             /* cty_attributes */cl[/* pci_attributes */5]
@@ -71228,7 +71227,7 @@ function type_classes(define_class, approx, kind, env, cls) {
             }
           }
           List.iter(generalize, clty[/* cty_params */0]);
-          generalize_class_type(/* true */1)(clty[/* cty_type */1]);
+          generalize_class_type(true)(clty[/* cty_type */1]);
           may(generalize, clty[/* cty_new */3]);
           List.iter(generalize, obj_abbr[/* type_params */0]);
           may(generalize, obj_abbr[/* type_manifest */4]);
@@ -71299,7 +71298,7 @@ function type_classes(define_class, approx, kind, env, cls) {
           var define_class$1 = define_class;
           var env = param;
           var param$2 = param$1;
-          return add_type$1(/* true */1, param$2[5], type_declaration(identity, param$2[6]), add_type$1(/* true */1, param$2[7], type_declaration(identity, param$2[8]), add_cltype(param$2[3], cltype_declaration(identity, param$2[4]), define_class$1 ? add_class(param$2[0], class_declaration(identity, param$2[2]), env) : env)));
+          return add_type$1(true, param$2[5], type_declaration(identity, param$2[6]), add_type$1(true, param$2[7], type_declaration(identity, param$2[8]), add_cltype(param$2[3], cltype_declaration(identity, param$2[4]), define_class$1 ? add_class(param$2[0], class_declaration(identity, param$2[2]), env) : env)));
         }), env$1, res$1);
   var res$2 = List.map((function (param) {
           var env$3 = env$2;
@@ -71415,15 +71414,15 @@ function class_description(env, sexpr) {
 }
 
 function class_declarations$2(env, cls) {
-  return type_classes(/* true */1, approx_declaration, class_declaration$2, env, cls);
+  return type_classes(true, approx_declaration, class_declaration$2, env, cls);
 }
 
 function class_descriptions(env, cls) {
-  return type_classes(/* true */1, approx_description, class_description, env, cls);
+  return type_classes(true, approx_description, class_description, env, cls);
 }
 
 function class_type_declarations$2(env, cls) {
-  var match = type_classes(/* false */0, approx_description, class_description, env, cls);
+  var match = type_classes(false, approx_description, class_description, env, cls);
   return /* tuple */[
           List.map((function (param) {
                   return /* tuple */[
@@ -71493,7 +71492,7 @@ function unify_parents_struct(env, ty, st) {
 
 function type_object$1(env, loc, s) {
   class_num[0] = class_num[0] + 1 | 0;
-  var match = class_structure(String(class_num[0]), /* true */1, env, env, loc, s);
+  var match = class_structure(String(class_num[0]), true, env, env, loc, s);
   var sign = match[1];
   var desc = match[0];
   var sty = expand_head(env, sign[/* csig_self */0]);
@@ -72721,7 +72720,7 @@ function add_rec_types(_env, _param) {
       var match = param[0];
       if (match.tag === 1 && match[2] >= 2) {
         _param = param[1];
-        _env = add_type$1(/* true */1, match[0], match[1], env);
+        _env = add_type$1(true, match[0], match[1], env);
         continue ;
       } else {
         return env;
@@ -72733,8 +72732,8 @@ function add_rec_types(_env, _param) {
 }
 
 function check_type_decl(env, loc, id, row_id, newdecl, decl, rs, rem) {
-  var env$1 = add_type$1(/* true */1, id, newdecl, env);
-  var env$2 = row_id ? add_type$1(/* true */1, row_id[0], newdecl, env$1) : env$1;
+  var env$1 = add_type$1(true, id, newdecl, env);
+  var env$2 = row_id ? add_type$1(true, row_id[0], newdecl, env$1) : env$1;
   var env$3 = rs === /* Trec_not */0 ? env$2 : add_rec_types(env$2, rem);
   type_declarations$3(env$3, id, newdecl, decl);
   return check_coherence(env$3, loc, id, newdecl);
@@ -72833,27 +72832,27 @@ function merge_constraint(initial_env, loc, sg, constr) {
                                 switch (param[1]) {
                                   case 0 : 
                                       match = /* tuple */[
-                                        /* true */1,
-                                        /* false */0
+                                        true,
+                                        false
                                       ];
                                       break;
                                   case 1 : 
                                       match = /* tuple */[
-                                        /* false */0,
-                                        /* true */1
+                                        false,
+                                        true
                                       ];
                                       break;
                                   case 2 : 
                                       match = /* tuple */[
-                                        /* false */0,
-                                        /* false */0
+                                        false,
+                                        false
                                       ];
                                       break;
                                   
                                 }
-                                var p = 1 - match[1];
-                                var n = 1 - match[0];
-                                var i = /* false */0;
+                                var p = !match[1];
+                                var n = !match[0];
+                                var i = false;
                                 return Curry._3(Types_003[/* set */7], /* May_pos */0, p, Curry._3(Types_003[/* set */7], /* May_neg */1, n, Curry._3(Types_003[/* set */7], /* May_weak */2, n, Curry._3(Types_003[/* set */7], /* Inj */3, i, Types_003[/* null */0]))));
                               }), sdecl[/* ptype_params */1]);
                         var decl_row_007 = /* type_loc */sdecl[/* ptype_loc */7];
@@ -72869,7 +72868,7 @@ function merge_constraint(initial_env, loc, sg, constr) {
                           /* type_attributes : [] */0
                         ];
                         var id_row = create(s + "#row");
-                        var initial_env$1 = add_type$1(/* true */1, id_row, decl_row, initial_env);
+                        var initial_env$1 = add_type$1(true, id_row, decl_row, initial_env);
                         var tdecl = transl_with_constraint(initial_env$1, id, /* Some */[/* Pident */Block.__(0, [id_row])], decl, sdecl);
                         var newdecl = tdecl[/* typ_type */3];
                         check_type_decl(env, sdecl[/* ptype_loc */7], id, row_id, newdecl, decl, rs, rem);
@@ -73264,7 +73263,7 @@ function map_rec(fn, decls, rem) {
 
 function map_rec_type(rec_flag, fn, decls, rem) {
   if (decls) {
-    var first = rec_flag !== 0 ? /* Trec_first */1 : /* Trec_not */0;
+    var first = rec_flag ? /* Trec_first */1 : /* Trec_not */0;
     return /* :: */[
             Curry._2(fn, first, decls[0]),
             map_end(Curry._1(fn, /* Trec_next */2), decls[1], rem)
@@ -73293,7 +73292,7 @@ function map_rec_type_with_row_types(rec_flag, fn, decls, rem) {
 function rec_flag_of_ptype_declarations(tds) {
   var is_nonrec = List.exists((function (td) {
           return List.exists((function (param) {
-                        return +(param[0][/* txt */0] === "nonrec");
+                        return param[0][/* txt */0] === "nonrec";
                       }), td[/* ptype_attributes */6]);
         }), tds);
   if (is_nonrec) {
@@ -73328,7 +73327,7 @@ function approx_modtype(env, _smty) {
           var arg = may_map((function (param) {
                   return approx_modtype(env, param);
                 }), match[1]);
-          var match$2 = enter_module(/* Some */[/* true */1], match[0][/* txt */0], default_mty(arg), env);
+          var match$2 = enter_module(/* Some */[true], match[0][/* txt */0], default_mty(arg), env);
           var res = approx_modtype(match$2[1], match[2]);
           return /* Mty_functor */Block.__(2, [
                     match$2[0],
@@ -73615,13 +73614,13 @@ function mem$7(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -73831,7 +73830,7 @@ function transl_modtype$1(env, smty) {
         var ty_arg = may_map((function (m) {
                 return m[/* mty_type */1];
               }), arg);
-        var match$1 = enter_module(/* Some */[/* true */1], param[/* txt */0], default_mty(ty_arg), env);
+        var match$1 = enter_module(/* Some */[true], param[/* txt */0], default_mty(ty_arg), env);
         var id = match$1[0];
         init_def(currentstamp[0]);
         var res = transl_modtype$1(match$1[1], match[2]);
@@ -73943,13 +73942,13 @@ function transl_signature(env, sg) {
                     match$4[2]
                   ];
         case 2 : 
-            var match$5 = transl_type_extension(/* false */0, env, item[/* psig_loc */1], match[0]);
+            var match$5 = transl_type_extension(false, env, item[/* psig_loc */1], match[0]);
             var tyext = match$5[0];
             var match$6 = transl_sig(match$5[1], srem);
             var rem$1 = match$6[1];
             var constructors = List.filter((function (ext) {
                       var partial_arg = ext[/* ext_id */0];
-                      return 1 - List.exists((function (param) {
+                      return !List.exists((function (param) {
                                     return equal(partial_arg, param);
                                   }), get_extension_constructors(rem$1));
                     }))(tyext[/* tyext_constructors */3]);
@@ -74293,12 +74292,12 @@ function transl_modtype_decl(modtype_names, env, _, param) {
 function transl_recmodule_modtypes(_, env, sdecls) {
   var make_env = function (curr) {
     return List.fold_left((function (env, param) {
-                  return add_module$1(/* Some */[/* true */1], param[0], param[2], env);
+                  return add_module$1(/* Some */[true], param[0], param[2], env);
                 }), env, curr);
   };
   var make_env2 = function (curr) {
     return List.fold_left((function (env, param) {
-                  return add_module$1(/* Some */[/* true */1], param[0], param[2][/* mty_type */1], env);
+                  return add_module$1(/* Some */[true], param[0], param[2][/* mty_type */1], env);
                 }), env, curr);
   };
   var transition = function (env_c, curr) {
@@ -74315,7 +74314,7 @@ function transl_recmodule_modtypes(_, env, sdecls) {
         }), sdecls);
   var approx_env = List.fold_left((function (env, id) {
           var dummy = /* Mty_ident */Block.__(0, [/* Pident */Block.__(0, [create("#recmod#")])]);
-          return add_module$1(/* Some */[/* true */1], id, dummy, env);
+          return add_module$1(/* Some */[true], id, dummy, env);
         }), env, ids);
   var init = List.map2((function (id, pmd) {
           return /* tuple */[
@@ -74478,7 +74477,7 @@ function closed_modtype(_param) {
           continue ;
       case 0 : 
       case 3 : 
-          return /* true */1;
+          return true;
       
     }
   };
@@ -74491,7 +74490,7 @@ function closed_signature_item(param) {
     case 3 : 
         return closed_modtype(param[1][/* md_type */0]);
     default:
-      return /* true */1;
+      return true;
   }
 }
 
@@ -74517,7 +74516,7 @@ function enrich_type_decls(anchor, decls, oldenv, newenv) {
                           id[/* name */1],
                           -1
                         ]), info[/* typ_type */3]);
-                  return add_type$1(/* true */1, id, info$prime, e);
+                  return add_type$1(true, id, info$prime, e);
                 }), oldenv, decls);
   } else {
     return newenv;
@@ -74540,7 +74539,7 @@ function check_recmodule_inclusion(env, bindings) {
   var subst_and_strengthen = function (env, s, id, mty) {
     return strengthen$1(env, modtype(s, mty), module_path(s, /* Pident */Block.__(0, [id])));
   };
-  var _first_time = /* true */1;
+  var _first_time = true;
   var _n = List.length(bindings);
   var _env = env;
   var _s = identity;
@@ -74562,7 +74561,7 @@ function check_recmodule_inclusion(env, bindings) {
           return function (env, param) {
             var mty_actual = param[2];
             var mty_actual$prime = first_time ? mty_actual : subst_and_strengthen(env, s, param[0], mty_actual);
-            return add_module$1(/* Some */[/* false */0], param[1], mty_actual$prime, env);
+            return add_module$1(/* Some */[false], param[1], mty_actual$prime, env);
           }
           }(first_time,s)), env$1, bindings1);
       var s$prime = List.fold_left((function (s, param) {
@@ -74571,7 +74570,7 @@ function check_recmodule_inclusion(env, bindings) {
       _s = s$prime;
       _env = env$prime;
       _n = n - 1 | 0;
-      _first_time = /* false */0;
+      _first_time = false;
       continue ;
     } else {
       var check_inclusion = (function(env$1,s){
@@ -74757,7 +74756,7 @@ function modtype_of_package(env, loc, p, nl, tl) {
 function package_subtype$1(env, p1, nl1, tl1, p2, nl2, tl2) {
   var mkmty = function (p, nl, tl) {
     var ntl = List.filter((function (param) {
-              return +(free_variables$1(/* None */0, param[1]) === /* [] */0);
+              return free_variables$1(/* None */0, param[1]) === /* [] */0;
             }))(List.combine(nl, tl));
     var match = List.split(ntl);
     return modtype_of_package(env, none, p, match[0], match[1]);
@@ -74765,12 +74764,12 @@ function package_subtype$1(env, p1, nl1, tl1, p2, nl2, tl2) {
   var mty1 = mkmty(p1, nl1, tl1);
   var mty2 = mkmty(p2, nl2, tl2);
   try {
-    return +(modtypes$1(env, mty1, mty2) === /* Tcoerce_none */0);
+    return modtypes$1(env, mty1, mty2) === /* Tcoerce_none */0;
   }
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn[0] === $$Error$5) {
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -74812,12 +74811,12 @@ function wrap_constraint(env, arg, mty, explicit) {
 }
 
 function type_module$1($staropt$star, sttn, funct_body, anchor, env, smod) {
-  var alias = $staropt$star ? $staropt$star[0] : /* false */0;
+  var alias = $staropt$star ? $staropt$star[0] : false;
   var match = smod[/* pmod_desc */0];
   switch (match.tag | 0) {
     case 0 : 
         var lid = match[0];
-        var path = lookup_module$1(/* Some */[1 - alias], env, smod[/* pmod_loc */1], lid[/* txt */0]);
+        var path = lookup_module$1(/* Some */[!alias], env, smod[/* pmod_loc */1], lid[/* txt */0]);
         var md_000 = /* mod_desc : Tmod_ident */Block.__(0, [
             path,
             lid
@@ -74837,7 +74836,7 @@ function type_module$1($staropt$star, sttn, funct_body, anchor, env, smod) {
           add_required_global(head(path));
           tmp = md;
         } else {
-          var mty = find_module(/* false */0, path, env)[/* md_type */0];
+          var mty = find_module(false, path, env)[/* md_type */0];
           var exit = 0;
           if (mty.tag === 3 && !alias) {
             var p1 = normalize_path$1(/* Some */[smod[/* pmod_loc */1]], env, mty[0]);
@@ -74898,14 +74897,14 @@ function type_module$1($staropt$star, sttn, funct_body, anchor, env, smod) {
                 return m[/* mty_type */1];
               }), mty$3);
         var match$2 = ty_arg ? /* tuple */[
-            enter_module(/* Some */[/* true */1], name[/* txt */0], ty_arg[0], env),
-            /* true */1
+            enter_module(/* Some */[true], name[/* txt */0], ty_arg[0], env),
+            true
           ] : /* tuple */[
             /* tuple */[
               create("*"),
               env
             ],
-            /* false */0
+            false
           ];
         var match$3 = match$2[0];
         var id = match$3[0];
@@ -74929,15 +74928,15 @@ function type_module$1($staropt$star, sttn, funct_body, anchor, env, smod) {
     case 3 : 
         var sarg = match[1];
         var sfunct = match[0];
-        var arg = type_module$1(/* None */0, /* true */1, funct_body, /* None */0, env, sarg);
+        var arg = type_module$1(/* None */0, true, funct_body, /* None */0, env, sarg);
         var path$1 = path_of_module$1(arg);
-        var funct = type_module$1(/* None */0, sttn && +(path$1 !== /* None */0), funct_body, /* None */0, env, sfunct);
+        var funct = type_module$1(/* None */0, sttn && path$1 !== /* None */0, funct_body, /* None */0, env, sfunct);
         var mty_functor = scrape_alias(env, /* None */0, funct[/* mod_type */2]);
         if (mty_functor.tag === 2) {
           var mty_res = mty_functor[2];
           var mty_param = mty_functor[1];
           var param = mty_functor[0];
-          var generative = +(mty_param === /* None */0);
+          var generative = mty_param === /* None */0;
           var mty_param$1 = default_mty(mty_param);
           if (generative) {
             if (Caml_obj.caml_notequal(sarg[/* pmod_desc */0], /* Pmod_structure */Block.__(1, [/* [] */0]))) {
@@ -74982,7 +74981,7 @@ function type_module$1($staropt$star, sttn, funct_body, anchor, env, smod) {
             mty_appl = mty_res;
           } else {
             try {
-              mty_appl = nondep_supertype(add_module$1(/* Some */[/* true */1], param, arg[/* mod_type */2], env), param, mty_res);
+              mty_appl = nondep_supertype(add_module$1(/* Some */[true], param, arg[/* mod_type */2], env), param, mty_res);
             }
             catch (exn$1){
               if (exn$1 === Caml_builtin_exceptions.not_found) {
@@ -75017,7 +75016,7 @@ function type_module$1($staropt$star, sttn, funct_body, anchor, env, smod) {
               ];
         }
     case 4 : 
-        var arg$1 = type_module$1(/* Some */[alias], /* true */1, funct_body, anchor, env, match[0]);
+        var arg$1 = type_module$1(/* Some */[alias], true, funct_body, anchor, env, match[0]);
         var mty$4 = transl_modtype$1(env, match[1]);
         var init = wrap_constraint(env, arg$1, mty$4[/* mty_type */1], /* Tmodtype_explicit */[mty$4]);
         return rm(/* record */[
@@ -75054,7 +75053,7 @@ function type_module$1($staropt$star, sttn, funct_body, anchor, env, smod) {
             case 11 : 
                 var tl = match$5[2];
                 if (List.exists((function (t) {
-                          return +(free_variables$1(/* None */0, t) !== /* [] */0);
+                          return free_variables$1(/* None */0, t) !== /* [] */0;
                         }), tl)) {
                   throw [
                         $$Error$10,
@@ -75108,7 +75107,7 @@ function type_module$1($staropt$star, sttn, funct_body, anchor, env, smod) {
 }
 
 function type_structure($staropt$star, funct_body, anchor, env, sstr, scope) {
-  var toplevel = $staropt$star ? $staropt$star[0] : /* false */0;
+  var toplevel = $staropt$star ? $staropt$star[0] : false;
   var type_names = [/* Empty */0];
   var module_names = [/* Empty */0];
   var modtype_names = [/* Empty */0];
@@ -75129,7 +75128,7 @@ function type_structure($staropt$star, funct_body, anchor, env, sstr, scope) {
       case 1 : 
           var rec_flag = desc[0];
           var scope$1;
-          if (rec_flag !== 0) {
+          if (rec_flag) {
             scope$1 = /* Some */[/* Idef */Block.__(1, [/* record */[
                     /* loc_start */loc[/* loc_start */0],
                     /* loc_end */scope[/* loc_end */1],
@@ -75193,7 +75192,7 @@ function type_structure($staropt$star, funct_body, anchor, env, sstr, scope) {
                   enrich_type_decls(anchor, decls, env, match$2[1])
                 ];
       case 4 : 
-          var match$3 = transl_type_extension(/* true */1, env, loc, desc[0]);
+          var match$3 = transl_type_extension(true, env, loc, desc[0]);
           var tyext = match$3[0];
           return /* tuple */[
                   /* Tstr_typext */Block.__(4, [tyext]),
@@ -75227,7 +75226,7 @@ function type_structure($staropt$star, funct_body, anchor, env, sstr, scope) {
           var attrs = match$5[/* pmb_attributes */2];
           var name = match$5[/* pmb_name */0];
           check_name("module", module_names, name);
-          var modl = type_module$1(/* Some */[/* true */1], /* true */1, funct_body, anchor_submodule(name[/* txt */0], anchor), env, match$5[/* pmb_expr */1]);
+          var modl = type_module$1(/* Some */[true], true, funct_body, anchor_submodule(name[/* txt */0], anchor), env, match$5[/* pmb_expr */1]);
           var md_000 = /* md_type */enrich_module_type(anchor, name[/* txt */0], modl[/* mod_type */2], env);
           var md = /* record */[
             md_000,
@@ -75293,7 +75292,7 @@ function type_structure($staropt$star, funct_body, anchor, env, sstr, scope) {
           var decls$1 = match$7[0];
           var bindings1 = List.map2((function (param, param$1) {
                   var id = param[/* md_id */0];
-                  var modl = type_module$1(/* None */0, /* true */1, funct_body, /* Some */[/* Pident */Block.__(0, [id])], newenv$1, param$1[2]);
+                  var modl = type_module$1(/* None */0, true, funct_body, /* Some */[/* Pident */Block.__(0, [id])], newenv$1, param$1[2]);
                   var mty$prime = enrich_module_type(anchor, id[/* name */1], modl[/* mod_type */2], newenv$1);
                   return /* tuple */[
                           id,
@@ -75442,7 +75441,7 @@ function type_structure($staropt$star, funct_body, anchor, env, sstr, scope) {
       case 12 : 
           var sincl = desc[0];
           var smodl = sincl[/* pincl_mod */0];
-          var modl$1 = type_module$1(/* None */0, /* true */1, funct_body, /* None */0, env, smodl);
+          var modl$1 = type_module$1(/* None */0, true, funct_body, /* None */0, env, smodl);
           var sg = signature$2(identity, extract_sig_open(env, smodl[/* pmod_loc */1], modl$1[/* mod_type */2]));
           var match$12 = modl$1[/* mod_desc */0];
           var sg$1;
@@ -75602,11 +75601,11 @@ function type_structure($staropt$star, funct_body, anchor, env, sstr, scope) {
 }
 
 function type_module$2(param, param$1) {
-  return type_module$1(/* None */0, /* true */1, /* false */0, /* None */0, param, param$1);
+  return type_module$1(/* None */0, true, false, /* None */0, param, param$1);
 }
 
 function type_structure$1(param, param$1, param$2) {
-  return type_structure(/* None */0, /* false */0, /* None */0, param, param$1, param$2);
+  return type_structure(/* None */0, false, /* None */0, param, param$1, param$2);
 }
 
 function normalize_signature_item(env, param) {
@@ -75683,7 +75682,7 @@ function type_package$1(env, m, p, nl, _) {
   var match = modl[/* mod_desc */0];
   var match$1;
   if (match.tag) {
-    var match$2 = enter_module(/* Some */[/* true */1], "%M", modl[/* mod_type */2], env);
+    var match$2 = enter_module(/* Some */[true], "%M", modl[/* mod_type */2], env);
     match$1 = /* tuple */[
       /* Pident */Block.__(0, [match$2[0]]),
       match$2[1]
@@ -76480,17 +76479,17 @@ function eq(loc, x, y) {
   return /* () */0;
 }
 
-dont_write_files[0] = /* true */1;
+dont_write_files[0] = true;
 
-unsafe_string = /* false */0;
+unsafe_string = false;
 
-debug = /* true */1;
+debug = true;
 
-record_event_when_debug = /* false */0;
+record_event_when_debug = false;
 
-binary_annotations[0] = /* false */0;
+binary_annotations[0] = false;
 
-nopervasives = /* true */1;
+nopervasives = true;
 
 assume_no_mli[0] = /* Mli_non_exists */2;
 
@@ -76511,7 +76510,7 @@ if (match$1) {
       if (match$6[/* name */1] === "int") {
         var match$7 = match$6[/* flags */2];
         if (match$7 !== 0) {
-          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
         } else {
           var match$8 = match$5[/* typ_name */1];
           if (match$8[/* txt */0] === "int") {
@@ -76519,30 +76518,30 @@ if (match$1) {
             var match$10 = match$9[/* loc_start */0];
             if (match$10[/* pos_fname */0] === "" && !(match$10[/* pos_lnum */1] !== 2 || match$10[/* pos_bol */2] !== 1 || match$10[/* pos_cnum */3] !== 6)) {
               var match$11 = match$9[/* loc_end */1];
-              if (match$11[/* pos_fname */0] === "" && !(match$11[/* pos_lnum */1] !== 2 || match$11[/* pos_bol */2] !== 1 || match$11[/* pos_cnum */3] !== 9 || match$9[/* loc_ghost */2] !== 0 || match$5[/* typ_params */2])) {
+              if (match$11[/* pos_fname */0] === "" && !(match$11[/* pos_lnum */1] !== 2 || match$11[/* pos_bol */2] !== 1 || match$11[/* pos_cnum */3] !== 9 || match$9[/* loc_ghost */2] || match$5[/* typ_params */2])) {
                 var match$12 = match$5[/* typ_type */3];
                 if (match$12[/* type_params */0] || match$12[/* type_arity */1] !== 0) {
-                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                 } else {
                   var match$13 = match$12[/* type_kind */2];
-                  if (typeof match$13 === "number" && !(match$13 !== 0 || !(match$12[/* type_private */3] !== 0 && !(match$12[/* type_manifest */4] || match$12[/* type_variance */5] || match$12[/* type_newtype_level */6])))) {
+                  if (typeof match$13 === "number" && !(match$13 !== 0 || !(match$12[/* type_private */3] && !(match$12[/* type_manifest */4] || match$12[/* type_variance */5] || match$12[/* type_newtype_level */6])))) {
                     var match$14 = match$12[/* type_loc */7];
                     var match$15 = match$14[/* loc_start */0];
                     if (match$15[/* pos_fname */0] === "" && !(match$15[/* pos_lnum */1] !== 2 || match$15[/* pos_bol */2] !== 1 || match$15[/* pos_cnum */3] !== 1)) {
                       var match$16 = match$14[/* loc_end */1];
-                      if (match$16[/* pos_fname */0] === "" && !(match$16[/* pos_lnum */1] !== 2 || match$16[/* pos_bol */2] !== 1 || match$16[/* pos_cnum */3] !== 9 || match$14[/* loc_ghost */2] !== 0 || match$12[/* type_attributes */8] || match$5[/* typ_cstrs */4])) {
+                      if (match$16[/* pos_fname */0] === "" && !(match$16[/* pos_lnum */1] !== 2 || match$16[/* pos_bol */2] !== 1 || match$16[/* pos_cnum */3] !== 9 || match$14[/* loc_ghost */2] || match$12[/* type_attributes */8] || match$5[/* typ_cstrs */4])) {
                         var match$17 = match$5[/* typ_kind */5];
-                        if (typeof match$17 === "number" && !(match$17 !== 0 || !(match$5[/* typ_private */6] !== 0 && !match$5[/* typ_manifest */7]))) {
+                        if (typeof match$17 === "number" && !(match$17 !== 0 || !(match$5[/* typ_private */6] && !match$5[/* typ_manifest */7]))) {
                           var match$18 = match$5[/* typ_loc */8];
                           var match$19 = match$18[/* loc_start */0];
                           if (match$19[/* pos_fname */0] === "" && !(match$19[/* pos_lnum */1] !== 2 || match$19[/* pos_bol */2] !== 1 || match$19[/* pos_cnum */3] !== 1)) {
                             var match$20 = match$18[/* loc_end */1];
-                            if (match$20[/* pos_fname */0] === "" && !(match$20[/* pos_lnum */1] !== 2 || match$20[/* pos_bol */2] !== 1 || match$20[/* pos_cnum */3] !== 9 || match$18[/* loc_ghost */2] !== 0 || match$5[/* typ_attributes */9] || match$4[1])) {
+                            if (match$20[/* pos_fname */0] === "" && !(match$20[/* pos_lnum */1] !== 2 || match$20[/* pos_bol */2] !== 1 || match$20[/* pos_cnum */3] !== 9 || match$18[/* loc_ghost */2] || match$5[/* typ_attributes */9] || match$4[1])) {
                               var match$21 = match$2[/* str_loc */1];
                               var match$22 = match$21[/* loc_start */0];
                               if (match$22[/* pos_fname */0] === "" && !(match$22[/* pos_lnum */1] !== 2 || match$22[/* pos_bol */2] !== 1 || match$22[/* pos_cnum */3] !== 1)) {
                                 var match$23 = match$21[/* loc_end */1];
-                                if (match$23[/* pos_fname */0] === "" && !(match$23[/* pos_lnum */1] !== 2 || match$23[/* pos_bol */2] !== 1 || match$23[/* pos_cnum */3] !== 9 || match$21[/* loc_ghost */2] !== 0)) {
+                                if (match$23[/* pos_fname */0] === "" && !(match$23[/* pos_lnum */1] !== 2 || match$23[/* pos_bol */2] !== 1 || match$23[/* pos_cnum */3] !== 9 || match$21[/* loc_ghost */2])) {
                                   var match$24 = match$1[1];
                                   if (match$24) {
                                     var match$25 = match$24[0][/* str_desc */0];
@@ -76552,7 +76551,7 @@ if (match$1) {
                                       if (match$27[/* name */1] === "~-") {
                                         var match$28 = match$27[/* flags */2];
                                         if (match$28 !== 0) {
-                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                         } else {
                                           var match$29 = match$26[/* val_name */1];
                                           if (match$29[/* txt */0] === "~-") {
@@ -76560,16 +76559,16 @@ if (match$1) {
                                             var match$31 = match$30[/* loc_start */0];
                                             if (match$31[/* pos_fname */0] === "" && !(match$31[/* pos_lnum */1] !== 3 || match$31[/* pos_bol */2] !== 10 || match$31[/* pos_cnum */3] !== 19)) {
                                               var match$32 = match$30[/* loc_end */1];
-                                              if (match$32[/* pos_fname */0] === "" && !(match$32[/* pos_lnum */1] !== 3 || match$32[/* pos_bol */2] !== 10 || match$32[/* pos_cnum */3] !== 25 || match$30[/* loc_ghost */2] !== 0)) {
+                                              if (match$32[/* pos_fname */0] === "" && !(match$32[/* pos_lnum */1] !== 3 || match$32[/* pos_bol */2] !== 10 || match$32[/* pos_cnum */3] !== 25 || match$30[/* loc_ghost */2])) {
                                                 var match$33 = match$26[/* val_desc */2];
                                                 var match$34 = match$33[/* ctyp_desc */0];
                                                 if (typeof match$34 === "number" || !(match$34.tag === 1 && match$34[0] === "")) {
-                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                 } else {
                                                   var match$35 = match$34[1];
                                                   var match$36 = match$35[/* ctyp_desc */0];
                                                   if (typeof match$36 === "number" || match$36.tag !== 3) {
-                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                   } else {
                                                     var match$37 = match$36[0];
                                                     switch (match$37.tag | 0) {
@@ -76578,7 +76577,7 @@ if (match$1) {
                                                           if (match$38[/* name */1] === "int") {
                                                             var match$39 = match$38[/* flags */2];
                                                             if (match$39 !== 0) {
-                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                             } else {
                                                               var match$40 = match$36[1];
                                                               var match$41 = match$40[/* txt */0];
@@ -76589,11 +76588,11 @@ if (match$1) {
                                                                       var match$43 = match$42[/* loc_start */0];
                                                                       if (match$43[/* pos_fname */0] === "" && !(match$43[/* pos_lnum */1] !== 3 || match$43[/* pos_bol */2] !== 10 || match$43[/* pos_cnum */3] !== 28)) {
                                                                         var match$44 = match$42[/* loc_end */1];
-                                                                        if (match$44[/* pos_fname */0] === "" && !(match$44[/* pos_lnum */1] !== 3 || match$44[/* pos_bol */2] !== 10 || match$44[/* pos_cnum */3] !== 31 || match$42[/* loc_ghost */2] !== 0 || match$36[2])) {
+                                                                        if (match$44[/* pos_fname */0] === "" && !(match$44[/* pos_lnum */1] !== 3 || match$44[/* pos_bol */2] !== 10 || match$44[/* pos_cnum */3] !== 31 || match$42[/* loc_ghost */2] || match$36[2])) {
                                                                           var match$45 = match$35[/* ctyp_type */1];
                                                                           var match$46 = match$45[/* desc */0];
                                                                           if (typeof match$46 === "number" || match$46.tag !== 3) {
-                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                           } else {
                                                                             var match$47 = match$46[0];
                                                                             switch (match$47.tag | 0) {
@@ -76602,7 +76601,7 @@ if (match$1) {
                                                                                   if (match$48[/* name */1] === "int") {
                                                                                     var match$49 = match$48[/* flags */2];
                                                                                     if (match$49 !== 0 || match$46[1]) {
-                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                     } else {
                                                                                       var match$50 = match$46[2][/* contents */0];
                                                                                       if (typeof match$50 === "number") {
@@ -76610,11 +76609,11 @@ if (match$1) {
                                                                                         var match$52 = match$51[/* loc_start */0];
                                                                                         if (match$52[/* pos_fname */0] === "" && !(match$52[/* pos_lnum */1] !== 3 || match$52[/* pos_bol */2] !== 10 || match$52[/* pos_cnum */3] !== 28)) {
                                                                                           var match$53 = match$51[/* loc_end */1];
-                                                                                          if (match$53[/* pos_fname */0] === "" && !(match$53[/* pos_lnum */1] !== 3 || match$53[/* pos_bol */2] !== 10 || match$53[/* pos_cnum */3] !== 31 || match$51[/* loc_ghost */2] !== 0 || match$35[/* ctyp_attributes */4])) {
+                                                                                          if (match$53[/* pos_fname */0] === "" && !(match$53[/* pos_lnum */1] !== 3 || match$53[/* pos_bol */2] !== 10 || match$53[/* pos_cnum */3] !== 31 || match$51[/* loc_ghost */2] || match$35[/* ctyp_attributes */4])) {
                                                                                             var match$54 = match$34[2];
                                                                                             var match$55 = match$54[/* ctyp_desc */0];
                                                                                             if (typeof match$55 === "number" || match$55.tag !== 3) {
-                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                             } else {
                                                                                               var match$56 = match$55[0];
                                                                                               switch (match$56.tag | 0) {
@@ -76623,7 +76622,7 @@ if (match$1) {
                                                                                                     if (match$57[/* name */1] === "int") {
                                                                                                       var match$58 = match$57[/* flags */2];
                                                                                                       if (match$58 !== 0) {
-                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                       } else {
                                                                                                         var match$59 = match$55[1];
                                                                                                         var match$60 = match$59[/* txt */0];
@@ -76634,11 +76633,11 @@ if (match$1) {
                                                                                                                 var match$62 = match$61[/* loc_start */0];
                                                                                                                 if (match$62[/* pos_fname */0] === "" && !(match$62[/* pos_lnum */1] !== 3 || match$62[/* pos_bol */2] !== 10 || match$62[/* pos_cnum */3] !== 35)) {
                                                                                                                   var match$63 = match$61[/* loc_end */1];
-                                                                                                                  if (match$63[/* pos_fname */0] === "" && !(match$63[/* pos_lnum */1] !== 3 || match$63[/* pos_bol */2] !== 10 || match$63[/* pos_cnum */3] !== 38 || match$61[/* loc_ghost */2] !== 0 || match$55[2])) {
+                                                                                                                  if (match$63[/* pos_fname */0] === "" && !(match$63[/* pos_lnum */1] !== 3 || match$63[/* pos_bol */2] !== 10 || match$63[/* pos_cnum */3] !== 38 || match$61[/* loc_ghost */2] || match$55[2])) {
                                                                                                                     var match$64 = match$54[/* ctyp_type */1];
                                                                                                                     var match$65 = match$64[/* desc */0];
                                                                                                                     if (typeof match$65 === "number" || match$65.tag !== 3) {
-                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                     } else {
                                                                                                                       var match$66 = match$65[0];
                                                                                                                       switch (match$66.tag | 0) {
@@ -76647,7 +76646,7 @@ if (match$1) {
                                                                                                                             if (match$67[/* name */1] === "int") {
                                                                                                                               var match$68 = match$67[/* flags */2];
                                                                                                                               if (match$68 !== 0 || match$65[1]) {
-                                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                               } else {
                                                                                                                                 var match$69 = match$65[2][/* contents */0];
                                                                                                                                 if (typeof match$69 === "number") {
@@ -76655,15 +76654,15 @@ if (match$1) {
                                                                                                                                   var match$71 = match$70[/* loc_start */0];
                                                                                                                                   if (match$71[/* pos_fname */0] === "" && !(match$71[/* pos_lnum */1] !== 3 || match$71[/* pos_bol */2] !== 10 || match$71[/* pos_cnum */3] !== 35)) {
                                                                                                                                     var match$72 = match$70[/* loc_end */1];
-                                                                                                                                    if (match$72[/* pos_fname */0] === "" && !(match$72[/* pos_lnum */1] !== 3 || match$72[/* pos_bol */2] !== 10 || match$72[/* pos_cnum */3] !== 38 || match$70[/* loc_ghost */2] !== 0 || match$54[/* ctyp_attributes */4])) {
+                                                                                                                                    if (match$72[/* pos_fname */0] === "" && !(match$72[/* pos_lnum */1] !== 3 || match$72[/* pos_bol */2] !== 10 || match$72[/* pos_cnum */3] !== 38 || match$70[/* loc_ghost */2] || match$54[/* ctyp_attributes */4])) {
                                                                                                                                       var match$73 = match$33[/* ctyp_type */1];
                                                                                                                                       var match$74 = match$73[/* desc */0];
                                                                                                                                       if (typeof match$74 === "number" || !(match$74.tag === 1 && match$74[0] === "")) {
-                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                       } else {
                                                                                                                                         var match$75 = match$74[1][/* desc */0];
                                                                                                                                         if (typeof match$75 === "number" || match$75.tag !== 3) {
-                                                                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                         } else {
                                                                                                                                           var match$76 = match$75[0];
                                                                                                                                           switch (match$76.tag | 0) {
@@ -76672,13 +76671,13 @@ if (match$1) {
                                                                                                                                                 if (match$77[/* name */1] === "int") {
                                                                                                                                                   var match$78 = match$77[/* flags */2];
                                                                                                                                                   if (match$78 !== 0 || match$75[1]) {
-                                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                   } else {
                                                                                                                                                     var match$79 = match$75[2][/* contents */0];
                                                                                                                                                     if (typeof match$79 === "number") {
                                                                                                                                                       var match$80 = match$74[2][/* desc */0];
                                                                                                                                                       if (typeof match$80 === "number" || match$80.tag !== 3) {
-                                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                       } else {
                                                                                                                                                         var match$81 = match$80[0];
                                                                                                                                                         switch (match$81.tag | 0) {
@@ -76687,7 +76686,7 @@ if (match$1) {
                                                                                                                                                               if (match$82[/* name */1] === "int") {
                                                                                                                                                                 var match$83 = match$82[/* flags */2];
                                                                                                                                                                 if (match$83 !== 0 || match$80[1]) {
-                                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                 } else {
                                                                                                                                                                   var match$84 = match$80[2][/* contents */0];
                                                                                                                                                                   if (typeof match$84 === "number") {
@@ -76697,15 +76696,15 @@ if (match$1) {
                                                                                                                                                                       var match$87 = match$86[/* loc_start */0];
                                                                                                                                                                       if (match$87[/* pos_fname */0] === "" && !(match$87[/* pos_lnum */1] !== 3 || match$87[/* pos_bol */2] !== 10 || match$87[/* pos_cnum */3] !== 28)) {
                                                                                                                                                                         var match$88 = match$86[/* loc_end */1];
-                                                                                                                                                                        if (match$88[/* pos_fname */0] === "" && !(match$88[/* pos_lnum */1] !== 3 || match$88[/* pos_bol */2] !== 10 || match$88[/* pos_cnum */3] !== 38 || match$86[/* loc_ghost */2] !== 0 || match$33[/* ctyp_attributes */4])) {
+                                                                                                                                                                        if (match$88[/* pos_fname */0] === "" && !(match$88[/* pos_lnum */1] !== 3 || match$88[/* pos_bol */2] !== 10 || match$88[/* pos_cnum */3] !== 38 || match$86[/* loc_ghost */2] || match$33[/* ctyp_attributes */4])) {
                                                                                                                                                                           var match$89 = match$26[/* val_val */3];
                                                                                                                                                                           var match$90 = match$89[/* val_type */0][/* desc */0];
                                                                                                                                                                           if (typeof match$90 === "number" || !(match$90.tag === 1 && match$90[0] === "")) {
-                                                                                                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                           } else {
                                                                                                                                                                             var match$91 = match$90[1][/* desc */0];
                                                                                                                                                                             if (typeof match$91 === "number" || match$91.tag !== 3) {
-                                                                                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                             } else {
                                                                                                                                                                               var match$92 = match$91[0];
                                                                                                                                                                               switch (match$92.tag | 0) {
@@ -76714,13 +76713,13 @@ if (match$1) {
                                                                                                                                                                                     if (match$93[/* name */1] === "int") {
                                                                                                                                                                                       var match$94 = match$93[/* flags */2];
                                                                                                                                                                                       if (match$94 !== 0 || match$91[1]) {
-                                                                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                       } else {
                                                                                                                                                                                         var match$95 = match$91[2][/* contents */0];
                                                                                                                                                                                         if (typeof match$95 === "number") {
                                                                                                                                                                                           var match$96 = match$90[2][/* desc */0];
                                                                                                                                                                                           if (typeof match$96 === "number" || match$96.tag !== 3) {
-                                                                                                                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                           } else {
                                                                                                                                                                                             var match$97 = match$96[0];
                                                                                                                                                                                             switch (match$97.tag | 0) {
@@ -76729,7 +76728,7 @@ if (match$1) {
                                                                                                                                                                                                   if (match$98[/* name */1] === "int") {
                                                                                                                                                                                                     var match$99 = match$98[/* flags */2];
                                                                                                                                                                                                     if (match$99 !== 0 || match$96[1]) {
-                                                                                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                     } else {
                                                                                                                                                                                                       var match$100 = match$96[2][/* contents */0];
                                                                                                                                                                                                       if (typeof match$100 === "number") {
@@ -76737,264 +76736,264 @@ if (match$1) {
                                                                                                                                                                                                         if (typeof match$101 === "number" && match$101 === 0) {
                                                                                                                                                                                                           var match$102 = match$89[/* val_kind */1];
                                                                                                                                                                                                           if (typeof match$102 === "number" || match$102.tag) {
-                                                                                                                                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                           } else {
                                                                                                                                                                                                             var match$103 = match$102[0];
-                                                                                                                                                                                                            if (match$103[/* prim_name */0] === "%negint" && !(match$103[/* prim_arity */1] !== 1 || !(match$103[/* prim_alloc */2] !== 0 && match$103[/* prim_native_name */3] === "" && match$103[/* prim_native_float */4] === 0))) {
+                                                                                                                                                                                                            if (match$103[/* prim_name */0] === "%negint" && !(match$103[/* prim_arity */1] !== 1 || !(match$103[/* prim_alloc */2] && match$103[/* prim_native_name */3] === "" && !match$103[/* prim_native_float */4]))) {
                                                                                                                                                                                                               var match$104 = match$89[/* val_loc */2];
                                                                                                                                                                                                               var match$105 = match$104[/* loc_start */0];
                                                                                                                                                                                                               if (match$105[/* pos_fname */0] === "" && !(match$105[/* pos_lnum */1] !== 3 || match$105[/* pos_bol */2] !== 10 || match$105[/* pos_cnum */3] !== 10)) {
                                                                                                                                                                                                                 var match$106 = match$104[/* loc_end */1];
-                                                                                                                                                                                                                if (match$106[/* pos_fname */0] === "" && !(match$106[/* pos_lnum */1] !== 3 || match$106[/* pos_bol */2] !== 10 || match$106[/* pos_cnum */3] !== 50 || match$104[/* loc_ghost */2] !== 0 || match$89[/* val_attributes */3])) {
-                                                                                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 220, characters 14-21", /* true */1, /* true */1);
+                                                                                                                                                                                                                if (match$106[/* pos_fname */0] === "" && !(match$106[/* pos_lnum */1] !== 3 || match$106[/* pos_bol */2] !== 10 || match$106[/* pos_cnum */3] !== 50 || match$104[/* loc_ghost */2] || match$89[/* val_attributes */3])) {
+                                                                                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 220, characters 14-21", true, true);
                                                                                                                                                                                                                 } else {
-                                                                                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                                 }
                                                                                                                                                                                                               } else {
-                                                                                                                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                               }
                                                                                                                                                                                                             } else {
-                                                                                                                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                             }
                                                                                                                                                                                                           }
                                                                                                                                                                                                         } else {
-                                                                                                                                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                         }
                                                                                                                                                                                                       } else {
-                                                                                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                       }
                                                                                                                                                                                                     }
                                                                                                                                                                                                   } else {
-                                                                                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                   }
                                                                                                                                                                                                   break;
                                                                                                                                                                                               case 1 : 
                                                                                                                                                                                               case 2 : 
-                                                                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                                   break;
                                                                                                                                                                                               
                                                                                                                                                                                             }
                                                                                                                                                                                           }
                                                                                                                                                                                         } else {
-                                                                                                                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                         }
                                                                                                                                                                                       }
                                                                                                                                                                                     } else {
-                                                                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                     }
                                                                                                                                                                                     break;
                                                                                                                                                                                 case 1 : 
                                                                                                                                                                                 case 2 : 
-                                                                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                                     break;
                                                                                                                                                                                 
                                                                                                                                                                               }
                                                                                                                                                                             }
                                                                                                                                                                           }
                                                                                                                                                                         } else {
-                                                                                                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                         }
                                                                                                                                                                       } else {
-                                                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                       }
                                                                                                                                                                     } else {
-                                                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                     }
                                                                                                                                                                   } else {
-                                                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                                   }
                                                                                                                                                                 }
                                                                                                                                                               } else {
-                                                                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                               }
                                                                                                                                                               break;
                                                                                                                                                           case 1 : 
                                                                                                                                                           case 2 : 
-                                                                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                               break;
                                                                                                                                                           
                                                                                                                                                         }
                                                                                                                                                       }
                                                                                                                                                     } else {
-                                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                     }
                                                                                                                                                   }
                                                                                                                                                 } else {
-                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                 }
                                                                                                                                                 break;
                                                                                                                                             case 1 : 
                                                                                                                                             case 2 : 
-                                                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                                 break;
                                                                                                                                             
                                                                                                                                           }
                                                                                                                                         }
                                                                                                                                       }
                                                                                                                                     } else {
-                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                     }
                                                                                                                                   } else {
-                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                   }
                                                                                                                                 } else {
-                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                                 }
                                                                                                                               }
                                                                                                                             } else {
-                                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                             }
                                                                                                                             break;
                                                                                                                         case 1 : 
                                                                                                                         case 2 : 
-                                                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                             break;
                                                                                                                         
                                                                                                                       }
                                                                                                                     }
                                                                                                                   } else {
-                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                   }
                                                                                                                 } else {
-                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                                 }
                                                                                                               } else {
-                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                               }
                                                                                                               break;
                                                                                                           case 1 : 
                                                                                                           case 2 : 
-                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                               break;
                                                                                                           
                                                                                                         }
                                                                                                       }
                                                                                                     } else {
-                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                     }
                                                                                                     break;
                                                                                                 case 1 : 
                                                                                                 case 2 : 
-                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                                     break;
                                                                                                 
                                                                                               }
                                                                                             }
                                                                                           } else {
-                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                           }
                                                                                         } else {
-                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                         }
                                                                                       } else {
-                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                       }
                                                                                     }
                                                                                   } else {
-                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                   }
                                                                                   break;
                                                                               case 1 : 
                                                                               case 2 : 
-                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                                   break;
                                                                               
                                                                             }
                                                                           }
                                                                         } else {
-                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                         }
                                                                       } else {
-                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                       }
                                                                     } else {
-                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                     }
                                                                     break;
                                                                 case 1 : 
                                                                 case 2 : 
-                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                                     break;
                                                                 
                                                               }
                                                             }
                                                           } else {
-                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                           }
                                                           break;
                                                       case 1 : 
                                                       case 2 : 
-                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                                           break;
                                                       
                                                     }
                                                   }
                                                 }
                                               } else {
-                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                               }
                                             } else {
-                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                             }
                                           } else {
-                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                           }
                                         }
                                       } else {
-                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                       }
                                     } else {
-                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                     }
                                   } else {
-                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                   }
                                 } else {
-                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                                 }
                               } else {
-                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                               }
                             } else {
-                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                             }
                           } else {
-                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                           }
                         } else {
-                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                          eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                         }
                       } else {
-                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                       }
                     } else {
-                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                     }
                   } else {
-                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
                   }
                 }
               } else {
-                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+                eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
               }
             } else {
-              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+              eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
             }
           } else {
-            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+            eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
           }
         }
       } else {
-        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+        eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
       }
     } else {
-      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+      eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
     }
   } else {
-    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+    eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
   }
 } else {
-  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", /* true */1, /* false */0);
+  eq("File \"ocaml_typed_tree_main.ml\", line 221, characters 12-19", true, false);
 }
 
 from_pair_suites("ocaml_typed_tree_main.ml", suites[0]);

--- a/jscomp/test/offset.js
+++ b/jscomp/test/offset.js
@@ -219,7 +219,7 @@ function split(x, param) {
     if (c === 0) {
       return /* tuple */[
               l,
-              /* true */1,
+              true,
               r
             ];
     } else if (c < 0) {
@@ -240,7 +240,7 @@ function split(x, param) {
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0,
+            false,
             /* Empty */0
           ];
   }
@@ -248,9 +248,9 @@ function split(x, param) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -260,13 +260,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -334,7 +334,7 @@ function inter(s1, s2) {
     var l1 = s1[0];
     var match = split(v1, s2);
     var l2 = match[0];
-    if (match[1] !== 0) {
+    if (match[1]) {
       return join(inter(l1, l2), v1, inter(r1, match[2]));
     } else {
       return concat(inter(l1, l2), inter(r1, match[2]));
@@ -352,7 +352,7 @@ function diff(s1, s2) {
       var l1 = s1[0];
       var match = split(v1, s2);
       var l2 = match[0];
-      if (match[1] !== 0) {
+      if (match[1]) {
         return concat(diff(l1, l2), diff(r1, match[2]));
       } else {
         return join(diff(l1, l2), v1, diff(r1, match[2]));
@@ -411,7 +411,7 @@ function compare(s1, s2) {
 }
 
 function equal(s1, s2) {
-  return +(compare(s1, s2) === 0);
+  return compare(s1, s2) === 0;
 }
 
 function subset(_s1, _s2) {
@@ -432,7 +432,7 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (c < 0) {
           if (subset(/* Node */[
@@ -444,7 +444,7 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (subset(/* Node */[
                 /* Empty */0,
@@ -455,13 +455,13 @@ function subset(_s1, _s2) {
           _s1 = l1;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -502,10 +502,10 @@ function for_all(p, _param) {
         _param = param[2];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -515,13 +515,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._1(p, param[1]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }

--- a/jscomp/test/poly_variant_test.js
+++ b/jscomp/test/poly_variant_test.js
@@ -53,13 +53,13 @@ var uu = /* array */[
   hey_string("in")
 ];
 
-var vv = /* int array */[
+var vv = /* array */[
   hey_int(3),
   hey_int(0),
   hey_int(4)
 ];
 
-eq("File \"poly_variant_test.ml\", line 58, characters 5-12", vv, /* int array */[
+eq("File \"poly_variant_test.ml\", line 58, characters 5-12", vv, /* array */[
       3,
       0,
       4

--- a/jscomp/test/ppx_this_obj_field.js
+++ b/jscomp/test/ppx_this_obj_field.js
@@ -129,7 +129,7 @@ var eventObj = {
     }),
   needRebuild: (function () {
       var self = this ;
-      return +(self.events.length !== 0);
+      return self.events.length !== 0;
     })
 };
 

--- a/jscomp/test/prepend_data_ffi.js
+++ b/jscomp/test/prepend_data_ffi.js
@@ -30,12 +30,12 @@ process.on((function (i) {
 xx(3, 3, "xxx", "a", "b");
 
 function f(x) {
-  x.xx(110, /* int array */[
+  x.xx(110, /* array */[
         1,
         2,
         3
       ]);
-  x.xx(111, 3, "xxx", /* int array */[
+  x.xx(111, 3, "xxx", /* array */[
         1,
         2,
         3

--- a/jscomp/test/promise_catch_test.js
+++ b/jscomp/test/promise_catch_test.js
@@ -75,8 +75,8 @@ try {
 }
 catch (raw_e){
   var e = Js_exn.internalToOCamlException(raw_e);
-  eq("File \"promise_catch_test.ml\", line 36, characters 7-14", /* true */1, Js_option.isSomeValue((function (xxx, y) {
-              return +(xxx === y);
+  eq("File \"promise_catch_test.ml\", line 36, characters 7-14", true, Js_option.isSomeValue((function (xxx, y) {
+              return xxx === y;
             }), 2, myHandler(e)));
 }
 

--- a/jscomp/test/qcc.js
+++ b/jscomp/test/qcc.js
@@ -18,7 +18,7 @@ var Caml_string = require("../../lib/js/caml_string.js");
 var Caml_missing_polyfill = require("../../lib/js/caml_missing_polyfill.js");
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js");
 
-var dbg = [/* true */1];
+var dbg = [true];
 
 var inch = [Pervasives.stdin];
 
@@ -131,14 +131,14 @@ function isid(param) {
   var switcher = param - 91 | 0;
   if (switcher > 5 || switcher < 0) {
     if ((switcher + 26 >>> 0) > 57) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   } else if (switcher !== 4) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -475,7 +475,7 @@ function patchlval() {
 }
 
 function read(param) {
-  if (param !== 0) {
+  if (param) {
     out(4722614);
     le(8, 0);
     lval[0] = /* tuple */[
@@ -835,7 +835,7 @@ function binary(stk, lvl) {
       };
     } else {
       var loc = foldtst(0);
-      return patch(/* true */1, loc, opos[0]);
+      return patch(true, loc, opos[0]);
     }
   }
 }
@@ -1256,13 +1256,13 @@ function stmt(brk, stk) {
       out(233);
       var l = opos[0];
       le(32, 0);
-      patch(/* true */1, loc, opos[0]);
+      patch(true, loc, opos[0]);
       stmt(brk, stk);
       loc$1 = l;
     } else {
       loc$1 = loc;
     }
-    return patch(/* true */1, loc$1, opos[0]);
+    return patch(true, loc$1, opos[0]);
   } else if (Caml_obj.caml_equal(t, tokwhile) || Caml_obj.caml_equal(t, tokfor)) {
     var bl = [0];
     var ba = align[0];
@@ -1302,14 +1302,14 @@ function stmt(brk, stk) {
         itr
       ];
     }
-    patch(/* true */1, match[0], opos[0]);
+    patch(true, match[0], opos[0]);
     stmt(/* tuple */[
           bl,
           ba
         ], stk);
     out(233);
     le(32, (match[1] - opos[0] | 0) - 4 | 0);
-    return patch(/* true */1, bl[0], opos[0]);
+    return patch(true, bl[0], opos[0]);
   } else if (Caml_obj.caml_equal(t, tokret)) {
     if (!nextis(/* Op */Block.__(0, [";"]))) {
       expr(stk);
@@ -1365,7 +1365,7 @@ function stmt(brk, stk) {
 }
 
 function block(brk, stk) {
-  var match = decl(/* false */0, 0, stk);
+  var match = decl(false, 0, stk);
   var stk$prime = match[1];
   var n = match[0];
   while(!nextis(/* Op */Block.__(0, ["}"]))) {
@@ -1387,7 +1387,7 @@ function top(_param) {
     if (nextis(/* Op */Block.__(0, ["EOF!"]))) {
       return 0;
     } else if (nextis(tokint)) {
-      decl(/* true */1, 0, /* [] */0);
+      decl(true, 0, /* [] */0);
       _param = /* () */0;
       continue ;
     } else {
@@ -1480,7 +1480,7 @@ function top(_param) {
               [0],
               0
             ], stk);
-        patch(/* true */1, retl[0], opos[0]);
+        patch(true, retl[0], opos[0]);
         out(51651);
         if (dbg[0]) {
           Curry._1(Printf.eprintf(/* Format */[
@@ -1600,9 +1600,9 @@ function elfgen(outf) {
   var patchloc = function (i, _) {
     var g = Caml_array.caml_array_get(globs, i);
     if (g[/* va */1] >= 0 && g[/* va */1] < 4194304) {
-      return patch(/* false */0, g[/* loc */0], va(g[/* va */1]));
+      return patch(false, g[/* loc */0], va(g[/* va */1]));
     } else if (g[/* va */1] >= 0) {
-      return patch(/* false */0, g[/* loc */0], g[/* va */1]);
+      return patch(false, g[/* loc */0], g[/* va */1]);
     } else {
       return 0;
     }
@@ -1738,7 +1738,7 @@ function elfgen(outf) {
           ]
         ];
   }
-  patch(/* false */0, 24, va(entry));
+  patch(false, 24, va(entry));
   return Pervasives.output_bytes(outf, Bytes.sub(obuf, 0, tend + off | 0));
 }
 

--- a/jscomp/test/queue_test.js
+++ b/jscomp/test/queue_test.js
@@ -29,7 +29,7 @@ function queue_1(x) {
 var suites_000 = /* tuple */[
   "simple push",
   (function () {
-      var x = /* int array */[
+      var x = /* array */[
         3,
         4,
         5,

--- a/jscomp/test/random_test.js
+++ b/jscomp/test/random_test.js
@@ -43,23 +43,23 @@ Mt_global.collect_neq(id, suites, "File \"random_test.ml\", line 12, characters 
 
 Random.init(0);
 
-var v = Caml_array.caml_make_vect(10, /* false */0);
+var v = Caml_array.caml_make_vect(10, false);
 
 for(var i = 0; i <= 9; ++i){
   Caml_array.caml_array_set(v, i, Random.bool(/* () */0));
 }
 
 var param$2 = /* array */[
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* false */0,
-  /* true */1,
-  /* true */1,
-  /* true */1,
-  /* false */0
+  true,
+  true,
+  true,
+  true,
+  true,
+  false,
+  true,
+  true,
+  true,
+  false
 ];
 
 Mt_global.collect_eq(id, suites, "File \"random_test.ml\", line 26, characters 5-12", v, param$2);

--- a/jscomp/test/rbset.js
+++ b/jscomp/test/rbset.js
@@ -4,7 +4,7 @@ var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js")
 
 function blackify(s) {
   if (s) {
-    if (s[0] !== 0) {
+    if (s[0]) {
       return /* tuple */[
               /* Node */[
                 /* Black */0,
@@ -12,27 +12,27 @@ function blackify(s) {
                 s[2],
                 s[3]
               ],
-              /* false */0
+              false
             ];
     } else {
       return /* tuple */[
               s,
-              /* true */1
+              true
             ];
     }
   } else {
     return /* tuple */[
             s,
-            /* true */1
+            true
           ];
   }
 }
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -42,7 +42,7 @@ function mem(x, _param) {
     if (param) {
       var y = param[2];
       if (x === y) {
-        return /* true */1;
+        return true;
       } else if (x < y) {
         _param = param[1];
         continue ;
@@ -51,7 +51,7 @@ function mem(x, _param) {
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -65,10 +65,10 @@ function balance_left(l, x, r) {
   var c;
   var z;
   var d;
-  if (l && l[0] !== 0) {
+  if (l && l[0]) {
     var a$1 = l[1];
     var exit$1 = 0;
-    if (a$1 && a$1[0] !== 0) {
+    if (a$1 && a$1[0]) {
       a = a$1[1];
       x$1 = a$1[2];
       b = a$1[3];
@@ -82,7 +82,7 @@ function balance_left(l, x, r) {
     }
     if (exit$1 === 3) {
       var match = l[3];
-      if (match && match[0] !== 0) {
+      if (match && match[0]) {
         a = a$1;
         x$1 = l[2];
         b = match[1];
@@ -137,10 +137,10 @@ function balance_right(l, x, r) {
   var c;
   var z;
   var d;
-  if (r && r[0] !== 0) {
+  if (r && r[0]) {
     var b$1 = r[1];
     var exit$1 = 0;
-    if (b$1 && b$1[0] !== 0) {
+    if (b$1 && b$1[0]) {
       a = l;
       x$1 = x;
       b = b$1[1];
@@ -154,7 +154,7 @@ function balance_right(l, x, r) {
     }
     if (exit$1 === 3) {
       var match = r[3];
-      if (match && match[0] !== 0) {
+      if (match && match[0]) {
         a = l;
         x$1 = x;
         b = b$1;
@@ -212,9 +212,9 @@ function singleton(x) {
 function unbalanced_left(param) {
   var exit = 0;
   if (param) {
-    if (param[0] !== 0) {
+    if (param[0]) {
       var match = param[1];
-      if (match && match[0] === 0) {
+      if (match && !match[0]) {
         return /* tuple */[
                 balance_left(/* Node */[
                       /* Red */1,
@@ -222,7 +222,7 @@ function unbalanced_left(param) {
                       match[2],
                       match[3]
                     ], param[2], param[3]),
-                /* false */0
+                false
               ];
       } else {
         exit = 1;
@@ -230,9 +230,9 @@ function unbalanced_left(param) {
     } else {
       var match$1 = param[1];
       if (match$1) {
-        if (match$1[0] !== 0) {
+        if (match$1[0]) {
           var match$2 = match$1[3];
-          if (match$2 && match$2[0] === 0) {
+          if (match$2 && !match$2[0]) {
             return /* tuple */[
                     /* Node */[
                       /* Black */0,
@@ -245,7 +245,7 @@ function unbalanced_left(param) {
                             match$2[3]
                           ], param[2], param[3])
                     ],
-                    /* false */0
+                    false
                   ];
           } else {
             exit = 1;
@@ -258,7 +258,7 @@ function unbalanced_left(param) {
                         match$1[2],
                         match$1[3]
                       ], param[2], param[3]),
-                  /* true */1
+                  true
                 ];
         }
       } else {
@@ -284,9 +284,9 @@ function unbalanced_left(param) {
 function unbalanced_right(param) {
   var exit = 0;
   if (param) {
-    if (param[0] !== 0) {
+    if (param[0]) {
       var match = param[3];
-      if (match && match[0] === 0) {
+      if (match && !match[0]) {
         return /* tuple */[
                 balance_right(param[1], param[2], /* Node */[
                       /* Red */1,
@@ -294,7 +294,7 @@ function unbalanced_right(param) {
                       match[2],
                       match[3]
                     ]),
-                /* false */0
+                false
               ];
       } else {
         exit = 1;
@@ -304,9 +304,9 @@ function unbalanced_right(param) {
       if (match$1) {
         var x = param[2];
         var a = param[1];
-        if (match$1[0] !== 0) {
+        if (match$1[0]) {
           var match$2 = match$1[1];
-          if (match$2 && match$2[0] === 0) {
+          if (match$2 && !match$2[0]) {
             return /* tuple */[
                     /* Node */[
                       /* Black */0,
@@ -319,7 +319,7 @@ function unbalanced_right(param) {
                       match$1[2],
                       match$1[3]
                     ],
-                    /* false */0
+                    false
                   ];
           } else {
             exit = 1;
@@ -332,7 +332,7 @@ function unbalanced_right(param) {
                         match$1[2],
                         match$1[3]
                       ]),
-                  /* true */1
+                  true
                 ];
         }
       } else {
@@ -357,11 +357,11 @@ function unbalanced_right(param) {
 
 function lbalance(x1, x2, x3) {
   if (x1) {
-    if (x1[0] !== 0) {
+    if (x1[0]) {
       var r = x1[3];
       var l = x1[1];
       var exit = 0;
-      if (l && l[0] !== 0) {
+      if (l && l[0]) {
         return /* Node */[
                 /* Red */1,
                 /* Node */[
@@ -383,7 +383,7 @@ function lbalance(x1, x2, x3) {
       }
       if (exit === 1) {
         if (r) {
-          if (r[0] !== 0) {
+          if (r[0]) {
             var y = r[2];
             return /* Node */[
                     /* Red */1,
@@ -439,10 +439,10 @@ function lbalance(x1, x2, x3) {
 
 function rbalance(x1, x2, x3) {
   var exit = 0;
-  if (x3 && x3[0] !== 0) {
+  if (x3 && x3[0]) {
     var b = x3[1];
     var exit$1 = 0;
-    if (b && b[0] !== 0) {
+    if (b && b[0]) {
       return /* Node */[
               /* Red */1,
               /* Node */[
@@ -464,7 +464,7 @@ function rbalance(x1, x2, x3) {
     }
     if (exit$1 === 2) {
       var match = x3[3];
-      if (match && match[0] !== 0) {
+      if (match && match[0]) {
         return /* Node */[
                 /* Red */1,
                 /* Node */[
@@ -502,7 +502,7 @@ function rbalance(x1, x2, x3) {
 
 function ins(x, s) {
   if (s) {
-    if (s[0] !== 0) {
+    if (s[0]) {
       var y = s[2];
       if (x === y) {
         return s;
@@ -551,7 +551,7 @@ function ins(x, s) {
 
 function add(x, s) {
   var s$1 = ins(x, s);
-  if (s$1 && s$1[0] !== 0) {
+  if (s$1 && s$1[0]) {
     return /* Node */[
             /* Black */0,
             s$1[1],
@@ -567,14 +567,14 @@ function remove_min(param) {
   if (param) {
     var c = param[0];
     var exit = 0;
-    if (c !== 0) {
+    if (c) {
       if (param[1]) {
         exit = 1;
       } else {
         return /* tuple */[
                 param[3],
                 param[2],
-                /* false */0
+                false
               ];
       }
     } else if (param[1]) {
@@ -583,7 +583,7 @@ function remove_min(param) {
       var match = param[3];
       var x = param[2];
       if (match) {
-        if (match[0] !== 0) {
+        if (match[0]) {
           return /* tuple */[
                   /* Node */[
                     /* Black */0,
@@ -592,7 +592,7 @@ function remove_min(param) {
                     match[3]
                   ],
                   x,
-                  /* false */0
+                  false
                 ];
         } else {
           throw [
@@ -608,7 +608,7 @@ function remove_min(param) {
         return /* tuple */[
                 /* Empty */0,
                 x,
-                /* true */1
+                true
               ];
       }
     }
@@ -635,7 +635,7 @@ function remove_min(param) {
         return /* tuple */[
                 s,
                 y,
-                /* false */0
+                false
               ];
       }
     }
@@ -674,13 +674,13 @@ function remove_aux(x, n) {
         } else {
           return /* tuple */[
                   n$1,
-                  /* false */0
+                  false
                 ];
         }
       } else if (c === /* Red */1) {
         return /* tuple */[
                 l,
-                /* false */0
+                false
               ];
       } else {
         return blackify(l);
@@ -699,7 +699,7 @@ function remove_aux(x, n) {
       } else {
         return /* tuple */[
                 n$2,
-                /* false */0
+                false
               ];
       }
     } else {
@@ -716,14 +716,14 @@ function remove_aux(x, n) {
       } else {
         return /* tuple */[
                 n$3,
-                /* false */0
+                false
               ];
       }
     }
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0
+            false
           ];
   }
 }

--- a/jscomp/test/rec_fun_test.js
+++ b/jscomp/test/rec_fun_test.js
@@ -33,12 +33,12 @@ function g() {
   var next = function (i, b) {
     called[0] = called[0] + 1 | 0;
     if (b) {
-      Curry._2(v[0], i, /* false */0);
+      Curry._2(v[0], i, false);
     }
     return i + 1 | 0;
   };
   Caml_obj.caml_update_dummy(v, [next]);
-  console.log(String(next(0, /* true */1)));
+  console.log(String(next(0, true)));
   return /* () */0;
 }
 

--- a/jscomp/test/rec_module_test.js
+++ b/jscomp/test/rec_module_test.js
@@ -22,9 +22,9 @@ var B = Caml_module.init_mod([
 
 function even(n) {
   if (n === 0) {
-    return /* true */1;
+    return true;
   } else if (n === 1) {
-    return /* false */0;
+    return false;
   } else {
     return Curry._1(B[/* odd */0], n - 1 | 0);
   }
@@ -34,9 +34,9 @@ Caml_module.update_mod([[0]], A, /* module */[/* even */even]);
 
 function odd(n) {
   if (n === 1) {
-    return /* true */1;
+    return true;
   } else if (n === 0) {
-    return /* false */0;
+    return false;
   } else {
     return Curry._1(A[/* even */0], n - 1 | 0);
   }
@@ -64,9 +64,9 @@ var BB = Caml_module.init_mod([
 
 function even$1(n) {
   if (n === 0) {
-    return /* true */1;
+    return true;
   } else if (n === 1) {
-    return /* false */0;
+    return false;
   } else {
     return Curry._1(BB[/* odd */0], n - 1 | 0);
   }
@@ -86,9 +86,9 @@ Caml_module.update_mod([[
 
 function odd$1(n) {
   if (n === 1) {
-    return /* true */1;
+    return true;
   } else if (n === 0) {
-    return /* false */0;
+    return false;
   } else {
     return Curry._1(AA[/* even */0], n - 1 | 0);
   }
@@ -325,7 +325,7 @@ function split(x, param) {
     if (c === 0) {
       return /* tuple */[
               l,
-              /* true */1,
+              true,
               r
             ];
     } else if (c < 0) {
@@ -346,7 +346,7 @@ function split(x, param) {
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0,
+            false,
             /* Empty */0
           ];
   }
@@ -354,9 +354,9 @@ function split(x, param) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -366,13 +366,13 @@ function mem(x, _param) {
     if (param) {
       var c = Curry._2(AAA[/* compare */0], x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -440,7 +440,7 @@ function inter(s1, s2) {
     var l1 = s1[0];
     var match = split(v1, s2);
     var l2 = match[0];
-    if (match[1] !== 0) {
+    if (match[1]) {
       return join(inter(l1, l2), v1, inter(r1, match[2]));
     } else {
       return concat(inter(l1, l2), inter(r1, match[2]));
@@ -458,7 +458,7 @@ function diff(s1, s2) {
       var l1 = s1[0];
       var match = split(v1, s2);
       var l2 = match[0];
-      if (match[1] !== 0) {
+      if (match[1]) {
         return concat(diff(l1, l2), diff(r1, match[2]));
       } else {
         return join(diff(l1, l2), v1, diff(r1, match[2]));
@@ -517,7 +517,7 @@ function compare(s1, s2) {
 }
 
 function equal(s1, s2) {
-  return +(compare(s1, s2) === 0);
+  return compare(s1, s2) === 0;
 }
 
 function subset(_s1, _s2) {
@@ -538,7 +538,7 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (c < 0) {
           if (subset(/* Node */[
@@ -550,7 +550,7 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (subset(/* Node */[
                 /* Empty */0,
@@ -561,13 +561,13 @@ function subset(_s1, _s2) {
           _s1 = l1;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -608,10 +608,10 @@ function for_all(p, _param) {
         _param = param[2];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -621,13 +621,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._1(p, param[1]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -923,10 +923,10 @@ var suites_000 = /* tuple */[
   (function () {
       return /* Eq */Block.__(0, [
                 /* tuple */[
-                  /* true */1,
-                  /* true */1,
-                  /* false */0,
-                  /* false */0
+                  true,
+                  true,
+                  false,
+                  false
                 ],
                 /* tuple */[
                   Curry._1(A[/* even */0], 2),
@@ -963,7 +963,7 @@ var suites_001 = /* :: */[
         "test4",
         (function () {
             return /* Eq */Block.__(0, [
-                      /* true */1,
+                      true,
                       Curry._1(A[/* even */0], 2)
                     ]);
           })
@@ -973,7 +973,7 @@ var suites_001 = /* :: */[
           "test4",
           (function () {
               return /* Eq */Block.__(0, [
-                        /* true */1,
+                        true,
                         Curry._1(AA[/* even */0], 4)
                       ]);
             })
@@ -983,7 +983,7 @@ var suites_001 = /* :: */[
             "test5",
             (function () {
                 return /* Eq */Block.__(0, [
-                          /* false */0,
+                          false,
                           Curry._1(B[/* odd */0], 2)
                         ]);
               })

--- a/jscomp/test/rec_value_test.js
+++ b/jscomp/test/rec_value_test.js
@@ -139,11 +139,11 @@ function fib3(n) {
 
 function even(n) {
   if (n === 0) {
-    return /* true */1;
+    return true;
   } else {
     var n$1 = n - 1 | 0;
     if (n$1 === 1) {
-      return /* true */1;
+      return true;
     } else {
       return even(n$1 - 1 | 0);
     }
@@ -154,7 +154,7 @@ function even2(_n) {
   while(true) {
     var n = _n;
     if (n === 0) {
-      return /* true */1;
+      return true;
     } else {
       _n = n - 1 | 0;
       continue ;

--- a/jscomp/test/runtime_encoding_test.js
+++ b/jscomp/test/runtime_encoding_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var v = /* int array */[
+var v = /* array */[
   0,
   1
 ];

--- a/jscomp/test/scanf_io.js
+++ b/jscomp/test/scanf_io.js
@@ -195,7 +195,7 @@ function test55() {
   var ib = Scanf.Scanning[/* from_string */6](s);
   add_digest_ib(ob, ib);
   var tscanf_data_file_lines_digest = $$Buffer.contents(ob);
-  return +(digest_file(tscanf_data_file) === tscanf_data_file_lines_digest);
+  return digest_file(tscanf_data_file) === tscanf_data_file_lines_digest;
 }
 
 exports.tscanf_data_file = tscanf_data_file;

--- a/jscomp/test/set_gen.js
+++ b/jscomp/test/set_gen.js
@@ -68,9 +68,9 @@ function max_elt(_param) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -149,10 +149,10 @@ function for_all(p, _param) {
         _param = param[2];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -162,13 +162,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._1(p, param[1]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -684,7 +684,7 @@ function is_ordered(cmp, tree) {
       return /* Empty */50834029;
     }
   };
-  return +(is_ordered_min_max(tree) !== /* No */17505);
+  return is_ordered_min_max(tree) !== /* No */17505;
 }
 
 function invariant(cmp, t) {

--- a/jscomp/test/sexpm.js
+++ b/jscomp/test/sexpm.js
@@ -87,11 +87,11 @@ function _must_escape(s) {
       }
       
     }
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Pervasives.Exit) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -363,9 +363,9 @@ function make($staropt$star, refill) {
 
 function _is_digit(c) {
   if (/* "0" */48 <= c) {
-    return +(c <= /* "9" */57);
+    return c <= /* "9" */57;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -889,12 +889,12 @@ function next(t) {
 
 function parse_string(s) {
   var n = s.length;
-  var stop = [/* false */0];
+  var stop = [false];
   var refill = function (bytes, i, _) {
     if (stop[0]) {
       return 0;
     } else {
-      stop[0] = /* true */1;
+      stop[0] = true;
       Bytes.blit_string(s, 0, bytes, i, n);
       return n;
     }
@@ -994,9 +994,9 @@ function MakeDecode(funarg) {
   };
   var _is_digit = function (c) {
     if (/* "0" */48 <= c) {
-      return +(c <= /* "9" */57);
+      return c <= /* "9" */57;
     } else {
-      return /* false */0;
+      return false;
     }
   };
   var _refill = function (t, k_succ, k_fail) {

--- a/jscomp/test/stack_comp_test.js
+++ b/jscomp/test/stack_comp_test.js
@@ -18,7 +18,7 @@ function eq(f, param) {
 function assert_(loc, v) {
   return eq(loc, /* tuple */[
               v,
-              /* true */1
+              true
             ]);
 }
 
@@ -51,11 +51,11 @@ var S = /* module */[
 function does_raise(f, s) {
   try {
     Curry._1(f, s);
-    return /* false */0;
+    return false;
   }
   catch (exn){
     if (exn === Stack.Empty) {
-      return /* true */1;
+      return true;
     } else {
       throw exn;
     }
@@ -64,14 +64,14 @@ function does_raise(f, s) {
 
 var s = /* record */[/* c : [] */0];
 
-assert_("File \"stack_comp_test.ml\", line 33, characters 32-39", +(to_list(s) === /* [] */0 && List.length(s[/* c */0]) === 0));
+assert_("File \"stack_comp_test.ml\", line 33, characters 32-39", to_list(s) === /* [] */0 && List.length(s[/* c */0]) === 0);
 
 Stack.push(1, s);
 
 assert_("File \"stack_comp_test.ml\", line 34, characters 32-39", Caml_obj.caml_equal(to_list(s), /* :: */[
           1,
           /* [] */0
-        ]) && +(List.length(s[/* c */0]) === 1));
+        ]) && List.length(s[/* c */0]) === 1);
 
 Stack.push(2, s);
 
@@ -81,7 +81,7 @@ assert_("File \"stack_comp_test.ml\", line 35, characters 32-39", Caml_obj.caml_
             2,
             /* [] */0
           ]
-        ]) && +(List.length(s[/* c */0]) === 2));
+        ]) && List.length(s[/* c */0]) === 2);
 
 Stack.push(3, s);
 
@@ -94,7 +94,7 @@ assert_("File \"stack_comp_test.ml\", line 36, characters 32-39", Caml_obj.caml_
               /* [] */0
             ]
           ]
-        ]) && +(List.length(s[/* c */0]) === 3));
+        ]) && List.length(s[/* c */0]) === 3);
 
 Stack.push(4, s);
 
@@ -110,9 +110,9 @@ assert_("File \"stack_comp_test.ml\", line 37, characters 32-39", Caml_obj.caml_
               ]
             ]
           ]
-        ]) && +(List.length(s[/* c */0]) === 4));
+        ]) && List.length(s[/* c */0]) === 4);
 
-assert_("File \"stack_comp_test.ml\", line 38, characters 10-17", +(Stack.pop(s) === 4));
+assert_("File \"stack_comp_test.ml\", line 38, characters 10-17", Stack.pop(s) === 4);
 
 assert_("File \"stack_comp_test.ml\", line 38, characters 41-48", Caml_obj.caml_equal(to_list(s), /* :: */[
           1,
@@ -123,9 +123,9 @@ assert_("File \"stack_comp_test.ml\", line 38, characters 41-48", Caml_obj.caml_
               /* [] */0
             ]
           ]
-        ]) && +(List.length(s[/* c */0]) === 3));
+        ]) && List.length(s[/* c */0]) === 3);
 
-assert_("File \"stack_comp_test.ml\", line 39, characters 10-17", +(Stack.pop(s) === 3));
+assert_("File \"stack_comp_test.ml\", line 39, characters 10-17", Stack.pop(s) === 3);
 
 assert_("File \"stack_comp_test.ml\", line 39, characters 41-48", Caml_obj.caml_equal(to_list(s), /* :: */[
           1,
@@ -133,18 +133,18 @@ assert_("File \"stack_comp_test.ml\", line 39, characters 41-48", Caml_obj.caml_
             2,
             /* [] */0
           ]
-        ]) && +(List.length(s[/* c */0]) === 2));
+        ]) && List.length(s[/* c */0]) === 2);
 
-assert_("File \"stack_comp_test.ml\", line 40, characters 10-17", +(Stack.pop(s) === 2));
+assert_("File \"stack_comp_test.ml\", line 40, characters 10-17", Stack.pop(s) === 2);
 
 assert_("File \"stack_comp_test.ml\", line 40, characters 41-48", Caml_obj.caml_equal(to_list(s), /* :: */[
           1,
           /* [] */0
-        ]) && +(List.length(s[/* c */0]) === 1));
+        ]) && List.length(s[/* c */0]) === 1);
 
-assert_("File \"stack_comp_test.ml\", line 41, characters 10-17", +(Stack.pop(s) === 1));
+assert_("File \"stack_comp_test.ml\", line 41, characters 10-17", Stack.pop(s) === 1);
 
-assert_("File \"stack_comp_test.ml\", line 41, characters 41-48", +(to_list(s) === /* [] */0 && List.length(s[/* c */0]) === 0));
+assert_("File \"stack_comp_test.ml\", line 41, characters 41-48", to_list(s) === /* [] */0 && List.length(s[/* c */0]) === 0);
 
 assert_("File \"stack_comp_test.ml\", line 42, characters 10-17", does_raise(Stack.pop, s));
 
@@ -152,43 +152,43 @@ var s$1 = /* record */[/* c : [] */0];
 
 Stack.push(1, s$1);
 
-assert_("File \"stack_comp_test.ml\", line 47, characters 22-29", +(Stack.pop(s$1) === 1));
+assert_("File \"stack_comp_test.ml\", line 47, characters 22-29", Stack.pop(s$1) === 1);
 
 assert_("File \"stack_comp_test.ml\", line 47, characters 53-60", does_raise(Stack.pop, s$1));
 
 Stack.push(2, s$1);
 
-assert_("File \"stack_comp_test.ml\", line 48, characters 22-29", +(Stack.pop(s$1) === 2));
+assert_("File \"stack_comp_test.ml\", line 48, characters 22-29", Stack.pop(s$1) === 2);
 
 assert_("File \"stack_comp_test.ml\", line 48, characters 53-60", does_raise(Stack.pop, s$1));
 
-assert_("File \"stack_comp_test.ml\", line 49, characters 10-17", +(List.length(s$1[/* c */0]) === 0));
+assert_("File \"stack_comp_test.ml\", line 49, characters 10-17", List.length(s$1[/* c */0]) === 0);
 
 var s$2 = /* record */[/* c : [] */0];
 
 Stack.push(1, s$2);
 
-assert_("File \"stack_comp_test.ml\", line 54, characters 22-29", +(Stack.top(s$2) === 1));
+assert_("File \"stack_comp_test.ml\", line 54, characters 22-29", Stack.top(s$2) === 1);
 
 Stack.push(2, s$2);
 
-assert_("File \"stack_comp_test.ml\", line 55, characters 22-29", +(Stack.top(s$2) === 2));
+assert_("File \"stack_comp_test.ml\", line 55, characters 22-29", Stack.top(s$2) === 2);
 
 Stack.push(3, s$2);
 
-assert_("File \"stack_comp_test.ml\", line 56, characters 22-29", +(Stack.top(s$2) === 3));
+assert_("File \"stack_comp_test.ml\", line 56, characters 22-29", Stack.top(s$2) === 3);
 
-assert_("File \"stack_comp_test.ml\", line 57, characters 10-17", +(Stack.top(s$2) === 3));
+assert_("File \"stack_comp_test.ml\", line 57, characters 10-17", Stack.top(s$2) === 3);
 
-assert_("File \"stack_comp_test.ml\", line 57, characters 41-48", +(Stack.pop(s$2) === 3));
+assert_("File \"stack_comp_test.ml\", line 57, characters 41-48", Stack.pop(s$2) === 3);
 
-assert_("File \"stack_comp_test.ml\", line 58, characters 10-17", +(Stack.top(s$2) === 2));
+assert_("File \"stack_comp_test.ml\", line 58, characters 10-17", Stack.top(s$2) === 2);
 
-assert_("File \"stack_comp_test.ml\", line 58, characters 41-48", +(Stack.pop(s$2) === 2));
+assert_("File \"stack_comp_test.ml\", line 58, characters 41-48", Stack.pop(s$2) === 2);
 
-assert_("File \"stack_comp_test.ml\", line 59, characters 10-17", +(Stack.top(s$2) === 1));
+assert_("File \"stack_comp_test.ml\", line 59, characters 10-17", Stack.top(s$2) === 1);
 
-assert_("File \"stack_comp_test.ml\", line 59, characters 41-48", +(Stack.pop(s$2) === 1));
+assert_("File \"stack_comp_test.ml\", line 59, characters 41-48", Stack.pop(s$2) === 1);
 
 assert_("File \"stack_comp_test.ml\", line 60, characters 10-17", does_raise(Stack.top, s$2));
 
@@ -202,7 +202,7 @@ for(var i = 1; i <= 10; ++i){
 
 s$3[/* c */0] = /* [] */0;
 
-assert_("File \"stack_comp_test.ml\", line 68, characters 10-17", +(List.length(s$3[/* c */0]) === 0));
+assert_("File \"stack_comp_test.ml\", line 68, characters 10-17", List.length(s$3[/* c */0]) === 0);
 
 assert_("File \"stack_comp_test.ml\", line 69, characters 10-17", does_raise(Stack.pop, s$3));
 
@@ -210,7 +210,7 @@ assert_("File \"stack_comp_test.ml\", line 70, characters 10-17", Caml_obj.caml_
 
 Stack.push(42, s$3);
 
-assert_("File \"stack_comp_test.ml\", line 72, characters 10-17", +(Stack.pop(s$3) === 42));
+assert_("File \"stack_comp_test.ml\", line 72, characters 10-17", Stack.pop(s$3) === 42);
 
 var s1 = /* record */[/* c : [] */0];
 
@@ -284,37 +284,37 @@ assert_("File \"stack_comp_test.ml\", line 80, characters 10-17", Caml_obj.caml_
           ]
         ]));
 
-assert_("File \"stack_comp_test.ml\", line 81, characters 10-17", +(List.length(s1[/* c */0]) === 10));
+assert_("File \"stack_comp_test.ml\", line 81, characters 10-17", List.length(s1[/* c */0]) === 10);
 
-assert_("File \"stack_comp_test.ml\", line 82, characters 10-17", +(List.length(s2[/* c */0]) === 10));
+assert_("File \"stack_comp_test.ml\", line 82, characters 10-17", List.length(s2[/* c */0]) === 10);
 
 for(var i$2 = 10; i$2 >= 1; --i$2){
-  assert_("File \"stack_comp_test.ml\", line 84, characters 12-19", +(Stack.pop(s1) === i$2));
+  assert_("File \"stack_comp_test.ml\", line 84, characters 12-19", Stack.pop(s1) === i$2);
 }
 
 for(var i$3 = 10; i$3 >= 1; --i$3){
-  assert_("File \"stack_comp_test.ml\", line 87, characters 12-19", +(Stack.pop(s2) === i$3));
+  assert_("File \"stack_comp_test.ml\", line 87, characters 12-19", Stack.pop(s2) === i$3);
 }
 
 var s$4 = /* record */[/* c : [] */0];
 
-assert_("File \"stack_comp_test.ml\", line 93, characters 10-17", +(s$4[/* c */0] === /* [] */0));
+assert_("File \"stack_comp_test.ml\", line 93, characters 10-17", s$4[/* c */0] === /* [] */0);
 
 for(var i$4 = 1; i$4 <= 10; ++i$4){
   Stack.push(i$4, s$4);
-  assert_("File \"stack_comp_test.ml\", line 96, characters 12-19", +(List.length(s$4[/* c */0]) === i$4));
-  assert_("File \"stack_comp_test.ml\", line 97, characters 12-19", +(s$4[/* c */0] !== /* [] */0));
+  assert_("File \"stack_comp_test.ml\", line 96, characters 12-19", List.length(s$4[/* c */0]) === i$4);
+  assert_("File \"stack_comp_test.ml\", line 97, characters 12-19", s$4[/* c */0] !== /* [] */0);
 }
 
 for(var i$5 = 10; i$5 >= 1; --i$5){
-  assert_("File \"stack_comp_test.ml\", line 100, characters 12-19", +(List.length(s$4[/* c */0]) === i$5));
-  assert_("File \"stack_comp_test.ml\", line 101, characters 12-19", +(s$4[/* c */0] !== /* [] */0));
+  assert_("File \"stack_comp_test.ml\", line 100, characters 12-19", List.length(s$4[/* c */0]) === i$5);
+  assert_("File \"stack_comp_test.ml\", line 101, characters 12-19", s$4[/* c */0] !== /* [] */0);
   Stack.pop(s$4);
 }
 
-assert_("File \"stack_comp_test.ml\", line 104, characters 10-17", +(List.length(s$4[/* c */0]) === 0));
+assert_("File \"stack_comp_test.ml\", line 104, characters 10-17", List.length(s$4[/* c */0]) === 0);
 
-assert_("File \"stack_comp_test.ml\", line 105, characters 10-17", +(s$4[/* c */0] === /* [] */0));
+assert_("File \"stack_comp_test.ml\", line 105, characters 10-17", s$4[/* c */0] === /* [] */0);
 
 var s$5 = /* record */[/* c : [] */0];
 
@@ -325,26 +325,26 @@ for(var i$6 = 10; i$6 >= 1; --i$6){
 var i$7 = [1];
 
 List.iter((function (j) {
-        assert_("File \"stack_comp_test.ml\", line 112, characters 27-34", +(i$7[0] === j));
+        assert_("File \"stack_comp_test.ml\", line 112, characters 27-34", i$7[0] === j);
         i$7[0] = i$7[0] + 1 | 0;
         return /* () */0;
       }), s$5[/* c */0]);
 
 var s1$1 = /* record */[/* c : [] */0];
 
-assert_("File \"stack_comp_test.ml\", line 117, characters 10-17", +(List.length(s1$1[/* c */0]) === 0));
+assert_("File \"stack_comp_test.ml\", line 117, characters 10-17", List.length(s1$1[/* c */0]) === 0);
 
-assert_("File \"stack_comp_test.ml\", line 117, characters 45-52", +(to_list(s1$1) === /* [] */0));
+assert_("File \"stack_comp_test.ml\", line 117, characters 45-52", to_list(s1$1) === /* [] */0);
 
 var s2$1 = /* record */[/* c */s1$1[/* c */0]];
 
-assert_("File \"stack_comp_test.ml\", line 119, characters 10-17", +(List.length(s1$1[/* c */0]) === 0));
+assert_("File \"stack_comp_test.ml\", line 119, characters 10-17", List.length(s1$1[/* c */0]) === 0);
 
-assert_("File \"stack_comp_test.ml\", line 119, characters 45-52", +(to_list(s1$1) === /* [] */0));
+assert_("File \"stack_comp_test.ml\", line 119, characters 45-52", to_list(s1$1) === /* [] */0);
 
-assert_("File \"stack_comp_test.ml\", line 120, characters 10-17", +(List.length(s2$1[/* c */0]) === 0));
+assert_("File \"stack_comp_test.ml\", line 120, characters 10-17", List.length(s2$1[/* c */0]) === 0);
 
-assert_("File \"stack_comp_test.ml\", line 120, characters 45-52", +(to_list(s2$1) === /* [] */0));
+assert_("File \"stack_comp_test.ml\", line 120, characters 45-52", to_list(s2$1) === /* [] */0);
 
 var s1$2 = /* record */[/* c : [] */0];
 
@@ -352,7 +352,7 @@ for(var i$8 = 1; i$8 <= 4; ++i$8){
   Stack.push(i$8, s1$2);
 }
 
-assert_("File \"stack_comp_test.ml\", line 126, characters 10-17", +(List.length(s1$2[/* c */0]) === 4));
+assert_("File \"stack_comp_test.ml\", line 126, characters 10-17", List.length(s1$2[/* c */0]) === 4);
 
 assert_("File \"stack_comp_test.ml\", line 126, characters 45-52", Caml_obj.caml_equal(to_list(s1$2), /* :: */[
           1,
@@ -370,7 +370,7 @@ assert_("File \"stack_comp_test.ml\", line 126, characters 45-52", Caml_obj.caml
 
 var s2$2 = /* record */[/* c */s1$2[/* c */0]];
 
-assert_("File \"stack_comp_test.ml\", line 128, characters 10-17", +(List.length(s1$2[/* c */0]) === 4));
+assert_("File \"stack_comp_test.ml\", line 128, characters 10-17", List.length(s1$2[/* c */0]) === 4);
 
 assert_("File \"stack_comp_test.ml\", line 128, characters 45-52", Caml_obj.caml_equal(to_list(s1$2), /* :: */[
           1,
@@ -386,7 +386,7 @@ assert_("File \"stack_comp_test.ml\", line 128, characters 45-52", Caml_obj.caml
           ]
         ]));
 
-assert_("File \"stack_comp_test.ml\", line 129, characters 10-17", +(List.length(s2$2[/* c */0]) === 4));
+assert_("File \"stack_comp_test.ml\", line 129, characters 10-17", List.length(s2$2[/* c */0]) === 4);
 
 assert_("File \"stack_comp_test.ml\", line 129, characters 45-52", Caml_obj.caml_equal(to_list(s2$2), /* :: */[
           1,

--- a/jscomp/test/string_runtime_test.js
+++ b/jscomp/test/string_runtime_test.js
@@ -10,7 +10,7 @@ var suites_000 = /* tuple */[
   "string_of_char_array",
   (function () {
       return /* Eq */Block.__(0, [
-                Caml_string.caml_string_of_char_array(/* int array */[
+                Caml_string.caml_string_of_char_array(/* array */[
                       /* "a" */97,
                       /* "b" */98,
                       /* "c" */99
@@ -26,7 +26,7 @@ var suites_001 = /* :: */[
     (function () {
         return /* Eq */Block.__(0, [
                   Caml_string.caml_is_printable(/* "a" */97),
-                  /* true */1
+                  true
                 ]);
       })
   ],

--- a/jscomp/test/string_set.js
+++ b/jscomp/test/string_set.js
@@ -16,7 +16,7 @@ function split(x, tree) {
     if (c === 0) {
       return /* tuple */[
               l,
-              /* true */1,
+              true,
               r
             ];
     } else if (c < 0) {
@@ -37,7 +37,7 @@ function split(x, tree) {
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0,
+            false,
             /* Empty */0
           ];
   }
@@ -101,7 +101,7 @@ function inter(s1, s2) {
     var l1 = s1[0];
     var match = split(v1, s2);
     var l2 = match[0];
-    if (match[1] !== 0) {
+    if (match[1]) {
       return Set_gen.internal_join(inter(l1, l2), v1, inter(r1, match[2]));
     } else {
       return Set_gen.internal_concat(inter(l1, l2), inter(r1, match[2]));
@@ -119,7 +119,7 @@ function diff(s1, s2) {
       var l1 = s1[0];
       var match = split(v1, s2);
       var l2 = match[0];
-      if (match[1] !== 0) {
+      if (match[1]) {
         return Set_gen.internal_concat(diff(l1, l2), diff(r1, match[2]));
       } else {
         return Set_gen.internal_join(diff(l1, l2), v1, diff(r1, match[2]));
@@ -138,13 +138,13 @@ function mem(x, _tree) {
     if (tree) {
       var c = Caml_primitive.caml_string_compare(x, tree[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _tree = c < 0 ? tree[0] : tree[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -172,7 +172,7 @@ function compare(s1, s2) {
 }
 
 function equal(s1, s2) {
-  return +(Set_gen.compare($$String.compare, s1, s2) === 0);
+  return Set_gen.compare($$String.compare, s1, s2) === 0;
 }
 
 function subset(_s1, _s2) {
@@ -193,7 +193,7 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (c < 0) {
           if (subset(/* Node */[
@@ -205,7 +205,7 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (subset(/* Node */[
                 /* Empty */0,
@@ -216,13 +216,13 @@ function subset(_s1, _s2) {
           _s1 = l1;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }

--- a/jscomp/test/string_test.js
+++ b/jscomp/test/string_test.js
@@ -262,7 +262,7 @@ Mt.from_pair_suites("string_test.ml", /* :: */[
                                           "test_unsafe_obj_ffi_ppx.cmi",
                                           /* [] */0
                                         ],
-                                        Ext_string_test.split(/* Some */[/* false */0], " test_unsafe_obj_ffi_ppx.cmi", /* " " */32)
+                                        Ext_string_test.split(/* Some */[false], " test_unsafe_obj_ffi_ppx.cmi", /* " " */32)
                                       ]);
                             })
                         ],

--- a/jscomp/test/tailcall_inline_test.js
+++ b/jscomp/test/tailcall_inline_test.js
@@ -62,7 +62,7 @@ var suites_001 = /* :: */[
                       ]
                     ]
                   ],
-                  $$Array.to_list(/* int array */[
+                  $$Array.to_list(/* array */[
                         1,
                         2,
                         3

--- a/jscomp/test/test_array.js
+++ b/jscomp/test/test_array.js
@@ -9,12 +9,12 @@ Caml_array.caml_make_float_vect(30);
 
 var h = $$Array.sub(v, 0, 2);
 
-var hhh = $$Array.append(/* int array */[
+var hhh = $$Array.append(/* array */[
       1,
       2,
       3,
       4
-    ], /* int array */[
+    ], /* array */[
       1,
       2,
       3,
@@ -22,17 +22,17 @@ var hhh = $$Array.append(/* int array */[
     ]);
 
 var u = Caml_array.caml_array_concat(/* :: */[
-      /* int array */[
+      /* array */[
         1,
         2
       ],
       /* :: */[
-        /* int array */[
+        /* array */[
           2,
           3
         ],
         /* :: */[
-          /* int array */[
+          /* array */[
             3,
             4
           ],

--- a/jscomp/test/test_array_append.js
+++ b/jscomp/test/test_array_append.js
@@ -2,10 +2,10 @@
 
 var $$Array = require("../../lib/js/array.js");
 
-var const_v = $$Array.append(/* int array */[
+var const_v = $$Array.append(/* array */[
       1,
       2
-    ], /* int array */[3]);
+    ], /* array */[3]);
 
 exports.const_v = const_v;
 /* const_v Not a pure module */

--- a/jscomp/test/test_bool_equal.js
+++ b/jscomp/test/test_bool_equal.js
@@ -3,21 +3,21 @@
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js");
 
 function bool_equal(x, y) {
-  if (x !== 0) {
-    if (y !== 0) {
-      return /* true */1;
+  if (x) {
+    if (y) {
+      return true;
     } else {
-      return /* false */0;
+      return false;
     }
-  } else if (y !== 0) {
-    return /* false */0;
+  } else if (y) {
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
 function assertions() {
-  if (!bool_equal(/* true */1, /* true */1)) {
+  if (!bool_equal(true, true)) {
     throw [
           Caml_builtin_exceptions.assert_failure,
           [
@@ -27,7 +27,7 @@ function assertions() {
           ]
         ];
   }
-  if (!bool_equal(/* false */0, /* false */0)) {
+  if (!bool_equal(false, false)) {
     throw [
           Caml_builtin_exceptions.assert_failure,
           [
@@ -37,7 +37,7 @@ function assertions() {
           ]
         ];
   }
-  if (bool_equal(/* true */1, /* false */0)) {
+  if (bool_equal(true, false)) {
     throw [
           Caml_builtin_exceptions.assert_failure,
           [
@@ -47,7 +47,7 @@ function assertions() {
           ]
         ];
   }
-  if (bool_equal(/* false */0, /* true */1)) {
+  if (bool_equal(false, true)) {
     throw [
           Caml_builtin_exceptions.assert_failure,
           [
@@ -61,7 +61,7 @@ function assertions() {
 }
 
 function f0(x) {
-  if (x === /* true */1) {
+  if (x === true) {
     return 1;
   } else {
     return 2;
@@ -69,7 +69,7 @@ function f0(x) {
 }
 
 function f1(x) {
-  if (x !== /* true */1) {
+  if (x !== true) {
     return 1;
   } else {
     return 2;

--- a/jscomp/test/test_for_map.js
+++ b/jscomp/test/test_for_map.js
@@ -94,9 +94,9 @@ function bal(l, x, d, r) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -154,13 +154,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_int_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -322,10 +322,10 @@ function for_all(p, _param) {
         _param = param[3];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -335,13 +335,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._2(p, param[1], param[2]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -584,12 +584,12 @@ function equal(cmp, m1, m2) {
         _e1 = cons_enum(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }

--- a/jscomp/test/test_functor_dead_code.js
+++ b/jscomp/test/test_functor_dead_code.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var v = /* true */1;
+var v = true;
 
 exports.v = v;
 /* No side effect */

--- a/jscomp/test/test_internalOO.js
+++ b/jscomp/test/test_internalOO.js
@@ -19,9 +19,9 @@ function copy(o) {
 }
 
 var params = /* record */[
-  /* compact_table : true */1,
-  /* copy_parent : true */1,
-  /* clean_when_copying : true */1,
+  /* compact_table */true,
+  /* copy_parent */true,
+  /* clean_when_copying */true,
   /* retry_count */3,
   /* bucket_small_size */16
 ];
@@ -131,9 +131,9 @@ function bal(l, x, d, r) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -191,13 +191,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -359,10 +359,10 @@ function for_all(p, _param) {
         _param = param[3];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -372,13 +372,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._2(p, param[1], param[2]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -621,12 +621,12 @@ function equal(cmp, m1, m2) {
         _e1 = cons_enum(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -780,9 +780,9 @@ function bal$1(l, x, d, r) {
 
 function is_empty$1(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -840,13 +840,13 @@ function mem$1(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1008,10 +1008,10 @@ function for_all$1(p, _param) {
         _param = param[3];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -1021,13 +1021,13 @@ function exists$1(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._2(p, param[1], param[2]) || exists$1(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1270,12 +1270,12 @@ function equal$1(cmp, m1, m2) {
         _e1 = cons_enum$1(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -1429,9 +1429,9 @@ function bal$2(l, x, d, r) {
 
 function is_empty$2(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -1489,13 +1489,13 @@ function mem$2(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_int_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1657,10 +1657,10 @@ function for_all$2(p, _param) {
         _param = param[3];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -1670,13 +1670,13 @@ function exists$2(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._2(p, param[1], param[2]) || exists$2(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1919,12 +1919,12 @@ function equal$2(cmp, m1, m2) {
         _e1 = cons_enum$2(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -2067,7 +2067,7 @@ function get_method_label(table, name) {
     if (exn === Caml_builtin_exceptions.not_found) {
       var label = new_method(table);
       table[/* methods_by_name */2] = add$1(name, label, table[/* methods_by_name */2]);
-      table[/* methods_by_label */3] = add$2(label, /* true */1, table[/* methods_by_label */3]);
+      table[/* methods_by_label */3] = add$2(label, true, table[/* methods_by_label */3]);
       return label;
     } else {
       throw exn;
@@ -2156,7 +2156,7 @@ function narrow(table, vars, virt_meths, concr_meths) {
           }
           catch (exn){
             if (exn === Caml_builtin_exceptions.not_found) {
-              tmp = /* true */1;
+              tmp = true;
             } else {
               throw exn;
             }
@@ -2166,7 +2166,7 @@ function narrow(table, vars, virt_meths, concr_meths) {
         }), concr_meths$1, concr_meth_labs);
   List.iter2((function (met, label) {
           by_name[0] = add$1(met, label, by_name[0]);
-          by_label[0] = add$2(label, /* false */0, by_label[0]);
+          by_label[0] = add$2(label, false, by_label[0]);
           return /* () */0;
         }), virt_meths$1, virt_meth_labs);
   table[/* methods_by_name */2] = by_name[0];
@@ -2294,7 +2294,7 @@ function create_table(public_methods) {
     $$Array.iteri((function (i, met) {
             var lab = (i << 1) + 2 | 0;
             table[/* methods_by_name */2] = add$1(met, lab, table[/* methods_by_name */2]);
-            table[/* methods_by_label */3] = add$2(lab, /* true */1, table[/* methods_by_label */3]);
+            table[/* methods_by_label */3] = add$2(lab, true, table[/* methods_by_label */3]);
             return /* () */0;
           }), public_methods);
     return table;

--- a/jscomp/test/test_list.js
+++ b/jscomp/test/test_list.js
@@ -346,10 +346,10 @@ function for_all(p, _param) {
         _param = param[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -359,13 +359,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._1(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -381,7 +381,7 @@ function for_all2(p, _l1, _l2) {
           _l1 = l1[1];
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
         throw [
@@ -395,7 +395,7 @@ function for_all2(p, _l1, _l2) {
             "List.for_all2"
           ];
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -407,7 +407,7 @@ function exists2(p, _l1, _l2) {
     if (l1) {
       if (l2) {
         if (Curry._2(p, l1[0], l2[0])) {
-          return /* true */1;
+          return true;
         } else {
           _l2 = l2[1];
           _l1 = l1[1];
@@ -425,7 +425,7 @@ function exists2(p, _l1, _l2) {
             "List.exists2"
           ];
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -435,13 +435,13 @@ function mem(x, _param) {
     var param = _param;
     if (param) {
       if (Caml_obj.caml_equal(param[0], x)) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -451,13 +451,13 @@ function memq(x, _param) {
     var param = _param;
     if (param) {
       if (param[0] === x) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -501,13 +501,13 @@ function mem_assoc(x, _param) {
     var param = _param;
     if (param) {
       if (Caml_obj.caml_equal(param[0][0], x)) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -517,13 +517,13 @@ function mem_assq(x, _param) {
     var param = _param;
     if (param) {
       if (param[0][0] === x) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }

--- a/jscomp/test/test_literal.js
+++ b/jscomp/test/test_literal.js
@@ -10,13 +10,13 @@ var v = [
   2
 ];
 
-var vv = /* float array */[
+var vv = /* array */[
   1,
   2,
   3
 ];
 
-var long_v = /* float array */[
+var long_v = /* array */[
   1,
   2,
   3,
@@ -34,7 +34,7 @@ var long_int_v = /* array */[
   6
 ];
 
-var short_int_v = /* int array */[1];
+var short_int_v = /* array */[1];
 
 var empty = /* array */[];
 

--- a/jscomp/test/test_order_tailcall.js
+++ b/jscomp/test/test_order_tailcall.js
@@ -61,7 +61,7 @@ function f6(b) {
     if (b) {
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -69,7 +69,7 @@ function f6(b) {
 function f7(b) {
   while(true) {
     if (b) {
-      return /* true */1;
+      return true;
     } else {
       continue ;
     }

--- a/jscomp/test/test_per.js
+++ b/jscomp/test/test_per.js
@@ -119,9 +119,9 @@ function string_of_bool(b) {
 function bool_of_string(param) {
   switch (param) {
     case "false" : 
-        return /* false */0;
+        return false;
     case "true" : 
-        return /* true */1;
+        return true;
     default:
       throw [
             Caml_builtin_exceptions.invalid_argument,

--- a/jscomp/test/test_primitive.js
+++ b/jscomp/test/test_primitive.js
@@ -35,7 +35,7 @@ var test_float = 3;
 
 var test_abs = Math.abs(3.0);
 
-var v = /* float array */[
+var v = /* array */[
   1.0,
   2.0
 ];
@@ -59,7 +59,7 @@ function f2(h, b, _) {
 
 Caml_array.caml_array_set(v, 1, 3.0);
 
-var unboxed_x = /* float array */[
+var unboxed_x = /* array */[
   0,
   0
 ];

--- a/jscomp/test/test_runtime_encoding.js
+++ b/jscomp/test/test_runtime_encoding.js
@@ -3,7 +3,7 @@
 var Caml_array = require("../../lib/js/caml_array.js");
 
 function g(x) {
-  return /* float array */[
+  return /* array */[
           3,
           x
         ];
@@ -17,7 +17,7 @@ function ff(v, u) {
 }
 
 function fff(vv, uu) {
-  return /* float array */[
+  return /* array */[
           vv,
           uu
         ];

--- a/jscomp/test/test_set.js
+++ b/jscomp/test/test_set.js
@@ -217,7 +217,7 @@ function Make(Ord) {
       if (c === 0) {
         return /* tuple */[
                 l,
-                /* true */1,
+                true,
                 r
               ];
       } else if (c < 0) {
@@ -238,16 +238,16 @@ function Make(Ord) {
     } else {
       return /* tuple */[
               /* Empty */0,
-              /* false */0,
+              false,
               /* Empty */0
             ];
     }
   };
   var is_empty = function (param) {
     if (param) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
   var mem = function (x, _param) {
@@ -256,13 +256,13 @@ function Make(Ord) {
       if (param) {
         var c = Curry._2(Ord[/* compare */0], x, param[1]);
         if (c === 0) {
-          return /* true */1;
+          return true;
         } else {
           _param = c < 0 ? param[0] : param[2];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };
@@ -317,7 +317,7 @@ function Make(Ord) {
       var l1 = s1[0];
       var match = split(v1, s2);
       var l2 = match[0];
-      if (match[1] !== 0) {
+      if (match[1]) {
         return join(inter(l1, l2), v1, inter(r1, match[2]));
       } else {
         return concat(inter(l1, l2), inter(r1, match[2]));
@@ -334,7 +334,7 @@ function Make(Ord) {
         var l1 = s1[0];
         var match = split(v1, s2);
         var l2 = match[0];
-        if (match[1] !== 0) {
+        if (match[1]) {
           return concat(diff(l1, l2), diff(r1, match[2]));
         } else {
           return join(diff(l1, l2), v1, diff(r1, match[2]));
@@ -391,7 +391,7 @@ function Make(Ord) {
     return compare_aux(cons_enum(s1, /* End */0), cons_enum(s2, /* End */0));
   };
   var equal = function (s1, s2) {
-    return +(compare(s1, s2) === 0);
+    return compare(s1, s2) === 0;
   };
   var subset = function (_s1, _s2) {
     while(true) {
@@ -411,7 +411,7 @@ function Make(Ord) {
               _s1 = r1;
               continue ;
             } else {
-              return /* false */0;
+              return false;
             }
           } else if (c < 0) {
             if (subset(/* Node */[
@@ -423,7 +423,7 @@ function Make(Ord) {
               _s1 = r1;
               continue ;
             } else {
-              return /* false */0;
+              return false;
             }
           } else if (subset(/* Node */[
                   /* Empty */0,
@@ -434,13 +434,13 @@ function Make(Ord) {
             _s1 = l1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* true */1;
+        return true;
       }
     };
   };
@@ -478,10 +478,10 @@ function Make(Ord) {
           _param = param[2];
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* true */1;
+        return true;
       }
     };
   };
@@ -490,13 +490,13 @@ function Make(Ord) {
       var param = _param;
       if (param) {
         if (Curry._1(p, param[1]) || exists(p, param[0])) {
-          return /* true */1;
+          return true;
         } else {
           _param = param[2];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };

--- a/jscomp/test/test_stack.js
+++ b/jscomp/test/test_stack.js
@@ -2,7 +2,7 @@
 
 
 function v(x) {
-  return +(x[/* c */0] === /* [] */0);
+  return x[/* c */0] === /* [] */0;
 }
 
 exports.v = v;

--- a/jscomp/test/test_string.js
+++ b/jscomp/test/test_string.js
@@ -36,9 +36,9 @@ function c(x, y) {
 
 function h(s, b) {
   if (Caml_string.get(s, 0) === /* "a" */97 && Caml_bytes.get(b, 0) === /* "b" */98) {
-    return +(Caml_string.get(s, 1) === Caml_bytes.get(b, 2));
+    return Caml_string.get(s, 1) === Caml_bytes.get(b, 2);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/jscomp/test/test_unsafe_cmp.js
+++ b/jscomp/test/test_unsafe_cmp.js
@@ -3,10 +3,10 @@
 
 function f(x, y) {
   return /* tuple */[
-          +(x < y),
-          +(x <= y),
-          +(x > y),
-          +(x >= y)
+          x < y,
+          x <= y,
+          x > y,
+          x >= y
         ];
 }
 

--- a/jscomp/test/test_while_side_effect.js
+++ b/jscomp/test/test_while_side_effect.js
@@ -3,7 +3,7 @@
 
 var v = [0];
 
-while(console.log(String(v[0])), v[0] = v[0] + 1 | 0, +(v[0] < 10)) {
+while(console.log(String(v[0])), v[0] = v[0] + 1 | 0, v[0] < 10) {
   
 };
 
@@ -22,7 +22,7 @@ while((function () {
         console.log(String(x[0]));
         y = y + 1 | 0;
         x[0] = x[0] + 1 | 0;
-        return +((fib(x[0]) + fib(x[0]) | 0) < 20);
+        return (fib(x[0]) + fib(x[0]) | 0) < 20;
       })()) {
   console.log(String(3));
 };

--- a/jscomp/test/test_zero_nullable.js
+++ b/jscomp/test/test_zero_nullable.js
@@ -61,7 +61,7 @@ function f4(h, x) {
 }
 
 function f6(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 function f7(x) {
@@ -91,10 +91,10 @@ function f9(x) {
 }
 
 function f10(x) {
-  return +(x === null);
+  return x === null;
 }
 
-var f11 = /* false */0;
+var f11 = false;
 
 var Test_null = /* module */[
   /* f1 */f1,
@@ -146,7 +146,7 @@ function f4$1(h, x) {
 }
 
 function f6$1(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 function f7$1(x) {
@@ -176,10 +176,10 @@ function f9$1(x) {
 }
 
 function f10$1(x) {
-  return +(x === undefined);
+  return x === undefined;
 }
 
-var f11$1 = /* false */0;
+var f11$1 = false;
 
 var Test_def = /* module */[
   /* f1 */f1$1,
@@ -231,7 +231,7 @@ function f4$2(h, x) {
 }
 
 function f6$2(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 function f7$2(x) {
@@ -259,10 +259,10 @@ function f9$2(x) {
 }
 
 function f10$2(x) {
-  return +(x == null);
+  return x == null;
 }
 
-var f11$2 = /* false */0;
+var f11$2 = false;
 
 var Test_null_def = /* module */[
   /* f1 */f1$2,

--- a/jscomp/test/testing.js
+++ b/jscomp/test/testing.js
@@ -10,11 +10,11 @@ var Caml_obj = require("../../lib/js/caml_obj.js");
 var Pervasives = require("../../lib/js/pervasives.js");
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js");
 
-var all_tests_ok = [/* true */1];
+var all_tests_ok = [true];
 
 function finish() {
   var match = all_tests_ok[0];
-  if (match !== 0) {
+  if (match) {
     console.log("\nAll tests succeeded.");
     return /* () */0;
   } else {
@@ -34,7 +34,7 @@ function print_test_number() {
 }
 
 function print_failure_test_fail() {
-  all_tests_ok[0] = /* false */0;
+  all_tests_ok[0] = false;
   return Pervasives.print_string(Curry._1(Printf.sprintf(/* Format */[
                       /* String_literal */Block.__(11, [
                           "\n********* Failure Test number ",
@@ -53,7 +53,7 @@ function print_failure_test_fail() {
 }
 
 function print_failure_test_succeed() {
-  all_tests_ok[0] = /* false */0;
+  all_tests_ok[0] = false;
   return Pervasives.print_string(Curry._1(Printf.sprintf(/* Format */[
                       /* String_literal */Block.__(11, [
                           "\n********* Failure Test number ",
@@ -77,7 +77,7 @@ function test(b) {
   if (b) {
     return 0;
   } else {
-    all_tests_ok[0] = /* false */0;
+    all_tests_ok[0] = false;
     return Pervasives.print_string(Curry._1(Printf.sprintf(/* Format */[
                         /* String_literal */Block.__(11, [
                             "\n********* Test number ",
@@ -102,15 +102,15 @@ function test_raises_exc_p(pred, f, x) {
   try {
     Curry._1(f, x);
     print_failure_test_succeed(/* () */0);
-    return /* false */0;
+    return false;
   }
   catch (raw_x){
     var x$1 = Js_exn.internalToOCamlException(raw_x);
     if (Curry._1(pred, x$1)) {
-      return /* true */1;
+      return true;
     } else {
       print_failure_test_fail(/* () */0);
-      return /* false */0;
+      return false;
     }
   }
 }
@@ -118,7 +118,7 @@ function test_raises_exc_p(pred, f, x) {
 function test_raises_some_exc(f) {
   return (function (param) {
       return test_raises_exc_p((function () {
-                    return /* true */1;
+                    return true;
                   }), f, param);
     });
 }
@@ -146,9 +146,9 @@ function failure_test(f, x, s) {
 function scan_failure_test(f, x) {
   return test_raises_exc_p((function (param) {
                 if (param[0] === Scanf.Scan_failure) {
-                  return /* true */1;
+                  return true;
                 } else {
-                  return /* false */0;
+                  return false;
                 }
               }), f, x);
 }

--- a/jscomp/test/tfloat_record_test.js
+++ b/jscomp/test/tfloat_record_test.js
@@ -34,7 +34,7 @@ function print_newline() {
             ]);
 }
 
-var s = /* float array */[1.0];
+var s = /* array */[1.0];
 
 print_float(s[/* f */0]);
 

--- a/jscomp/test/ticker.js
+++ b/jscomp/test/ticker.js
@@ -101,7 +101,7 @@ function string_of_rank(param) {
 
 function find_ticker_by_name(all_tickers, ticker) {
   return List.find((function (param) {
-                return +(param[/* ticker_name */2] === ticker);
+                return param[/* ticker_name */2] === ticker;
               }), all_tickers);
 }
 
@@ -206,9 +206,9 @@ function bal(l, x, d, r) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -266,13 +266,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_obj.caml_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -434,10 +434,10 @@ function for_all(p, _param) {
         _param = param[3];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -447,13 +447,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._2(p, param[1], param[2]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[3];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -696,12 +696,12 @@ function equal(cmp, m1, m2) {
         _e1 = cons_enum(e1[2], e1[3]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (e2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -860,7 +860,7 @@ function process_quote(ticker_map, new_ticker, new_value) {
                   if (match$2 && match$3) {
                     var y = match$3[0];
                     var x = match$2[0];
-                    value = match$1[/* op */0] !== 0 ? /* Some */[x - y] : /* Some */[x + y];
+                    value = match$1[/* op */0] ? /* Some */[x - y] : /* Some */[x + y];
                   } else {
                     value = /* None */0;
                   }

--- a/jscomp/test/topsort_test.js
+++ b/jscomp/test/topsort_test.js
@@ -659,7 +659,7 @@ function split(x, param) {
     if (c === 0) {
       return /* tuple */[
               l,
-              /* true */1,
+              true,
               r
             ];
     } else if (c < 0) {
@@ -680,7 +680,7 @@ function split(x, param) {
   } else {
     return /* tuple */[
             /* Empty */0,
-            /* false */0,
+            false,
             /* Empty */0
           ];
   }
@@ -688,9 +688,9 @@ function split(x, param) {
 
 function is_empty(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -700,13 +700,13 @@ function mem(x, _param) {
     if (param) {
       var c = Caml_primitive.caml_string_compare(x, param[1]);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _param = c < 0 ? param[0] : param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -774,7 +774,7 @@ function inter(s1, s2) {
     var l1 = s1[0];
     var match = split(v1, s2);
     var l2 = match[0];
-    if (match[1] !== 0) {
+    if (match[1]) {
       return join(inter(l1, l2), v1, inter(r1, match[2]));
     } else {
       return concat(inter(l1, l2), inter(r1, match[2]));
@@ -792,7 +792,7 @@ function diff(s1, s2) {
       var l1 = s1[0];
       var match = split(v1, s2);
       var l2 = match[0];
-      if (match[1] !== 0) {
+      if (match[1]) {
         return concat(diff(l1, l2), diff(r1, match[2]));
       } else {
         return join(diff(l1, l2), v1, diff(r1, match[2]));
@@ -851,7 +851,7 @@ function compare(s1, s2) {
 }
 
 function equal(s1, s2) {
-  return +(compare(s1, s2) === 0);
+  return compare(s1, s2) === 0;
 }
 
 function subset(_s1, _s2) {
@@ -872,7 +872,7 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (c < 0) {
           if (subset(/* Node */[
@@ -884,7 +884,7 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (subset(/* Node */[
                 /* Empty */0,
@@ -895,13 +895,13 @@ function subset(_s1, _s2) {
           _s1 = l1;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -942,10 +942,10 @@ function for_all(p, _param) {
         _param = param[2];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -955,13 +955,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._1(p, param[1]) || exists(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }

--- a/jscomp/test/tscanf_test.js
+++ b/jscomp/test/tscanf_test.js
@@ -30,7 +30,7 @@ function eq(f, param) {
 function test(loc, b) {
   return eq(loc, /* tuple */[
               b,
-              /* true */1
+              true
             ]);
 }
 
@@ -80,7 +80,7 @@ function test0() {
                 ]), id) | 0;
 }
 
-test("File \"tscanf_test.ml\", line 42, characters 5-12", +(test0(/* () */0) === 21));
+test("File \"tscanf_test.ml\", line 42, characters 5-12", test0(/* () */0) === 21);
 
 function test1() {
   return (((Curry._1(Scanf.sscanf("1", /* Format */[
@@ -141,7 +141,7 @@ function test1() {
                 ]), id) | 0;
 }
 
-test("File \"tscanf_test.ml\", line 54, characters 5-12", +(test1(/* () */0) === 5));
+test("File \"tscanf_test.ml\", line 54, characters 5-12", test1(/* () */0) === 5);
 
 function test2() {
   return (Curry._1(Scanf.sscanf("123", /* Format */[
@@ -183,7 +183,7 @@ function test2() {
                 ]), id) | 0;
 }
 
-test("File \"tscanf_test.ml\", line 63, characters 5-12", +(test2(/* () */0) === 259));
+test("File \"tscanf_test.ml\", line 63, characters 5-12", test2(/* () */0) === 259);
 
 function test3() {
   return ((Curry._1(Scanf.sscanf("0xff", /* Format */[
@@ -239,7 +239,7 @@ function test3() {
                 ]), id) | 0;
 }
 
-test("File \"tscanf_test.ml\", line 73, characters 5-12", +(test3(/* () */0) === -214));
+test("File \"tscanf_test.ml\", line 73, characters 5-12", test3(/* () */0) === -214);
 
 function test4() {
   if (Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("1"), /* Format */[
@@ -251,7 +251,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === 1.0);
+            return b0 === 1.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("-1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -261,7 +261,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === -1.0);
+            return b0 === -1.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("+1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -271,7 +271,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === 1.0);
+            return b0 === 1.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("1."), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -281,7 +281,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === 1.0);
+            return b0 === 1.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6](".1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -291,7 +291,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === 0.1);
+            return b0 === 0.1;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("-.1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -301,7 +301,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === -0.1);
+            return b0 === -0.1;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("+.1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -311,7 +311,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === 0.1);
+            return b0 === 0.1;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("+1."), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -321,7 +321,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === 1.0);
+            return b0 === 1.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("-1."), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -331,7 +331,7 @@ function test4() {
                 ]),
               "%f"
             ]), (function (b0) {
-            return +(b0 === -1.0);
+            return b0 === -1.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("0 1. 1.3"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -357,7 +357,7 @@ function test4() {
                 ]),
               "%f %f %f"
             ]), (function (b0, b1, b2) {
-            return b0 === 0.0 && b1 === 1.0 ? +(b2 === 1.3) : /* false */0;
+            return b0 === 0.0 && b1 === 1.0 ? b2 === 1.3 : false;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("0.113"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -370,7 +370,7 @@ function test4() {
                 ]),
               "%4f"
             ]), (function (b0) {
-            return +(b0 === 0.11);
+            return b0 === 0.11;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("0.113"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -383,7 +383,7 @@ function test4() {
                 ]),
               "%5f"
             ]), (function (b0) {
-            return +(b0 === 0.113);
+            return b0 === 0.113;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("000.113"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -396,7 +396,7 @@ function test4() {
                 ]),
               "%15f"
             ]), (function (b0) {
-            return +(b0 === 0.113);
+            return b0 === 0.113;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("+000.113"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_f */0,
@@ -409,7 +409,7 @@ function test4() {
                 ]),
               "%15f"
             ]), (function (b0) {
-            return +(b0 === 0.113);
+            return b0 === 0.113;
           }))) {
     return Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("-000.113"), /* Format */[
                     /* Float */Block.__(8, [
@@ -423,10 +423,10 @@ function test4() {
                       ]),
                     "%15f"
                   ]), (function (b0) {
-                  return +(b0 === -0.113);
+                  return b0 === -0.113;
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -442,7 +442,7 @@ function test5() {
                 ]),
               "%e"
             ]), (function (b) {
-            return +(b === 10.0);
+            return b === 10.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("1e+1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_e */3,
@@ -452,7 +452,7 @@ function test5() {
                 ]),
               "%e"
             ]), (function (b) {
-            return +(b === 10.0);
+            return b === 10.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("10e-1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_e */3,
@@ -462,7 +462,7 @@ function test5() {
                 ]),
               "%e"
             ]), (function (b) {
-            return +(b === 1.0);
+            return b === 1.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("10.e-1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_e */3,
@@ -472,7 +472,7 @@ function test5() {
                 ]),
               "%e"
             ]), (function (b) {
-            return +(b === 1.0);
+            return b === 1.0;
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("1e1 1.e+1 1.3e-1"), /* Format */[
               /* Float */Block.__(8, [
                   /* Float_e */3,
@@ -498,7 +498,7 @@ function test5() {
                 ]),
               "%e %e %e"
             ]), (function (b1, b2, b3) {
-            return b1 === 10.0 && b2 === b1 ? +(b3 === 0.13) : /* false */0;
+            return b1 === 10.0 && b2 === b1 ? b3 === 0.13 : false;
           }))) {
     return Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("1 1.1 0e+1 1.3e-1"), /* Format */[
                     /* Float */Block.__(8, [
@@ -534,13 +534,13 @@ function test5() {
                     "%g %g %g %g"
                   ]), (function (b1, b2, b3, b4) {
                   if (b1 === 1.0 && b2 === 1.1 && b3 === 0.0) {
-                    return +(b4 === 0.13);
+                    return b4 === 0.13;
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -555,8 +555,8 @@ function test6() {
                         b1,
                         b2
                       ], /* tuple */[
-                        /* true */1,
-                        /* true */1
+                        true,
+                        true
                       ]);
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("truefalse"), /* Format */[
               /* Bool */Block.__(9, [/* Bool */Block.__(9, [/* End_of_format */0])]),
@@ -566,8 +566,8 @@ function test6() {
                         b1,
                         b2
                       ], /* tuple */[
-                        /* true */1,
-                        /* false */0
+                        true,
+                        false
                       ]);
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("falsetrue"), /* Format */[
               /* Bool */Block.__(9, [/* Bool */Block.__(9, [/* End_of_format */0])]),
@@ -577,8 +577,8 @@ function test6() {
                         b1,
                         b2
                       ], /* tuple */[
-                        /* false */0,
-                        /* true */1
+                        false,
+                        true
                       ]);
           })) && Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("falsefalse"), /* Format */[
               /* Bool */Block.__(9, [/* Bool */Block.__(9, [/* End_of_format */0])]),
@@ -588,8 +588,8 @@ function test6() {
                         b1,
                         b2
                       ], /* tuple */[
-                        /* false */0,
-                        /* false */0
+                        false,
+                        false
                       ]);
           }))) {
     return Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("true false"), /* Format */[
@@ -603,12 +603,12 @@ function test6() {
                               b1,
                               b2
                             ], /* tuple */[
-                              /* true */1,
-                              /* false */0
+                              true,
+                              false
                             ]);
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -631,7 +631,7 @@ function test7() {
                     ])]),
               "%C %C %C %C %C"
             ]), (function (c1, c2, c3, c4, c5) {
-            return c1 === /* "a" */97 && c2 === /* "\n" */10 && c3 === /* "\t" */9 && c4 === /* "\000" */0 ? +(c5 === /* " " */32) : /* false */0;
+            return c1 === /* "a" */97 && c2 === /* "\n" */10 && c3 === /* "\t" */9 && c4 === /* "\000" */0 ? c5 === /* " " */32 : false;
           }))) {
     return Curry._1(Scanf.bscanf(Scanf.Scanning[/* from_string */6]("a \n \t \0  b"), /* Format */[
                     /* Char */Block.__(0, [/* Char_literal */Block.__(12, [
@@ -647,13 +647,13 @@ function test7() {
                     "%c %c %c "
                   ]), (function (c1, c2, c3) {
                   if (c1 === /* "a" */97 && c2 === /* "\000" */0) {
-                    return +(c3 === /* "b" */98);
+                    return c3 === /* "b" */98;
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -690,10 +690,10 @@ function verify_scan_Chars() {
 }
 
 function test8() {
-  return +(verify_scan_Chars(/* () */0) === /* () */0);
+  return verify_scan_Chars(/* () */0) === /* () */0;
 }
 
-test("File \"tscanf_test.ml\", line 183, characters 5-12", +(verify_scan_Chars(/* () */0) === /* () */0));
+test("File \"tscanf_test.ml\", line 183, characters 5-12", verify_scan_Chars(/* () */0) === /* () */0);
 
 function unit(fmt, s) {
   var ib = Scanf.Scanning[/* from_string */6](Curry._1(Printf.sprintf(/* Format */[
@@ -707,7 +707,7 @@ function unit(fmt, s) {
 }
 
 function test_fmt(fmt, s) {
-  return +(unit(fmt, s) === s);
+  return unit(fmt, s) === s;
 }
 
 var test9_string = "\xef\xbb\xbf";
@@ -766,17 +766,17 @@ function test9() {
             ]), (function (s) {
             return s;
           })) === "\\xef\\xbb\\xbf") {
-    return +(Curry._1(Scanf.sscanf("\" \"", /* Format */[
-                      /* Caml_string */Block.__(3, [
-                          /* No_padding */0,
-                          /* End_of_format */0
-                        ]),
-                      "%S"
-                    ]), (function (s) {
-                    return s;
-                  })) === " ");
+    return Curry._1(Scanf.sscanf("\" \"", /* Format */[
+                    /* Caml_string */Block.__(3, [
+                        /* No_padding */0,
+                        /* End_of_format */0
+                      ]),
+                    "%S"
+                  ]), (function (s) {
+                  return s;
+                })) === " ";
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -833,9 +833,9 @@ function test10() {
           return s1 + (s2 + (s3 + (s4 + (s5 + s6))));
         }));
   if (res === "Unechaine:celle-cietcelle-la!" && unit("\"a\\\n  b\"") === "ab" && unit("\"\\\n  ab\"") === "ab" && unit("\"\n\\\n  ab\"") === "\nab" && unit("\"\n\\\n  a\nb\"") === "\na\nb" && unit("\"\n\\\n  \\\n  a\nb\"") === "\na\nb" && unit("\"\n\\\n  a\n\\\nb\\\n\"") === "\na\nb" && unit("\"a\\\n  \"") === "a") {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -861,7 +861,7 @@ function test11() {
                 ]),
               "%s %s %s"
             ]), (function (prenom, nom, poids) {
-            return prenom === "Pierre" && nom === "Weis" ? +(Caml_format.caml_int_of_string(poids) === 70) : /* false */0;
+            return prenom === "Pierre" && nom === "Weis" ? Caml_format.caml_int_of_string(poids) === 70 : false;
           })) && Curry._1(Scanf.sscanf("Jean-Luc\tde Leage\t68", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -885,7 +885,7 @@ function test11() {
                 ]),
               "%[^\t] %[^\t] %d"
             ]), (function (prenom, nom, poids) {
-            return prenom === "Jean-Luc" && nom === "de Leage" ? +(poids === 68) : /* false */0;
+            return prenom === "Jean-Luc" && nom === "de Leage" ? poids === 68 : false;
           }))) {
     return Curry._1(Scanf.sscanf("Daniel\tde Rauglaudre\t66", /* Format */[
                     /* String */Block.__(2, [
@@ -915,13 +915,13 @@ function test11() {
                     "%s@\t %s@\t %d"
                   ]), (function (prenom, nom, poids) {
                   if (prenom === "Daniel" && nom === "de Rauglaudre") {
-                    return +(poids === 66);
+                    return poids === 66;
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -941,7 +941,7 @@ function test110() {
                 ]),
               "%s"
             ]), (function (x) {
-            return +(x === "");
+            return x === "";
           })) && Curry._1(Scanf.sscanf("", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -952,7 +952,7 @@ function test110() {
                 ]),
               "%s%s"
             ]), (function (x, y) {
-            return x === "" ? +(y === "") : /* false */0;
+            return x === "" ? y === "" : false;
           })) && Curry._1(Scanf.sscanf("", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -963,7 +963,7 @@ function test110() {
                 ]),
               "%s "
             ]), (function (x) {
-            return +(x === "");
+            return x === "";
           })) && Curry._1(Scanf.sscanf("", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* " " */32,
@@ -974,7 +974,7 @@ function test110() {
                 ]),
               " %s"
             ]), (function (x) {
-            return +(x === "");
+            return x === "";
           })) && Curry._1(Scanf.sscanf("", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* " " */32,
@@ -988,7 +988,7 @@ function test110() {
                 ]),
               " %s "
             ]), (function (x) {
-            return +(x === "");
+            return x === "";
           })) && Curry._1(Scanf.sscanf("", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -997,7 +997,7 @@ function test110() {
                 ]),
               "%[^\n]"
             ]), (function (x) {
-            return +(x === "");
+            return x === "";
           })) && Curry._1(Scanf.sscanf("", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -1009,7 +1009,7 @@ function test110() {
                 ]),
               "%[^\n] "
             ]), (function (x) {
-            return +(x === "");
+            return x === "";
           })) && Curry._1(Scanf.sscanf(" ", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -1017,7 +1017,7 @@ function test110() {
                 ]),
               "%s"
             ]), (function (x) {
-            return +(x === "");
+            return x === "";
           })) && Curry._1(Scanf.sscanf(" ", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -1028,7 +1028,7 @@ function test110() {
                 ]),
               "%s%s"
             ]), (function (x, y) {
-            return x === "" ? +(y === "") : /* false */0;
+            return x === "" ? y === "" : false;
           })) && Curry._1(Scanf.sscanf(" ", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* " " */32,
@@ -1042,7 +1042,7 @@ function test110() {
                 ]),
               " %s "
             ]), (function (x) {
-            return +(x === "");
+            return x === "";
           })) && Curry._1(Scanf.sscanf(" ", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* " " */32,
@@ -1059,7 +1059,7 @@ function test110() {
                 ]),
               " %s %s"
             ]), (function (x, y) {
-            return x === "" ? +(x === y) : /* false */0;
+            return x === "" ? x === y : false;
           })) && Curry._1(Scanf.sscanf(" ", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* " " */32,
@@ -1080,7 +1080,7 @@ function test110() {
                 ]),
               " %s@ %s"
             ]), (function (x, y) {
-            return x === "" ? +(x === y) : /* false */0;
+            return x === "" ? x === y : false;
           })) && Curry._1(Scanf.sscanf(" poi !", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* " " */32,
@@ -1104,7 +1104,7 @@ function test110() {
                 ]),
               " %s@ %s@."
             ]), (function (x, y) {
-            return x === "poi" ? +(y === "!") : /* false */0;
+            return x === "poi" ? y === "!" : false;
           }))) {
     return Curry._1(Scanf.sscanf(" poi !", /* Format */[
                     /* String */Block.__(2, [
@@ -1127,13 +1127,13 @@ function test110() {
                     "%s@ %s@."
                   ]), (function (x, y) {
                   if (x === "") {
-                    return +(y === "poi !");
+                    return y === "poi !";
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -1149,7 +1149,7 @@ function test111() {
                     ]),
                   "%[^\n]@\n"
                 ]), (function (x) {
-                return +(x === "");
+                return x === "";
               }));
 }
 
@@ -1549,7 +1549,7 @@ function test16() {
                     ]
                   ]));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -1643,7 +1643,7 @@ function test17() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -1804,13 +1804,13 @@ function test18() {
                     ]
                   ]);
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -1942,7 +1942,7 @@ function test22() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2048,7 +2048,7 @@ function test23() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2177,7 +2177,7 @@ function test28() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2271,7 +2271,7 @@ function test29() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2328,7 +2328,7 @@ function test30() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2458,7 +2458,7 @@ function test31() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2495,7 +2495,7 @@ function test32() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2608,7 +2608,7 @@ function test33() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2645,7 +2645,7 @@ function test34() {
                 ]
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -2879,7 +2879,7 @@ function test35() {
                 1
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3003,7 +3003,7 @@ function test36() {
                 0
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3013,20 +3013,20 @@ function test37() {
   if (Curry._1(Scanf.sscanf("", /* Format */[
               /* End_of_format */0,
               ""
-            ]), /* true */1) && Curry._2(Scanf.sscanf("", /* Format */[
+            ]), true) && Curry._2(Scanf.sscanf("", /* Format */[
               /* End_of_format */0,
               ""
             ]), (function (x) {
             return x;
           }), 1) === 1) {
-    return +(Curry._2(Scanf.sscanf("123", /* Format */[
-                      /* End_of_format */0,
-                      ""
-                    ]), (function (x) {
-                    return x;
-                  }), 1) === 1);
+    return Curry._2(Scanf.sscanf("123", /* Format */[
+                    /* End_of_format */0,
+                    ""
+                  ]), (function (x) {
+                  return x;
+                }), 1) === 1;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3039,49 +3039,49 @@ function test38() {
                   /* Flush */Block.__(10, [/* End_of_format */0])
                 ]),
               "a%!"
-            ]), /* true */1) && Curry._1(Scanf.sscanf("a", /* Format */[
+            ]), true) && Curry._1(Scanf.sscanf("a", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* "a" */97,
                   /* Flush */Block.__(10, [/* Flush */Block.__(10, [/* End_of_format */0])])
                 ]),
               "a%!%!"
-            ]), /* true */1) && Curry._1(Scanf.sscanf(" a", /* Format */[
+            ]), true) && Curry._1(Scanf.sscanf(" a", /* Format */[
               /* String_literal */Block.__(11, [
                   " a",
                   /* Flush */Block.__(10, [/* End_of_format */0])
                 ]),
               " a%!"
-            ]), /* true */1) && Curry._1(Scanf.sscanf("a ", /* Format */[
+            ]), true) && Curry._1(Scanf.sscanf("a ", /* Format */[
               /* String_literal */Block.__(11, [
                   "a ",
                   /* Flush */Block.__(10, [/* End_of_format */0])
                 ]),
               "a %!"
-            ]), /* true */1) && Curry._1(Scanf.sscanf("", /* Format */[
+            ]), true) && Curry._1(Scanf.sscanf("", /* Format */[
               /* Flush */Block.__(10, [/* End_of_format */0]),
               "%!"
-            ]), /* true */1) && Curry._1(Scanf.sscanf(" ", /* Format */[
+            ]), true) && Curry._1(Scanf.sscanf(" ", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* " " */32,
                   /* Flush */Block.__(10, [/* End_of_format */0])
                 ]),
               " %!"
-            ]), /* true */1) && Curry._1(Scanf.sscanf("", /* Format */[
+            ]), true) && Curry._1(Scanf.sscanf("", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* " " */32,
                   /* Flush */Block.__(10, [/* End_of_format */0])
                 ]),
               " %!"
-            ]), /* true */1)) {
+            ]), true)) {
     return Curry._1(Scanf.sscanf("", /* Format */[
                     /* Char_literal */Block.__(12, [
                         /* " " */32,
                         /* Flush */Block.__(10, [/* Flush */Block.__(10, [/* End_of_format */0])])
                       ]),
                     " %!%!"
-                  ]), /* true */1);
+                  ]), true);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3092,14 +3092,14 @@ function test39() {
     if (Scanf.Scanning[/* beginning_of_input */10](ib)) {
       return Scanf.Scanning[/* end_of_input */9](ib);
     } else {
-      return /* false */0;
+      return false;
     }
   };
   var ib = Scanf.Scanning[/* from_string */6]("");
   if (is_empty_buff(ib)) {
     return is_empty_buff(ib);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3119,9 +3119,9 @@ function test40() {
                   "%[^ab]%s%!"
                 ]), (function (s1, s2) {
                 if (s1 === "c") {
-                  return +(s2 === "ba");
+                  return s2 === "ba";
                 } else {
-                  return /* false */0;
+                  return false;
                 }
               }));
 }
@@ -3143,9 +3143,9 @@ function test41() {
                   "%[^abc]%[cba]%!"
                 ]), (function (s1, s2) {
                 if (s1 === "") {
-                  return +(s2 === "cba");
+                  return s2 === "cba";
                 } else {
-                  return /* false */0;
+                  return false;
                 }
               }));
 }
@@ -3171,9 +3171,9 @@ function test42() {
               "%[^abc]%[abc]%s%!"
             ]), (function (s1, s2, s3) {
             if (s1 === "def" && s2 === "cbaa") {
-              return +(s3 === "ghi");
+              return s3 === "ghi";
             } else {
-              return /* false */0;
+              return false;
             }
           }))) {
     var ib$1 = Scanf.Scanning[/* from_string */6](s);
@@ -3187,10 +3187,10 @@ function test42() {
                       ]),
                     "%s@\t"
                   ]), (function (s) {
-                  return +(s === "defcbaaghi");
+                  return s === "defcbaaghi";
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3249,9 +3249,9 @@ function test45() {
                   "%[0-9].%[0-9]%s%!"
                 ]), (function (s1, s2, s3) {
                 if (s1 === "12" && s2 === "2") {
-                  return +(s3 === "");
+                  return s3 === "";
                 } else {
-                  return /* false */0;
+                  return false;
                 }
               }));
 }
@@ -3326,9 +3326,9 @@ function test47() {
             ], "in english");
 }
 
-test("File \"tscanf_test.ml\", line 1104, characters 5-12", +(test46(/* () */0) === "1 spells one, in english."));
+test("File \"tscanf_test.ml\", line 1104, characters 5-12", test46(/* () */0) === "1 spells one, in english.");
 
-test("File \"tscanf_test.ml\", line 1106, characters 5-12", +(test47(/* () */0) === "1 %s, in english."));
+test("File \"tscanf_test.ml\", line 1106, characters 5-12", test47(/* () */0) === "1 %s, in english.");
 
 function test48() {
   var test_meta_read = function (s, fmt, efmt) {
@@ -3390,9 +3390,9 @@ function test48() {
                       ]),
                     "%i"
                   ])) {
-              return +(s === "89");
+              return s === "89";
             } else {
-              return /* false */0;
+              return false;
             }
           }))) {
     var k = function (s) {
@@ -3488,19 +3488,19 @@ function test48() {
                         "yens"
                       ]);
           } else {
-            return /* false */0;
+            return false;
           }
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3515,7 +3515,7 @@ function test49() {
                 ]),
               "%[\\]"
             ]), (function (s) {
-            return +(s === "");
+            return s === "";
           })) && Curry._1(Scanf.sscanf("as", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -3527,7 +3527,7 @@ function test49() {
                 ]),
               "%[\\]%s"
             ]), (function (s, t) {
-            return s === "" ? +(t === "as") : /* false */0;
+            return s === "" ? t === "as" : false;
           })) && Curry._1(Scanf.sscanf("as", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -3539,7 +3539,7 @@ function test49() {
                 ]),
               "%[\\]%s%!"
             ]), (function (s, t) {
-            return s === "" ? +(t === "as") : /* false */0;
+            return s === "" ? t === "as" : false;
           })) && Curry._1(Scanf.sscanf("as", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -3548,7 +3548,7 @@ function test49() {
                 ]),
               "%[a..z]"
             ]), (function (s) {
-            return +(s === "a");
+            return s === "a";
           })) && Curry._1(Scanf.sscanf("as", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -3557,7 +3557,7 @@ function test49() {
                 ]),
               "%[a-z]"
             ]), (function (s) {
-            return +(s === "as");
+            return s === "as";
           })) && Curry._1(Scanf.sscanf("as", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -3569,7 +3569,7 @@ function test49() {
                 ]),
               "%[a..z]%s"
             ]), (function (s, t) {
-            return s === "a" ? +(t === "s") : /* false */0;
+            return s === "a" ? t === "s" : false;
           })) && Curry._1(Scanf.sscanf("as", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -3581,7 +3581,7 @@ function test49() {
                 ]),
               "%[a-z]%s"
             ]), (function (s, t) {
-            return s === "as" ? +(t === "") : /* false */0;
+            return s === "as" ? t === "" : false;
           })) && Curry._1(Scanf.sscanf("-as", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -3590,7 +3590,7 @@ function test49() {
                 ]),
               "%[-a-z]"
             ]), (function (s) {
-            return +(s === "-as");
+            return s === "-as";
           })) && Curry._1(Scanf.sscanf("-as", /* Format */[
               /* Scan_char_set */Block.__(20, [
                   /* None */0,
@@ -3602,7 +3602,7 @@ function test49() {
                 ]),
               "%[-a-z]@s"
             ]), (function (s) {
-            return +(s === "-a");
+            return s === "-a";
           })) && Curry._1(Scanf.sscanf("-as", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* "-" */45,
@@ -3617,7 +3617,7 @@ function test49() {
                 ]),
               "-%[a]@s"
             ]), (function (s) {
-            return +(s === "a");
+            return s === "a";
           })) && Curry._1(Scanf.sscanf("-asb", /* Format */[
               /* Char_literal */Block.__(12, [
                   /* "-" */45,
@@ -3635,7 +3635,7 @@ function test49() {
                 ]),
               "-%[a]@sb%!"
             ]), (function (s) {
-            return +(s === "a");
+            return s === "a";
           }))) {
     return Curry._1(Scanf.sscanf("-asb", /* Format */[
                     /* Char_literal */Block.__(12, [
@@ -3655,13 +3655,13 @@ function test49() {
                     "-%[a]@s%s"
                   ]), (function (s, t) {
                   if (s === "a") {
-                    return +(t === "b");
+                    return t === "b";
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3770,10 +3770,10 @@ function go() {
 }
 
 function test50() {
-  return +(go(/* () */0) === 100);
+  return go(/* () */0) === 100;
 }
 
-test("File \"tscanf_test.ml\", line 1228, characters 5-12", +(go(/* () */0) === 100));
+test("File \"tscanf_test.ml\", line 1228, characters 5-12", go(/* () */0) === 100);
 
 function test51() {
   if (Curry._1(Scanf.sscanf("Hello", /* Format */[
@@ -3804,7 +3804,7 @@ function test51() {
                 ]),
               "%s%s\n"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "") : /* false */0;
+            return s1 === "Hello" ? s2 === "" : false;
           })) && Curry._1(Scanf.sscanf("Hello\nWorld", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -3818,7 +3818,7 @@ function test51() {
                 ]),
               "%s\n%s%!"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "World") : /* false */0;
+            return s1 === "Hello" ? s2 === "World" : false;
           })) && Curry._1(Scanf.sscanf("Hello\nWorld!", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -3832,7 +3832,7 @@ function test51() {
                 ]),
               "%s\n%s"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "World!") : /* false */0;
+            return s1 === "Hello" ? s2 === "World!" : false;
           })) && Curry._1(Scanf.sscanf("Hello\n", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -3846,7 +3846,7 @@ function test51() {
                 ]),
               "%s@\n%s"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "") : /* false */0;
+            return s1 === "Hello" ? s2 === "" : false;
           }))) {
     return Curry._1(Scanf.sscanf("Hello \n", /* Format */[
                     /* String */Block.__(2, [
@@ -3862,13 +3862,13 @@ function test51() {
                     "%s@\n%s"
                   ]), (function (s1, s2) {
                   if (s1 === "Hello ") {
-                    return +(s2 === "");
+                    return s2 === "";
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -3906,7 +3906,7 @@ function test52() {
                 ]),
               "%s%s@\n"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "") : /* false */0;
+            return s1 === "Hello" ? s2 === "" : false;
           })) && Curry._1(Scanf.sscanf("Hello\nWorld", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -3920,7 +3920,7 @@ function test52() {
                 ]),
               "%s@\n%s%!"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "World") : /* false */0;
+            return s1 === "Hello" ? s2 === "World" : false;
           })) && Curry._1(Scanf.sscanf("Hello\nWorld!", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -3937,7 +3937,7 @@ function test52() {
                 ]),
               "%s@\n%s@\n"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "World!") : /* false */0;
+            return s1 === "Hello" ? s2 === "World!" : false;
           })) && Curry._1(Scanf.sscanf("Hello\n", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -3951,7 +3951,7 @@ function test52() {
                 ]),
               "%s@\n%s"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "") : /* false */0;
+            return s1 === "Hello" ? s2 === "" : false;
           })) && Curry._1(Scanf.sscanf("Hello \n", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -3965,7 +3965,7 @@ function test52() {
                 ]),
               "%s%s@\n"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === " ") : /* false */0;
+            return s1 === "Hello" ? s2 === " " : false;
           })) && Curry._1(Scanf.sscanf("Hello \n", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -3985,7 +3985,7 @@ function test52() {
                 ]),
               "%s%s%_1[ ]\n"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "") : /* false */0;
+            return s1 === "Hello" ? s2 === "" : false;
           })) && Curry._1(Scanf.sscanf("Hello \n", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -4005,7 +4005,7 @@ function test52() {
                 ]),
               "%s%_1[ ]%s\n"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "") : /* false */0;
+            return s1 === "Hello" ? s2 === "" : false;
           })) && Curry._1(Scanf.sscanf("Hello\nWorld", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -4019,7 +4019,7 @@ function test52() {
                 ]),
               "%s\n%s%!"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "World") : /* false */0;
+            return s1 === "Hello" ? s2 === "World" : false;
           })) && Curry._1(Scanf.sscanf("Hello\nWorld!", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -4033,7 +4033,7 @@ function test52() {
                 ]),
               "%s\n%s%!"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "World!") : /* false */0;
+            return s1 === "Hello" ? s2 === "World!" : false;
           })) && Curry._1(Scanf.sscanf("Hello\nWorld!", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -4050,7 +4050,7 @@ function test52() {
                 ]),
               "%s\n%s@!%!"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "World") : /* false */0;
+            return s1 === "Hello" ? s2 === "World" : false;
           })) && Curry._1(Scanf.sscanf("Hello{foo}", /* Format */[
               /* String */Block.__(2, [
                   /* No_padding */0,
@@ -4067,7 +4067,7 @@ function test52() {
                 ]),
               "%s@{%s"
             ]), (function (s1, s2) {
-            return s1 === "Hello" ? +(s2 === "foo}") : /* false */0;
+            return s1 === "Hello" ? s2 === "foo}" : false;
           }))) {
     return Curry._1(Scanf.sscanf("Hello[foo]", /* Format */[
                     /* String */Block.__(2, [
@@ -4086,13 +4086,13 @@ function test52() {
                     "%s@[%s"
                   ]), (function (s1, s2) {
                   if (s1 === "Hello") {
-                    return +(s2 === "foo]");
+                    return s2 === "foo]";
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4116,7 +4116,7 @@ function test53() {
                 ]),
               "%nd"
             ]), (function (i) {
-            return +(i - 1 === 123);
+            return i - 1 === 123;
           })) && Curry._1(Scanf.sscanf("123", /* Format */[
               /* Int32 */Block.__(5, [
                   /* Int_d */0,
@@ -4134,7 +4134,7 @@ function test53() {
                 ]),
               "%ld"
             ]), (function (i) {
-            return +((i + 1 | 0) === 125);
+            return (i + 1 | 0) === 125;
           })) && Caml_int64.eq(Curry._1(Scanf.sscanf("123", /* Format */[
                   /* Int64 */Block.__(7, [
                       /* Int_d */0,
@@ -4165,7 +4165,7 @@ function test53() {
                             ]);
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4203,7 +4203,7 @@ function test56() {
                 3
               ]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4403,13 +4403,13 @@ function test57() {
                             ]),
                           "%i"
                         ])) {
-                    return +(s === "89");
+                    return s === "89";
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -4458,33 +4458,33 @@ function test58() {
             ]), (function (prim, prim$1) {
             return prim + prim$1;
           })) === "string1string2") {
-    return +(Curry._1(Scanf.sscanf("string1@%string2", /* Format */[
-                      /* Scan_char_set */Block.__(20, [
-                          /* None */0,
-                          "\0\0\0\0\0\0\xff\x03\0\0\0\0\xfe\xff\xff\x07\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
-                          /* Char_literal */Block.__(12, [
-                              /* "@" */64,
-                              /* Char_literal */Block.__(12, [
-                                  /* "%" */37,
-                                  /* String */Block.__(2, [
-                                      /* No_padding */0,
-                                      /* End_of_format */0
-                                    ])
-                                ])
-                            ])
-                        ]),
-                      "%[a-z0-9]%@%%%s"
-                    ]), (function (prim, prim$1) {
-                    return prim + prim$1;
-                  })) === "string1string2");
+    return Curry._1(Scanf.sscanf("string1@%string2", /* Format */[
+                    /* Scan_char_set */Block.__(20, [
+                        /* None */0,
+                        "\0\0\0\0\0\0\xff\x03\0\0\0\0\xfe\xff\xff\x07\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+                        /* Char_literal */Block.__(12, [
+                            /* "@" */64,
+                            /* Char_literal */Block.__(12, [
+                                /* "%" */37,
+                                /* String */Block.__(2, [
+                                    /* No_padding */0,
+                                    /* End_of_format */0
+                                  ])
+                              ])
+                          ])
+                      ]),
+                    "%[a-z0-9]%@%%%s"
+                  ]), (function (prim, prim$1) {
+                  return prim + prim$1;
+                })) === "string1string2";
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 test("File \"tscanf_test.ml\", line 1367, characters 5-12", test58(/* () */0));
 
-test("File \"tscanf_test.ml\", line 1371, characters 14-21", /* true */1);
+test("File \"tscanf_test.ml\", line 1371, characters 14-21", true);
 
 function test60() {
   if (Curry._1(Scanf.sscanf("abc", /* Format */[
@@ -4494,7 +4494,7 @@ function test60() {
                             ])])])]),
               "%0c%0c%c%n"
             ]), (function (c1, c2, c3, n) {
-            return c1 === /* "a" */97 && c2 === /* "a" */97 && c3 === /* "a" */97 ? +(n === 1) : /* false */0;
+            return c1 === /* "a" */97 && c2 === /* "a" */97 && c3 === /* "a" */97 ? n === 1 : false;
           })) && Curry._1(Scanf.sscanf("abc", /* Format */[
               /* String */Block.__(2, [
                   /* Lit_padding */Block.__(0, [
@@ -4508,7 +4508,7 @@ function test60() {
                 ]),
               "%0s%s"
             ]), (function (s1, s2) {
-            return s1 === "" ? +(s2 === "abc") : /* false */0;
+            return s1 === "" ? s2 === "abc" : false;
           }))) {
     return Curry._1(Scanf.sscanf("abc", /* Format */[
                     /* String */Block.__(2, [
@@ -4524,13 +4524,13 @@ function test60() {
                     "%1s%s"
                   ]), (function (s1, s2) {
                   if (s1 === "a") {
-                    return +(s2 === "bc");
+                    return s2 === "bc";
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 }));
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/jscomp/test/typeof_test.js
+++ b/jscomp/test/typeof_test.js
@@ -10,19 +10,19 @@ function string_or_number(x) {
   switch (match[0]) {
     case 3 : 
         console.log(v + 3);
-        return /* true */1;
+        return true;
     case 4 : 
         console.log(v + "hei");
-        return /* true */1;
+        return true;
     case 5 : 
         console.log("Function");
-        return /* false */0;
+        return false;
     case 0 : 
     case 1 : 
     case 2 : 
     case 6 : 
     case 7 : 
-        return /* false */0;
+        return false;
     
   }
 }
@@ -53,7 +53,7 @@ var suites_001 = /* :: */[
       (function () {
           return /* Eq */Block.__(0, [
                     Js_types.test(3, /* Number */3),
-                    /* true */1
+                    true
                   ]);
         })
     ],
@@ -63,7 +63,7 @@ var suites_001 = /* :: */[
         (function () {
             return /* Eq */Block.__(0, [
                       Js_types.test(true, /* Boolean */2),
-                      /* true */1
+                      true
                     ]);
           })
       ],
@@ -73,7 +73,7 @@ var suites_001 = /* :: */[
           (function () {
               return /* Eq */Block.__(0, [
                         Js_types.test(undefined, /* Undefined */0),
-                        /* true */1
+                        true
                       ]);
             })
         ],
@@ -83,7 +83,7 @@ var suites_001 = /* :: */[
             (function () {
                 return /* Eq */Block.__(0, [
                           string_or_number("xx"),
-                          /* true */1
+                          true
                         ]);
               })
           ],
@@ -93,7 +93,7 @@ var suites_001 = /* :: */[
               (function () {
                   return /* Eq */Block.__(0, [
                             string_or_number(3.02),
-                            /* true */1
+                            true
                           ]);
                 })
             ],
@@ -105,7 +105,7 @@ var suites_001 = /* :: */[
                               string_or_number((function (x) {
                                       return x;
                                     })),
-                              /* false */0
+                              false
                             ]);
                   })
               ],
@@ -115,7 +115,7 @@ var suites_001 = /* :: */[
                   (function () {
                       return /* Eq */Block.__(0, [
                                 Js_types.test("3", /* String */4),
-                                /* true */1
+                                true
                               ]);
                     })
                 ],
@@ -125,7 +125,7 @@ var suites_001 = /* :: */[
                     (function () {
                         return /* Eq */Block.__(0, [
                                   Js_types.test(3, /* String */4),
-                                  /* false */0
+                                  false
                                 ]);
                       })
                   ],
@@ -137,7 +137,7 @@ var suites_001 = /* :: */[
                                     Js_types.test((function (x) {
                                             return x;
                                           }), /* Function */5),
-                                    /* true */1
+                                    true
                                   ]);
                         })
                     ],
@@ -149,7 +149,7 @@ var suites_001 = /* :: */[
                                       Js_types.test({
                                             x: 3
                                           }, /* Object */6),
-                                      /* true */1
+                                      true
                                     ]);
                           })
                       ],

--- a/jscomp/test/undef_regression2_test.js
+++ b/jscomp/test/undef_regression2_test.js
@@ -75,10 +75,10 @@ function test3() {
 }
 
 function f(x) {
-  return +(x === undefined);
+  return x === undefined;
 }
 
-ok("File \"undef_regression2_test.ml\", line 44, characters 5-12", +(a > 0));
+ok("File \"undef_regression2_test.ml\", line 44, characters 5-12", a > 0);
 
 eq("File \"undef_regression2_test.ml\", line 45, characters 5-12", a, 1);
 

--- a/jscomp/test/utf8_decode_test.js
+++ b/jscomp/test/utf8_decode_test.js
@@ -168,12 +168,12 @@ function eq_list(cmp, _xs, _ys) {
         _xs = xs[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (ys) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -220,9 +220,9 @@ Stream.iter(add, utf8_decode(Stream.of_string("\xe4\xbd\xa0\xe5\xa5\xbdBuckleScr
 var codes = List.rev(v[0]);
 
 eq("File \"utf8_decode_test.ml\", line 125, characters 5-12", /* tuple */[
-      /* true */1,
+      true,
       eq_list((function (x, y) {
-              return +(x === y);
+              return x === y;
             }), codes, /* :: */[
             20320,
             /* :: */[

--- a/jscomp/xwatcher/xwatcher.js
+++ b/jscomp/xwatcher/xwatcher.js
@@ -37,16 +37,16 @@ function idle() {
   Js_vector.filterInPlace((function (param) {
           var dir = param[/* dir */0];
           if (dir === bsconfig || Js_vector.memByRef(dir, watchFiles)) {
-            return /* true */1;
+            return true;
           } else {
             console.log(" " + (String(dir) + " is no longer watched"));
             param[/* watcher */1].close();
-            return /* false */0;
+            return false;
           }
         }), watchers);
   watchFiles.forEach((function (dir) {
           if (watchers.some((function (param) {
-                    return +(param[/* dir */0] === dir);
+                    return param[/* dir */0] === dir;
                   }))) {
             return 0;
           } else {

--- a/jscomp/xwatcher/xwatcher_util.js
+++ b/jscomp/xwatcher/xwatcher_util.js
@@ -7,7 +7,7 @@ import * as Child_process from "child_process";
 function getWatchFiles(file) {
   if (Fs.existsSync(file)) {
     return Fs.readFileSync(file, "utf8").split("\n").filter((function (x) {
-                  return +(x.trim().length !== 0);
+                  return x.trim().length !== 0;
                 }));
   } else {
     return /* array */[];
@@ -48,7 +48,7 @@ function makeEventObj() {
             }),
           needRebuild: (function () {
               var self = this ;
-              return +(self.events.length !== 0);
+              return self.events.length !== 0;
             }),
           currentEvents: (function () {
               var self = this ;
@@ -59,19 +59,19 @@ function makeEventObj() {
 
 function makeLock() {
   return {
-          isBuilding: /* false */0,
+          isBuilding: false,
           acquire: (function () {
               var self = this ;
               if (self.isBuilding) {
-                return /* false */0;
+                return false;
               } else {
-                self.isBuilding = /* true */1;
-                return /* true */1;
+                self.isBuilding = true;
+                return true;
               }
             }),
           release: (function () {
               var self = this ;
-              self.isBuilding = /* false */0;
+              self.isBuilding = false;
               return /* () */0;
             })
         };

--- a/lib/bsdep.ml
+++ b/lib/bsdep.ml
@@ -31770,7 +31770,6 @@ type return_wrapper =
   | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
-  | Return_to_ocaml_bool
   | Return_replaced_with_unit
 
 type t  =
@@ -31930,7 +31929,6 @@ type return_wrapper =
   | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
-  | Return_to_ocaml_bool
   | Return_replaced_with_unit
 type t  =
   | Ffi_bs of External_arg_spec.t list  *
@@ -32829,8 +32827,6 @@ let check_return_wrapper
   | Return_unset  ->
     if Ast_core_type.is_unit result_type then
       Return_replaced_with_unit
-    else if Ast_core_type.is_user_bool result_type then
-      Return_to_ocaml_bool
     else
       wrapper
   | Return_undefined_to_opt
@@ -32841,8 +32837,7 @@ let check_return_wrapper
       wrapper
     else
       Bs_syntaxerr.err loc Expect_opt_in_bs_return_to_opt
-  | Return_replaced_with_unit
-  | Return_to_ocaml_bool  ->
+  | Return_replaced_with_unit ->
     assert false (* Not going to happen from user input*)
 
 

--- a/lib/bsppx.ml
+++ b/lib/bsppx.ml
@@ -13775,7 +13775,6 @@ type return_wrapper =
   | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
-  | Return_to_ocaml_bool
   | Return_replaced_with_unit
 
 type t  =
@@ -13935,7 +13934,6 @@ type return_wrapper =
   | Return_undefined_to_opt
   | Return_null_to_opt
   | Return_null_undefined_to_opt
-  | Return_to_ocaml_bool
   | Return_replaced_with_unit
 type t  =
   | Ffi_bs of External_arg_spec.t list  *
@@ -14834,8 +14832,6 @@ let check_return_wrapper
   | Return_unset  ->
     if Ast_core_type.is_unit result_type then
       Return_replaced_with_unit
-    else if Ast_core_type.is_user_bool result_type then
-      Return_to_ocaml_bool
     else
       wrapper
   | Return_undefined_to_opt
@@ -14846,8 +14842,7 @@ let check_return_wrapper
       wrapper
     else
       Bs_syntaxerr.err loc Expect_opt_in_bs_return_to_opt
-  | Return_replaced_with_unit
-  | Return_to_ocaml_bool  ->
+  | Return_replaced_with_unit ->
     assert false (* Not going to happen from user input*)
 
 

--- a/lib/js/arg.js
+++ b/lib/js/arg.js
@@ -355,10 +355,10 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                       ];
                 }
             case 2 : 
-                param[0][0] = /* true */1;
+                param[0][0] = true;
                 return /* () */0;
             case 3 : 
-                param[0][0] = /* false */0;
+                param[0][0] = false;
                 return /* () */0;
             case 4 : 
                 if ((current$1[0] + 1 | 0) < l) {

--- a/lib/js/belt_Array.js
+++ b/lib/js/belt_Array.js
@@ -22,9 +22,9 @@ function getExn(arr, i) {
 function set(arr, i, v) {
   if (i >= 0 && i < arr.length) {
     arr[i] = v;
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -127,7 +127,7 @@ function makeByAndShuffle(l, f) {
 function range(start, finish) {
   var cut = finish - start | 0;
   if (cut < 0) {
-    return /* int array */[];
+    return /* array */[];
   } else {
     var arr = new Array(cut + 1 | 0);
     for(var i = 0; i <= cut; ++i){
@@ -140,7 +140,7 @@ function range(start, finish) {
 function rangeBy(start, finish, step) {
   var cut = finish - start | 0;
   if (cut < 0 || step <= 0) {
-    return /* int array */[];
+    return /* array */[];
   } else {
     var nb = (cut / step | 0) + 1 | 0;
     var arr = new Array(nb);
@@ -420,12 +420,12 @@ function everyU(arr, b) {
   while(true) {
     var i = _i;
     if (i === len$1) {
-      return /* true */1;
+      return true;
     } else if (b$1(arr$1[i])) {
       _i = i + 1 | 0;
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -443,9 +443,9 @@ function someU(arr, b) {
   while(true) {
     var i = _i;
     if (i === len$1) {
-      return /* false */0;
+      return false;
     } else if (b$1(arr$1[i])) {
-      return /* true */1;
+      return true;
     } else {
       _i = i + 1 | 0;
       continue ;
@@ -461,12 +461,12 @@ function everyAux2(arr1, arr2, _i, b, len) {
   while(true) {
     var i = _i;
     if (i === len) {
-      return /* true */1;
+      return true;
     } else if (b(arr1[i], arr2[i])) {
       _i = i + 1 | 0;
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -488,9 +488,9 @@ function some2U(a, b, p) {
   while(true) {
     var i = _i;
     if (i === len) {
-      return /* false */0;
+      return false;
     } else if (b$1(arr1[i], arr2[i])) {
-      return /* true */1;
+      return true;
     } else {
       _i = i + 1 | 0;
       continue ;
@@ -508,7 +508,7 @@ function eqU(a, b, p) {
   if (lena === lenb) {
     return everyAux2(a, b, 0, p, lena);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/belt_HashMap.js
+++ b/lib/js/belt_HashMap.js
@@ -32,14 +32,14 @@ function replaceInBucket(eq, key, info, _cell) {
     var cell = _cell;
     if (eq(cell.key, key)) {
       cell.value = info;
-      return /* false */0;
+      return false;
     } else {
       var match = cell.next;
       if (match !== undefined) {
         _cell = match;
         continue ;
       } else {
-        return /* true */1;
+        return true;
       }
     }
   };
@@ -201,19 +201,19 @@ function has(h, key) {
     while(true) {
       var cell = _cell;
       if (eq(cell.key, key$1)) {
-        return /* true */1;
+        return true;
       } else {
         var match = cell.next;
         if (match !== undefined) {
           _cell = match;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/belt_HashMapInt.js
+++ b/lib/js/belt_HashMapInt.js
@@ -30,14 +30,14 @@ function replaceInBucket(key, info, _cell) {
     var cell = _cell;
     if (cell.key === key) {
       cell.value = info;
-      return /* false */0;
+      return false;
     } else {
       var match = cell.next;
       if (match !== undefined) {
         _cell = match;
         continue ;
       } else {
-        return /* true */1;
+        return true;
       }
     }
   };
@@ -189,19 +189,19 @@ function has(h, key) {
     while(true) {
       var cell = _cell;
       if (cell.key === key$1) {
-        return /* true */1;
+        return true;
       } else {
         var match = cell.next;
         if (match !== undefined) {
           _cell = match;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/belt_HashMapString.js
+++ b/lib/js/belt_HashMapString.js
@@ -30,14 +30,14 @@ function replaceInBucket(key, info, _cell) {
     var cell = _cell;
     if (cell.key === key) {
       cell.value = info;
-      return /* false */0;
+      return false;
     } else {
       var match = cell.next;
       if (match !== undefined) {
         _cell = match;
         continue ;
       } else {
-        return /* true */1;
+        return true;
       }
     }
   };
@@ -189,19 +189,19 @@ function has(h, key) {
     while(true) {
       var cell = _cell;
       if (cell.key === key$1) {
-        return /* true */1;
+        return true;
       } else {
         var match = cell.next;
         if (match !== undefined) {
           _cell = match;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/belt_HashSet.js
+++ b/lib/js/belt_HashSet.js
@@ -145,19 +145,19 @@ function has(h, key) {
     while(true) {
       var cell = _cell;
       if (eq$1(cell.key, key$1)) {
-        return /* true */1;
+        return true;
       } else {
         var match = cell.next;
         if (match !== undefined) {
           _cell = match;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/belt_HashSetInt.js
+++ b/lib/js/belt_HashSetInt.js
@@ -138,19 +138,19 @@ function has(h, key) {
     while(true) {
       var cell = _cell;
       if (cell.key === key$1) {
-        return /* true */1;
+        return true;
       } else {
         var match = cell.next;
         if (match !== undefined) {
           _cell = match;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/belt_HashSetString.js
+++ b/lib/js/belt_HashSetString.js
@@ -138,19 +138,19 @@ function has(h, key) {
     while(true) {
       var cell = _cell;
       if (cell.key === key$1) {
-        return /* true */1;
+        return true;
       } else {
         var match = cell.next;
         if (match !== undefined) {
           _cell = match;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/belt_List.js
+++ b/lib/js/belt_List.js
@@ -227,7 +227,7 @@ function removeAssocAuxWithMap(_cellX, x, _prec, f) {
       var h = cellX[0];
       if (f(h[0], x)) {
         prec[1] = t;
-        return /* true */1;
+        return true;
       } else {
         var next = /* :: */[
           h,
@@ -239,7 +239,7 @@ function removeAssocAuxWithMap(_cellX, x, _prec, f) {
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -259,7 +259,7 @@ function setAssocAuxWithMap(_cellX, x, k, _prec, eq) {
           ],
           t
         ];
-        return /* true */1;
+        return true;
       } else {
         var next = /* :: */[
           h,
@@ -271,7 +271,7 @@ function setAssocAuxWithMap(_cellX, x, k, _prec, eq) {
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -367,7 +367,7 @@ function takeAux(_n, _cell, _prec) {
     var cell = _cell;
     var n = _n;
     if (n === 0) {
-      return /* true */1;
+      return true;
     } else if (cell) {
       var cell$1 = /* :: */[
         cell[0],
@@ -379,7 +379,7 @@ function takeAux(_n, _cell, _prec) {
       _n = n - 1 | 0;
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -928,10 +928,10 @@ function everyU(_xs, p) {
         _xs = xs[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -945,13 +945,13 @@ function someU(_xs, p) {
     var xs = _xs;
     if (xs) {
       if (p(xs[0])) {
-        return /* true */1;
+        return true;
       } else {
         _xs = xs[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -970,10 +970,10 @@ function every2U(_l1, _l2, p) {
         _l1 = l1[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -1041,12 +1041,12 @@ function eqU(_l1, _l2, p) {
         _l1 = l1[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (l2) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -1061,14 +1061,14 @@ function some2U(_l1, _l2, p) {
     var l1 = _l1;
     if (l1 && l2) {
       if (p(l1[0], l2[0])) {
-        return /* true */1;
+        return true;
       } else {
         _l2 = l2[1];
         _l1 = l1[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1082,13 +1082,13 @@ function hasU(_xs, x, eq) {
     var xs = _xs;
     if (xs) {
       if (eq(xs[0], x)) {
-        return /* true */1;
+        return true;
       } else {
         _xs = xs[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1123,13 +1123,13 @@ function hasAssocU(_xs, x, eq) {
     var xs = _xs;
     if (xs) {
       if (eq(xs[0][0], x)) {
-        return /* true */1;
+        return true;
       } else {
         _xs = xs[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }

--- a/lib/js/belt_MutableQueue.js
+++ b/lib/js/belt_MutableQueue.js
@@ -186,7 +186,7 @@ function map(q, f) {
 }
 
 function isEmpty(q) {
-  return +(q.length === 0);
+  return q.length === 0;
 }
 
 function size(q) {

--- a/lib/js/belt_MutableSet.js
+++ b/lib/js/belt_MutableSet.js
@@ -89,7 +89,7 @@ function removeCheck0(nt, x, removed, cmp) {
   var k = nt.value;
   var c = cmp(x, k);
   if (c === 0) {
-    removed[0] = /* true */1;
+    removed[0] = true;
     var l = nt.left;
     var r = nt.right;
     if (l !== null) {
@@ -124,14 +124,14 @@ function removeCheck0(nt, x, removed, cmp) {
 function removeCheck(d, v) {
   var oldRoot = d.data;
   if (oldRoot !== null) {
-    var removed = [/* false */0];
+    var removed = [false];
     var newRoot = removeCheck0(oldRoot, v, removed, d.cmp);
     if (newRoot !== oldRoot) {
       d.data = newRoot;
     }
     return removed[0];
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -153,14 +153,14 @@ function addCheck0(t, x, added, cmp) {
       return Belt_internalAVLset.balMutate(t);
     }
   } else {
-    added[0] = /* true */1;
+    added[0] = true;
     return Belt_internalAVLset.singleton(x);
   }
 }
 
 function addCheck(m, e) {
   var oldRoot = m.data;
-  var added = [/* false */0];
+  var added = [false];
   var newRoot = addCheck0(oldRoot, e, added, m.cmp);
   if (newRoot !== oldRoot) {
     m.data = newRoot;
@@ -320,7 +320,7 @@ function split(d, key) {
                 data: Belt_internalAVLset.fromSortedArrayAux(arr, next, len - next | 0)
               }
             ],
-            /* false */0
+            false
           ];
   } else {
     return /* tuple */[
@@ -334,7 +334,7 @@ function split(d, key) {
                 data: Belt_internalAVLset.fromSortedArrayAux(arr, i + 1 | 0, (len - i | 0) - 1 | 0)
               }
             ],
-            /* true */1
+            true
           ];
   }
 }

--- a/lib/js/belt_MutableSetInt.js
+++ b/lib/js/belt_MutableSetInt.js
@@ -88,7 +88,7 @@ function removeMany(d, xs) {
 function removeCheck0(nt, x, removed) {
   var k = nt.value;
   if (x === k) {
-    removed[0] = /* true */1;
+    removed[0] = true;
     var l = nt.left;
     var r = nt.right;
     if (l !== null) {
@@ -123,14 +123,14 @@ function removeCheck0(nt, x, removed) {
 function removeCheck(d, v) {
   var oldRoot = d.data;
   if (oldRoot !== null) {
-    var removed = [/* false */0];
+    var removed = [false];
     var newRoot = removeCheck0(oldRoot, v, removed);
     if (newRoot !== oldRoot) {
       d.data = newRoot;
     }
     return removed[0];
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -151,14 +151,14 @@ function addCheck0(t, x, added) {
       return Belt_internalAVLset.balMutate(t);
     }
   } else {
-    added[0] = /* true */1;
+    added[0] = true;
     return Belt_internalAVLset.singleton(x);
   }
 }
 
 function addCheck(m, e) {
   var oldRoot = m.data;
-  var added = [/* false */0];
+  var added = [false];
   var newRoot = addCheck0(oldRoot, e, added);
   if (newRoot !== oldRoot) {
     m.data = newRoot;
@@ -311,7 +311,7 @@ function split(d, key) {
                 data: Belt_internalAVLset.fromSortedArrayAux(arr, next, len - next | 0)
               }
             ],
-            /* false */0
+            false
           ];
   } else {
     return /* tuple */[
@@ -323,7 +323,7 @@ function split(d, key) {
                 data: Belt_internalAVLset.fromSortedArrayAux(arr, i + 1 | 0, (len - i | 0) - 1 | 0)
               }
             ],
-            /* true */1
+            true
           ];
   }
 }

--- a/lib/js/belt_MutableSetString.js
+++ b/lib/js/belt_MutableSetString.js
@@ -88,7 +88,7 @@ function removeMany(d, xs) {
 function removeCheck0(nt, x, removed) {
   var k = nt.value;
   if (x === k) {
-    removed[0] = /* true */1;
+    removed[0] = true;
     var l = nt.left;
     var r = nt.right;
     if (l !== null) {
@@ -123,14 +123,14 @@ function removeCheck0(nt, x, removed) {
 function removeCheck(d, v) {
   var oldRoot = d.data;
   if (oldRoot !== null) {
-    var removed = [/* false */0];
+    var removed = [false];
     var newRoot = removeCheck0(oldRoot, v, removed);
     if (newRoot !== oldRoot) {
       d.data = newRoot;
     }
     return removed[0];
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -151,14 +151,14 @@ function addCheck0(t, x, added) {
       return Belt_internalAVLset.balMutate(t);
     }
   } else {
-    added[0] = /* true */1;
+    added[0] = true;
     return Belt_internalAVLset.singleton(x);
   }
 }
 
 function addCheck(m, e) {
   var oldRoot = m.data;
-  var added = [/* false */0];
+  var added = [false];
   var newRoot = addCheck0(oldRoot, e, added);
   if (newRoot !== oldRoot) {
     m.data = newRoot;
@@ -311,7 +311,7 @@ function split(d, key) {
                 data: Belt_internalAVLset.fromSortedArrayAux(arr, next, len - next | 0)
               }
             ],
-            /* false */0
+            false
           ];
   } else {
     return /* tuple */[
@@ -323,7 +323,7 @@ function split(d, key) {
                 data: Belt_internalAVLset.fromSortedArrayAux(arr, i + 1 | 0, (len - i | 0) - 1 | 0)
               }
             ],
-            /* true */1
+            true
           ];
   }
 }

--- a/lib/js/belt_MutableStack.js
+++ b/lib/js/belt_MutableStack.js
@@ -46,7 +46,7 @@ function top(s) {
 }
 
 function isEmpty(s) {
-  return +(s.root === null);
+  return s.root === null;
 }
 
 function popUndefined(s) {

--- a/lib/js/belt_Option.js
+++ b/lib/js/belt_Option.js
@@ -56,17 +56,17 @@ function getWithDefault(opt, $$default) {
 
 function isSome(param) {
   if (param) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function isNone(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -75,12 +75,12 @@ function eqU(a, b, f) {
     if (b) {
       return f(a[0], b[0]);
     } else {
-      return /* false */0;
+      return false;
     }
   } else if (b) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 

--- a/lib/js/belt_Range.js
+++ b/lib/js/belt_Range.js
@@ -17,12 +17,12 @@ function everyU(_s, f, p) {
   while(true) {
     var s = _s;
     if (s > f) {
-      return /* true */1;
+      return true;
     } else if (p(s)) {
       _s = s + 1 | 0;
       continue ;
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -40,16 +40,16 @@ function everyByU(s, f, step, p) {
     while(true) {
       var s$1 = _s;
       if (s$1 > f$1) {
-        return /* true */1;
+        return true;
       } else if (p$1(s$1)) {
         _s = s$1 + step$1 | 0;
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     };
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -61,9 +61,9 @@ function someU(_s, f, p) {
   while(true) {
     var s = _s;
     if (s > f) {
-      return /* false */0;
+      return false;
     } else if (p(s)) {
-      return /* true */1;
+      return true;
     } else {
       _s = s + 1 | 0;
       continue ;
@@ -84,16 +84,16 @@ function someByU(s, f, step, p) {
     while(true) {
       var s$1 = _s;
       if (s$1 > f$1) {
-        return /* false */0;
+        return false;
       } else if (p$1(s$1)) {
-        return /* true */1;
+        return true;
       } else {
         _s = s$1 + step$1 | 0;
         continue ;
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/belt_SetDict.js
+++ b/lib/js/belt_SetDict.js
@@ -133,7 +133,7 @@ function splitAuxPivot(cmp, n, x, pres) {
   var r = n.right;
   var c = cmp(x, v);
   if (c === 0) {
-    pres[0] = /* true */1;
+    pres[0] = true;
     return /* tuple */[
             l,
             r
@@ -167,7 +167,7 @@ function splitAuxPivot(cmp, n, x, pres) {
 
 function split(t, x, cmp) {
   if (t !== null) {
-    var pres = [/* false */0];
+    var pres = [false];
     var v = splitAuxPivot(cmp, t, x, pres);
     return /* tuple */[
             v,
@@ -179,7 +179,7 @@ function split(t, x, cmp) {
               Belt_internalAVLset.empty,
               Belt_internalAVLset.empty
             ],
-            /* false */0
+            false
           ];
   }
 }
@@ -221,7 +221,7 @@ function intersect(s1, s2, cmp) {
     var l1 = s1.left;
     var v1 = s1.value;
     var r1 = s1.right;
-    var pres = [/* false */0];
+    var pres = [false];
     var match = splitAuxPivot(cmp, s2, v1, pres);
     var ll = intersect(l1, match[0], cmp);
     var rr = intersect(r1, match[1], cmp);
@@ -240,7 +240,7 @@ function diff(s1, s2, cmp) {
     var l1 = s1.left;
     var v1 = s1.value;
     var r1 = s1.right;
-    var pres = [/* false */0];
+    var pres = [false];
     var match = splitAuxPivot(cmp, s2, v1, pres);
     var ll = diff(l1, match[0], cmp);
     var rr = diff(r1, match[1], cmp);

--- a/lib/js/belt_SetInt.js
+++ b/lib/js/belt_SetInt.js
@@ -130,7 +130,7 @@ function splitAuxPivot(n, x, pres) {
   var v = n.value;
   var r = n.right;
   if (x === v) {
-    pres[0] = /* true */1;
+    pres[0] = true;
     return /* tuple */[
             l,
             r
@@ -164,7 +164,7 @@ function splitAuxPivot(n, x, pres) {
 
 function split(t, x) {
   if (t !== null) {
-    var pres = [/* false */0];
+    var pres = [false];
     var v = splitAuxPivot(t, x, pres);
     return /* tuple */[
             v,
@@ -176,7 +176,7 @@ function split(t, x) {
               Belt_internalAVLset.empty,
               Belt_internalAVLset.empty
             ],
-            /* false */0
+            false
           ];
   }
 }
@@ -218,7 +218,7 @@ function intersect(s1, s2) {
     var l1 = s1.left;
     var v1 = s1.value;
     var r1 = s1.right;
-    var pres = [/* false */0];
+    var pres = [false];
     var match = splitAuxPivot(s2, v1, pres);
     var ll = intersect(l1, match[0]);
     var rr = intersect(r1, match[1]);
@@ -237,7 +237,7 @@ function diff(s1, s2) {
     var l1 = s1.left;
     var v1 = s1.value;
     var r1 = s1.right;
-    var pres = [/* false */0];
+    var pres = [false];
     var match = splitAuxPivot(s2, v1, pres);
     var ll = diff(l1, match[0]);
     var rr = diff(r1, match[1]);

--- a/lib/js/belt_SetString.js
+++ b/lib/js/belt_SetString.js
@@ -130,7 +130,7 @@ function splitAuxPivot(n, x, pres) {
   var v = n.value;
   var r = n.right;
   if (x === v) {
-    pres[0] = /* true */1;
+    pres[0] = true;
     return /* tuple */[
             l,
             r
@@ -164,7 +164,7 @@ function splitAuxPivot(n, x, pres) {
 
 function split(t, x) {
   if (t !== null) {
-    var pres = [/* false */0];
+    var pres = [false];
     var v = splitAuxPivot(t, x, pres);
     return /* tuple */[
             v,
@@ -176,7 +176,7 @@ function split(t, x) {
               Belt_internalAVLset.empty,
               Belt_internalAVLset.empty
             ],
-            /* false */0
+            false
           ];
   }
 }
@@ -218,7 +218,7 @@ function intersect(s1, s2) {
     var l1 = s1.left;
     var v1 = s1.value;
     var r1 = s1.right;
-    var pres = [/* false */0];
+    var pres = [false];
     var match = splitAuxPivot(s2, v1, pres);
     var ll = intersect(l1, match[0]);
     var rr = intersect(r1, match[1]);
@@ -237,7 +237,7 @@ function diff(s1, s2) {
     var l1 = s1.left;
     var v1 = s1.value;
     var r1 = s1.right;
-    var pres = [/* false */0];
+    var pres = [false];
     var match = splitAuxPivot(s2, v1, pres);
     var ll = diff(l1, match[0]);
     var rr = diff(r1, match[1]);

--- a/lib/js/belt_SortArray.js
+++ b/lib/js/belt_SortArray.js
@@ -66,7 +66,7 @@ function strictlySortedLength(xs, lt) {
 function isSortedU(a, cmp) {
   var len = a.length;
   if (len === 0) {
-    return /* true */1;
+    return true;
   } else {
     var a$1 = a;
     var _i = 0;
@@ -75,12 +75,12 @@ function isSortedU(a, cmp) {
     while(true) {
       var i = _i;
       if (i === last_bound) {
-        return /* true */1;
+        return true;
       } else if (cmp$1(a$1[i], a$1[i + 1 | 0]) <= 0) {
         _i = i + 1 | 0;
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     };
   }

--- a/lib/js/belt_SortArrayInt.js
+++ b/lib/js/belt_SortArrayInt.js
@@ -60,7 +60,7 @@ function strictlySortedLength(xs) {
 function isSorted(a) {
   var len = a.length;
   if (len === 0) {
-    return /* true */1;
+    return true;
   } else {
     var a$1 = a;
     var _i = 0;
@@ -68,12 +68,12 @@ function isSorted(a) {
     while(true) {
       var i = _i;
       if (i === last_bound) {
-        return /* true */1;
+        return true;
       } else if (a$1[i] <= a$1[i + 1 | 0]) {
         _i = i + 1 | 0;
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     };
   }

--- a/lib/js/belt_SortArrayString.js
+++ b/lib/js/belt_SortArrayString.js
@@ -60,7 +60,7 @@ function strictlySortedLength(xs) {
 function isSorted(a) {
   var len = a.length;
   if (len === 0) {
-    return /* true */1;
+    return true;
   } else {
     var a$1 = a;
     var _i = 0;
@@ -68,12 +68,12 @@ function isSorted(a) {
     while(true) {
       var i = _i;
       if (i === last_bound) {
-        return /* true */1;
+        return true;
       } else if (a$1[i] <= a$1[i + 1 | 0]) {
         _i = i + 1 | 0;
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     };
   }

--- a/lib/js/belt_internalAVLset.js
+++ b/lib/js/belt_internalAVLset.js
@@ -49,12 +49,12 @@ function singleton(x) {
 function heightGe(l, r) {
   if (r !== null) {
     if (l !== null) {
-      return +(l.height >= r.height);
+      return l.height >= r.height;
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -167,9 +167,9 @@ function removeMinAuxWithRef(n, v) {
 
 function isEmpty(n) {
   if (n !== null) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -237,10 +237,10 @@ function everyU(_n, p) {
         _n = n.right;
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -254,13 +254,13 @@ function someU(_n, p) {
     var n = _n;
     if (n !== null) {
       if (p(n.value) || someU(n.left, p)) {
-        return /* true */1;
+        return true;
       } else {
         _n = n.right;
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -638,13 +638,13 @@ function has(_t, x, cmp) {
       var v = t.value;
       var c = cmp(x, v);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _t = c < 0 ? t.left : t.right;
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -682,7 +682,7 @@ function cmp(s1, s2, cmp$1) {
 }
 
 function eq(s1, s2, c) {
-  return +(cmp(s1, s2, c) === 0);
+  return cmp(s1, s2, c) === 0;
 }
 
 function subset(_s1, _s2, cmp) {
@@ -704,26 +704,26 @@ function subset(_s1, _s2, cmp) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (c < 0) {
           if (subset(create(l1, v1, null), l2, cmp)) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (subset(create(null, v1, r1), r2, cmp)) {
           _s1 = l1;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -894,7 +894,7 @@ function fromArray(xs, cmp) {
     return null;
   } else {
     var next = Belt_SortArray.strictlySortedLengthU(xs, (function (x, y) {
-            return +(cmp(x, y) < 0);
+            return cmp(x, y) < 0;
           }));
     var result;
     if (next >= 0) {

--- a/lib/js/belt_internalAVLtree.js
+++ b/lib/js/belt_internalAVLtree.js
@@ -52,12 +52,12 @@ function singleton(x, d) {
 function heightGe(l, r) {
   if (r !== null) {
     if (l !== null) {
-      return +(l.height >= r.height);
+      return l.height >= r.height;
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -255,9 +255,9 @@ function removeMinAuxWithRef(n, kr, vr) {
 
 function isEmpty(x) {
   if (x !== null) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -369,10 +369,10 @@ function everyU(_n, p) {
         _n = n.right;
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -386,13 +386,13 @@ function someU(_n, p) {
     var n = _n;
     if (n !== null) {
       if (p(n.key, n.value) || someU(n.left, p)) {
-        return /* true */1;
+        return true;
       } else {
         _n = n.right;
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -857,14 +857,14 @@ function eqU(s1, s2, kcmp, veq) {
           _e1 = stackAllLeft(h1.right, e1[1]);
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* true */1;
+        return true;
       }
     };
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -951,13 +951,13 @@ function has(_n, x, cmp) {
       var v = n.key;
       var c = cmp(x, v);
       if (c === 0) {
-        return /* true */1;
+        return true;
       } else {
         _n = c < 0 ? n.left : n.right;
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -1075,7 +1075,7 @@ function fromArray(xs, cmp) {
     return null;
   } else {
     var next = Belt_SortArray.strictlySortedLengthU(xs, (function (param, param$1) {
-            return +(cmp(param[0], param$1[0]) < 0);
+            return cmp(param[0], param$1[0]) < 0;
           }));
     var result;
     if (next >= 0) {

--- a/lib/js/belt_internalBucketsType.js
+++ b/lib/js/belt_internalBucketsType.js
@@ -36,7 +36,7 @@ function clear(h) {
 }
 
 function isEmpty(h) {
-  return +(h.size === 0);
+  return h.size === 0;
 }
 
 exports.emptyOpt = emptyOpt;

--- a/lib/js/belt_internalMapInt.js
+++ b/lib/js/belt_internalMapInt.js
@@ -97,13 +97,13 @@ function has(_n, x) {
     if (n !== null) {
       var v = n.key;
       if (x === v) {
-        return /* true */1;
+        return true;
       } else {
         _n = x < v ? n.left : n.right;
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -283,10 +283,10 @@ function eqAux(_e1, _e2, eq) {
         _e1 = Belt_internalAVLtree.stackAllLeft(h1.right, e1[1]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -297,7 +297,7 @@ function eqU(s1, s2, eq) {
   if (len1 === len2) {
     return eqAux(Belt_internalAVLtree.stackAllLeft(s1, /* [] */0), Belt_internalAVLtree.stackAllLeft(s2, /* [] */0), eq);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -334,7 +334,7 @@ function fromArray(xs) {
     return Belt_internalAVLtree.empty;
   } else {
     var next = Belt_SortArray.strictlySortedLengthU(xs, (function (param, param$1) {
-            return +(param[0] < param$1[0]);
+            return param[0] < param$1[0];
           }));
     var result;
     if (next >= 0) {

--- a/lib/js/belt_internalMapString.js
+++ b/lib/js/belt_internalMapString.js
@@ -97,13 +97,13 @@ function has(_n, x) {
     if (n !== null) {
       var v = n.key;
       if (x === v) {
-        return /* true */1;
+        return true;
       } else {
         _n = x < v ? n.left : n.right;
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -283,10 +283,10 @@ function eqAux(_e1, _e2, eq) {
         _e1 = Belt_internalAVLtree.stackAllLeft(h1.right, e1[1]);
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -297,7 +297,7 @@ function eqU(s1, s2, eq) {
   if (len1 === len2) {
     return eqAux(Belt_internalAVLtree.stackAllLeft(s1, /* [] */0), Belt_internalAVLtree.stackAllLeft(s2, /* [] */0), eq);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -334,7 +334,7 @@ function fromArray(xs) {
     return Belt_internalAVLtree.empty;
   } else {
     var next = Belt_SortArray.strictlySortedLengthU(xs, (function (param, param$1) {
-            return +(param[0] < param$1[0]);
+            return param[0] < param$1[0];
           }));
     var result;
     if (next >= 0) {

--- a/lib/js/belt_internalSetInt.js
+++ b/lib/js/belt_internalSetInt.js
@@ -9,13 +9,13 @@ function has(_t, x) {
     if (t !== null) {
       var v = t.value;
       if (x === v) {
-        return /* true */1;
+        return true;
       } else {
         _t = x < v ? t.left : t.right;
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -57,7 +57,7 @@ function cmp(s1, s2) {
 }
 
 function eq(s1, s2) {
-  return +(cmp(s1, s2) === 0);
+  return cmp(s1, s2) === 0;
 }
 
 function subset(_s1, _s2) {
@@ -78,26 +78,26 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (v1 < v2) {
           if (subset(Belt_internalAVLset.create(l1, v1, Belt_internalAVLset.empty), l2)) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (subset(Belt_internalAVLset.create(Belt_internalAVLset.empty, v1, r1), r2)) {
           _s1 = l1;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }

--- a/lib/js/belt_internalSetString.js
+++ b/lib/js/belt_internalSetString.js
@@ -9,13 +9,13 @@ function has(_t, x) {
     if (t !== null) {
       var v = t.value;
       if (x === v) {
-        return /* true */1;
+        return true;
       } else {
         _t = x < v ? t.left : t.right;
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -57,7 +57,7 @@ function cmp(s1, s2) {
 }
 
 function eq(s1, s2) {
-  return +(cmp(s1, s2) === 0);
+  return cmp(s1, s2) === 0;
 }
 
 function subset(_s1, _s2) {
@@ -78,26 +78,26 @@ function subset(_s1, _s2) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (v1 < v2) {
           if (subset(Belt_internalAVLset.create(l1, v1, Belt_internalAVLset.empty), l2)) {
             _s1 = r1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else if (subset(Belt_internalAVLset.create(Belt_internalAVLset.empty, v1, r1), r2)) {
           _s1 = l1;
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }

--- a/lib/js/bigarray.js
+++ b/lib/js/bigarray.js
@@ -32,7 +32,7 @@ function create(_, _$1, _$2) {
 
 function of_array(kind, layout, data) {
   var ba = create(kind, layout, data.length);
-  layout !== 0 ? 1 : 0;
+  layout ? 1 : 0;
   for(var i = 0 ,i_finish = data.length - 1 | 0; i <= i_finish; ++i){
     Caml_missing_polyfill.not_implemented("caml_ba_set_1 not implemented by bucklescript yet\n");
   }
@@ -40,7 +40,7 @@ function of_array(kind, layout, data) {
 }
 
 function map_file$1(fd, pos, kind, layout, shared, dim) {
-  return map_file(fd, pos, kind, layout, shared, /* int array */[dim]);
+  return map_file(fd, pos, kind, layout, shared, /* array */[dim]);
 }
 
 var Array1 = /* module */[
@@ -65,7 +65,7 @@ function of_array$1(kind, layout, data) {
   var dim1 = data.length;
   var dim2 = dim1 === 0 ? 0 : Caml_array.caml_array_get(data, 0).length;
   var ba = create$1(kind, layout, dim1, dim2);
-  layout !== 0 ? 1 : 0;
+  layout ? 1 : 0;
   for(var i = 0 ,i_finish = dim1 - 1 | 0; i <= i_finish; ++i){
     var row = Caml_array.caml_array_get(data, i);
     if (row.length !== dim2) {
@@ -82,7 +82,7 @@ function of_array$1(kind, layout, data) {
 }
 
 function map_file$2(fd, pos, kind, layout, shared, dim1, dim2) {
-  return map_file(fd, pos, kind, layout, shared, /* int array */[
+  return map_file(fd, pos, kind, layout, shared, /* array */[
               dim1,
               dim2
             ]);
@@ -121,7 +121,7 @@ function of_array$2(kind, layout, data) {
   var dim2 = dim1 === 0 ? 0 : Caml_array.caml_array_get(data, 0).length;
   var dim3 = dim2 === 0 ? 0 : Caml_array.caml_array_get(Caml_array.caml_array_get(data, 0), 0).length;
   var ba = create$2(kind, layout, dim1, dim2, dim3);
-  layout !== 0 ? 1 : 0;
+  layout ? 1 : 0;
   for(var i = 0 ,i_finish = dim1 - 1 | 0; i <= i_finish; ++i){
     var row = Caml_array.caml_array_get(data, i);
     if (row.length !== dim2) {
@@ -147,7 +147,7 @@ function of_array$2(kind, layout, data) {
 }
 
 function map_file$3(fd, pos, kind, layout, shared, dim1, dim2, dim3) {
-  return map_file(fd, pos, kind, layout, shared, /* int array */[
+  return map_file(fd, pos, kind, layout, shared, /* array */[
               dim1,
               dim2,
               dim3

--- a/lib/js/bytes.js
+++ b/lib/js/bytes.js
@@ -162,14 +162,14 @@ function is_space(param) {
   var switcher = param - 9 | 0;
   if (switcher > 4 || switcher < 0) {
     if (switcher !== 23) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   } else if (switcher !== 2) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -418,11 +418,11 @@ function contains_from(s, i, c) {
   } else {
     try {
       index_rec(s, l, i, c);
-      return /* true */1;
+      return true;
     }
     catch (exn){
       if (exn === Caml_builtin_exceptions.not_found) {
-        return /* false */0;
+        return false;
       } else {
         throw exn;
       }
@@ -443,11 +443,11 @@ function rcontains_from(s, i, c) {
   } else {
     try {
       rindex_rec(s, i, c);
-      return /* true */1;
+      return true;
     }
     catch (exn){
       if (exn === Caml_builtin_exceptions.not_found) {
-        return /* false */0;
+        return false;
       } else {
         throw exn;
       }

--- a/lib/js/caml_basic.js
+++ b/lib/js/caml_basic.js
@@ -6,11 +6,7 @@ function some(x) {
 }
 
 function is_none(x) {
-  if (x) {
-    return false;
-  } else {
-    return true;
-  }
+  return x === /* None */0;
 }
 
 function to_def(x) {
@@ -29,11 +25,7 @@ function cons(x, y) {
 }
 
 function is_list_empty(x) {
-  if (x) {
-    return false;
-  } else {
-    return true;
-  }
+  return x === /* [] */0;
 }
 
 var none = /* None */0;

--- a/lib/js/caml_exceptions.js
+++ b/lib/js/caml_exceptions.js
@@ -26,15 +26,15 @@ function create(str) {
 
 function isCamlExceptionOrOpenVariant(e) {
   if (e === undefined) {
-    return /* false */0;
+    return false;
   } else if (e.tag === 248) {
-    return /* true */1;
+    return true;
   } else {
     var slot = e[0];
     if (slot !== undefined) {
-      return +(slot.tag === 248);
+      return slot.tag === 248;
     } else {
-      return /* false */0;
+      return false;
     }
   }
 }

--- a/lib/js/caml_float.js
+++ b/lib/js/caml_float.js
@@ -8,7 +8,7 @@ function caml_int32_float_of_bits(x) {
 }
 
 function caml_int32_bits_of_float(x) {
-  var float32 = new Float32Array(/* float array */[x]);
+  var float32 = new Float32Array(/* array */[x]);
   return new Int32Array(float32.buffer)[0];
 }
 
@@ -30,7 +30,7 @@ function caml_classify_float(x) {
 
 function caml_modf_float(x) {
   if (isFinite(x)) {
-    var neg = +(1 / x < 0);
+    var neg = 1 / x < 0;
     var x$1 = Math.abs(x);
     var i = Math.floor(x$1);
     var f = x$1 - i;
@@ -83,7 +83,7 @@ function caml_frexp_float(x) {
             0
           ];
   } else {
-    var neg = +(x < 0);
+    var neg = x < 0;
     var x$prime = Math.abs(x);
     var exp = Math.floor(Math.LOG2E * Math.log(x$prime)) + 1;
     x$prime = x$prime * Math.pow(2, -exp);

--- a/lib/js/caml_format.js
+++ b/lib/js/caml_format.js
@@ -283,11 +283,11 @@ function parse_format(fmt) {
     /* justify */"+",
     /* signstyle */"-",
     /* filter */" ",
-    /* alternate : false */0,
+    /* alternate */false,
     /* base : Dec */2,
-    /* signedconv : false */0,
+    /* signedconv */false,
     /* width */0,
-    /* uppercase : false */0,
+    /* uppercase */false,
     /* sign */1,
     /* prec */-1,
     /* conv */"f"
@@ -308,7 +308,7 @@ function parse_format(fmt) {
             switch (c - 88 | 0) {
               case 0 : 
                   f[/* base */4] = /* Hex */1;
-                  f[/* uppercase */7] = /* true */1;
+                  f[/* uppercase */7] = true;
                   _i = i + 1 | 0;
                   continue ;
               case 13 : 
@@ -364,8 +364,8 @@ function parse_format(fmt) {
         } else if (c >= 72) {
           exit = 1;
         } else {
-          f[/* signedconv */5] = /* true */1;
-          f[/* uppercase */7] = /* true */1;
+          f[/* signedconv */5] = true;
+          f[/* uppercase */7] = true;
           f[/* conv */10] = String.fromCharCode(lowercase(c));
           _i = i + 1 | 0;
           continue ;
@@ -377,7 +377,7 @@ function parse_format(fmt) {
         } else {
           switch (switcher) {
             case 3 : 
-                f[/* alternate */3] = /* true */1;
+                f[/* alternate */3] = true;
                 _i = i + 1 | 0;
                 continue ;
             case 0 : 
@@ -394,7 +394,7 @@ function parse_format(fmt) {
                 while((function(j){
                     return function () {
                       var w = fmt.charCodeAt(j) - /* "0" */48 | 0;
-                      return +(w >= 0 && w <= 9);
+                      return w >= 0 && w <= 9;
                     }
                     }(j))()) {
                   f[/* prec */9] = (Caml_int32.imul(f[/* prec */9], 10) + fmt.charCodeAt(j) | 0) - /* "0" */48 | 0;
@@ -448,7 +448,7 @@ function parse_format(fmt) {
             while((function(j$1){
                 return function () {
                   var w = fmt.charCodeAt(j$1) - /* "0" */48 | 0;
-                  return +(w >= 0 && w <= 9);
+                  return w >= 0 && w <= 9;
                 }
                 }(j$1))()) {
               f[/* width */6] = (Caml_int32.imul(f[/* width */6], 10) + fmt.charCodeAt(j$1) | 0) - /* "0" */48 | 0;
@@ -457,12 +457,12 @@ function parse_format(fmt) {
             _i = j$1;
             continue ;
         case 4 : 
-            f[/* signedconv */5] = /* true */1;
+            f[/* signedconv */5] = true;
             f[/* base */4] = /* Dec */2;
             _i = i + 1 | 0;
             continue ;
         case 5 : 
-            f[/* signedconv */5] = /* true */1;
+            f[/* signedconv */5] = true;
             f[/* conv */10] = String.fromCharCode(c);
             _i = i + 1 | 0;
             continue ;
@@ -714,7 +714,7 @@ function caml_format_float(fmt, x) {
             } else {
               while((function () {
                       s = x$1.toFixed(p);
-                      return +(s.length > (prec$1 + 1 | 0));
+                      return s.length > (prec$1 + 1 | 0);
                     })()) {
                 p = p - 1 | 0;
               };

--- a/lib/js/caml_int64.js
+++ b/lib/js/caml_int64.js
@@ -31,7 +31,7 @@ var neg_one = /* record */[
 ];
 
 function neg_signed(x) {
-  return +((x & 2147483648) !== 0);
+  return (x & 2147483648) !== 0;
 }
 
 function add(param, param$1) {
@@ -57,9 +57,9 @@ function not(param) {
 
 function eq(x, y) {
   if (x[/* hi */0] === y[/* hi */0]) {
-    return +(x[/* lo */1] === y[/* lo */1]);
+    return x[/* lo */1] === y[/* lo */1];
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -67,7 +67,7 @@ function equal_null(x, y) {
   if (y !== null) {
     return eq(x, y);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -75,13 +75,13 @@ function equal_undefined(x, y) {
   if (y !== undefined) {
     return eq(x, y);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function equal_nullable(x, y) {
   if (y == null) {
-    return /* false */0;
+    return false;
   } else {
     return eq(x, y);
   }
@@ -171,9 +171,9 @@ function asr_(x, numBits) {
 
 function is_zero(param) {
   if (param[/* hi */0] !== 0 || param[/* lo */1] !== 0) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -308,34 +308,34 @@ function ge(param, param$1) {
   var other_hi = param$1[/* hi */0];
   var hi = param[/* hi */0];
   if (hi > other_hi) {
-    return /* true */1;
+    return true;
   } else if (hi < other_hi) {
-    return /* false */0;
+    return false;
   } else {
-    return +(param[/* lo */1] >= param$1[/* lo */1]);
+    return param[/* lo */1] >= param$1[/* lo */1];
   }
 }
 
 function neq(x, y) {
-  return 1 - eq(x, y);
+  return !eq(x, y);
 }
 
 function lt(x, y) {
-  return 1 - ge(x, y);
+  return !ge(x, y);
 }
 
 function gt(x, y) {
   if (x[/* hi */0] > y[/* hi */0]) {
-    return /* true */1;
+    return true;
   } else if (x[/* hi */0] < y[/* hi */0]) {
-    return /* false */0;
+    return false;
   } else {
-    return +(x[/* lo */1] > y[/* lo */1]);
+    return x[/* lo */1] > y[/* lo */1];
   }
 }
 
 function le(x, y) {
-  return 1 - gt(x, y);
+  return !gt(x, y);
 }
 
 function min(x, y) {
@@ -558,7 +558,7 @@ function float_of_bits(x) {
 }
 
 function bits_of_float(x) {
-  var u = new Float64Array(/* float array */[x]);
+  var u = new Float64Array(/* array */[x]);
   var int32 = new Int32Array(u.buffer);
   var x$1 = int32[1];
   var hi = x$1;

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -73,15 +73,15 @@ function caml_compare(_a, _b) {
       if (a_type === "string") {
         return Caml_primitive.caml_string_compare(a, b);
       } else {
-        var is_a_number = +(a_type === "number");
-        var is_b_number = +(b_type === "number");
-        if (is_a_number !== 0) {
-          if (is_b_number !== 0) {
+        var is_a_number = a_type === "number";
+        var is_b_number = b_type === "number";
+        if (is_a_number) {
+          if (is_b_number) {
             return Caml_primitive.caml_int_compare(a, b);
           } else {
             return -1;
           }
-        } else if (is_b_number !== 0) {
+        } else if (is_b_number) {
           return 1;
         } else if (a_type === "boolean" || a_type === "undefined" || a === null) {
           var x = a;
@@ -255,11 +255,11 @@ function caml_equal(_a, _b) {
     var b = _b;
     var a = _a;
     if (a === b) {
-      return /* true */1;
+      return true;
     } else {
       var a_type = typeof a;
       if (a_type === "string" || a_type === "number" || a_type === "boolean" || a_type === "undefined" || a === null) {
-        return /* false */0;
+        return false;
       } else {
         var b_type = typeof b;
         if (a_type === "function" || b_type === "function") {
@@ -268,7 +268,7 @@ function caml_equal(_a, _b) {
                 "equal: functional value"
               ];
         } else if (b_type === "number" || b_type === "undefined" || b === null) {
-          return /* false */0;
+          return false;
         } else {
           var tag_a = a.tag | 0;
           var tag_b = b.tag | 0;
@@ -279,14 +279,14 @@ function caml_equal(_a, _b) {
             _b = b[0];
             continue ;
           } else if (tag_a === 248) {
-            return +(a[1] === b[1]);
+            return a[1] === b[1];
           } else if (tag_a === 251) {
             throw [
                   Caml_builtin_exceptions.invalid_argument,
                   "equal: abstract value"
                 ];
           } else if (tag_a !== tag_b) {
-            return /* false */0;
+            return false;
           } else {
             var len_a = a.length | 0;
             var len_b = b.length | 0;
@@ -299,24 +299,24 @@ function caml_equal(_a, _b) {
                 while(true) {
                   var i = _i;
                   if (i === same_length) {
-                    return /* true */1;
+                    return true;
                   } else if (caml_equal(a$1[i], b$1[i])) {
                     _i = i + 1 | 0;
                     continue ;
                   } else {
-                    return /* false */0;
+                    return false;
                   }
                 };
               } else {
                 var a$2 = a;
                 var b$2 = b;
-                var result = [/* true */1];
+                var result = [true];
                 var do_key_a = (function(b$2,result){
                 return function do_key_a(key) {
                   if (b$2.hasOwnProperty(key)) {
                     return 0;
                   } else {
-                    result[0] = /* false */0;
+                    result[0] = false;
                     return /* () */0;
                   }
                 }
@@ -324,7 +324,7 @@ function caml_equal(_a, _b) {
                 var do_key_b = (function(a$2,b$2,result){
                 return function do_key_b(key) {
                   if (!a$2.hasOwnProperty(key) || !caml_equal(b$2[key], a$2[key])) {
-                    result[0] = /* false */0;
+                    result[0] = false;
                     return /* () */0;
                   } else {
                     return 0;
@@ -338,7 +338,7 @@ function caml_equal(_a, _b) {
                 return result[0];
               }
             } else {
-              return /* false */0;
+              return false;
             }
           }
         }
@@ -351,7 +351,7 @@ function caml_equal_null(x, y) {
   if (y !== null) {
     return caml_equal(x, y);
   } else {
-    return +(x === y);
+    return x === y;
   }
 }
 
@@ -359,36 +359,36 @@ function caml_equal_undefined(x, y) {
   if (y !== undefined) {
     return caml_equal(x, y);
   } else {
-    return +(x === y);
+    return x === y;
   }
 }
 
 function caml_equal_nullable(x, y) {
   if (y == null) {
-    return +(x === y);
+    return x === y;
   } else {
     return caml_equal(x, y);
   }
 }
 
 function caml_notequal(a, b) {
-  return 1 - caml_equal(a, b);
+  return !caml_equal(a, b);
 }
 
 function caml_greaterequal(a, b) {
-  return +(caml_compare(a, b) >= 0);
+  return caml_compare(a, b) >= 0;
 }
 
 function caml_greaterthan(a, b) {
-  return +(caml_compare(a, b) > 0);
+  return caml_compare(a, b) > 0;
 }
 
 function caml_lessequal(a, b) {
-  return +(caml_compare(a, b) <= 0);
+  return caml_compare(a, b) <= 0;
 }
 
 function caml_lessthan(a, b) {
-  return +(caml_compare(a, b) < 0);
+  return caml_compare(a, b) < 0;
 }
 
 function caml_min(x, y) {

--- a/lib/js/caml_parser.js
+++ b/lib/js/caml_parser.js
@@ -364,7 +364,7 @@ function caml_parse_engine(prim, prim$1, prim$2, prim$3) {
 }
 
 function caml_set_parser_trace(prim) {
-  return +$$caml_set_parser_trace(prim);
+  return $$caml_set_parser_trace(prim);
 }
 
 exports.caml_parse_engine = caml_parse_engine;

--- a/lib/js/caml_primitive.js
+++ b/lib/js/caml_primitive.js
@@ -11,6 +11,20 @@ function caml_int_compare(x, y) {
   }
 }
 
+function caml_bool_compare(x, y) {
+  if (x) {
+    if (y) {
+      return 0;
+    } else {
+      return 1;
+    }
+  } else if (y) {
+    return -1;
+  } else {
+    return 0;
+  }
+}
+
 function caml_float_compare(x, y) {
   if (x === y) {
     return 0;
@@ -32,6 +46,14 @@ function caml_string_compare(s1, s2) {
     return -1;
   } else {
     return 1;
+  }
+}
+
+function caml_bool_min(x, y) {
+  if (x) {
+    return y;
+  } else {
+    return x;
   }
 }
 
@@ -69,6 +91,14 @@ function caml_nativeint_min(x, y) {
 
 function caml_int32_min(x, y) {
   if (x < y) {
+    return x;
+  } else {
+    return y;
+  }
+}
+
+function caml_bool_max(x, y) {
+  if (x) {
     return x;
   } else {
     return y;
@@ -120,15 +150,18 @@ var caml_nativeint_compare = caml_int_compare;
 var caml_int32_compare = caml_int_compare;
 
 exports.caml_int_compare = caml_int_compare;
+exports.caml_bool_compare = caml_bool_compare;
 exports.caml_float_compare = caml_float_compare;
 exports.caml_nativeint_compare = caml_nativeint_compare;
 exports.caml_string_compare = caml_string_compare;
 exports.caml_int32_compare = caml_int32_compare;
+exports.caml_bool_min = caml_bool_min;
 exports.caml_int_min = caml_int_min;
 exports.caml_float_min = caml_float_min;
 exports.caml_string_min = caml_string_min;
 exports.caml_nativeint_min = caml_nativeint_min;
 exports.caml_int32_min = caml_int32_min;
+exports.caml_bool_max = caml_bool_max;
 exports.caml_int_max = caml_int_max;
 exports.caml_float_max = caml_float_max;
 exports.caml_string_max = caml_string_max;

--- a/lib/js/caml_queue.js
+++ b/lib/js/caml_queue.js
@@ -43,7 +43,7 @@ function unsafe_pop(q) {
 }
 
 function is_empty(q) {
-  return +(q[/* length */0] === 0);
+  return q[/* length */0] === 0;
 }
 
 exports.create = create;

--- a/lib/js/caml_string.js
+++ b/lib/js/caml_string.js
@@ -155,9 +155,9 @@ function caml_string_of_char_array(chars) {
 
 function caml_is_printable(c) {
   if (c > 31) {
-    return +(c < 127);
+    return c < 127;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/caml_weak.js
+++ b/lib/js/caml_weak.js
@@ -31,7 +31,7 @@ function caml_weak_get_copy(xs, i) {
 }
 
 function caml_weak_check(xs, i) {
-  return +(xs[i] !== undefined);
+  return xs[i] !== undefined;
 }
 
 var caml_weak_blit = Caml_array.caml_array_blit;

--- a/lib/js/camlinternalFormat.js
+++ b/lib/js/camlinternalFormat.js
@@ -44,7 +44,7 @@ function rev_char_set(char_set) {
 function is_in_char_set(char_set, c) {
   var str_ind = (c >>> 3);
   var mask = (1 << (c & 7));
-  return +((Caml_string.get(char_set, str_ind) & mask) !== 0);
+  return (Caml_string.get(char_set, str_ind) & mask) !== 0;
 }
 
 function pad_of_pad_opt(pad_opt) {
@@ -354,9 +354,9 @@ function bprint_char_set(buf, char_set) {
       var before = Char.chr(c - 1 | 0);
       var after = Char.chr(c + 1 | 0);
       if (is_in_char_set(set, c)) {
-        return 1 - (is_in_char_set(set, before) && is_in_char_set(set, after));
+        return !(is_in_char_set(set, before) && is_in_char_set(set, after));
       } else {
-        return /* false */0;
+        return false;
       }
     };
     if (is_alone(/* "]" */93)) {
@@ -641,7 +641,7 @@ function int_of_custom_arity(param) {
 
 function bprint_fmt(buf, fmt) {
   var _fmt = fmt;
-  var _ign_flag = /* false */0;
+  var _ign_flag = false;
   while(true) {
     var ign_flag = _ign_flag;
     var fmt$1 = _fmt;
@@ -653,14 +653,14 @@ function bprint_fmt(buf, fmt) {
             buffer_add_char(buf, /* "%" */37);
             bprint_ignored_flag(buf, ign_flag);
             buffer_add_char(buf, /* "c" */99);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[0];
             continue ;
         case 1 : 
             buffer_add_char(buf, /* "%" */37);
             bprint_ignored_flag(buf, ign_flag);
             buffer_add_char(buf, /* "C" */67);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[0];
             continue ;
         case 2 : 
@@ -668,7 +668,7 @@ function bprint_fmt(buf, fmt) {
             bprint_ignored_flag(buf, ign_flag);
             bprint_padding(buf, fmt$1[0]);
             buffer_add_char(buf, /* "s" */115);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[1];
             continue ;
         case 3 : 
@@ -676,39 +676,39 @@ function bprint_fmt(buf, fmt) {
             bprint_ignored_flag(buf, ign_flag);
             bprint_padding(buf, fmt$1[0]);
             buffer_add_char(buf, /* "S" */83);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[1];
             continue ;
         case 4 : 
             bprint_int_fmt(buf, ign_flag, fmt$1[0], fmt$1[1], fmt$1[2]);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[3];
             continue ;
         case 5 : 
             bprint_altint_fmt(buf, ign_flag, fmt$1[0], fmt$1[1], fmt$1[2], /* "l" */108);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[3];
             continue ;
         case 6 : 
             bprint_altint_fmt(buf, ign_flag, fmt$1[0], fmt$1[1], fmt$1[2], /* "n" */110);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[3];
             continue ;
         case 7 : 
             bprint_altint_fmt(buf, ign_flag, fmt$1[0], fmt$1[1], fmt$1[2], /* "L" */76);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[3];
             continue ;
         case 8 : 
             bprint_float_fmt(buf, ign_flag, fmt$1[0], fmt$1[1], fmt$1[2]);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[3];
             continue ;
         case 9 : 
             buffer_add_char(buf, /* "%" */37);
             bprint_ignored_flag(buf, ign_flag);
             buffer_add_char(buf, /* "B" */66);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[0];
             continue ;
         case 10 : 
@@ -731,7 +731,7 @@ function bprint_fmt(buf, fmt) {
             bprint_fmtty(buf, fmt$1[1]);
             buffer_add_char(buf, /* "%" */37);
             buffer_add_char(buf, /* "}" */125);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[2];
             continue ;
         case 14 : 
@@ -742,21 +742,21 @@ function bprint_fmt(buf, fmt) {
             bprint_fmtty(buf, fmt$1[1]);
             buffer_add_char(buf, /* "%" */37);
             buffer_add_char(buf, /* ")" */41);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[2];
             continue ;
         case 15 : 
             buffer_add_char(buf, /* "%" */37);
             bprint_ignored_flag(buf, ign_flag);
             buffer_add_char(buf, /* "a" */97);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[0];
             continue ;
         case 16 : 
             buffer_add_char(buf, /* "%" */37);
             bprint_ignored_flag(buf, ign_flag);
             buffer_add_char(buf, /* "t" */116);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[0];
             continue ;
         case 17 : 
@@ -772,7 +772,7 @@ function bprint_fmt(buf, fmt) {
             buffer_add_char(buf, /* "%" */37);
             bprint_ignored_flag(buf, ign_flag);
             buffer_add_char(buf, /* "r" */114);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[0];
             continue ;
         case 20 : 
@@ -780,26 +780,26 @@ function bprint_fmt(buf, fmt) {
             bprint_ignored_flag(buf, ign_flag);
             bprint_pad_opt(buf, fmt$1[0]);
             bprint_char_set(buf, fmt$1[1]);
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[2];
             continue ;
         case 21 : 
             buffer_add_char(buf, /* "%" */37);
             bprint_ignored_flag(buf, ign_flag);
             buffer_add_char(buf, char_of_counter(fmt$1[0]));
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[1];
             continue ;
         case 22 : 
             buffer_add_char(buf, /* "%" */37);
             bprint_ignored_flag(buf, ign_flag);
             bprint_string_literal(buf, "0c");
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[0];
             continue ;
         case 23 : 
             var match = param_format_of_ignored_format(fmt$1[0], fmt$1[1]);
-            _ign_flag = /* true */1;
+            _ign_flag = true;
             _fmt = match[0];
             continue ;
         case 24 : 
@@ -808,7 +808,7 @@ function bprint_fmt(buf, fmt) {
               bprint_ignored_flag(buf, ign_flag);
               buffer_add_char(buf, /* "?" */63);
             }
-            _ign_flag = /* false */0;
+            _ign_flag = false;
             _fmt = fmt$1[2];
             continue ;
         
@@ -2937,7 +2937,7 @@ function convert_float(fconv, prec, x) {
       while(true) {
         var i = _i;
         if (i === len) {
-          return /* false */0;
+          return false;
         } else {
           var match = Caml_string.get(str, i);
           var switcher = match - 46 | 0;
@@ -2946,10 +2946,10 @@ function convert_float(fconv, prec, x) {
               _i = i + 1 | 0;
               continue ;
             } else {
-              return /* true */1;
+              return true;
             }
           } else if (switcher > 22 || switcher < 1) {
-            return /* true */1;
+            return true;
           } else {
             _i = i + 1 | 0;
             continue ;
@@ -3981,7 +3981,7 @@ function make_padprec_fmt_ebb(pad, prec, fmt) {
 }
 
 function fmt_ebb_of_string(legacy_behavior, str) {
-  var legacy_behavior$1 = legacy_behavior ? legacy_behavior[0] : /* true */1;
+  var legacy_behavior$1 = legacy_behavior ? legacy_behavior[0] : true;
   var invalid_format_message = function (str_ind, msg) {
     return Curry._3(failwith_message(/* Format */[
                     /* String_literal */Block.__(11, [
@@ -4073,10 +4073,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       var plus = _plus;
       var exit = 0;
       var exit$1 = 0;
-      if (plus !== 0) {
-        if (sharp !== 0) {
+      if (plus) {
+        if (sharp) {
           exit$1 = 2;
-        } else if (space !== 0) {
+        } else if (space) {
           exit = 1;
         } else if (symb !== 100) {
           if (symb !== 105) {
@@ -4087,8 +4087,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         } else {
           return /* Int_pd */1;
         }
-      } else if (sharp !== 0) {
-        if (space !== 0) {
+      } else if (sharp) {
+        if (space) {
           exit$1 = 2;
         } else if (symb !== 88) {
           if (symb !== 111) {
@@ -4103,7 +4103,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         } else {
           return /* Int_CX */9;
         }
-      } else if (space !== 0) {
+      } else if (space) {
         if (symb !== 100) {
           if (symb !== 105) {
             exit = 1;
@@ -4231,7 +4231,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         }
         if (exit$2 === 3) {
           if (legacy_behavior$1) {
-            _sharp = /* false */0;
+            _sharp = false;
             continue ;
           } else {
             return incompatible_flag(pct_ind, str_ind, symb, "'#'");
@@ -4240,23 +4240,23 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         
       }
       if (exit === 1) {
-        if (plus !== 0) {
-          if (space !== 0) {
+        if (plus) {
+          if (space) {
             if (legacy_behavior$1) {
-              _space = /* false */0;
+              _space = false;
               continue ;
             } else {
               return incompatible_flag(pct_ind, str_ind, /* " " */32, "'+'");
             }
           } else if (legacy_behavior$1) {
-            _plus = /* false */0;
+            _plus = false;
             continue ;
           } else {
             return incompatible_flag(pct_ind, str_ind, symb, "'+'");
           }
-        } else if (space !== 0) {
+        } else if (space) {
           if (legacy_behavior$1) {
-            _space = /* false */0;
+            _space = false;
             continue ;
           } else {
             return incompatible_flag(pct_ind, str_ind, symb, "' '");
@@ -4347,7 +4347,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         exit = 1;
       }
       if (exit === 1) {
-        if (minus !== 0) {
+        if (minus) {
           if (typeof prec === "number") {
             return parse_conv(/* Arg_padding */Block.__(1, [/* Left */0]));
           } else {
@@ -4423,7 +4423,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       }
       if (exit$1 === 2) {
         if (legacy_behavior$1) {
-          return parse_literal(minus$1 || +(symb$1 === /* "-" */45), str_ind$1 + 1 | 0);
+          return parse_literal(minus$1 || symb$1 === /* "-" */45, str_ind$1 + 1 | 0);
         } else {
           exit = 1;
         }
@@ -4469,9 +4469,9 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     }
     var match = Caml_string.get(str, str_ind);
     if (match !== 95) {
-      return parse_flags(pct_ind$1, str_ind, end_ind$1, /* false */0);
+      return parse_flags(pct_ind$1, str_ind, end_ind$1, false);
     } else {
-      return parse_flags(pct_ind$1, str_ind + 1 | 0, end_ind$1, /* true */1);
+      return parse_flags(pct_ind$1, str_ind + 1 | 0, end_ind$1, true);
     }
   };
   var parse_after_at = function (str_ind, end_ind) {
@@ -4491,7 +4491,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           } else {
             switch (switcher) {
               case 0 : 
-                  return parse_tag(/* true */1, str_ind + 1 | 0, end_ind);
+                  return parse_tag(true, str_ind + 1 | 0, end_ind);
               case 1 : 
                   exit = 1;
                   break;
@@ -4508,7 +4508,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         } else if (c >= 91) {
           switch (c - 91 | 0) {
             case 0 : 
-                return parse_tag(/* false */0, str_ind + 1 | 0, end_ind);
+                return parse_tag(false, str_ind + 1 | 0, end_ind);
             case 1 : 
                 exit = 1;
                 break;
@@ -4867,10 +4867,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     while(true) {
       var space = _space;
       var plus = _plus;
-      if (plus !== 0) {
-        if (space !== 0) {
+      if (plus) {
+        if (space) {
           if (legacy_behavior$1) {
-            _space = /* false */0;
+            _space = false;
             continue ;
           } else {
             return incompatible_flag(pct_ind, str_ind, /* " " */32, "'+'");
@@ -4908,7 +4908,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           }
           if (exit === 1) {
             if (legacy_behavior$1) {
-              _plus = /* false */0;
+              _plus = false;
               continue ;
             } else {
               return incompatible_flag(pct_ind, str_ind, symb, "'+'");
@@ -4916,7 +4916,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           }
           
         }
-      } else if (space !== 0) {
+      } else if (space) {
         var exit$1 = 0;
         if (symb >= 72) {
           var switcher$1 = symb - 101 | 0;
@@ -4949,7 +4949,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         }
         if (exit$1 === 1) {
           if (legacy_behavior$1) {
-            _space = /* false */0;
+            _space = false;
             continue ;
           } else {
             return incompatible_flag(pct_ind, str_ind, symb, "' '");
@@ -5103,12 +5103,12 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     };
   };
   var parse_conversion = function (pct_ind, str_ind, end_ind, plus, sharp, space, ign, pad, prec, padprec, symb) {
-    var plus_used = /* false */0;
-    var sharp_used = /* false */0;
-    var space_used = /* false */0;
-    var ign_used = [/* false */0];
-    var pad_used = /* false */0;
-    var prec_used = [/* false */0];
+    var plus_used = false;
+    var sharp_used = false;
+    var space_used = false;
+    var ign_used = [false];
+    var pad_used = false;
+    var prec_used = [false];
     var check_no_0 = function (symb, pad) {
       if (typeof pad === "number") {
         return pad;
@@ -5161,7 +5161,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       }
     };
     var get_prec_opt = function () {
-      prec_used[0] = /* true */1;
+      prec_used[0] = true;
       if (typeof prec === "number") {
         if (prec !== 0) {
           return incompatible_flag(pct_ind, str_ind, /* "_" */95, "'*'");
@@ -5191,8 +5191,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             var fmt_rest = match$1[0];
             var match$2 = parse_literal(str_ind, str_ind, sub_end);
             var sub_fmtty = fmtty_of_fmt(match$2[0]);
-            if (ign_used[0] = /* true */1, ign) {
-              pad_used = /* true */1;
+            if (ign_used[0] = true, ign) {
+              pad_used = true;
               var ignored_000 = opt_of_pad(/* "_" */95, pad);
               var ignored = /* Ignored_format_subst */Block.__(8, [
                   ignored_000,
@@ -5203,7 +5203,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                     fmt_rest
                   ])];
             } else {
-              pad_used = /* true */1;
+              pad_used = true;
               fmt_result = /* Fmt_EBB */[/* Format_subst */Block.__(14, [
                     opt_of_pad(/* "(" */40, pad),
                     sub_fmtty,
@@ -5221,7 +5221,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         case 67 : 
             var match$3 = parse_literal(str_ind, str_ind, end_ind);
             var fmt_rest$1 = match$3[0];
-            fmt_result = (ign_used[0] = /* true */1, ign) ? /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
+            fmt_result = (ign_used[0] = true, ign) ? /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                     /* Ignored_caml_char */1,
                     fmt_rest$1
                   ])] : /* Fmt_EBB */[/* Caml_char */Block.__(1, [fmt_rest$1])];
@@ -5229,7 +5229,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         case 78 : 
             var match$4 = parse_literal(str_ind, str_ind, end_ind);
             var fmt_rest$2 = match$4[0];
-            if (ign_used[0] = /* true */1, ign) {
+            if (ign_used[0] = true, ign) {
               var ignored$1 = /* Ignored_scan_get_counter */Block.__(10, [/* Token_counter */2]);
               fmt_result = /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                     ignored$1,
@@ -5243,12 +5243,12 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             }
             break;
         case 83 : 
-            pad_used = /* true */1;
+            pad_used = true;
             var pad$1 = check_no_0(symb, padprec);
             var match$5 = parse_literal(str_ind, str_ind, end_ind);
             var fmt_rest$3 = match$5[0];
-            if (ign_used[0] = /* true */1, ign) {
-              pad_used = /* true */1;
+            if (ign_used[0] = true, ign) {
+              pad_used = true;
               var ignored$2 = /* Ignored_caml_string */Block.__(1, [opt_of_pad(/* "_" */95, padprec)]);
               fmt_result = /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                     ignored$2,
@@ -5268,8 +5268,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             var next_ind = match$7[0];
             var match$8 = parse_literal(next_ind, next_ind, end_ind);
             var fmt_rest$4 = match$8[0];
-            if (ign_used[0] = /* true */1, ign) {
-              pad_used = /* true */1;
+            if (ign_used[0] = true, ign) {
+              pad_used = true;
               var ignored_000$1 = opt_of_pad(/* "_" */95, pad);
               var ignored$3 = /* Ignored_scan_char_set */Block.__(9, [
                   ignored_000$1,
@@ -5280,7 +5280,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                     fmt_rest$4
                   ])];
             } else {
-              pad_used = /* true */1;
+              pad_used = true;
               fmt_result = /* Fmt_EBB */[/* Scan_char_set */Block.__(20, [
                     opt_of_pad(/* "[" */91, pad),
                     char_set,
@@ -5305,7 +5305,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             break;
         case 99 : 
             var char_format = function (fmt_rest) {
-              if (ign_used[0] = /* true */1, ign) {
+              if (ign_used[0] = true, ign) {
                 return /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                             /* Ignored_char */0,
                             fmt_rest
@@ -5315,7 +5315,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               }
             };
             var scan_format = function (fmt_rest) {
-              if (ign_used[0] = /* true */1, ign) {
+              if (ign_used[0] = true, ign) {
                 return /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                             /* Ignored_scan_next_char */4,
                             fmt_rest
@@ -5326,7 +5326,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             };
             var match$10 = parse_literal(str_ind, str_ind, end_ind);
             var fmt_rest$5 = match$10[0];
-            pad_used = /* true */1;
+            pad_used = true;
             var match$11 = opt_of_pad(/* "c" */99, pad);
             fmt_result = match$11 ? (
                 match$11[0] !== 0 ? (
@@ -5350,18 +5350,18 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         case 114 : 
             var match$12 = parse_literal(str_ind, str_ind, end_ind);
             var fmt_rest$6 = match$12[0];
-            fmt_result = (ign_used[0] = /* true */1, ign) ? /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
+            fmt_result = (ign_used[0] = true, ign) ? /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                     /* Ignored_reader */3,
                     fmt_rest$6
                   ])] : /* Fmt_EBB */[/* Reader */Block.__(19, [fmt_rest$6])];
             break;
         case 115 : 
-            pad_used = /* true */1;
+            pad_used = true;
             var pad$2 = check_no_0(symb, padprec);
             var match$13 = parse_literal(str_ind, str_ind, end_ind);
             var fmt_rest$7 = match$13[0];
-            if (ign_used[0] = /* true */1, ign) {
-              pad_used = /* true */1;
+            if (ign_used[0] = true, ign) {
+              pad_used = true;
               var ignored$4 = /* Ignored_string */Block.__(0, [opt_of_pad(/* "_" */95, padprec)]);
               fmt_result = /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                     ignored$4,
@@ -5483,8 +5483,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             var match$17 = parse_literal(beg_ind$1, beg_ind$1, end_ind);
             var fmt_rest$8 = match$17[0];
             var sub_fmtty$1 = fmtty_of_fmt(match$16[0]);
-            if (ign_used[0] = /* true */1, ign) {
-              pad_used = /* true */1;
+            if (ign_used[0] = true, ign) {
+              pad_used = true;
               var ignored_000$2 = opt_of_pad(/* "_" */95, pad);
               var ignored$5 = /* Ignored_format_arg */Block.__(7, [
                   ignored_000$2,
@@ -5495,7 +5495,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                     fmt_rest$8
                   ])];
             } else {
-              pad_used = /* true */1;
+              pad_used = true;
               fmt_result = /* Fmt_EBB */[/* Format_arg */Block.__(13, [
                     opt_of_pad(/* "{" */123, pad),
                     sub_fmtty$1,
@@ -5508,14 +5508,14 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     }
     switch (exit$2) {
       case 7 : 
-          plus_used = /* true */1;
-          sharp_used = /* true */1;
-          space_used = /* true */1;
+          plus_used = true;
+          sharp_used = true;
+          space_used = true;
           var iconv = compute_int_conv(pct_ind, str_ind, plus, sharp, space, symb);
           var match$18 = parse_literal(str_ind, str_ind, end_ind);
           var fmt_rest$9 = match$18[0];
-          if (ign_used[0] = /* true */1, ign) {
-            pad_used = /* true */1;
+          if (ign_used[0] = true, ign) {
+            pad_used = true;
             var ignored_001 = opt_of_pad(/* "_" */95, pad);
             var ignored$6 = /* Ignored_int */Block.__(2, [
                 iconv,
@@ -5526,8 +5526,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                   fmt_rest$9
                 ])];
           } else {
-            pad_used = /* true */1;
-            prec_used[0] = /* true */1;
+            pad_used = true;
+            prec_used[0] = true;
             var pad$3;
             var exit$3 = 0;
             if (typeof prec === "number" && prec === 0) {
@@ -5551,7 +5551,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                     )
                 );
             }
-            var match$19 = make_padprec_fmt_ebb(pad$3, (prec_used[0] = /* true */1, prec), fmt_rest$9);
+            var match$19 = make_padprec_fmt_ebb(pad$3, (prec_used[0] = true, prec), fmt_rest$9);
             fmt_result = /* Fmt_EBB */[/* Int */Block.__(4, [
                   iconv,
                   match$19[0],
@@ -5565,7 +5565,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             var match$20 = parse_literal(str_ind, str_ind, end_ind);
             var fmt_rest$10 = match$20[0];
             var counter = counter_of_char(symb);
-            if (ign_used[0] = /* true */1, ign) {
+            if (ign_used[0] = true, ign) {
               var ignored$7 = /* Ignored_scan_get_counter */Block.__(10, [counter]);
               fmt_result = /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                     ignored$7,
@@ -5585,13 +5585,13 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     }
     switch (exit$1) {
       case 2 : 
-          plus_used = /* true */1;
-          space_used = /* true */1;
+          plus_used = true;
+          space_used = true;
           var fconv = compute_float_conv(pct_ind, str_ind, plus, space, symb);
           var match$21 = parse_literal(str_ind, str_ind, end_ind);
           var fmt_rest$11 = match$21[0];
-          if (ign_used[0] = /* true */1, ign) {
-            pad_used = /* true */1;
+          if (ign_used[0] = true, ign) {
+            pad_used = true;
             var ignored_000$3 = opt_of_pad(/* "_" */95, pad);
             var ignored_001$1 = get_prec_opt(/* () */0);
             var ignored$8 = /* Ignored_float */Block.__(6, [
@@ -5603,8 +5603,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                   fmt_rest$11
                 ])];
           } else {
-            pad_used = /* true */1;
-            var match$22 = make_padprec_fmt_ebb(pad, (prec_used[0] = /* true */1, prec), fmt_rest$11);
+            pad_used = true;
+            var match$22 = make_padprec_fmt_ebb(pad, (prec_used[0] = true, prec), fmt_rest$11);
             fmt_result = /* Fmt_EBB */[/* Float */Block.__(8, [
                   fconv,
                   match$22[0],
@@ -5616,7 +5616,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       case 3 : 
           var match$23 = parse_literal(str_ind, str_ind, end_ind);
           var fmt_rest$12 = match$23[0];
-          fmt_result = (ign_used[0] = /* true */1, ign) ? /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
+          fmt_result = (ign_used[0] = true, ign) ? /* Fmt_EBB */[/* Ignored_param */Block.__(23, [
                   /* Ignored_bool */2,
                   fmt_rest$12
                 ])] : /* Fmt_EBB */[/* Bool */Block.__(9, [fmt_rest$12])];
@@ -5667,15 +5667,15 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             } else {
               switch (symb - 108 | 0) {
                 case 0 : 
-                    plus_used = /* true */1;
-                    sharp_used = /* true */1;
-                    space_used = /* true */1;
+                    plus_used = true;
+                    sharp_used = true;
+                    space_used = true;
                     var iconv$1 = compute_int_conv(pct_ind, str_ind + 1 | 0, plus, sharp, space, Caml_string.get(str, str_ind));
                     var beg_ind$2 = str_ind + 1 | 0;
                     var match$25 = parse_literal(beg_ind$2, beg_ind$2, end_ind);
                     var fmt_rest$13 = match$25[0];
-                    if (ign_used[0] = /* true */1, ign) {
-                      pad_used = /* true */1;
+                    if (ign_used[0] = true, ign) {
+                      pad_used = true;
                       var ignored_001$2 = opt_of_pad(/* "_" */95, pad);
                       var ignored$9 = /* Ignored_int32 */Block.__(3, [
                           iconv$1,
@@ -5686,8 +5686,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                             fmt_rest$13
                           ])];
                     } else {
-                      pad_used = /* true */1;
-                      var match$26 = make_padprec_fmt_ebb(pad, (prec_used[0] = /* true */1, prec), fmt_rest$13);
+                      pad_used = true;
+                      var match$26 = make_padprec_fmt_ebb(pad, (prec_used[0] = true, prec), fmt_rest$13);
                       fmt_result = /* Fmt_EBB */[/* Int32 */Block.__(5, [
                             iconv$1,
                             match$26[0],
@@ -5700,15 +5700,15 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                     exit = 1;
                     break;
                 case 2 : 
-                    plus_used = /* true */1;
-                    sharp_used = /* true */1;
-                    space_used = /* true */1;
+                    plus_used = true;
+                    sharp_used = true;
+                    space_used = true;
                     var iconv$2 = compute_int_conv(pct_ind, str_ind + 1 | 0, plus, sharp, space, Caml_string.get(str, str_ind));
                     var beg_ind$3 = str_ind + 1 | 0;
                     var match$27 = parse_literal(beg_ind$3, beg_ind$3, end_ind);
                     var fmt_rest$14 = match$27[0];
-                    if (ign_used[0] = /* true */1, ign) {
-                      pad_used = /* true */1;
+                    if (ign_used[0] = true, ign) {
+                      pad_used = true;
                       var ignored_001$3 = opt_of_pad(/* "_" */95, pad);
                       var ignored$10 = /* Ignored_nativeint */Block.__(4, [
                           iconv$2,
@@ -5719,8 +5719,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                             fmt_rest$14
                           ])];
                     } else {
-                      pad_used = /* true */1;
-                      var match$28 = make_padprec_fmt_ebb(pad, (prec_used[0] = /* true */1, prec), fmt_rest$14);
+                      pad_used = true;
+                      var match$28 = make_padprec_fmt_ebb(pad, (prec_used[0] = true, prec), fmt_rest$14);
                       fmt_result = /* Fmt_EBB */[/* Nativeint */Block.__(6, [
                             iconv$2,
                             match$28[0],
@@ -5735,15 +5735,15 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           } else if (symb !== 76) {
             exit = 1;
           } else {
-            plus_used = /* true */1;
-            sharp_used = /* true */1;
-            space_used = /* true */1;
+            plus_used = true;
+            sharp_used = true;
+            space_used = true;
             var iconv$3 = compute_int_conv(pct_ind, str_ind + 1 | 0, plus, sharp, space, Caml_string.get(str, str_ind));
             var beg_ind$4 = str_ind + 1 | 0;
             var match$29 = parse_literal(beg_ind$4, beg_ind$4, end_ind);
             var fmt_rest$15 = match$29[0];
-            if (ign_used[0] = /* true */1, ign) {
-              pad_used = /* true */1;
+            if (ign_used[0] = true, ign) {
+              pad_used = true;
               var ignored_001$4 = opt_of_pad(/* "_" */95, pad);
               var ignored$11 = /* Ignored_int64 */Block.__(5, [
                   iconv$3,
@@ -5754,8 +5754,8 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                     fmt_rest$15
                   ])];
             } else {
-              pad_used = /* true */1;
-              var match$30 = make_padprec_fmt_ebb(pad, (prec_used[0] = /* true */1, prec), fmt_rest$15);
+              pad_used = true;
+              var match$30 = make_padprec_fmt_ebb(pad, (prec_used[0] = true, prec), fmt_rest$15);
               fmt_result = /* Fmt_EBB */[/* Int64 */Block.__(7, [
                     iconv$3,
                     match$30[0],
@@ -5851,11 +5851,11 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     return fmt_result;
   };
   var parse_flags = function (pct_ind, str_ind, end_ind, ign) {
-    var zero = [/* false */0];
-    var minus = [/* false */0];
-    var plus = [/* false */0];
-    var space = [/* false */0];
-    var sharp = [/* false */0];
+    var zero = [false];
+    var minus = [false];
+    var plus = [false];
+    var space = [false];
+    var sharp = [false];
     var set_flag = function (str_ind, flag) {
       if (flag[0] && !legacy_behavior$1) {
         Curry._3(failwith_message(/* Format */[
@@ -5880,7 +5880,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                   "invalid format %S: at character number %d, duplicate flag %C"
                 ]), str, str_ind, Caml_string.get(str, str_ind));
       }
-      flag[0] = /* true */1;
+      flag[0] = true;
       return /* () */0;
     };
     var _str_ind = str_ind;
@@ -5946,12 +5946,12 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         if (str_ind$2 === end_ind$1) {
           invalid_format_message(end_ind$1, "unexpected end of format");
         }
-        var padty = zero$1 !== 0 ? (
-            minus$1 !== 0 ? (
+        var padty = zero$1 ? (
+            minus$1 ? (
                 legacy_behavior$1 ? /* Left */0 : incompatible_flag(pct_ind$1, str_ind$2, /* "-" */45, "0")
               ) : /* Zeros */2
           ) : (
-            minus$1 !== 0 ? /* Left */0 : /* Right */1
+            minus$1 ? /* Left */0 : /* Right */1
           );
         var match$1 = Caml_string.get(str, str_ind$2);
         var exit$1 = 0;
@@ -5995,7 +5995,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
   var is_int_base = function (symb) {
     var switcher = symb - 88 | 0;
     if (switcher > 32 || switcher < 0) {
-      return /* false */0;
+      return false;
     } else {
       switch (switcher) {
         case 1 : 
@@ -6025,14 +6025,14 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         case 28 : 
         case 30 : 
         case 31 : 
-            return /* false */0;
+            return false;
         case 0 : 
         case 12 : 
         case 17 : 
         case 23 : 
         case 29 : 
         case 32 : 
-            return /* true */1;
+            return true;
         
       }
     }
@@ -6235,10 +6235,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     var match = Caml_string.get(str, str_ind);
     var match$1 = match !== 94 ? /* tuple */[
         str_ind,
-        /* false */0
+        false
       ] : /* tuple */[
         str_ind + 1 | 0,
-        /* true */1
+        true
       ];
     var next_ind = parse_char_set_start(match$1[0], end_ind);
     var char_set$1 = Bytes.to_string(char_set);

--- a/lib/js/camlinternalOO.js
+++ b/lib/js/camlinternalOO.js
@@ -19,9 +19,9 @@ function copy(o) {
 }
 
 var params = /* record */[
-  /* compact_table : true */1,
-  /* copy_parent : true */1,
-  /* clean_when_copying : true */1,
+  /* compact_table */true,
+  /* copy_parent */true,
+  /* clean_when_copying */true,
   /* retry_count */3,
   /* bucket_small_size */16
 ];
@@ -112,7 +112,7 @@ function get_method_label(table, name) {
   } else {
     var label = new_method(table);
     table[/* methods_by_name */2] = Belt_MapString.set(table[/* methods_by_name */2], name, label);
-    table[/* methods_by_label */3] = Belt_MapInt.set(table[/* methods_by_label */3], label, /* true */1);
+    table[/* methods_by_label */3] = Belt_MapInt.set(table[/* methods_by_label */3], label, true);
     return label;
   }
 }
@@ -196,12 +196,12 @@ function narrow(table, vars, virt_meths, concr_meths) {
   var by_label = [Belt_MapInt.empty];
   List.iter2((function (met, label) {
           by_name[0] = Belt_MapString.set(by_name[0], met, label);
-          by_label[0] = Belt_MapInt.set(by_label[0], label, Belt_MapInt.getWithDefault(table[/* methods_by_label */3], label, /* true */1));
+          by_label[0] = Belt_MapInt.set(by_label[0], label, Belt_MapInt.getWithDefault(table[/* methods_by_label */3], label, true));
           return /* () */0;
         }), concr_meths$1, concr_meth_labs);
   List.iter2((function (met, label) {
           by_name[0] = Belt_MapString.set(by_name[0], met, label);
-          by_label[0] = Belt_MapInt.set(by_label[0], label, /* false */0);
+          by_label[0] = Belt_MapInt.set(by_label[0], label, false);
           return /* () */0;
         }), virt_meths$1, virt_meth_labs);
   table[/* methods_by_name */2] = by_name[0];
@@ -309,7 +309,7 @@ function create_table(public_methods) {
     $$Array.iteri((function (i, met) {
             var lab = (i << 1) + 2 | 0;
             table[/* methods_by_name */2] = Belt_MapString.set(table[/* methods_by_name */2], met, lab);
-            table[/* methods_by_label */3] = Belt_MapInt.set(table[/* methods_by_label */3], lab, /* true */1);
+            table[/* methods_by_label */3] = Belt_MapInt.set(table[/* methods_by_label */3], lab, true);
             return /* () */0;
           }), public_methods);
     return table;

--- a/lib/js/complex.js
+++ b/lib/js/complex.js
@@ -1,41 +1,41 @@
 'use strict';
 
 
-var one = /* float array */[
+var one = /* array */[
   1.0,
   0.0
 ];
 
 function add(x, y) {
-  return /* float array */[
+  return /* array */[
           x[/* re */0] + y[/* re */0],
           x[/* im */1] + y[/* im */1]
         ];
 }
 
 function sub(x, y) {
-  return /* float array */[
+  return /* array */[
           x[/* re */0] - y[/* re */0],
           x[/* im */1] - y[/* im */1]
         ];
 }
 
 function neg(x) {
-  return /* float array */[
+  return /* array */[
           -x[/* re */0],
           -x[/* im */1]
         ];
 }
 
 function conj(x) {
-  return /* float array */[
+  return /* array */[
           x[/* re */0],
           -x[/* im */1]
         ];
 }
 
 function mul(x, y) {
-  return /* float array */[
+  return /* array */[
           x[/* re */0] * y[/* re */0] - x[/* im */1] * y[/* im */1],
           x[/* re */0] * y[/* im */1] + x[/* im */1] * y[/* re */0]
         ];
@@ -45,14 +45,14 @@ function div(x, y) {
   if (Math.abs(y[/* re */0]) >= Math.abs(y[/* im */1])) {
     var r = y[/* im */1] / y[/* re */0];
     var d = y[/* re */0] + r * y[/* im */1];
-    return /* float array */[
+    return /* array */[
             (x[/* re */0] + r * x[/* im */1]) / d,
             (x[/* im */1] - r * x[/* re */0]) / d
           ];
   } else {
     var r$1 = y[/* re */0] / y[/* im */1];
     var d$1 = y[/* im */1] + r$1 * y[/* re */0];
-    return /* float array */[
+    return /* array */[
             (r$1 * x[/* re */0] + x[/* im */1]) / d$1,
             (r$1 * x[/* im */1] - x[/* re */0]) / d$1
           ];
@@ -88,7 +88,7 @@ function arg(x) {
 }
 
 function polar(n, a) {
-  return /* float array */[
+  return /* array */[
           Math.cos(a) * n,
           Math.sin(a) * n
         ];
@@ -96,7 +96,7 @@ function polar(n, a) {
 
 function sqrt(x) {
   if (x[/* re */0] === 0.0 && x[/* im */1] === 0.0) {
-    return /* float array */[
+    return /* array */[
             0.0,
             0.0
           ];
@@ -112,12 +112,12 @@ function sqrt(x) {
       w = Math.sqrt(i) * Math.sqrt(0.5 * (q$1 + Math.sqrt(1.0 + q$1 * q$1)));
     }
     if (x[/* re */0] >= 0.0) {
-      return /* float array */[
+      return /* array */[
               w,
               0.5 * x[/* im */1] / w
             ];
     } else {
-      return /* float array */[
+      return /* array */[
               0.5 * i / w,
               x[/* im */1] >= 0.0 ? w : -w
             ];
@@ -127,14 +127,14 @@ function sqrt(x) {
 
 function exp(x) {
   var e = Math.exp(x[/* re */0]);
-  return /* float array */[
+  return /* array */[
           e * Math.cos(x[/* im */1]),
           e * Math.sin(x[/* im */1])
         ];
 }
 
 function log(x) {
-  return /* float array */[
+  return /* array */[
           Math.log(norm(x)),
           Math.atan2(x[/* im */1], x[/* re */0])
         ];
@@ -144,12 +144,12 @@ function pow(x, y) {
   return exp(mul(y, log(x)));
 }
 
-var zero = /* float array */[
+var zero = /* array */[
   0.0,
   0.0
 ];
 
-var i = /* float array */[
+var i = /* array */[
   0.0,
   1.0
 ];

--- a/lib/js/filename.js
+++ b/lib/js/filename.js
@@ -89,34 +89,34 @@ function generic_dirname(is_dir_sep, current_dir_name, name) {
 var current_dir_name = ".";
 
 function is_dir_sep(s, i) {
-  return +(Caml_string.get(s, i) === /* "/" */47);
+  return Caml_string.get(s, i) === /* "/" */47;
 }
 
 function is_relative(n) {
   if (n.length < 1) {
-    return /* true */1;
+    return true;
   } else {
-    return +(Caml_string.get(n, 0) !== /* "/" */47);
+    return Caml_string.get(n, 0) !== /* "/" */47;
   }
 }
 
 function is_implicit(n) {
   if (is_relative(n) && (n.length < 2 || $$String.sub(n, 0, 2) !== "./")) {
     if (n.length < 3) {
-      return /* true */1;
+      return true;
     } else {
-      return +($$String.sub(n, 0, 3) !== "../");
+      return $$String.sub(n, 0, 3) !== "../";
     }
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function check_suffix(name, suff) {
   if (name.length >= suff.length) {
-    return +($$String.sub(name, name.length - suff.length | 0, suff.length) === suff);
+    return $$String.sub(name, name.length - suff.length | 0, suff.length) === suff;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 

--- a/lib/js/format.js
+++ b/lib/js/format.js
@@ -78,7 +78,7 @@ function pp_output_string(state, s) {
 
 function break_new_line(state, offset, width) {
   Curry._1(state[/* pp_out_newline */18], /* () */0);
-  state[/* pp_is_new_line */10] = /* true */1;
+  state[/* pp_is_new_line */10] = true;
   var indent = (state[/* pp_margin */5] - width | 0) + offset | 0;
   var real_indent = Caml_primitive.caml_int_min(state[/* pp_max_indent */7], indent);
   state[/* pp_current_indent */9] = real_indent;
@@ -190,7 +190,7 @@ function format_pp_token(state, size, param) {
       case 0 : 
           state[/* pp_space_left */8] = state[/* pp_space_left */8] - size | 0;
           pp_output_string(state, param[0]);
-          state[/* pp_is_new_line */10] = /* false */0;
+          state[/* pp_is_new_line */10] = false;
           return /* () */0;
       case 1 : 
           var off = param[1];
@@ -413,7 +413,7 @@ function set_size(state, ty) {
 function scan_push(state, b, tok) {
   pp_enqueue(state, tok);
   if (b) {
-    set_size(state, /* true */1);
+    set_size(state, true);
   }
   state[/* pp_scan_stack */0] = /* :: */[
     /* Scan_elem */[
@@ -436,7 +436,7 @@ function pp_open_box_gen(state, indent, br_ty) {
         ]),
       /* length */0
     ];
-    return scan_push(state, /* false */0, elem);
+    return scan_push(state, false, elem);
   } else if (state[/* pp_curr_depth */13] === state[/* pp_max_boxes */14]) {
     var state$1 = state;
     var s = state[/* pp_ellipsis */15];
@@ -455,8 +455,8 @@ function pp_close_box(state, _) {
             /* token : Pp_end */1,
             /* length */0
           ]);
-      set_size(state, /* true */1);
-      set_size(state, /* false */0);
+      set_size(state, true);
+      set_size(state, false);
     }
     state[/* pp_curr_depth */13] = state[/* pp_curr_depth */13] - 1 | 0;
     return /* () */0;
@@ -623,12 +623,12 @@ function pp_open_box(state, indent) {
 }
 
 function pp_print_newline(state, _) {
-  pp_flush_queue(state, /* true */1);
+  pp_flush_queue(state, true);
   return Curry._1(state[/* pp_out_flush */17], /* () */0);
 }
 
 function pp_print_flush(state, _) {
-  pp_flush_queue(state, /* false */0);
+  pp_flush_queue(state, false);
   return Curry._1(state[/* pp_out_flush */17], /* () */0);
 }
 
@@ -666,7 +666,7 @@ function pp_print_break(state, width, offset) {
         ]),
       /* length */width
     ];
-    return scan_push(state, /* true */1, elem);
+    return scan_push(state, true, elem);
   } else {
     return 0;
   }
@@ -719,7 +719,7 @@ function pp_print_tbreak(state, width, offset) {
         ]),
       /* length */width
     ];
-    return scan_push(state, /* true */1, elem);
+    return scan_push(state, true, elem);
   } else {
     return 0;
   }
@@ -810,7 +810,7 @@ function pp_get_max_boxes(state, _) {
 }
 
 function pp_over_max_boxes(state, _) {
-  return +(state[/* pp_curr_depth */13] === state[/* pp_max_boxes */14]);
+  return state[/* pp_curr_depth */13] === state[/* pp_max_boxes */14];
 }
 
 function pp_set_ellipsis_text(state, s) {
@@ -996,7 +996,7 @@ function pp_make_formatter(f, g, h, i) {
           /* pp_max_indent */68,
           /* pp_space_left */78,
           /* pp_current_indent */0,
-          /* pp_is_new_line : true */1,
+          /* pp_is_new_line */true,
           /* pp_left_total */1,
           /* pp_right_total */1,
           /* pp_curr_depth */1,
@@ -1006,8 +1006,8 @@ function pp_make_formatter(f, g, h, i) {
           /* pp_out_flush */g,
           /* pp_out_newline */h,
           /* pp_out_spaces */i,
-          /* pp_print_tags : false */0,
-          /* pp_mark_tags : false */0,
+          /* pp_print_tags */false,
+          /* pp_mark_tags */false,
           /* pp_mark_open_tag */default_pp_mark_open_tag,
           /* pp_mark_close_tag */default_pp_mark_close_tag,
           /* pp_print_open_tag */default_pp_print_open_tag,
@@ -1056,14 +1056,14 @@ var err_formatter = formatter_of_out_channel(Pervasives.stderr);
 var str_formatter = formatter_of_buffer(stdbuf);
 
 function flush_str_formatter() {
-  pp_flush_queue(str_formatter, /* false */0);
+  pp_flush_queue(str_formatter, false);
   var s = $$Buffer.contents(stdbuf);
   $$Buffer.reset(stdbuf);
   return s;
 }
 
 function flush_buf_formatter(buf, ppf) {
-  pp_flush_queue(ppf, /* false */0);
+  pp_flush_queue(ppf, false);
   var s = $$Buffer.contents(buf);
   $$Buffer.reset(buf);
   return s;
@@ -1654,7 +1654,7 @@ function asprintf(param) {
   var ppf = formatter_of_buffer(b);
   var k$prime = function (ppf, acc) {
     output_acc(ppf, acc);
-    pp_flush_queue(ppf, /* false */0);
+    pp_flush_queue(ppf, false);
     return flush_buf_formatter(b, ppf);
   };
   return CamlinternalFormat.make_printf(k$prime, ppf, /* End_of_acc */0, param[0]);
@@ -1663,7 +1663,7 @@ function asprintf(param) {
 function bprintf(b, param) {
   var k = function (ppf, acc) {
     output_acc(ppf, acc);
-    return pp_flush_queue(ppf, /* false */0);
+    return pp_flush_queue(ppf, false);
   };
   return CamlinternalFormat.make_printf(k, formatter_of_buffer(b), /* End_of_acc */0, param[0]);
 }

--- a/lib/js/gc.js
+++ b/lib/js/gc.js
@@ -249,7 +249,7 @@ function call_alarm(arec) {
 }
 
 function create_alarm(f) {
-  var arec_000 = /* active */[/* true */1];
+  var arec_000 = /* active */[true];
   var arec = /* record */[
     arec_000,
     /* f */f
@@ -259,7 +259,7 @@ function create_alarm(f) {
 }
 
 function delete_alarm(a) {
-  a[0] = /* false */0;
+  a[0] = false;
   return /* () */0;
 }
 

--- a/lib/js/hashtbl.js
+++ b/lib/js/hashtbl.js
@@ -24,10 +24,10 @@ function seeded_hash(seed, x) {
   return Caml_hash.caml_hash(10, 100, seed, x);
 }
 
-var randomized = [/* false */0];
+var randomized = [false];
 
 function randomize() {
-  randomized[0] = /* true */1;
+  randomized[0] = true;
   return /* () */0;
 }
 
@@ -298,13 +298,13 @@ function mem(h, key) {
     var param = _param;
     if (param) {
       if (Caml_obj.caml_equal(param[0], key)) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[2];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -537,13 +537,13 @@ function MakeSeeded(H) {
       var param = _param;
       if (param) {
         if (Curry._2(H[/* equal */0], param[0], key)) {
-          return /* true */1;
+          return true;
         } else {
           _param = param[2];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };
@@ -721,18 +721,18 @@ function Make(H) {
       var param = _param;
       if (param) {
         if (Curry._2(equal, param[0], key)) {
-          return /* true */1;
+          return true;
         } else {
           _param = param[2];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };
   var create$1 = function (sz) {
-    return create(/* Some */[/* false */0], sz);
+    return create(/* Some */[false], sz);
   };
   return /* module */[
           /* create */create$1,

--- a/lib/js/js.js
+++ b/lib/js/js.js
@@ -5,6 +5,10 @@ var MapperRt = 0;
 
 var Internal = 0;
 
+var true_ = true;
+
+var false_ = false;
+
 var Null = 0;
 
 var Undefined = 0;
@@ -57,6 +61,8 @@ var Console = 0;
 
 exports.MapperRt = MapperRt;
 exports.Internal = Internal;
+exports.true_ = true_;
+exports.false_ = false_;
 exports.Null = Null;
 exports.Undefined = Undefined;
 exports.Nullable = Nullable;

--- a/lib/js/js_boolean.js
+++ b/lib/js/js_boolean.js
@@ -1,13 +1,1 @@
-'use strict';
-
-
-function to_js_boolean(b) {
-  if (b) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-exports.to_js_boolean = to_js_boolean;
-/* No side effect */
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/lib/js/js_int.js
+++ b/lib/js/js_int.js
@@ -2,7 +2,7 @@
 
 
 function equal(x, y) {
-  return +(x === y);
+  return x === y;
 }
 
 var max = 2147483647;

--- a/lib/js/js_json.js
+++ b/lib/js/js_json.js
@@ -26,21 +26,21 @@ function classify(x) {
 function test(x, v) {
   switch (v) {
     case 0 : 
-        return +(typeof x === "string");
+        return typeof x === "string";
     case 1 : 
-        return +(typeof x === "number");
+        return typeof x === "number";
     case 2 : 
         if (x !== null && typeof x === "object") {
-          return 1 - +Array.isArray(x);
+          return !Array.isArray(x);
         } else {
-          return /* false */0;
+          return false;
         }
     case 3 : 
-        return +Array.isArray(x);
+        return Array.isArray(x);
     case 4 : 
-        return +(typeof x === "boolean");
+        return typeof x === "boolean";
     case 5 : 
-        return +(x === null);
+        return x === null;
     
   }
 }

--- a/lib/js/js_list.js
+++ b/lib/js/js_list.js
@@ -26,7 +26,7 @@ function cons(x, xs) {
 }
 
 function isEmpty(x) {
-  return +(x === /* [] */0);
+  return x === /* [] */0;
 }
 
 function hd(param) {
@@ -216,7 +216,7 @@ function filterRevAux(f, _acc, _xs) {
       var y = xs[0];
       var match = f(y);
       _xs = ys;
-      if (match !== 0) {
+      if (match) {
         _acc = /* :: */[
           y,
           acc
@@ -315,12 +315,12 @@ function equal(cmp, _xs, _ys) {
         _xs = xs[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else if (ys) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }

--- a/lib/js/js_null.js
+++ b/lib/js/js_null.js
@@ -2,7 +2,7 @@
 
 
 function test(x) {
-  return +(x === null);
+  return x === null;
 }
 
 function getExn(f) {

--- a/lib/js/js_option.js
+++ b/lib/js/js_option.js
@@ -7,9 +7,9 @@ function some(x) {
 
 function isSome(param) {
   if (param) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -17,15 +17,15 @@ function isSomeValue(eq, v, x) {
   if (x) {
     return eq(v, x[0]);
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
 function isNone(param) {
   if (param) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -42,10 +42,10 @@ function equal(eq, a, b) {
     if (b) {
       return eq(a[0], b[0]);
     } else {
-      return /* false */0;
+      return false;
     }
   } else {
-    return +(b === /* None */0);
+    return b === /* None */0;
   }
 }
 

--- a/lib/js/js_primitive.js
+++ b/lib/js/js_primitive.js
@@ -3,9 +3,9 @@
 
 function is_nil_undef(x) {
   if (x === null) {
-    return /* true */1;
+    return true;
   } else {
-    return +(x === undefined);
+    return x === undefined;
   }
 }
 

--- a/lib/js/js_types.js
+++ b/lib/js/js_types.js
@@ -74,21 +74,21 @@ function classify(x) {
 function test(x, v) {
   switch (v) {
     case 0 : 
-        return +(typeof x === "undefined");
+        return typeof x === "undefined";
     case 1 : 
-        return +(x === null);
+        return x === null;
     case 2 : 
-        return +(typeof x === "boolean");
+        return typeof x === "boolean";
     case 3 : 
-        return +(typeof x === "number");
+        return typeof x === "number";
     case 4 : 
-        return +(typeof x === "string");
+        return typeof x === "string";
     case 5 : 
-        return +(typeof x === "function");
+        return typeof x === "function";
     case 6 : 
-        return +(typeof x === "object");
+        return typeof x === "object";
     case 7 : 
-        return +(typeof x === "symbol");
+        return typeof x === "symbol";
     
   }
 }

--- a/lib/js/js_undefined.js
+++ b/lib/js/js_undefined.js
@@ -2,11 +2,11 @@
 
 
 function test(x) {
-  return +(x === undefined);
+  return x === undefined;
 }
 
 function testAny(x) {
-  return +(x === undefined);
+  return x === undefined;
 }
 
 function getExn(f) {

--- a/lib/js/js_vector.js
+++ b/lib/js/js_vector.js
@@ -27,7 +27,7 @@ function pushBack(x, xs) {
 }
 
 function memByRef(x, xs) {
-  return +(xs.indexOf(x) >= 0);
+  return xs.indexOf(x) >= 0;
 }
 
 function iter(f, xs) {

--- a/lib/js/lazy.js
+++ b/lib/js/lazy.js
@@ -21,7 +21,7 @@ function from_val(v) {
 }
 
 function is_val(l) {
-  return +((l.tag | 0) !== Obj.lazy_tag);
+  return (l.tag | 0) !== Obj.lazy_tag;
 }
 
 var Undefined = CamlinternalLazy.Undefined;

--- a/lib/js/lexing.js
+++ b/lib/js/lexing.js
@@ -54,7 +54,7 @@ function from_function(f) {
               var aux_buffer = partial_arg;
               var lexbuf = param;
               var read = Curry._2(read_fun, aux_buffer, aux_buffer.length);
-              var n = read > 0 ? read : (lexbuf[/* lex_eof_reached */8] = /* true */1, 0);
+              var n = read > 0 ? read : (lexbuf[/* lex_eof_reached */8] = true, 0);
               if ((lexbuf[/* lex_buffer_len */2] + n | 0) > lexbuf[/* lex_buffer */1].length) {
                 if (((lexbuf[/* lex_buffer_len */2] - lexbuf[/* lex_start_pos */4] | 0) + n | 0) <= lexbuf[/* lex_buffer */1].length) {
                   Bytes.blit(lexbuf[/* lex_buffer */1], lexbuf[/* lex_start_pos */4], lexbuf[/* lex_buffer */1], 0, lexbuf[/* lex_buffer_len */2] - lexbuf[/* lex_start_pos */4] | 0);
@@ -96,8 +96,8 @@ function from_function(f) {
           /* lex_curr_pos */0,
           /* lex_last_pos */0,
           /* lex_last_action */0,
-          /* lex_eof_reached : false */0,
-          /* lex_mem : int array */[],
+          /* lex_eof_reached */false,
+          /* lex_mem : array */[],
           /* lex_start_p */zero_pos,
           /* lex_curr_p */zero_pos
         ];
@@ -112,7 +112,7 @@ function from_channel(ic) {
 function from_string(s) {
   return /* record */[
           /* refill_buff */(function (lexbuf) {
-              lexbuf[/* lex_eof_reached */8] = /* true */1;
+              lexbuf[/* lex_eof_reached */8] = true;
               return /* () */0;
             }),
           /* lex_buffer */Bytes.of_string(s),
@@ -122,8 +122,8 @@ function from_string(s) {
           /* lex_curr_pos */0,
           /* lex_last_pos */0,
           /* lex_last_action */0,
-          /* lex_eof_reached : true */1,
-          /* lex_mem : int array */[],
+          /* lex_eof_reached */true,
+          /* lex_mem : array */[],
           /* lex_start_p */zero_pos,
           /* lex_curr_p */zero_pos
         ];

--- a/lib/js/list.js
+++ b/lib/js/list.js
@@ -343,10 +343,10 @@ function for_all(p, _param) {
         _param = param[1];
         continue ;
       } else {
-        return /* false */0;
+        return false;
       }
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -356,13 +356,13 @@ function exists(p, _param) {
     var param = _param;
     if (param) {
       if (Curry._1(p, param[0])) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -378,7 +378,7 @@ function for_all2(p, _l1, _l2) {
           _l1 = l1[1];
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
         throw [
@@ -392,7 +392,7 @@ function for_all2(p, _l1, _l2) {
             "List.for_all2"
           ];
     } else {
-      return /* true */1;
+      return true;
     }
   };
 }
@@ -404,7 +404,7 @@ function exists2(p, _l1, _l2) {
     if (l1) {
       if (l2) {
         if (Curry._2(p, l1[0], l2[0])) {
-          return /* true */1;
+          return true;
         } else {
           _l2 = l2[1];
           _l1 = l1[1];
@@ -422,7 +422,7 @@ function exists2(p, _l1, _l2) {
             "List.exists2"
           ];
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -432,13 +432,13 @@ function mem(x, _param) {
     var param = _param;
     if (param) {
       if (Caml_obj.caml_equal(param[0], x)) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -448,13 +448,13 @@ function memq(x, _param) {
     var param = _param;
     if (param) {
       if (param[0] === x) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -498,13 +498,13 @@ function mem_assoc(x, _param) {
     var param = _param;
     if (param) {
       if (Caml_obj.caml_equal(param[0][0], x)) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }
@@ -514,13 +514,13 @@ function mem_assq(x, _param) {
     var param = _param;
     if (param) {
       if (param[0][0] === x) {
-        return /* true */1;
+        return true;
       } else {
         _param = param[1];
         continue ;
       }
     } else {
-      return /* false */0;
+      return false;
     }
   };
 }

--- a/lib/js/map.js
+++ b/lib/js/map.js
@@ -90,9 +90,9 @@ function Make(funarg) {
   };
   var is_empty = function (param) {
     if (param) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
   var add = function (x, data, param) {
@@ -147,13 +147,13 @@ function Make(funarg) {
       if (param) {
         var c = Curry._2(funarg[/* compare */0], x, param[1]);
         if (c === 0) {
-          return /* true */1;
+          return true;
         } else {
           _param = c < 0 ? param[0] : param[3];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };
@@ -306,10 +306,10 @@ function Make(funarg) {
           _param = param[3];
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* true */1;
+        return true;
       }
     };
   };
@@ -318,13 +318,13 @@ function Make(funarg) {
       var param = _param;
       if (param) {
         if (Curry._2(p, param[1], param[2]) || exists(p, param[0])) {
-          return /* true */1;
+          return true;
         } else {
           _param = param[3];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };
@@ -555,12 +555,12 @@ function Make(funarg) {
           _e1 = cons_enum(e1[2], e1[3]);
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else if (e2) {
-        return /* false */0;
+        return false;
       } else {
-        return /* true */1;
+        return true;
       }
     };
   };

--- a/lib/js/parsing.js
+++ b/lib/js/parsing.js
@@ -58,7 +58,7 @@ function clear_parser() {
 }
 
 var current_lookahead_fun = [(function () {
-      return /* false */0;
+      return false;
     })];
 
 function yyparse(tables, start, lexer, lexbuf) {
@@ -144,9 +144,9 @@ function yyparse(tables, start, lexer, lexbuf) {
     } else {
       current_lookahead_fun[0] = (function (tok) {
           if (tok.length !== undefined) {
-            return +(Caml_array.caml_array_get(tables[/* transl_block */2], tok.tag | 0) === curr_char);
+            return Caml_array.caml_array_get(tables[/* transl_block */2], tok.tag | 0) === curr_char;
           } else {
-            return +(Caml_array.caml_array_get(tables[/* transl_const */1], tok) === curr_char);
+            return Caml_array.caml_array_get(tables[/* transl_const */1], tok) === curr_char;
           }
         });
       throw exn$1;

--- a/lib/js/pervasives.js
+++ b/lib/js/pervasives.js
@@ -62,9 +62,9 @@ function string_of_bool(b) {
 function bool_of_string(param) {
   switch (param) {
     case "false" : 
-        return /* false */0;
+        return false;
     case "true" : 
-        return /* true */1;
+        return true;
     default:
       throw [
             Caml_builtin_exceptions.invalid_argument,

--- a/lib/js/printexc.js
+++ b/lib/js/printexc.js
@@ -266,7 +266,7 @@ function format_backtrace_slot(pos, slot) {
     }
   };
   if (slot.tag) {
-    if (slot[0] !== 0) {
+    if (slot[0]) {
       return /* None */0;
     } else {
       return /* Some */[Curry._1(Printf.sprintf(/* Format */[
@@ -278,7 +278,7 @@ function format_backtrace_slot(pos, slot) {
                               ])
                           ]),
                         "%s unknown location"
-                      ]), info(/* false */0))];
+                      ]), info(false))];
     }
   } else {
     return /* Some */[Curry._5(Printf.sprintf(/* Format */[
@@ -411,9 +411,9 @@ function backtrace_slots(raw_backtrace) {
     var backtrace = match[0];
     var usable_slot = function (param) {
       if (param.tag) {
-        return /* false */0;
+        return false;
       } else {
-        return /* true */1;
+        return true;
       }
     };
     var exists_usable = function (_i) {
@@ -421,13 +421,13 @@ function backtrace_slots(raw_backtrace) {
         var i = _i;
         if (i !== -1) {
           if (usable_slot(Caml_array.caml_array_get(backtrace, i))) {
-            return /* true */1;
+            return true;
           } else {
             _i = i - 1 | 0;
             continue ;
           }
         } else {
-          return /* false */0;
+          return false;
         }
       };
     };

--- a/lib/js/queue.js
+++ b/lib/js/queue.js
@@ -104,7 +104,7 @@ function copy(q) {
 }
 
 function is_empty(q) {
-  return +(q[/* length */0] === 0);
+  return q[/* length */0] === 0;
 }
 
 function length(q) {

--- a/lib/js/random.js
+++ b/lib/js/random.js
@@ -25,7 +25,7 @@ function full_init(s, seed) {
   var extract = function (d) {
     return ((Caml_string.get(d, 0) + (Caml_string.get(d, 1) << 8) | 0) + (Caml_string.get(d, 2) << 16) | 0) + (Caml_string.get(d, 3) << 24) | 0;
   };
-  var seed$1 = seed.length === 0 ? /* int array */[0] : seed;
+  var seed$1 = seed.length === 0 ? /* array */[0] : seed;
   var l = seed$1.length;
   for(var i = 0; i <= 54; ++i){
     Caml_array.caml_array_set(s[/* st */0], i, i);
@@ -166,7 +166,7 @@ function $$float(s, bound) {
 }
 
 function bool(s) {
-  return +((bits(s) & 1) === 0);
+  return (bits(s) & 1) === 0;
 }
 
 var $$default = /* record */[
@@ -263,7 +263,7 @@ function full_init$1(seed) {
 }
 
 function init(seed) {
-  return full_init($$default, /* int array */[seed]);
+  return full_init($$default, /* array */[seed]);
 }
 
 function self_init() {

--- a/lib/js/scanf.js
+++ b/lib/js/scanf.js
@@ -23,7 +23,7 @@ function next_char(ib) {
   try {
     var c = Curry._1(ib[/* get_next_char */6], /* () */0);
     ib[/* current_char */1] = c;
-    ib[/* current_char_is_valid */2] = /* true */1;
+    ib[/* current_char_is_valid */2] = true;
     ib[/* char_count */3] = ib[/* char_count */3] + 1 | 0;
     if (c === /* "\n" */10) {
       ib[/* line_count */4] = ib[/* line_count */4] + 1 | 0;
@@ -33,8 +33,8 @@ function next_char(ib) {
   catch (exn){
     if (exn === Caml_builtin_exceptions.end_of_file) {
       ib[/* current_char */1] = /* "\000" */0;
-      ib[/* current_char_is_valid */2] = /* false */0;
-      ib[/* eof */0] = /* true */1;
+      ib[/* current_char_is_valid */2] = false;
+      ib[/* eof */0] = true;
       return /* "\000" */0;
     } else {
       throw exn;
@@ -64,7 +64,7 @@ function end_of_input(ib) {
 }
 
 function beginning_of_input(ib) {
-  return +(ib[/* char_count */3] === 0);
+  return ib[/* char_count */3] === 0;
 }
 
 function name_of_input(ib) {
@@ -100,7 +100,7 @@ function token(ib) {
 
 function ignore_char(width, ib) {
   var width$1 = width - 1 | 0;
-  ib[/* current_char_is_valid */2] = /* false */0;
+  ib[/* current_char_is_valid */2] = false;
   return width$1;
 }
 
@@ -111,9 +111,9 @@ function store_char(width, ib, c) {
 
 function create(iname, next) {
   return /* record */[
-          /* eof : false */0,
+          /* eof */false,
           /* current_char : "\000" */0,
-          /* current_char_is_valid : false */0,
+          /* current_char_is_valid */false,
           /* char_count */0,
           /* line_count */0,
           /* token_count */0,
@@ -158,7 +158,7 @@ function from_ic(scan_close_ic, iname, ic) {
   var buf = Caml_string.caml_create_string(len);
   var i = [0];
   var lim = [0];
-  var eof = [/* false */0];
+  var eof = [false];
   var next = function () {
     if (i[0] < lim[0]) {
       var c = Caml_bytes.get(buf, i[0]);
@@ -169,7 +169,7 @@ function from_ic(scan_close_ic, iname, ic) {
     } else {
       lim[0] = Pervasives.input(ic, buf, 0, len);
       if (lim[0] === 0) {
-        eof[0] = /* true */1;
+        eof[0] = true;
         return Curry._1(scan_close_ic, ic);
       } else {
         i[0] = 1;
@@ -309,13 +309,13 @@ function check_char(ib, _c) {
             if (switcher !== 23) {
               return /* () */0;
             } else {
-              ib$1[/* current_char_is_valid */2] = /* false */0;
+              ib$1[/* current_char_is_valid */2] = false;
               continue ;
             }
           } else if (switcher === 3 || switcher === 2) {
             return /* () */0;
           } else {
-            ib$1[/* current_char_is_valid */2] = /* false */0;
+            ib$1[/* current_char_is_valid */2] = false;
             continue ;
           }
         }
@@ -323,7 +323,7 @@ function check_char(ib, _c) {
     } else {
       var ci = checked_peek_char(ib);
       if (ci === c) {
-        ib[/* current_char_is_valid */2] = /* false */0;
+        ib[/* current_char_is_valid */2] = false;
         return /* () */0;
       } else if (ci !== 13) {
         var s = character_mismatch_err(c, ci);
@@ -332,7 +332,7 @@ function check_char(ib, _c) {
               s
             ];
       } else if (c === /* "\n" */10) {
-        ib[/* current_char_is_valid */2] = /* false */0;
+        ib[/* current_char_is_valid */2] = false;
         _c = /* "\n" */10;
         continue ;
       } else {
@@ -354,9 +354,9 @@ function token_bool(ib) {
   var s = token(ib);
   switch (s) {
     case "false" : 
-        return /* false */0;
+        return false;
     case "true" : 
-        return /* true */1;
+        return true;
     default:
       var s$1 = Curry._1(Printf.sprintf(/* Format */[
                 /* String_literal */Block.__(11, [
@@ -559,9 +559,9 @@ function scan_digits_plus(basis, digitp, width, ib) {
 
 function is_binary_digit(param) {
   if (param === 49 || param === 48) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -571,9 +571,9 @@ function scan_binary_int(param, param$1) {
 
 function is_octal_digit(param) {
   if (param > 55 || param < 48) {
-    return /* false */0;
+    return false;
   } else {
-    return /* true */1;
+    return true;
   }
 }
 
@@ -585,14 +585,14 @@ function is_hexa_digit(param) {
   var switcher = param - 48 | 0;
   if (switcher > 22 || switcher < 0) {
     if (switcher > 54 || switcher < 49) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   } else if (switcher > 16 || switcher < 10) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -828,7 +828,7 @@ function scan_string(stp, width, ib) {
         return width$1;
       } else if (stp) {
         if (c === stp[0]) {
-          ib[/* current_char_is_valid */2] = /* false */0;
+          ib[/* current_char_is_valid */2] = false;
           return width$1;
         } else {
           _width = store_char(width$1, ib, c);
@@ -1192,7 +1192,7 @@ function scan_chars_in_char_set(char_set, scan_indic, width, ib) {
     } else {
       var ci = peek_char(ib);
       if (c === ci) {
-        ib[/* current_char_is_valid */2] = /* false */0;
+        ib[/* current_char_is_valid */2] = false;
         return /* () */0;
       } else {
         var s = character_mismatch_err(c, ci);

--- a/lib/js/set.js
+++ b/lib/js/set.js
@@ -206,7 +206,7 @@ function Make(funarg) {
       if (c === 0) {
         return /* tuple */[
                 l,
-                /* true */1,
+                true,
                 r
               ];
       } else if (c < 0) {
@@ -227,16 +227,16 @@ function Make(funarg) {
     } else {
       return /* tuple */[
               /* Empty */0,
-              /* false */0,
+              false,
               /* Empty */0
             ];
     }
   };
   var is_empty = function (param) {
     if (param) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   };
   var mem = function (x, _param) {
@@ -245,13 +245,13 @@ function Make(funarg) {
       if (param) {
         var c = Curry._2(funarg[/* compare */0], x, param[1]);
         if (c === 0) {
-          return /* true */1;
+          return true;
         } else {
           _param = c < 0 ? param[0] : param[2];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };
@@ -316,7 +316,7 @@ function Make(funarg) {
       var l1 = s1[0];
       var match = split(v1, s2);
       var l2 = match[0];
-      if (match[1] !== 0) {
+      if (match[1]) {
         return join(inter(l1, l2), v1, inter(r1, match[2]));
       } else {
         return concat(inter(l1, l2), inter(r1, match[2]));
@@ -333,7 +333,7 @@ function Make(funarg) {
         var l1 = s1[0];
         var match = split(v1, s2);
         var l2 = match[0];
-        if (match[1] !== 0) {
+        if (match[1]) {
           return concat(diff(l1, l2), diff(r1, match[2]));
         } else {
           return join(diff(l1, l2), v1, diff(r1, match[2]));
@@ -389,7 +389,7 @@ function Make(funarg) {
     };
   };
   var equal = function (s1, s2) {
-    return +(compare(s1, s2) === 0);
+    return compare(s1, s2) === 0;
   };
   var subset = function (_s1, _s2) {
     while(true) {
@@ -409,7 +409,7 @@ function Make(funarg) {
               _s1 = r1;
               continue ;
             } else {
-              return /* false */0;
+              return false;
             }
           } else if (c < 0) {
             if (subset(/* Node */[
@@ -421,7 +421,7 @@ function Make(funarg) {
               _s1 = r1;
               continue ;
             } else {
-              return /* false */0;
+              return false;
             }
           } else if (subset(/* Node */[
                   /* Empty */0,
@@ -432,13 +432,13 @@ function Make(funarg) {
             _s1 = l1;
             continue ;
           } else {
-            return /* false */0;
+            return false;
           }
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* true */1;
+        return true;
       }
     };
   };
@@ -476,10 +476,10 @@ function Make(funarg) {
           _param = param[2];
           continue ;
         } else {
-          return /* false */0;
+          return false;
         }
       } else {
-        return /* true */1;
+        return true;
       }
     };
   };
@@ -488,13 +488,13 @@ function Make(funarg) {
       var param = _param;
       if (param) {
         if (Curry._1(p, param[1]) || exists(p, param[0])) {
-          return /* true */1;
+          return true;
         } else {
           _param = param[2];
           continue ;
         }
       } else {
-        return /* false */0;
+        return false;
       }
     };
   };

--- a/lib/js/stack.js
+++ b/lib/js/stack.js
@@ -46,7 +46,7 @@ function top(s) {
 }
 
 function is_empty(s) {
-  return +(s[/* c */0] === /* [] */0);
+  return s[/* c */0] === /* [] */0;
 }
 
 function length(s) {

--- a/lib/js/string.js
+++ b/lib/js/string.js
@@ -68,14 +68,14 @@ function is_space(param) {
   var switcher = param - 9 | 0;
   if (switcher > 4 || switcher < 0) {
     if (switcher !== 23) {
-      return /* false */0;
+      return false;
     } else {
-      return /* true */1;
+      return true;
     }
   } else if (switcher !== 2) {
-    return /* true */1;
+    return true;
   } else {
-    return /* false */0;
+    return false;
   }
 }
 
@@ -92,26 +92,26 @@ function escaped(s) {
     while(true) {
       var i = _i;
       if (i >= s.length) {
-        return /* false */0;
+        return false;
       } else {
         var match = s.charCodeAt(i);
         if (match >= 32) {
           var switcher = match - 34 | 0;
           if (switcher > 58 || switcher < 0) {
             if (switcher >= 93) {
-              return /* true */1;
+              return true;
             } else {
               _i = i + 1 | 0;
               continue ;
             }
           } else if (switcher > 57 || switcher < 1) {
-            return /* true */1;
+            return true;
           } else {
             _i = i + 1 | 0;
             continue ;
           }
         } else {
-          return /* true */1;
+          return true;
         }
       }
     };

--- a/lib/js/sys.js
+++ b/lib/js/sys.js
@@ -3,19 +3,19 @@
 var Caml_sys = require("./caml_sys.js");
 var Caml_exceptions = require("./caml_exceptions.js");
 
-var is_js = /* true */1;
+var is_js = true;
 
 var match = Caml_sys.caml_sys_get_argv(/* () */0);
 
-var big_endian = /* false */0;
+var big_endian = false;
 
-var unix = /* true */1;
+var unix = true;
 
-var win32 = /* false */0;
+var win32 = false;
 
-var cygwin = /* false */0;
+var cygwin = false;
 
-var interactive = [/* false */0];
+var interactive = [false];
 
 function set_signal(_, _$1) {
   return /* () */0;

--- a/lib/js/unix.js
+++ b/lib/js/unix.js
@@ -355,12 +355,12 @@ function single_write_substring(fd, buf, ofs, len) {
 function try_set_close_on_exec() {
   try {
     Caml_missing_polyfill.not_implemented("unix_set_close_on_exec not implemented by bucklescript yet\n");
-    return /* true */1;
+    return true;
   }
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn[0] === Caml_builtin_exceptions.invalid_argument) {
-      return /* false */0;
+      return false;
     } else {
       throw exn;
     }
@@ -523,11 +523,11 @@ function getaddrinfo(node, service, opts) {
       var opts$1 = opts;
       var opt_socktype = [/* None */0];
       var opt_protocol = [0];
-      var opt_passive = [/* false */0];
+      var opt_passive = [false];
       List.iter((function (param) {
               if (typeof param === "number") {
                 if (param === 2) {
-                  opt_passive[0] = /* true */1;
+                  opt_passive[0] = true;
                   return /* () */0;
                 } else {
                   return /* () */0;
@@ -1191,7 +1191,7 @@ function accept_non_intr() {
 
 function establish_server(server_fun, _) {
   var sock = Caml_missing_polyfill.not_implemented("unix_socket not implemented by bucklescript yet\n");
-  setsockopt(sock, /* SO_REUSEADDR */2, /* true */1);
+  setsockopt(sock, /* SO_REUSEADDR */2, true);
   Caml_missing_polyfill.not_implemented("unix_bind not implemented by bucklescript yet\n");
   Caml_missing_polyfill.not_implemented("unix_listen not implemented by bucklescript yet\n");
   while(true) {

--- a/lib/js/weak.js
+++ b/lib/js/weak.js
@@ -38,7 +38,7 @@ function Make(H) {
     var sz$2 = sz$1 > 2147483647 ? 2147483647 : sz$1;
     return /* record */[
             /* table */Caml_array.caml_make_vect(sz$2, emptybucket),
-            /* hashes */Caml_array.caml_make_vect(sz$2, /* int array */[]),
+            /* hashes */Caml_array.caml_make_vect(sz$2, /* array */[]),
             /* limit */7,
             /* oversize */0,
             /* rover */0
@@ -47,7 +47,7 @@ function Make(H) {
   var clear = function (t) {
     for(var i = 0 ,i_finish = t[/* table */0].length - 1 | 0; i <= i_finish; ++i){
       Caml_array.caml_array_set(t[/* table */0], i, emptybucket);
-      Caml_array.caml_array_set(t[/* hashes */1], i, /* int array */[]);
+      Caml_array.caml_array_set(t[/* hashes */1], i, /* array */[]);
     }
     t[/* limit */2] = 7;
     t[/* oversize */3] = 0;
@@ -110,7 +110,7 @@ function Make(H) {
                       return /* () */0;
                     } else {
                       var match = Caml_weak.caml_weak_check(b, i);
-                      if (match !== 0) {
+                      if (match) {
                         Curry._3(f, b, Caml_array.caml_array_get(t[/* hashes */1], j), i);
                         _i = i + 1 | 0;
                         continue ;
@@ -181,7 +181,7 @@ function Make(H) {
       loop(0, (bucket.length - 1 | 0) - 1 | 0);
       if (prev_len === 0) {
         Caml_array.caml_array_set(t[/* table */0], t[/* rover */4], emptybucket);
-        Caml_array.caml_array_set(t[/* hashes */1], t[/* rover */4], /* int array */[]);
+        Caml_array.caml_array_set(t[/* hashes */1], t[/* rover */4], /* array */[]);
       } else {
         Caml_obj.caml_obj_truncate(bucket, prev_len + 1 | 0);
         Caml_obj.caml_obj_truncate(hbucket, prev_len);
@@ -350,8 +350,8 @@ function Make(H) {
   };
   var mem = function (t, d) {
     return find_shadow(t, d, (function (_, _$1) {
-                  return /* true */1;
-                }), /* false */0);
+                  return true;
+                }), false);
   };
   var find_all = function (t, d) {
     var h = Curry._1(H[/* hash */1], d);

--- a/vendor/ocaml/bytecomp/lambda.ml
+++ b/vendor/ocaml/bytecomp/lambda.ml
@@ -190,6 +190,7 @@ type pointer_info =
   | Pt_constructor of string
   | Pt_variant of string 
   | Pt_module_alias
+  | Pt_builtin_boolean
   | Pt_na
 
 let default_pointer_info = Pt_na

--- a/vendor/ocaml/bytecomp/lambda.mli
+++ b/vendor/ocaml/bytecomp/lambda.mli
@@ -56,6 +56,7 @@ type pointer_info =
   | Pt_constructor of string
   | Pt_variant of string 
   | Pt_module_alias
+  | Pt_builtin_boolean
   | Pt_na 
 
 val default_pointer_info : pointer_info

--- a/vendor/ocaml/bytecomp/matching.ml
+++ b/vendor/ocaml/bytecomp/matching.ml
@@ -2440,6 +2440,9 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
           with
           | (1, 1, [0, act1], [0, act2]) ->
               Lifthenelse(arg, act2, act1)
+          | (2,0, [(i1,act1); (_,act2)],[]) ->
+            if i1 = 0 then Lifthenelse(arg, act2, act1)
+            else Lifthenelse (arg,act1,act2)
           | (n,_,_,[])  ->
               call_switcher None arg 0 (n-1) consts
           | (n, _, _, _) ->

--- a/vendor/ocaml/bytecomp/translcore.ml
+++ b/vendor/ocaml/bytecomp/translcore.ml
@@ -38,220 +38,279 @@ let transl_object =
   ref (fun id s cl -> assert false :
        Ident.t -> string list -> class_expr -> lambda)
 
+
+type specialized = {
+  gencomp : Lambda.primitive;
+  intcomp : Lambda.primitive;
+  boolcomp : Lambda.primitive; 
+  floatcomp : Lambda.primitive;
+  stringcomp : Lambda.primitive;
+  nativeintcomp : Lambda.primitive;
+  int32comp : Lambda.primitive;
+  int64comp : Lambda.primitive;
+  simplify_constant_constructor : bool;
+}
+
 let more_bs_primitives ls =        
   if !Clflags.bs_only then 
       ("%bs_max",
-    (Pccall{prim_name = "caml_max"; prim_arity = 2; prim_alloc = true;
-            prim_native_name = ""; prim_native_float = false},
-     Pccall{prim_name = "caml_int_max"; prim_arity = 2;
+    { gencomp = Pccall{prim_name = "caml_max"; prim_arity = 2; prim_alloc = true;
+            prim_native_name = ""; prim_native_float = false};
+     intcomp = Pccall{prim_name = "caml_int_max"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_float_max"; prim_arity = 2;
+            prim_native_float = false};
+     boolcomp =Pccall{prim_name = "caml_bool_max"; prim_arity = 2;
+                       prim_alloc = false; prim_native_name = "";
+                       prim_native_float = false}; 
+     floatcomp = Pccall{prim_name = "caml_float_max"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_string_max"; prim_arity = 2;
+            prim_native_float = false};
+     stringcomp = Pccall{prim_name = "caml_string_max"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_nativeint_max"; prim_arity = 2;
+            prim_native_float = false};
+     nativeintcomp = Pccall{prim_name = "caml_nativeint_max"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_int32_max"; prim_arity = 2;
+            prim_native_float = false};
+     int32comp = Pccall{prim_name = "caml_int32_max"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_int64_max"; prim_arity = 2;
+            prim_native_float = false};
+     int64comp = Pccall{prim_name = "caml_int64_max"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     false)) ::
+            prim_native_float = false};
+     simplify_constant_constructor = false}) ::
     ("%bs_min",
-    (Pccall{prim_name = "caml_min"; prim_arity = 2; prim_alloc = true;
-            prim_native_name = ""; prim_native_float = false},
-     Pccall{prim_name = "caml_int_min"; prim_arity = 2;
+    { gencomp = Pccall{prim_name = "caml_min"; prim_arity = 2; prim_alloc = true;
+            prim_native_name = ""; prim_native_float = false};
+     intcomp = Pccall{prim_name = "caml_int_min"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_float_min"; prim_arity = 2;
+            prim_native_float = false};
+     boolcomp = Pccall{prim_name = "caml_bool_min"; prim_arity = 2;
+                       prim_alloc = false; prim_native_name = "";
+                       prim_native_float = false};
+     floatcomp = Pccall{prim_name = "caml_float_min"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_string_min"; prim_arity = 2;
+            prim_native_float = false};
+     stringcomp = Pccall{prim_name = "caml_string_min"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_nativeint_min"; prim_arity = 2;
+            prim_native_float = false};
+     nativeintcomp = Pccall{prim_name = "caml_nativeint_min"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_int32_min"; prim_arity = 2;
+            prim_native_float = false};
+     int32comp = Pccall{prim_name = "caml_int32_min"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     Pccall{prim_name = "caml_int64_min"; prim_arity = 2;
+            prim_native_float = false};
+     int64comp = Pccall{prim_name = "caml_int64_min"; prim_arity = 2;
             prim_alloc = false; prim_native_name = "";
-            prim_native_float = false},
-     false)) ::
+            prim_native_float = false};
+     simplify_constant_constructor = false}) ::
      (
        "%bs_equal_null",
-       (Pccall{prim_name = "caml_equal_null"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_int_equal_null"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_float_equal_null"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_string_equal_null"; prim_arity = 2;
+       { gencomp = Pccall{prim_name = "caml_equal_null"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+         intcomp = Pccall{prim_name = "caml_int_equal_null"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+         boolcomp = Pccall{prim_name = "caml_bool_equal_null"; prim_arity = 2; prim_alloc = true;
+                          prim_native_name = ""; prim_native_float = false};       
+         floatcomp = Pccall{prim_name = "caml_float_equal_null"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};       
+         stringcomp = Pccall{prim_name = "caml_string_equal_null"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_nativeint_equal_null"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};
+         nativeintcomp = Pccall{prim_name = "caml_nativeint_equal_null"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_int32_equal_null"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};
+         int32comp = Pccall{prim_name = "caml_int32_equal_null"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_int64_equal_null"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};       
+         int64comp = Pccall{prim_name = "caml_int64_equal_null"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},       
-       true)
+              prim_native_name = ""; prim_native_float = false};       
+        simplify_constant_constructor = true}
      ) :: 
      (
        "%bs_equal_undefined",
-       (Pccall{prim_name = "caml_equal_undefined"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_int_equal_undefined"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_float_equal_undefined"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_string_equal_undefined"; prim_arity = 2;
+       { gencomp = Pccall{prim_name = "caml_equal_undefined"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+         intcomp = Pccall{prim_name = "caml_int_equal_undefined"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+         boolcomp = Pccall{prim_name = "caml_bool_equal_undefined"; prim_arity = 2; prim_alloc = true;
+                          prim_native_name = ""; prim_native_float = false};
+         floatcomp = Pccall{prim_name = "caml_float_equal_undefined"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};       
+         stringcomp = Pccall{prim_name = "caml_string_equal_undefined"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_nativeint_equal_undefined"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};
+         nativeintcomp = Pccall{prim_name = "caml_nativeint_equal_undefined"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_int32_equal_undefined"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};
+         int32comp = Pccall{prim_name = "caml_int32_equal_undefined"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_int64_equal_undefined"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};       
+         int64comp = Pccall{prim_name = "caml_int64_equal_undefined"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},       
-       true)
+              prim_native_name = ""; prim_native_float = false};       
+         simplify_constant_constructor = true}
      ) :: 
      (
        "%bs_equal_nullable",
-       (Pccall{prim_name = "caml_equal_nullable"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_int_equal_nullable"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_float_equal_nullable"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_string_equal_nullable"; prim_arity = 2;
+       { gencomp = Pccall{prim_name = "caml_equal_nullable"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+         intcomp = Pccall{prim_name = "caml_int_equal_nullable"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+         boolcomp = Pccall{prim_name = "caml_bool_equal_nullable"; prim_arity = 2; prim_alloc = true;
+                          prim_native_name = ""; prim_native_float = false};       
+         floatcomp = Pccall{prim_name = "caml_float_equal_nullable"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};       
+         stringcomp = Pccall{prim_name = "caml_string_equal_nullable"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_nativeint_equal_nullable"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};
+         nativeintcomp = Pccall{prim_name = "caml_nativeint_equal_nullable"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_int32_equal_nullable"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};
+         int32comp = Pccall{prim_name = "caml_int32_equal_nullable"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},       
-       Pccall{prim_name = "caml_int64_equal_nullable"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};       
+         int64comp = Pccall{prim_name = "caml_int64_equal_nullable"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},       
-       true)
+              prim_native_name = ""; prim_native_float = false};       
+         simplify_constant_constructor = true}
      ) ::     
      ls
      else ls 
 
 (* Translation of primitives *)
-
+ 
 let comparisons_table = Lazy.from_fun @@ fun _ ->
   create_hashtable 11 @@ more_bs_primitives [
   "%equal",
-      (Pccall{prim_name = "caml_equal"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pintcomp Ceq,
-       Pfloatcomp Ceq,
-       Pccall{prim_name = "caml_string_equal"; prim_arity = 2;
+      { gencomp = Pccall{prim_name = "caml_equal"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+        intcomp = Pintcomp Ceq;
+        boolcomp = if not !Clflags.bs_only then Pintcomp Ceq
+          else Pccall{prim_name = "caml_bool_equal"; prim_arity = 2;
+                      prim_alloc = false;
+                      prim_native_name = ""; prim_native_float = false}; 
+        floatcomp = Pfloatcomp Ceq;
+        stringcomp = Pccall{prim_name = "caml_string_equal"; prim_arity = 2;
               prim_alloc = false;
-              prim_native_name = ""; prim_native_float = false},
-       Pbintcomp(Pnativeint, Ceq),
-       Pbintcomp(Pint32, Ceq),
-       Pbintcomp(Pint64, Ceq),
-       true);
+              prim_native_name = ""; prim_native_float = false};
+        nativeintcomp = Pbintcomp(Pnativeint, Ceq);
+        int32comp = Pbintcomp(Pint32, Ceq);
+        int64comp = Pbintcomp(Pint64, Ceq);
+        simplify_constant_constructor = true};
   "%notequal",
-      (Pccall{prim_name = "caml_notequal"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pintcomp Cneq,
-       Pfloatcomp Cneq,
-       Pccall{prim_name = "caml_string_notequal"; prim_arity = 2;
+      { gencomp = Pccall{prim_name = "caml_notequal"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+        intcomp = Pintcomp Cneq;
+        boolcomp = if not !Clflags.bs_only then Pintcomp Cneq
+            else Pccall{prim_name = "caml_bool_notequal"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pbintcomp(Pnativeint, Cneq),
-       Pbintcomp(Pint32, Cneq),
-       Pbintcomp(Pint64, Cneq),
-       true);
+              prim_native_float = false} ; 
+        floatcomp = Pfloatcomp Cneq;
+        stringcomp = Pccall{prim_name = "caml_string_notequal"; prim_arity = 2;
+              prim_alloc = false; prim_native_name = "";
+              prim_native_float = false};
+        nativeintcomp = Pbintcomp(Pnativeint, Cneq);
+        int32comp = Pbintcomp(Pint32, Cneq);
+        int64comp = Pbintcomp(Pint64, Cneq);
+        simplify_constant_constructor = true};
   "%lessthan",
-      (Pccall{prim_name = "caml_lessthan"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pintcomp Clt,
-       Pfloatcomp Clt,
-       Pccall{prim_name = "caml_string_lessthan"; prim_arity = 2;
+      { gencomp = Pccall{prim_name = "caml_lessthan"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+        intcomp = Pintcomp Clt;
+        boolcomp = if not !Clflags.bs_only then Pintcomp Clt
+          else Pccall{prim_name = "caml_bool_lessthan"; prim_arity = 2;
+                      prim_alloc = false; prim_native_name = "";
+                      prim_native_float = false};
+        floatcomp = Pfloatcomp Clt;
+        stringcomp = Pccall{prim_name = "caml_string_lessthan"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pbintcomp(Pnativeint, Clt),
-       Pbintcomp(Pint32, Clt),
-       Pbintcomp(Pint64, Clt),
-       false);
+              prim_native_float = false};
+        nativeintcomp = Pbintcomp(Pnativeint, Clt);
+        int32comp = Pbintcomp(Pint32, Clt);
+        int64comp = Pbintcomp(Pint64, Clt);
+        simplify_constant_constructor = false};
   "%greaterthan",
-      (Pccall{prim_name = "caml_greaterthan"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pintcomp Cgt,
-       Pfloatcomp Cgt,
-       Pccall{prim_name = "caml_string_greaterthan"; prim_arity = 2;
+      { gencomp = Pccall{prim_name = "caml_greaterthan"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+        intcomp = Pintcomp Cgt;
+        boolcomp = if not !Clflags.bs_only then Pintcomp Cgt
+          else Pccall{prim_name = "caml_bool_greaterthan"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pbintcomp(Pnativeint, Cgt),
-       Pbintcomp(Pint32, Cgt),
-       Pbintcomp(Pint64, Cgt),
-       false);
+              prim_native_float = false};
+        floatcomp = Pfloatcomp Cgt;
+        stringcomp = Pccall{prim_name = "caml_string_greaterthan"; prim_arity = 2;
+              prim_alloc = false; prim_native_name = "";
+              prim_native_float = false};
+        nativeintcomp = Pbintcomp(Pnativeint, Cgt);
+        int32comp = Pbintcomp(Pint32, Cgt);
+        int64comp = Pbintcomp(Pint64, Cgt);
+        simplify_constant_constructor = false};
   "%lessequal",
-      (Pccall{prim_name = "caml_lessequal"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pintcomp Cle,
-       Pfloatcomp Cle,
-       Pccall{prim_name = "caml_string_lessequal"; prim_arity = 2;
+      { gencomp = Pccall{prim_name = "caml_lessequal"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+        intcomp = Pintcomp Cle;
+        boolcomp = if not !Clflags.bs_only then Pintcomp Cle
+          else Pccall{prim_name = "caml_bool_lessequal"; prim_arity = 2;
+                      prim_alloc = false; prim_native_name = "";
+                      prim_native_float = false};
+        floatcomp = Pfloatcomp Cle;
+        stringcomp = Pccall{prim_name = "caml_string_lessequal"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pbintcomp(Pnativeint, Cle),
-       Pbintcomp(Pint32, Cle),
-       Pbintcomp(Pint64, Cle),
-       false);
+              prim_native_float = false};
+        nativeintcomp = Pbintcomp(Pnativeint, Cle);
+        int32comp = Pbintcomp(Pint32, Cle);
+        int64comp = Pbintcomp(Pint64, Cle);
+        simplify_constant_constructor = false};
   "%greaterequal",
-      (Pccall{prim_name = "caml_greaterequal"; prim_arity = 2;
+      {gencomp = Pccall{prim_name = "caml_greaterequal"; prim_arity = 2;
               prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pintcomp Cge,
-       Pfloatcomp Cge,
-       Pccall{prim_name = "caml_string_greaterequal"; prim_arity = 2;
+              prim_native_name = ""; prim_native_float = false};
+       intcomp = Pintcomp Cge;
+       boolcomp = if not !Clflags.bs_only then Pintcomp Cge
+         else Pccall{prim_name = "caml_bool_greaterequal"; prim_arity = 2;
+                     prim_alloc = false; prim_native_name = "";
+                     prim_native_float = false};
+       floatcomp = Pfloatcomp Cge;
+       stringcomp = Pccall{prim_name = "caml_string_greaterequal"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pbintcomp(Pnativeint, Cge),
-       Pbintcomp(Pint32, Cge),
-       Pbintcomp(Pint64, Cge),
-       false);
+              prim_native_float = false};
+       nativeintcomp = Pbintcomp(Pnativeint, Cge);
+       int32comp = Pbintcomp(Pint32, Cge);
+       int64comp = Pbintcomp(Pint64, Cge);
+       simplify_constant_constructor = false};
   "%compare",
-      (Pccall{prim_name = "caml_compare"; prim_arity = 2; prim_alloc = true;
-              prim_native_name = ""; prim_native_float = false},
-       Pccall{prim_name = "caml_int_compare"; prim_arity = 2;
+      { gencomp = Pccall{prim_name = "caml_compare"; prim_arity = 2; prim_alloc = true;
+              prim_native_name = ""; prim_native_float = false};
+        intcomp = Pccall{prim_name = "caml_int_compare"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pccall{prim_name = "caml_float_compare"; prim_arity = 2;
+              prim_native_float = false};
+        boolcomp = if not !Clflags.bs_only then
+            Pccall {prim_name = "caml_int_compare";
+             prim_arity = 2;
+             prim_alloc = false; prim_native_name = "";
+             prim_native_float = false}                                               
+          else
+            Pccall {prim_name = "caml_bool_compare";
+             prim_arity = 2;
+             prim_alloc = false; prim_native_name = "";
+             prim_native_float = false};
+        floatcomp = Pccall{prim_name = "caml_float_compare"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pccall{prim_name = "caml_string_compare"; prim_arity = 2;
+              prim_native_float = false};
+        stringcomp = Pccall{prim_name = "caml_string_compare"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pccall{prim_name = "caml_nativeint_compare"; prim_arity = 2;
+              prim_native_float = false};
+        nativeintcomp = Pccall{prim_name = "caml_nativeint_compare"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pccall{prim_name = "caml_int32_compare"; prim_arity = 2;
+              prim_native_float = false};
+        int32comp = Pccall{prim_name = "caml_int32_compare"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       Pccall{prim_name = "caml_int64_compare"; prim_arity = 2;
+              prim_native_float = false};
+        int64comp = Pccall{prim_name = "caml_int64_compare"; prim_arity = 2;
               prim_alloc = false; prim_native_name = "";
-              prim_native_float = false},
-       false)
+              prim_native_float = false};
+       simplify_constant_constructor = false}
 ]
 
 let primitives_table = create_hashtable 57 [
@@ -464,12 +523,14 @@ let find_primitive loc prim_name =
 let transl_prim loc prim args =
   let prim_name = prim.prim_name in
   try
-    let (gencomp, intcomp, floatcomp, stringcomp,
-         nativeintcomp, int32comp, int64comp,
-         simplify_constant_constructor) =
+    let {gencomp; intcomp; boolcomp; floatcomp; stringcomp;
+         nativeintcomp; int32comp; int64comp;
+         simplify_constant_constructor} =
       Hashtbl.find (Lazy.force comparisons_table) prim_name in
     begin match args with
-      [arg1; {exp_desc = Texp_construct(_, {cstr_tag = Cstr_constant _}, _)}]
+    | [arg1 ; _] when has_base_type arg1 Predef.path_bool
+      -> boolcomp
+    | [arg1; {exp_desc = Texp_construct(_, {cstr_tag = Cstr_constant _}, _)}]
       when simplify_constant_constructor ->
         intcomp
     | [{exp_desc = Texp_construct(_, {cstr_tag = Cstr_constant _}, _)}; arg2]
@@ -530,7 +591,7 @@ let transl_prim loc prim args =
 let transl_primitive loc p =
   let prim =
     try
-      let (gencomp, _, _, _, _, _, _, _) =
+      let {gencomp; _ } =
         Hashtbl.find (Lazy.force comparisons_table) p.prim_name in
       gencomp
     with Not_found ->
@@ -874,11 +935,15 @@ and transl_exp0 e =
       with Not_constant ->
         Lprim(Pmakeblock(0,  tag_info, Immutable), ll, e.exp_loc)
       end
-  | Texp_construct(_, cstr, args) ->
+  | Texp_construct(lid, cstr, args) ->
       let ll = transl_list args in
       begin match cstr.cstr_tag with
         Cstr_constant n ->
-          Lconst(Const_pointer (n, Lambda.Pt_constructor cstr.cstr_name))
+          Lconst(Const_pointer (n,
+            match lid.txt with
+            | Lident ("false"|"true") -> Pt_builtin_boolean
+            | _ -> (Lambda.Pt_constructor cstr.cstr_name)
+            ))
       | Cstr_block n ->
           let tag_info = (Lambda.Blk_constructor (cstr.cstr_name, cstr.cstr_nonconsts)) in
           begin try


### PR DESCRIPTION
checkout type specialized operations, and min max

Note min happens to work. But we should give it a special name:

```ocaml
let ff (x : bool ) y = min x (y ())
```

```js
function ff(x, y) {
  return Caml_primitive.caml_int_min(x, Curry._1(y, /* () */0)); // change int_min to bool_min
}
```
Another non-breaking consistency is 
```ocaml
let bool_array = [|true; false|]
```
```js
var bool_array = /* int array */[
  true,
  false
];
```
`Pintarray` will not be precise which can be boolean as well
