### PR TITLE
Delete warning “You are passing a OCaml bool type into JS”.

### DIFF
--- a/jscomp/common/bs_warnings.ml
+++ b/jscomp/common/bs_warnings.ml
@@ -24,9 +24,7 @@
 
 
 
-type t = 
-  | Unsafe_ffi_bool_type
-
+type t =
   | Unsafe_poly_variant_type
   (* for users write code like this:
      {[ external f : [`a of int ] -> string = ""]}
@@ -37,9 +35,6 @@ type t =
 
 let to_string t =
   match t with
-  | Unsafe_ffi_bool_type
-    ->   
-    "You are passing a OCaml bool type into JS, probably you want to pass Js.boolean"
   | Unsafe_poly_variant_type 
     -> 
     "Here a OCaml polymorphic variant type passed into JS, probably you forgot annotations like `[@bs.int]` or `[@bs.string]`  "

--- a/jscomp/common/bs_warnings.mli
+++ b/jscomp/common/bs_warnings.mli
@@ -23,8 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
-type t = 
-  | Unsafe_ffi_bool_type
+type t =
   | Unsafe_poly_variant_type
 
 val prerr_bs_ffi_warning : Location.t -> t -> unit

--- a/jscomp/syntax/external_process.ml
+++ b/jscomp/syntax/external_process.ml
@@ -151,10 +151,6 @@ let get_arg_type ~nolabel optional
        end, {ptyp with ptyp_attributes})
     | (`Nothing, ptyp_attributes) ->
       begin match ptyp_desc with
-        | Ptyp_constr ({txt = Lident "bool"; _}, [])
-          ->
-          Bs_warnings.prerr_bs_ffi_warning ptyp.ptyp_loc Unsafe_ffi_bool_type;
-          Nothing
         | Ptyp_constr ({txt = Lident "unit"; _}, [])
           -> if nolabel then Extern_unit else  Nothing
         | Ptyp_constr ({txt = Lident "array"; _}, [_])


### PR DESCRIPTION
The warning "You are passing a OCaml bool type into JS, probably you want to pass Js.boolean" can be deleted now that Js.boolean is the same as bool.