### PR TITLE
Deprecate type Js.boolean

### DIFF
--- a/jscomp/others/js_boolean.ml
+++ b/jscomp/others/js_boolean.ml
@@ -24,5 +24,5 @@
 
 (** Contains functions for dealing with JavaScript booleans *)
 
-external to_js_boolean : bool -> Js.boolean = "%identity"
+external to_js_boolean : bool -> bool = "%identity"
 

--- a/jscomp/others/js_boolean.mli
+++ b/jscomp/others/js_boolean.mli
@@ -24,5 +24,5 @@
 
 (** Contains functions for dealing with JavaScript booleans *)
 
-external to_js_boolean : bool -> Js.boolean = "%identity"
+external to_js_boolean : bool -> bool = "%identity"
 [@@ocaml.deprecated "This function is not needed any more"]

--- a/jscomp/others/js_json.ml
+++ b/jscomp/others/js_json.ml
@@ -31,7 +31,7 @@ type _ kind =
   | Number : float kind 
   | Object : t Js_dict.t kind 
   | Array : t array kind 
-  | Boolean : Js.boolean kind
+  | Boolean : bool kind
   | Null : Js_types.null_val kind
 
 
@@ -94,7 +94,7 @@ let decodeArray json =
 
 let decodeBoolean json = 
   if Js.typeof json = "boolean"
-  then Some (Obj.magic (json:t) : Js.boolean)
+  then Some (Obj.magic (json:t) : bool)
   else None 
 
 let decodeNull json = 
@@ -115,7 +115,7 @@ external stringifyAny : 'a -> string option =
 external null : t = "" [@@bs.val]
 external string : string -> t = "%identity"
 external number : float -> t = "%identity"
-external boolean : Js.boolean -> t = "%identity" 
+external boolean : bool -> t = "%identity" 
 external object_ : t Js_dict.t -> t = "%identity"
 
 external array_ : t array -> t = "%identity"
@@ -123,7 +123,7 @@ external array_ : t array -> t = "%identity"
 external array : t array -> t = "%identity"
 external stringArray : string array -> t = "%identity"
 external numberArray : float array -> t = "%identity"
-external booleanArray : Js.boolean array -> t = "%identity"
+external booleanArray : bool array -> t = "%identity"
 external objectArray : t Js_dict.t array -> t = "%identity"
 external stringify: t -> string = "stringify" 
   [@@bs.val] [@@bs.scope "JSON"]

--- a/jscomp/others/js_json.mli
+++ b/jscomp/others/js_json.mli
@@ -38,7 +38,7 @@ type _ kind =
   | Number : float kind 
   | Object : t Js_dict.t kind 
   | Array : t array kind 
-  | Boolean : Js.boolean kind
+  | Boolean : bool kind
   | Null : Js_types.null_val kind
 
 type tagged_t = 
@@ -75,7 +75,7 @@ val decodeArray : t -> t array option
 (** [decodeArray json] returns [Some a] if [json] is an array, [None]
     otherwise *)
 
-val decodeBoolean : t -> Js.boolean option
+val decodeBoolean : t -> bool option
 (** [decodeBoolean json] returns [Some b] if [json] is a boolean, [None]
     otherwise *)
 
@@ -98,8 +98,8 @@ external string : string -> t = "%identity"
 external number : float -> t = "%identity"
 (** [number n] makes a JSON number of the [float] [n] *)
 
-external boolean : Js.boolean -> t = "%identity" 
-(** [boolean b] makes a JSON boolean of the [Js.boolean] [b] *)
+external boolean : bool -> t = "%identity" 
+(** [boolean b] makes a JSON boolean of the [bool] [b] *)
 
 external object_ : t Js_dict.t -> t = "%identity"
 (** [object_ dict] makes a JSON objet of the [Js.Dict.t] [dict] *)
@@ -118,8 +118,8 @@ external stringArray : string array -> t = "%identity"
 external numberArray : float array -> t = "%identity"
 (** [numberArray a] makes a JSON array of the [float array] [a] *)
 
-external booleanArray : Js.boolean array -> t = "%identity"
-(** [booleanArray] makes a JSON array of the [Js.boolean array] [a] *)
+external booleanArray : bool array -> t = "%identity"
+(** [booleanArray] makes a JSON array of the [bool array] [a] *)
 
 external objectArray : t Js_dict.t array -> t = "%identity"
 (** [objectArray a] makes a JSON array of the [JsDict.t array] [a] *)

--- a/jscomp/others/js_types.ml
+++ b/jscomp/others/js_types.ml
@@ -37,7 +37,7 @@ type function_val
 type _ t = 
   | Undefined :  undefined_val t
   | Null : null_val t
-  | Boolean : Js.boolean t
+  | Boolean : bool t
   | Number : float t
   | String : string t
   | Function : function_val t

--- a/jscomp/others/js_types.mli
+++ b/jscomp/others/js_types.mli
@@ -38,7 +38,7 @@ type function_val
 type _ t =
   | Undefined :  undefined_val t
   | Null : null_val t
-  | Boolean : Js.boolean t
+  | Boolean : bool t
   | Number : float t
   | String : string t
   | Function : function_val t

--- a/jscomp/others/node.ml
+++ b/jscomp/others/node.ml
@@ -45,7 +45,7 @@ type node_module = <
        
        filename : string ;       
 
-       loaded : Js.boolean;
+       loaded : bool;
        children : node_module array ;
        paths : string array;       
 > Js.t

--- a/jscomp/others/node_fs.ml
+++ b/jscomp/others/node_fs.ml
@@ -47,8 +47,8 @@ module Watch = struct
   type t
   type config 
   external config :
-    ?persistent:Js.boolean ->
-    ?recursive:Js.boolean -> 
+    ?persistent: bool ->
+    ?recursive: bool -> 
     ?encoding: Js_string.t -> 
     unit -> config = 
     "" [@@bs.obj]

--- a/jscomp/runtime/Makefile
+++ b/jscomp/runtime/Makefile
@@ -40,7 +40,7 @@ BS_COMMON_FLAGS= -absname -no-alias-deps -bs-no-version-header -bs-diagnose -bs-
 
 BS_FLAGS=  $(BS_COMMON_FLAGS) $(BS_PKG_FLAGS)
 
-COMPFLAGS += $(BS_FLAGS) -I ../stdlib -nostdlib -nopervasives -open Pervasives -unsafe -warn-error A -w -40-49-103 -bin-annot 
+COMPFLAGS += $(BS_FLAGS) -I ../stdlib -nostdlib -nopervasives -open Pervasives -unsafe -warn-error -3 -w -40-49-103 -bin-annot 
 
 
 $(RUNTIME): $(COMPILER)

--- a/jscomp/runtime/caml_basic.mli
+++ b/jscomp/runtime/caml_basic.mli
@@ -27,7 +27,7 @@
 
 val none : 'a option
 val some : 'a -> 'a option
-val is_none : 'a option -> Js.boolean
+val is_none : 'a option -> bool
 val to_def : 'a option -> 'a Js_undefined.t
 val cons : 'a -> 'a list -> 'a list
-val is_list_empty : 'a list -> Js.boolean
+val is_list_empty : 'a list -> bool

--- a/jscomp/runtime/js.mli
+++ b/jscomp/runtime/js.mli
@@ -83,6 +83,7 @@ external test : 'a nullable -> bool = "#is_nil_undef"
 external testAny : 'a -> bool = "#is_nil_undef"
 
 type boolean = bool
+[@@ocaml.deprecated "Use type bool instead"]
 (** The value could be either  {!Js.true_} or {!Js.false_}.
      Note in BuckleScript, [boolean] has different representation from OCaml's [bool],
      see conversion functions in {!Boolean} *)

--- a/jscomp/runtime/js_typed_array.ml
+++ b/jscomp/runtime/js_typed_array.ml
@@ -97,7 +97,7 @@ module type S =  sig
 
   (* Accessor functions
   *)
-  external includes : elt -> Js.boolean = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
 
   external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
   external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
@@ -125,12 +125,12 @@ module type S =  sig
   external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
   *)
 
-  external every : (elt  -> Js.boolean [@bs]) -> Js.boolean = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> Js.boolean [@bs]) -> Js.boolean = "every" [@@bs.send.pipe: t]
+  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
+  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
 
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
   external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> Js.boolean[@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
 
   external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
   external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
@@ -154,8 +154,8 @@ module type S =  sig
   external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
   external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
 
-  external some : (elt  -> Js.boolean [@bs]) -> Js.boolean = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> Js.boolean [@bs]) -> Js.boolean = "some" [@@bs.send.pipe: t]
+  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
+  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
 
   (* commented out until bs has a plan for iterators
   external values : elt array_iter = "" [@@bs.send.pipe: t]
@@ -204,7 +204,7 @@ module TypedArray (Type: Type) : S with type elt = Type.t  = struct
 
   (* Accessor functions
   *)
-  external includes : elt -> Js.boolean = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
 
   external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
   external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
@@ -234,12 +234,12 @@ module TypedArray (Type: Type) : S with type elt = Type.t  = struct
   external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
   *)
 
-  external every : (elt  -> Js.boolean [@bs]) -> Js.boolean = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> Js.boolean [@bs]) -> Js.boolean = "every" [@@bs.send.pipe: t]
+  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
+  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
 
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
   external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> Js.boolean[@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
 
   external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
   external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
@@ -263,8 +263,8 @@ module TypedArray (Type: Type) : S with type elt = Type.t  = struct
   external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
   external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
 
-  external some : (elt  -> Js.boolean [@bs]) -> Js.boolean = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> Js.boolean [@bs]) -> Js.boolean = "some" [@@bs.send.pipe: t]
+  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
+  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
 
   (* commented out until bs has a plan for iterators
   external values : elt array_iter = "" [@@bs.send.pipe: t]


### PR DESCRIPTION
There’s one issue with deprecating types, where other occurrences of the type in the .mli also trigger the deprecation, see https://caml.inria.fr/mantis/view.php?id=7005 .

In particular, the deprecation of true_ mentions boolean, and when compiled, js.mli triggers a deprecation warning. Adding `[@@ocaml.warning “-3”]` did not help. So I’ve made deprecation warnings not fatal when compiling `jscomp/runtime`.