### PR TITLE
Fix Buffer.toString function

### DIFF
--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -36,4 +36,4 @@ external fromStringWithEncoding : string -> ([ `ascii  | `utf8  | `utf16le  | `u
 [@@bs.val] [@@bs.scope "Buffer"]
 
 external toString : t -> string = ""
-[@@bs.send] [@@bs.scope "Buffer"]
+[@@bs.send]


### PR DESCRIPTION
This [@bs.scope] was an accidental copy paste when originally submitted. The resulting output was `Buffer.fromString(...).Buffer.toString()`