### PR TITLE
[Experiment] In Belt, Set.Int is not a Set

### DIFF
--- a/jscomp/others/belt_Set.ml
+++ b/jscomp/others/belt_Set.ml
@@ -40,11 +40,36 @@ module S = struct
 end 
 
 type ('value, 'id) t = ('value, 'id) S.t
-    
+
+module ComparableInt = Belt.Id.MakeComparable(struct
+  type t = int
+  let cmp (a:int) (b:int) = compare a b
+end)
+
+type intId = ComparableInt.identity
+
+let intId : (int, intId) Belt.Id.comparable = (module ComparableInt)
+
+let fromSetInt (s : Int.t) : (int, intId) t =
+  let data = Obj.magic s in
+  S.t ~cmp:ComparableInt.cmp ~data
+
+let toSetInt (x: (int, intId) t) : Int.t =
+  Obj.magic (S.data x)
+
+let toSetIntMaybe (x: (int, _) t) : Int.t option =
+  if S.cmp x == (Obj.magic ComparableInt.cmp)
+  then Some (Obj.magic (S.data x))
+  else None
+
 let fromArray (type value) (type identity) data ~(id : (value,identity) id)  = 
   let module M = (val id ) in
   let cmp = M.cmp in 
-  S.t ~cmp ~data:(Dict.fromArray ~cmp data)
+  if cmp == (Obj.magic ComparableInt.cmp)
+  then (* example fast path *)
+    S.t ~cmp:cmp ~data:(Obj.magic (Int.fromArray (Obj.magic(data))))
+  else
+    S.t ~cmp ~data:(Dict.fromArray ~cmp data)
 
 let ofArray = fromArray
 

--- a/jscomp/others/belt_Set.mli
+++ b/jscomp/others/belt_Set.mli
@@ -87,6 +87,15 @@ val make: id:('value, 'id) id -> ('value, 'id) t
 
 *)
 
+type intId
+
+val intId: (int, intId) Belt.Id.comparable
+
+val fromSetInt: Int.t -> (int, intId) t
+
+val toSetInt: (int, intId) t -> Int.t
+
+val toSetIntMaybe: (int, _) t -> Int.t option
 
 val ofArray: 'value array -> id:('value, 'id) id ->  ('value, 'id) t
 [@@ocaml.deprecated "Use fromArray instead"]

--- a/jscomp/test/bs_set_int_test.js
+++ b/jscomp/test/bs_set_int_test.js
@@ -3,8 +3,9 @@
 var Mt = require("./mt.js");
 var List = require("../../lib/js/list.js");
 var $$Array = require("../../lib/js/array.js");
+var Belt_Set = require("../../lib/js/belt_Set.js");
 var Belt_Array = require("../../lib/js/belt_Array.js");
-var Belt_SetInt = require("../../lib/js/belt_SetInt.js");
+var Belt_SetDict = require("../../lib/js/belt_SetDict.js");
 var Array_data_util = require("./array_data_util.js");
 
 var suites = [/* [] */0];
@@ -19,15 +20,78 @@ function b(loc, v) {
   return Mt.bool_suites(test_id, suites, loc, v);
 }
 
+function ofA(a) {
+  return Belt_Set.fromArray(a, Belt_Set.intId);
+}
+
+var empty = {
+  cmp: Belt_Set.intId[/* cmp */0],
+  data: Belt_SetDict.empty
+};
+
+var N = /* module */[
+  /* Int */0,
+  /* String */0,
+  /* Dict */0,
+  /* make */Belt_Set.make,
+  /* intId */Belt_Set.intId,
+  /* fromSetInt */Belt_Set.fromSetInt,
+  /* toSetInt */Belt_Set.toSetInt,
+  /* ofArray */Belt_Set.ofArray,
+  /* ofSortedArrayUnsafe */Belt_Set.ofSortedArrayUnsafe,
+  /* fromSortedArrayUnsafe */Belt_Set.fromSortedArrayUnsafe,
+  /* isEmpty */Belt_Set.isEmpty,
+  /* has */Belt_Set.has,
+  /* add */Belt_Set.add,
+  /* mergeMany */Belt_Set.mergeMany,
+  /* remove */Belt_Set.remove,
+  /* removeMany */Belt_Set.removeMany,
+  /* union */Belt_Set.union,
+  /* intersect */Belt_Set.intersect,
+  /* diff */Belt_Set.diff,
+  /* subset */Belt_Set.subset,
+  /* cmp */Belt_Set.cmp,
+  /* eq */Belt_Set.eq,
+  /* forEachU */Belt_Set.forEachU,
+  /* forEach */Belt_Set.forEach,
+  /* reduceU */Belt_Set.reduceU,
+  /* reduce */Belt_Set.reduce,
+  /* everyU */Belt_Set.everyU,
+  /* every */Belt_Set.every,
+  /* someU */Belt_Set.someU,
+  /* some */Belt_Set.some,
+  /* keepU */Belt_Set.keepU,
+  /* keep */Belt_Set.keep,
+  /* partitionU */Belt_Set.partitionU,
+  /* partition */Belt_Set.partition,
+  /* size */Belt_Set.size,
+  /* toArray */Belt_Set.toArray,
+  /* toList */Belt_Set.toList,
+  /* minimum */Belt_Set.minimum,
+  /* minUndefined */Belt_Set.minUndefined,
+  /* maximum */Belt_Set.maximum,
+  /* maxUndefined */Belt_Set.maxUndefined,
+  /* get */Belt_Set.get,
+  /* getUndefined */Belt_Set.getUndefined,
+  /* getExn */Belt_Set.getExn,
+  /* split */Belt_Set.split,
+  /* checkInvariantInternal */Belt_Set.checkInvariantInternal,
+  /* getData */Belt_Set.getData,
+  /* getId */Belt_Set.getId,
+  /* packIdData */Belt_Set.packIdData,
+  /* empty */empty,
+  /* fromArray */ofA
+];
+
 function $eq$tilde(s, i) {
-  return Belt_SetInt.eq(Belt_SetInt.fromArray(i), s);
+  return Belt_Set.eq(Belt_Set.fromArray(i, Belt_Set.intId), s);
 }
 
 function $eq$star(a, b) {
-  return Belt_SetInt.eq(Belt_SetInt.fromArray(a), Belt_SetInt.fromArray(b));
+  return Belt_Set.eq(Belt_Set.fromArray(a, Belt_Set.intId), Belt_Set.fromArray(b, Belt_Set.intId));
 }
 
-b("File \"bs_set_int_test.ml\", line 17, characters 4-11", $eq$star(/* array */[
+b("File \"bs_set_int_test.ml\", line 22, characters 4-11", $eq$star(/* array */[
           1,
           2,
           3
@@ -37,17 +101,17 @@ b("File \"bs_set_int_test.ml\", line 17, characters 4-11", $eq$star(/* array */[
           1
         ]));
 
-var u = Belt_SetInt.intersect(Belt_SetInt.fromArray(/* array */[
+var u = Belt_Set.intersect(Belt_Set.fromArray(/* array */[
           1,
           2,
           3
-        ]), Belt_SetInt.fromArray(/* array */[
+        ], Belt_Set.intId), Belt_Set.fromArray(/* array */[
           3,
           4,
           5
-        ]));
+        ], Belt_Set.intId));
 
-b("File \"bs_set_int_test.ml\", line 23, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(/* array */[3]), u));
+b("File \"bs_set_int_test.ml\", line 28, characters 4-11", Belt_Set.eq(Belt_Set.fromArray(/* array */[3], Belt_Set.intId), u));
 
 function range(i, j) {
   return $$Array.init((j - i | 0) + 1 | 0, (function (k) {
@@ -61,25 +125,27 @@ function revRange(i, j) {
                           })))));
 }
 
-var v = Belt_SetInt.fromArray($$Array.append(range(100, 1000), revRange(400, 1500)));
+var a = $$Array.append(range(100, 1000), revRange(400, 1500));
+
+var v = Belt_Set.fromArray(a, Belt_Set.intId);
 
 var i = range(100, 1500);
 
-b("File \"bs_set_int_test.ml\", line 36, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(i), v));
+b("File \"bs_set_int_test.ml\", line 41, characters 4-11", Belt_Set.eq(Belt_Set.fromArray(i, Belt_Set.intId), v));
 
-var match = Belt_SetInt.partition(v, (function (x) {
+var match = Belt_Set.partition(v, (function (x) {
         return x % 3 === 0;
       }));
 
-var l = Belt_SetInt.empty;
+var l = empty;
 
-var r = Belt_SetInt.empty;
+var r = empty;
 
 for(var i$1 = 100; i$1 <= 1500; ++i$1){
   if (i$1 % 3 === 0) {
-    l = Belt_SetInt.add(l, i$1);
+    l = Belt_Set.add(l, i$1);
   } else {
-    r = Belt_SetInt.add(r, i$1);
+    r = Belt_Set.add(r, i$1);
   }
 }
 
@@ -87,45 +153,69 @@ var nl = l;
 
 var nr = r;
 
-b("File \"bs_set_int_test.ml\", line 47, characters 4-11", Belt_SetInt.eq(match[0], nl));
+b("File \"bs_set_int_test.ml\", line 52, characters 4-11", Belt_Set.eq(match[0], nl));
 
-b("File \"bs_set_int_test.ml\", line 48, characters 4-11", Belt_SetInt.eq(match[1], nr));
+b("File \"bs_set_int_test.ml\", line 53, characters 4-11", Belt_Set.eq(match[1], nr));
 
 var i$2 = range(50, 100);
 
-var s = Belt_SetInt.intersect(Belt_SetInt.fromArray(range(1, 100)), Belt_SetInt.fromArray(range(50, 200)));
+var a$1 = range(1, 100);
 
-b("File \"bs_set_int_test.ml\", line 51, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(i$2), s));
+var a$2 = range(50, 200);
+
+var s = Belt_Set.intersect(Belt_Set.fromArray(a$1, Belt_Set.intId), Belt_Set.fromArray(a$2, Belt_Set.intId));
+
+b("File \"bs_set_int_test.ml\", line 56, characters 4-11", Belt_Set.eq(Belt_Set.fromArray(i$2, Belt_Set.intId), s));
 
 var i$3 = range(1, 200);
 
-var s$1 = Belt_SetInt.union(Belt_SetInt.fromArray(range(1, 100)), Belt_SetInt.fromArray(range(50, 200)));
+var a$3 = range(1, 100);
 
-b("File \"bs_set_int_test.ml\", line 54, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(i$3), s$1));
+var a$4 = range(50, 200);
+
+var s$1 = Belt_Set.union(Belt_Set.fromArray(a$3, Belt_Set.intId), Belt_Set.fromArray(a$4, Belt_Set.intId));
+
+b("File \"bs_set_int_test.ml\", line 59, characters 4-11", Belt_Set.eq(Belt_Set.fromArray(i$3, Belt_Set.intId), s$1));
 
 var i$4 = range(1, 49);
 
-var s$2 = Belt_SetInt.diff(Belt_SetInt.fromArray(range(1, 100)), Belt_SetInt.fromArray(range(50, 200)));
+var a$5 = range(1, 100);
 
-b("File \"bs_set_int_test.ml\", line 57, characters 6-13", Belt_SetInt.eq(Belt_SetInt.fromArray(i$4), s$2));
+var a$6 = range(50, 200);
+
+var s$2 = Belt_Set.diff(Belt_Set.fromArray(a$5, Belt_Set.intId), Belt_Set.fromArray(a$6, Belt_Set.intId));
+
+b("File \"bs_set_int_test.ml\", line 62, characters 6-13", Belt_Set.eq(Belt_Set.fromArray(i$4, Belt_Set.intId), s$2));
 
 var i$5 = revRange(50, 100);
 
-var s$3 = Belt_SetInt.intersect(Belt_SetInt.fromArray(revRange(1, 100)), Belt_SetInt.fromArray(revRange(50, 200)));
+var a$7 = revRange(1, 100);
 
-b("File \"bs_set_int_test.ml\", line 60, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(i$5), s$3));
+var a$8 = revRange(50, 200);
+
+var s$3 = Belt_Set.intersect(Belt_Set.fromArray(a$7, Belt_Set.intId), Belt_Set.fromArray(a$8, Belt_Set.intId));
+
+b("File \"bs_set_int_test.ml\", line 65, characters 4-11", Belt_Set.eq(Belt_Set.fromArray(i$5, Belt_Set.intId), s$3));
 
 var i$6 = revRange(1, 200);
 
-var s$4 = Belt_SetInt.union(Belt_SetInt.fromArray(revRange(1, 100)), Belt_SetInt.fromArray(revRange(50, 200)));
+var a$9 = revRange(1, 100);
 
-b("File \"bs_set_int_test.ml\", line 63, characters 4-11", Belt_SetInt.eq(Belt_SetInt.fromArray(i$6), s$4));
+var a$10 = revRange(50, 200);
+
+var s$4 = Belt_Set.union(Belt_Set.fromArray(a$9, Belt_Set.intId), Belt_Set.fromArray(a$10, Belt_Set.intId));
+
+b("File \"bs_set_int_test.ml\", line 68, characters 4-11", Belt_Set.eq(Belt_Set.fromArray(i$6, Belt_Set.intId), s$4));
 
 var i$7 = revRange(1, 49);
 
-var s$5 = Belt_SetInt.diff(Belt_SetInt.fromArray(revRange(1, 100)), Belt_SetInt.fromArray(revRange(50, 200)));
+var a$11 = revRange(1, 100);
 
-b("File \"bs_set_int_test.ml\", line 66, characters 6-13", Belt_SetInt.eq(Belt_SetInt.fromArray(i$7), s$5));
+var a$12 = revRange(50, 200);
+
+var s$5 = Belt_Set.diff(Belt_Set.fromArray(a$11, Belt_Set.intId), Belt_Set.fromArray(a$12, Belt_Set.intId));
+
+b("File \"bs_set_int_test.ml\", line 71, characters 6-13", Belt_Set.eq(Belt_Set.fromArray(i$7, Belt_Set.intId), s$5));
 
 var ss = /* array */[
   1,
@@ -138,7 +228,7 @@ var ss = /* array */[
   -1
 ];
 
-var v$1 = Belt_SetInt.fromArray(/* array */[
+var v$1 = Belt_Set.fromArray(/* array */[
       1,
       222,
       3,
@@ -147,131 +237,143 @@ var v$1 = Belt_SetInt.fromArray(/* array */[
       0,
       33,
       -1
-    ]);
+    ], Belt_Set.intId);
 
-var minv = Belt_SetInt.minUndefined(v$1);
+var minv = Belt_SetDict.minUndefined(v$1.data);
 
-var maxv = Belt_SetInt.maxUndefined(v$1);
+var maxv = Belt_SetDict.maxUndefined(v$1.data);
 
 function approx(loc, x, y) {
   return b(loc, x === y);
 }
 
-eq("File \"bs_set_int_test.ml\", line 74, characters 5-12", Belt_SetInt.reduce(v$1, 0, (function (x, y) {
+eq("File \"bs_set_int_test.ml\", line 79, characters 5-12", Belt_Set.reduce(v$1, 0, (function (x, y) {
             return x + y | 0;
           })), Belt_Array.reduce(ss, 0, (function (prim, prim$1) {
             return prim + prim$1 | 0;
           })));
 
-approx("File \"bs_set_int_test.ml\", line 75, characters 9-16", -1, minv);
+approx("File \"bs_set_int_test.ml\", line 80, characters 9-16", -1, minv);
 
-approx("File \"bs_set_int_test.ml\", line 76, characters 9-16", 222, maxv);
+approx("File \"bs_set_int_test.ml\", line 81, characters 9-16", 222, maxv);
 
-var v$2 = Belt_SetInt.remove(v$1, 3);
+var v$2 = Belt_Set.remove(v$1, 3);
 
-var minv$1 = Belt_SetInt.minimum(v$2);
+var minv$1 = Belt_SetDict.minimum(v$2.data);
 
-var maxv$1 = Belt_SetInt.maximum(v$2);
+var maxv$1 = Belt_SetDict.maximum(v$2.data);
 
-eq("File \"bs_set_int_test.ml\", line 79, characters 5-12", minv$1, /* Some */[-1]);
+eq("File \"bs_set_int_test.ml\", line 84, characters 5-12", minv$1, /* Some */[-1]);
 
-eq("File \"bs_set_int_test.ml\", line 80, characters 5-12", maxv$1, /* Some */[222]);
+eq("File \"bs_set_int_test.ml\", line 85, characters 5-12", maxv$1, /* Some */[222]);
 
-var v$3 = Belt_SetInt.remove(v$2, 222);
+var v$3 = Belt_Set.remove(v$2, 222);
 
-var minv$2 = Belt_SetInt.minimum(v$3);
+var minv$2 = Belt_SetDict.minimum(v$3.data);
 
-var maxv$2 = Belt_SetInt.maximum(v$3);
+var maxv$2 = Belt_SetDict.maximum(v$3.data);
 
-eq("File \"bs_set_int_test.ml\", line 83, characters 5-12", minv$2, /* Some */[-1]);
+eq("File \"bs_set_int_test.ml\", line 88, characters 5-12", minv$2, /* Some */[-1]);
 
-eq("File \"bs_set_int_test.ml\", line 84, characters 5-12", maxv$2, /* Some */[33]);
+eq("File \"bs_set_int_test.ml\", line 89, characters 5-12", maxv$2, /* Some */[33]);
 
-var v$4 = Belt_SetInt.remove(v$3, -1);
+var v$4 = Belt_Set.remove(v$3, -1);
 
-var minv$3 = Belt_SetInt.minimum(v$4);
+var minv$3 = Belt_SetDict.minimum(v$4.data);
 
-var maxv$3 = Belt_SetInt.maximum(v$4);
+var maxv$3 = Belt_SetDict.maximum(v$4.data);
 
-eq("File \"bs_set_int_test.ml\", line 87, characters 5-12", minv$3, /* Some */[0]);
+eq("File \"bs_set_int_test.ml\", line 92, characters 5-12", minv$3, /* Some */[0]);
 
-eq("File \"bs_set_int_test.ml\", line 88, characters 5-12", maxv$3, /* Some */[33]);
+eq("File \"bs_set_int_test.ml\", line 93, characters 5-12", maxv$3, /* Some */[33]);
 
-var v$5 = Belt_SetInt.remove(v$4, 0);
+var v$5 = Belt_Set.remove(v$4, 0);
 
-var v$6 = Belt_SetInt.remove(v$5, 33);
+var v$6 = Belt_Set.remove(v$5, 33);
 
-var v$7 = Belt_SetInt.remove(v$6, 2);
+var v$7 = Belt_Set.remove(v$6, 2);
 
-var v$8 = Belt_SetInt.remove(v$7, 3);
+var v$8 = Belt_Set.remove(v$7, 3);
 
-var v$9 = Belt_SetInt.remove(v$8, 4);
+var v$9 = Belt_Set.remove(v$8, 4);
 
-var v$10 = Belt_SetInt.remove(v$9, 1);
+var v$10 = Belt_Set.remove(v$9, 1);
 
-b("File \"bs_set_int_test.ml\", line 95, characters 4-11", Belt_SetInt.isEmpty(v$10));
+b("File \"bs_set_int_test.ml\", line 100, characters 4-11", Belt_SetDict.isEmpty(v$10.data));
 
 var v$11 = Belt_Array.makeByAndShuffle(1000000, (function (i) {
         return i;
       }));
 
-var u$1 = Belt_SetInt.fromArray(v$11);
+var u$1 = Belt_Set.fromArray(v$11, Belt_Set.intId);
 
-Belt_SetInt.checkInvariantInternal(u$1);
+Belt_SetDict.checkInvariantInternal(u$1.data);
 
 var firstHalf = Belt_Array.slice(v$11, 0, 2000);
 
-var xx = Belt_Array.reduce(firstHalf, u$1, Belt_SetInt.remove);
+var xx = Belt_Array.reduce(firstHalf, u$1, Belt_Set.remove);
 
-Belt_SetInt.checkInvariantInternal(u$1);
+Belt_SetDict.checkInvariantInternal(u$1.data);
 
-b("File \"bs_set_int_test.ml\", line 106, characters 4-11", Belt_SetInt.eq(Belt_SetInt.union(Belt_SetInt.fromArray(firstHalf), xx), u$1));
+b("File \"bs_set_int_test.ml\", line 111, characters 4-11", Belt_Set.eq(Belt_Set.union(Belt_Set.fromArray(firstHalf, Belt_Set.intId), xx), u$1));
 
-var aa = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100));
+var a$13 = Array_data_util.randomRange(0, 100);
 
-var bb = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 200));
+var aa = Belt_Set.fromArray(a$13, Belt_Set.intId);
 
-var cc = Belt_SetInt.fromArray(Array_data_util.randomRange(120, 200));
+var a$14 = Array_data_util.randomRange(0, 200);
 
-var dd = Belt_SetInt.union(aa, cc);
+var bb = Belt_Set.fromArray(a$14, Belt_Set.intId);
 
-b("File \"bs_set_int_test.ml\", line 113, characters 4-11", Belt_SetInt.subset(aa, bb));
+var a$15 = Array_data_util.randomRange(120, 200);
 
-b("File \"bs_set_int_test.ml\", line 114, characters 4-11", Belt_SetInt.subset(dd, bb));
+var cc = Belt_Set.fromArray(a$15, Belt_Set.intId);
 
-b("File \"bs_set_int_test.ml\", line 115, characters 4-11", Belt_SetInt.subset(Belt_SetInt.add(dd, 200), bb));
+var dd = Belt_Set.union(aa, cc);
 
-b("File \"bs_set_int_test.ml\", line 116, characters 4-11", Belt_SetInt.add(dd, 200) === dd);
+b("File \"bs_set_int_test.ml\", line 118, characters 4-11", Belt_Set.subset(aa, bb));
 
-b("File \"bs_set_int_test.ml\", line 117, characters 4-11", Belt_SetInt.add(dd, 0) === dd);
+b("File \"bs_set_int_test.ml\", line 119, characters 4-11", Belt_Set.subset(dd, bb));
 
-b("File \"bs_set_int_test.ml\", line 118, characters 4-11", !Belt_SetInt.subset(Belt_SetInt.add(dd, 201), bb));
+b("File \"bs_set_int_test.ml\", line 120, characters 4-11", Belt_Set.subset(Belt_Set.add(dd, 200), bb));
 
-var aa$1 = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100));
+b("File \"bs_set_int_test.ml\", line 121, characters 4-11", Belt_Set.add(dd, 200) === dd);
 
-var bb$1 = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100));
+b("File \"bs_set_int_test.ml\", line 122, characters 4-11", Belt_Set.add(dd, 0) === dd);
 
-var cc$1 = Belt_SetInt.add(bb$1, 101);
+b("File \"bs_set_int_test.ml\", line 123, characters 4-11", !Belt_Set.subset(Belt_Set.add(dd, 201), bb));
 
-var dd$1 = Belt_SetInt.remove(bb$1, 99);
+var a$16 = Array_data_util.randomRange(0, 100);
 
-var ee = Belt_SetInt.add(dd$1, 101);
+var aa$1 = Belt_Set.fromArray(a$16, Belt_Set.intId);
 
-b("File \"bs_set_int_test.ml\", line 127, characters 4-11", Belt_SetInt.eq(aa$1, bb$1));
+var a$17 = Array_data_util.randomRange(0, 100);
 
-b("File \"bs_set_int_test.ml\", line 128, characters 4-11", !Belt_SetInt.eq(aa$1, cc$1));
+var bb$1 = Belt_Set.fromArray(a$17, Belt_Set.intId);
 
-b("File \"bs_set_int_test.ml\", line 129, characters 4-11", !Belt_SetInt.eq(dd$1, cc$1));
+var cc$1 = Belt_Set.add(bb$1, 101);
 
-b("File \"bs_set_int_test.ml\", line 130, characters 4-11", !Belt_SetInt.eq(bb$1, ee));
+var dd$1 = Belt_Set.remove(bb$1, 99);
 
-var a1 = Belt_SetInt.mergeMany(Belt_SetInt.empty, Array_data_util.randomRange(0, 100));
+var ee = Belt_Set.add(dd$1, 101);
 
-var a2 = Belt_SetInt.removeMany(a1, Array_data_util.randomRange(40, 100));
+b("File \"bs_set_int_test.ml\", line 132, characters 4-11", Belt_Set.eq(aa$1, bb$1));
 
-var a3 = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 39));
+b("File \"bs_set_int_test.ml\", line 133, characters 4-11", !Belt_Set.eq(aa$1, cc$1));
 
-var match$1 = Belt_SetInt.split(a1, 40);
+b("File \"bs_set_int_test.ml\", line 134, characters 4-11", !Belt_Set.eq(dd$1, cc$1));
+
+b("File \"bs_set_int_test.ml\", line 135, characters 4-11", !Belt_Set.eq(bb$1, ee));
+
+var a1 = Belt_Set.mergeMany(empty, Array_data_util.randomRange(0, 100));
+
+var a2 = Belt_Set.removeMany(a1, Array_data_util.randomRange(40, 100));
+
+var a$18 = Array_data_util.randomRange(0, 39);
+
+var a3 = Belt_Set.fromArray(a$18, Belt_Set.intId);
+
+var match$1 = Belt_Set.split(a1, 40);
 
 var match$2 = match$1[0];
 
@@ -279,65 +381,75 @@ var a5 = match$2[1];
 
 var a4 = match$2[0];
 
-b("File \"bs_set_int_test.ml\", line 138, characters 4-11", Belt_SetInt.eq(a1, Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100))));
+var a$19 = Array_data_util.randomRange(0, 100);
 
-b("File \"bs_set_int_test.ml\", line 139, characters 4-11", Belt_SetInt.eq(a2, a3));
+b("File \"bs_set_int_test.ml\", line 143, characters 4-11", Belt_Set.eq(a1, Belt_Set.fromArray(a$19, Belt_Set.intId)));
 
-b("File \"bs_set_int_test.ml\", line 140, characters 4-11", match$1[1]);
+b("File \"bs_set_int_test.ml\", line 144, characters 4-11", Belt_Set.eq(a2, a3));
 
-b("File \"bs_set_int_test.ml\", line 141, characters 4-11", Belt_SetInt.eq(a3, a4));
+b("File \"bs_set_int_test.ml\", line 145, characters 4-11", match$1[1]);
 
-var a6 = Belt_SetInt.remove(Belt_SetInt.removeMany(a1, Array_data_util.randomRange(0, 39)), 40);
+b("File \"bs_set_int_test.ml\", line 146, characters 4-11", Belt_Set.eq(a3, a4));
 
-b("File \"bs_set_int_test.ml\", line 143, characters 4-11", Belt_SetInt.eq(a5, a6));
+var a6 = Belt_Set.remove(Belt_Set.removeMany(a1, Array_data_util.randomRange(0, 39)), 40);
 
-var a7 = Belt_SetInt.remove(a1, 40);
+b("File \"bs_set_int_test.ml\", line 148, characters 4-11", Belt_Set.eq(a5, a6));
 
-var match$3 = Belt_SetInt.split(a7, 40);
+var a7 = Belt_Set.remove(a1, 40);
+
+var match$3 = Belt_Set.split(a7, 40);
 
 var match$4 = match$3[0];
 
 var a9 = match$4[1];
 
-b("File \"bs_set_int_test.ml\", line 146, characters 4-11", !match$3[1]);
+b("File \"bs_set_int_test.ml\", line 151, characters 4-11", !match$3[1]);
 
-b("File \"bs_set_int_test.ml\", line 147, characters 4-11", Belt_SetInt.eq(a4, match$4[0]));
+b("File \"bs_set_int_test.ml\", line 152, characters 4-11", Belt_Set.eq(a4, match$4[0]));
 
-b("File \"bs_set_int_test.ml\", line 148, characters 4-11", Belt_SetInt.eq(a5, a9));
+b("File \"bs_set_int_test.ml\", line 153, characters 4-11", Belt_Set.eq(a5, a9));
 
-var a10 = Belt_SetInt.removeMany(a9, Array_data_util.randomRange(42, 2000));
+var a10 = Belt_Set.removeMany(a9, Array_data_util.randomRange(42, 2000));
 
-eq("File \"bs_set_int_test.ml\", line 150, characters 5-12", Belt_SetInt.size(a10), 1);
+eq("File \"bs_set_int_test.ml\", line 155, characters 5-12", Belt_SetDict.size(a10.data), 1);
 
-var a11 = Belt_SetInt.removeMany(a9, Array_data_util.randomRange(0, 2000));
+var a11 = Belt_Set.removeMany(a9, Array_data_util.randomRange(0, 2000));
 
-b("File \"bs_set_int_test.ml\", line 152, characters 4-11", Belt_SetInt.isEmpty(a11));
+b("File \"bs_set_int_test.ml\", line 157, characters 4-11", Belt_SetDict.isEmpty(a11.data));
 
-var match$5 = Belt_SetInt.split(Belt_SetInt.empty, 0);
+var match$5 = Belt_Set.split(empty, 0);
 
 var match$6 = match$5[0];
 
-b("File \"bs_set_int_test.ml\", line 156, characters 4-11", Belt_SetInt.isEmpty(match$6[0]));
+b("File \"bs_set_int_test.ml\", line 161, characters 4-11", Belt_SetDict.isEmpty(match$6[0].data));
 
-b("File \"bs_set_int_test.ml\", line 157, characters 4-11", Belt_SetInt.isEmpty(match$6[1]));
+b("File \"bs_set_int_test.ml\", line 162, characters 4-11", Belt_SetDict.isEmpty(match$6[1].data));
 
-b("File \"bs_set_int_test.ml\", line 158, characters 4-11", !match$5[1]);
+b("File \"bs_set_int_test.ml\", line 163, characters 4-11", !match$5[1]);
 
-var v$12 = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 2000));
+var a$20 = Array_data_util.randomRange(0, 2000);
 
-var v0 = Belt_SetInt.fromArray(Array_data_util.randomRange(0, 2000));
+var v$12 = Belt_Set.fromArray(a$20, Belt_Set.intId);
 
-var v1 = Belt_SetInt.fromArray(Array_data_util.randomRange(1, 2001));
+var a$21 = Array_data_util.randomRange(0, 2000);
 
-var v2 = Belt_SetInt.fromArray(Array_data_util.randomRange(3, 2002));
+var v0 = Belt_Set.fromArray(a$21, Belt_Set.intId);
 
-var v3 = Belt_SetInt.removeMany(v2, /* array */[
+var a$22 = Array_data_util.randomRange(1, 2001);
+
+var v1 = Belt_Set.fromArray(a$22, Belt_Set.intId);
+
+var a$23 = Array_data_util.randomRange(3, 2002);
+
+var v2 = Belt_Set.fromArray(a$23, Belt_Set.intId);
+
+var v3 = Belt_Set.removeMany(v2, /* array */[
       2002,
       2001
     ]);
 
 var us = Belt_Array.map(Array_data_util.randomRange(1000, 3000), (function (x) {
-        return Belt_SetInt.has(v$12, x);
+        return Belt_Set.has(v$12, x);
       }));
 
 var counted = Belt_Array.reduce(us, 0, (function (acc, x) {
@@ -348,44 +460,40 @@ var counted = Belt_Array.reduce(us, 0, (function (acc, x) {
         }
       }));
 
-eq("File \"bs_set_int_test.ml\", line 168, characters 5-12", counted, 1001);
+eq("File \"bs_set_int_test.ml\", line 173, characters 5-12", counted, 1001);
 
-b("File \"bs_set_int_test.ml\", line 169, characters 4-11", Belt_SetInt.eq(v$12, v0));
+b("File \"bs_set_int_test.ml\", line 174, characters 4-11", Belt_Set.eq(v$12, v0));
 
-b("File \"bs_set_int_test.ml\", line 170, characters 4-11", Belt_SetInt.cmp(v$12, v0) === 0);
+b("File \"bs_set_int_test.ml\", line 175, characters 4-11", Belt_Set.cmp(v$12, v0) === 0);
 
-b("File \"bs_set_int_test.ml\", line 171, characters 4-11", Belt_SetInt.cmp(v$12, v1) < 0);
+b("File \"bs_set_int_test.ml\", line 176, characters 4-11", Belt_Set.cmp(v$12, v1) < 0);
 
-b("File \"bs_set_int_test.ml\", line 172, characters 4-11", Belt_SetInt.cmp(v$12, v2) > 0);
+b("File \"bs_set_int_test.ml\", line 177, characters 4-11", Belt_Set.cmp(v$12, v2) > 0);
 
-b("File \"bs_set_int_test.ml\", line 173, characters 4-11", Belt_SetInt.subset(v3, v0));
+b("File \"bs_set_int_test.ml\", line 178, characters 4-11", Belt_Set.subset(v3, v0));
 
-b("File \"bs_set_int_test.ml\", line 174, characters 4-11", !Belt_SetInt.subset(v1, v0));
+b("File \"bs_set_int_test.ml\", line 179, characters 4-11", !Belt_Set.subset(v1, v0));
 
-eq("File \"bs_set_int_test.ml\", line 175, characters 5-12", Belt_SetInt.get(v$12, 30), /* Some */[30]);
+eq("File \"bs_set_int_test.ml\", line 180, characters 5-12", Belt_Set.get(v$12, 30), /* Some */[30]);
 
-eq("File \"bs_set_int_test.ml\", line 176, characters 5-12", Belt_SetInt.get(v$12, 3000), /* None */0);
+eq("File \"bs_set_int_test.ml\", line 181, characters 5-12", Belt_Set.get(v$12, 3000), /* None */0);
 
 Mt.from_pair_suites("bs_set_int_test.ml", suites[0]);
-
-var N = 0;
 
 var I = 0;
 
 var A = 0;
 
-var ofA = Belt_SetInt.fromArray;
-
 exports.suites = suites;
 exports.test_id = test_id;
 exports.eq = eq;
 exports.b = b;
+exports.ofA = ofA;
 exports.N = N;
 exports.I = I;
 exports.A = A;
 exports.$eq$tilde = $eq$tilde;
 exports.$eq$star = $eq$star;
-exports.ofA = ofA;
 exports.u = u;
 exports.range = range;
 exports.revRange = revRange;

--- a/jscomp/test/bs_set_int_test.ml
+++ b/jscomp/test/bs_set_int_test.ml
@@ -4,20 +4,25 @@ let eq loc x y = Mt.eq_suites ~suites ~test_id loc x y
 
 let b loc v  = Mt.bool_suites ~suites ~test_id loc v 
 
-module N = Belt.Set.Int
+let ofA a = Belt.Set.fromArray ~id:Belt.Set.intId a
+
+module N = struct
+  include Belt.Set
+  let empty = Belt.Set.make ~id:Belt.Set.intId
+  let fromArray = ofA
+end
 module I = Array_data_util
 module A = Belt.Array
 let (=~) s i = 
-  N.(eq (fromArray i) s)
+  Belt.Set.eq (ofA i) s
 let (=*) a b =  
-  N.(eq (fromArray a) (fromArray b))
-let ofA = N.fromArray
+  Belt.Set.eq (ofA a) (ofA b)
 
 let ()= 
   b __LOC__ 
   ([|1;2;3|] =*
     [|3;2;1|])
-let u = N.(intersect (ofA [|1;2;3|]) (ofA [|3;4;5|]) )
+let u = Belt.Set.(intersect ((ofA [|1;2;3|])) ((ofA [|3;4;5|])) )
 
 let ()= 
   b __LOC__ 


### PR DESCRIPTION
Experiment with an efficient conversion between Set.Int and Set. Currently a bit crude with Obj.magic just to test the ideas.

Since specialized versions of data structures are not an instance of general versions, one cannot use polymorphic code. Don’t know how prevalent this would be, so this is just an experiment.
Converting efficiently between the two amounts to never changing the underlying data component.

One could also provide a hot path for the operations on specialized datastructures, tried with one example. Though this would slow down both cases a bit, at least one-off for each invocation of one operation.