### PR TITLE
[Belt] More consistency in mli for Maps and Sets.

### DIFF
--- a/jscomp/others/belt_MapDict.mli
+++ b/jscomp/others/belt_MapDict.mli
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type ('key,  'value, 'id) t
+type ('key, 'value, 'id) t
 
 type ('key, 'id) cmp = ('key, 'id) Belt_Id.cmp
 
@@ -31,119 +31,140 @@ val empty: ('k, 'v, 'id) t
 val isEmpty: ('k, 'v, 'id) t -> bool
 
 val has:
-  ('k, 'a, 'id) t -> 'k  ->
-  cmp:('k, 'id) cmp -> 
-  bool    
+  ('k, 'a, 'id) t -> 'k ->
+  cmp:('k, 'id) cmp ->
+  bool
 
-val cmpU: 
-    ('k, 'v, 'id) t -> 
+val cmpU:
+    ('k, 'v, 'id) t ->
     ('k, 'v, 'id) t ->
     kcmp:('k, 'id) cmp ->
     vcmp:('v -> 'v -> int [@bs]) -> 
      int
 val cmp: 
-    ('k, 'v, 'id) t -> 
+    ('k, 'v, 'id) t ->
     ('k, 'v, 'id) t ->
     kcmp:('k, 'id) cmp ->
-    vcmp:('v -> 'v -> int) -> 
+    vcmp:('v -> 'v -> int) ->
      int
 
-val eqU:  
-    ('k, 'a, 'id) t -> 
+val eqU:
+    ('k, 'a, 'id) t ->
     ('k, 'a, 'id) t ->
     kcmp:('k, 'id) cmp ->
-    veq:('a -> 'a -> bool [@bs]) -> 
+    veq:('a -> 'a -> bool [@bs]) ->
     bool
-val eq:  
-    ('k, 'a, 'id) t -> 
+val eq:
+    ('k, 'a, 'id) t ->
     ('k, 'a, 'id) t ->
     kcmp:('k, 'id) cmp ->
-    veq:('a -> 'a -> bool) -> 
+    veq:('a -> 'a -> bool) ->
     bool
 (** [eq m1 m2 cmp] tests whether the maps [m1] and [m2] are
     equal, that is, contain equal keys and associate them with
     equal data.  [cmp] is the equality predicate used to compare
     the data associated with the keys. *)
-    
-val forEachU:  ('k, 'a, 'id) t -> ('k -> 'a -> unit [@bs]) -> unit
-val forEach:  ('k, 'a, 'id) t -> ('k -> 'a -> unit) -> unit  
+
+val forEachU: ('k, 'a, 'id) t -> ('k -> 'a -> unit [@bs]) -> unit
+val forEach: ('k, 'a, 'id) t -> ('k -> 'a -> unit) -> unit
 (** [forEach m f] applies [f] to all bindings in map [m].
-    [f] receives the 'k as first argument, and the associated value
-    as second argument.  The bindings are passed to [f] in increasing
+    [f] receives the key as first argument, and the associated value
+    as second argument. The bindings are passed to [f] in increasing
     order with respect to the ordering over the type of the keys. *)
-    
-val reduceU: ('k, 'a, 'id) t -> 'b ->  ('b -> 'k -> 'a -> 'b [@bs]) ->  'b
-val reduce: ('k, 'a, 'id) t -> 'b ->  ('b -> 'k -> 'a -> 'b) ->  'b  
+
+val reduceU: ('k, 'a, 'id) t -> 'b -> ('b -> 'k -> 'a -> 'b [@bs]) -> 'b
+val reduce: ('k, 'a, 'id) t -> 'b -> ('b -> 'k -> 'a -> 'b) -> 'b
 (** [reduce m a f] computes [(f kN dN ... (f k1 d1 a)...)],
     where [k1 ... kN] are the keys of all bindings in [m]
     (in increasing order), and [d1 ... dN] are the associated data. *)
 
-val everyU: ('k, 'a, 'id) t -> ('k -> 'a -> bool [@bs]) ->  bool
-val every: ('k, 'a, 'id) t -> ('k -> 'a -> bool) ->  bool  
+val everyU: ('k, 'a, 'id) t -> ('k -> 'a -> bool [@bs]) -> bool
+val every: ('k, 'a, 'id) t -> ('k -> 'a -> bool) -> bool
 (** [every m p] checks if all the bindings of the map
     satisfy the predicate [p]. Order unspecified *)
-    
-val someU: ('k, 'a, 'id) t -> ('k -> 'a -> bool [@bs]) ->  bool
-val some: ('k, 'a, 'id) t -> ('k -> 'a -> bool) ->  bool  
+
+val someU: ('k, 'a, 'id) t -> ('k -> 'a -> bool [@bs]) -> bool
+val some: ('k, 'a, 'id) t -> ('k -> 'a -> bool) -> bool
 (** [some m p] checks if at least one binding of the map
     satisfy the predicate [p]. Order unspecified *)
 
 val size: ('k, 'a, 'id) t -> int
+
 val toList: ('k, 'a, 'id) t -> ('k * 'a) list
-(** In increasing order*)
+(** In increasing order. *)
+
 val toArray: ('k, 'a, 'id) t -> ('k * 'a) array
+
 val ofArray: ('k * 'a) array -> cmp:('k,'id) cmp -> ('k,'a,'id) t
 [@@ocaml.deprecated "Use fromArray instead"]
+
 val fromArray: ('k * 'a) array -> cmp:('k,'id) cmp -> ('k,'a,'id) t
-val keysToArray: ('k, 'a, 'id) t -> 'k  array
-val valuesToArray: ('k, 'a, 'id) t -> 'a  array
+
+val keysToArray: ('k, 'a, 'id) t -> 'k array
+
+val valuesToArray: ('k, 'a, 'id) t -> 'a array
+
 val minKey: ('k, _, _) t -> 'k option
+
 val minKeyUndefined: ('k, _, _) t -> 'k Js.undefined
+
 val maxKey: ('k, _, _) t -> 'k option
+
 val maxKeyUndefined: ('k, _, _) t -> 'k Js.undefined
-val minimum: ('k, 'a,  _) t -> ('k * 'a) option
+
+val minimum: ('k, 'a, _) t -> ('k * 'a) option
+
 val minUndefined: ('k, 'a, _) t -> ('k * 'a) Js.undefined
+
 val maximum: ('k, 'a, _) t -> ('k * 'a) option
+
 val maxUndefined:('k, 'a, _) t -> ('k * 'a) Js.undefined
+
 val get:
   ('k, 'a, 'id) t -> 'k ->
-  cmp:('k, 'id) cmp -> 
+  cmp:('k, 'id) cmp ->
   'a option
+
 val getUndefined:
   ('k, 'a, 'id) t -> 'k ->
   cmp:('k, 'id) cmp ->
   'a Js.undefined
-    
+
 val getWithDefault:
-    ('k, 'a, 'id) t -> 'k ->  'a ->
+    ('k, 'a, 'id) t -> 'k -> 'a ->
     cmp:('k, 'id) cmp ->
-    'a 
+    'a
+
 val getExn:
   ('k, 'a, 'id) t -> 'k ->
   cmp:('k, 'id) cmp ->
   'a
-  
+
 val checkInvariantInternal: _ t -> unit
 (**
    {b raise} when invariant is not held
-*)  
+*)
 
 val remove:
   ('a, 'b, 'id) t -> 'a ->
   cmp:('a, 'id) cmp ->
   ('a, 'b, 'id) t
-
+(** [remove m x] returns a map containing the same bindings as
+   [m], except for [x] which is unbound in the returned map. *)
 
 val removeMany:
   ('a, 'b, 'id) t ->
   'a array ->
   cmp:('a, 'id) cmp ->
   ('a, 'b, 'id) t
-  
+
 val set:
   ('a, 'b, 'id) t -> 'a -> 'b ->
   cmp:('a, 'id) cmp ->
   ('a, 'b, 'id) t
+(** [add m x y] returns a map containing the same bindings as
+   [m], plus a binding of [x] to [y]. If [x] was already bound
+   in [m], its previous binding disappears. *)
 
 val updateU:
   ('a, 'b, 'id) t ->
@@ -160,14 +181,18 @@ val update:
 
 val mergeU:
   ('a, 'b, 'id) t ->
-  ('a, 'c, 'id) t -> 
+  ('a, 'c, 'id) t ->
   ('a -> 'b option -> 'c option -> 'd option [@bs]) ->
   cmp:('a, 'id) cmp -> ('a, 'd, 'id) t
 val merge:
   ('a, 'b, 'id) t ->
-  ('a, 'c, 'id) t -> 
+  ('a, 'c, 'id) t ->
   ('a -> 'b option -> 'c option -> 'd option) ->
   cmp:('a, 'id) cmp -> ('a, 'd, 'id) t
+(** [merge m1 m2 f] computes a map whose keys is a subset of keys of [m1]
+    and of [m2]. The presence of each such binding, and the corresponding
+    value, is determined with the function [f].
+ *)
 
 val mergeMany:
   ('a, 'b, 'id) t ->
@@ -175,22 +200,22 @@ val mergeMany:
   cmp:('a, 'id) cmp ->
   ('a, 'b, 'id) t
 
-val keepU: 
-    ('k, 'a, 'id) t -> 
-    ('k -> 'a -> bool [@bs]) -> 
+val keepU:
+    ('k, 'a, 'id) t ->
+    ('k -> 'a -> bool [@bs]) ->
     ('k, 'a, 'id) t
-val keep: 
-    ('k, 'a, 'id) t -> 
-    ('k -> 'a -> bool) -> 
+val keep:
+    ('k, 'a, 'id) t ->
+    ('k -> 'a -> bool) ->
     ('k, 'a, 'id) t
 (** [keep m p] returns the map with all the bindings in [m]
     that satisfy predicate [p]. *)
-    
-val partitionU: 
+
+val partitionU:
     ('k, 'a, 'id) t ->
-    ('k -> 'a -> bool [@bs]) -> 
+    ('k -> 'a -> bool [@bs]) ->
     ('k, 'a, 'id) t * ('k, 'a, 'id) t
-val partition: 
+val partition:
     ('k, 'a, 'id) t ->
     ('k -> 'a -> bool) -> 
     ('k, 'a, 'id) t * ('k, 'a, 'id) t
@@ -205,10 +230,17 @@ val split:
   'a ->
   cmp:('a, 'id) cmp ->
   (('a,'b,'id) t * ('a, 'b, 'id) t) * 'b option
+(** [split x m] returns a triple [(l, data, r)], where
+      [l] is the map with all the bindings of [m] whose key
+    is strictly less than [x];
+      [r] is the map with all the bindings of [m] whose key
+    is strictly greater than [x];
+      [data] is [None] if [m] contains no binding for [x],
+      or [Some v] if [m] binds [v] to [x].
+ *)
 
-
-val mapU: ('k, 'a, 'id) t -> ('a -> 'b [@bs]) ->  ('k ,'b,'id ) t
-val map: ('k, 'a, 'id) t -> ('a -> 'b) ->  ('k ,'b,'id ) t    
+val mapU: ('k, 'a, 'id) t -> ('a -> 'b [@bs]) -> ('k ,'b,'id) t
+val map: ('k, 'a, 'id) t -> ('a -> 'b) -> ('k ,'b,'id) t
 (** [map m f] returns a map with same domain as [m], where the
     associated value [a] of all bindings of [m] has been
     replaced by the result of the application of [f] to [a].

--- a/jscomp/others/belt_MapInt.ml
+++ b/jscomp/others/belt_MapInt.ml
@@ -2,7 +2,7 @@
 type key = int
 module I = Belt_internalMapInt    
 
-# 11 "map.cppo.ml"
+# 11
 module N = Belt_internalAVLtree
 module A = Belt_Array 
 
@@ -140,7 +140,7 @@ let removeMany t keys =
   | None -> N.empty
   | Some t ->  removeMany0 t keys 0 len
 
-let mergeArray h arr =   
+let mergeMany h arr =   
   let len = A.length arr in 
   let v = ref h in  
   for i = 0 to len - 1 do 

--- a/jscomp/others/belt_MapInt.ml
+++ b/jscomp/others/belt_MapInt.ml
@@ -149,6 +149,8 @@ let mergeMany h arr =
   done ;
   !v 
 
+let mergeArray = mergeMany
+
 let has = I.has
 let cmpU = I.cmpU
 let cmp = I.cmp

--- a/jscomp/others/belt_MapInt.ml
+++ b/jscomp/others/belt_MapInt.ml
@@ -2,7 +2,7 @@
 type key = int
 module I = Belt_internalMapInt    
 
-# 11
+# 11 "map.cppo.ml"
 module N = Belt_internalAVLtree
 module A = Belt_Array 
 

--- a/jscomp/others/belt_MapInt.mli
+++ b/jscomp/others/belt_MapInt.mli
@@ -1,90 +1,111 @@
 # 4 "map.cppo.mli"
 type key = int
-# 8 "map.cppo.mli"
+# 8
 type 'value t
 (** The type of maps from type [key] to type ['value]. *)
 
 val empty: 'v t
-val isEmpty: 'v t -> bool
-val has:  'v t -> key -> bool    
 
-val cmpU:  'v t -> 'v t -> ('v -> 'v -> int [@bs]) -> int
-val cmp:  'v t -> 'v t -> ('v -> 'v -> int) -> int
+val isEmpty: 'v t -> bool
+
+val has: 'v t -> key -> bool
+
+val cmpU: 'v t -> 'v t -> ('v -> 'v -> int [@bs]) -> int
+val cmp: 'v t -> 'v t -> ('v -> 'v -> int) -> int
 
 val eqU: 'v t -> 'v t -> ('v -> 'v -> bool [@bs]) -> bool
 val eq: 'v t -> 'v t -> ('v -> 'v -> bool) -> bool
-(** [equal m1 m2 cmp] tests whether the maps [m1] and [m2] are
+(** [eq m1 m2] tests whether the maps [m1] and [m2] are
    equal, that is, contain equal keys and associate them with
-   equal data.  [cmp] is the equality predicate used to compare
-   the data associated with the keys. *)
+   equal data. *)
 
-val forEachU: 'v t -> (key -> 'v -> unit [@bs]) ->  unit
-val forEach: 'v t -> (key -> 'v -> unit) ->  unit
+val forEachU: 'v t -> (key -> 'v -> unit [@bs]) -> unit
+val forEach: 'v t -> (key -> 'v -> unit) -> unit
 (** [forEach m f] applies [f] to all bindings in map [m].
-   [f] receives the key as first argument, and the associated value
-   as second argument.  The bindings are passed to [f] in increasing
-   order with respect to the ordering over the type of the keys. *)
+    [f] receives the key as first argument, and the associated value
+    as second argument. The bindings are passed to [f] in increasing
+    order with respect to the ordering over the type of the keys. *)
 
-val reduceU:  'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2 [@bs]) -> 'v2
-val reduce:  'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2) -> 'v2
+val reduceU: 'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2 [@bs]) -> 'v2
+val reduce: 'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2) -> 'v2
 (** [reduce m a f] computes [(f kN dN ... (f k1 d1 a)...)],
-   where [k1 ... kN] are the keys of all bindings in [m]
-   (in increasing order), and [d1 ... dN] are the associated data. *)
+    where [k1 ... kN] are the keys of all bindings in [m]
+    (in increasing order), and [d1 ... dN] are the associated data. *)
 
-val everyU:  'v t -> (key -> 'v -> bool [@bs]) -> bool
-val every:  'v t -> (key -> 'v -> bool) -> bool
+val everyU: 'v t -> (key -> 'v -> bool [@bs]) -> bool
+val every: 'v t -> (key -> 'v -> bool) -> bool
 (** [every m p] checks if all the bindings of the map
-    satisfy the predicate [p].
- *)
+    satisfy the predicate [p]. Order unspecified *)
 
-val someU:  'v t -> (key -> 'v -> bool [@bs]) -> bool
-val some:  'v t -> (key -> 'v -> bool) -> bool
+val someU: 'v t -> (key -> 'v -> bool [@bs]) -> bool
+val some: 'v t -> (key -> 'v -> bool) -> bool
 (** [some m p] checks if at least one binding of the map
-    satisfy the predicate [p].
- *)
+    satisfy the predicate [p]. Order unspecified *)
+
 val size: 'v t -> int
+
 val toList: 'v t -> (key * 'v) list
-(** In increasing order with respect *)
+(** In increasing order. *)
+
 val toArray: 'v t -> (key * 'v) array
-val ofArray: (key * 'v) array -> 'v t     
+
+val ofArray: (key * 'v) array -> 'v t
 [@@ocaml.deprecated "Use fromArray instead"]
-val fromArray: (key * 'v) array -> 'v t     
-val keysToArray: 'v t -> key array 
+
+val fromArray: (key * 'v) array -> 'v t
+
+val keysToArray: 'v t -> key array
+
 val valuesToArray: 'v t -> 'v array
-val minKey: _ t -> key option 
+
+val minKey: _ t -> key option
+
 val minKeyUndefined: _ t -> key Js.undefined
+
 val maxKey: _ t -> key option
+
 val maxKeyUndefined: _ t -> key Js.undefined
+
 val minimum: 'v t -> (key * 'v) option
+
 val minUndefined: 'v t -> (key * 'v) Js.undefined
+
 val maximum: 'v t -> (key * 'v) option
+
 val maxUndefined: 'v t -> (key * 'v) Js.undefined
+
 val get: 'v t -> key -> 'v option
+
 val getUndefined: 'v t -> key -> 'v Js.undefined
-val getWithDefault:  'v t -> key -> 'v  -> 'v
-val getExn: 'v t -> key -> 'v 
+
+val getWithDefault: 'v t -> key -> 'v -> 'v
+
+val getExn: 'v t -> key -> 'v
 
 val checkInvariantInternal: _ t -> unit
 (**
    {b raise} when invariant is not held
 *)  
 
-(****************************************************************************)
+val checkInvariantInternal: _ t -> unit
+(**
+   {b raise} when invariant is not held
+*)
 
-val remove: 'v t ->  key -> 'v t
+val remove: 'v t -> key -> 'v t
 (** [remove m x] returns a map containing the same bindings as
    [m], except for [x] which is unbound in the returned map. *)
+
 val removeMany: 'v t -> key array -> 'v t
 
-val set: 'v t ->  key -> 'v -> 'v t
+val set: 'v t -> key -> 'v -> 'v t
 (** [add m x y] returns a map containing the same bindings as
    [m], plus a binding of [x] to [y]. If [x] was already bound
    in [m], its previous binding disappears. *)
 
-val updateU: 'v t -> key -> ('v option -> 'v option [@bs]) -> 'v t 
-val update: 'v t -> key -> ('v option -> 'v option) -> 'v t 
-val mergeArray: 'v t -> (key * 'v) array -> 'v t
-    
+val updateU: 'v t -> key -> ('v option -> 'v option [@bs]) -> 'v t
+val update: 'v t -> key -> ('v option -> 'v option) -> 'v t
+
 val mergeU:
     'v t -> 'v2 t ->
     (key -> 'v option -> 'v2 option -> 'c option [@bs]) ->
@@ -92,41 +113,38 @@ val mergeU:
 val merge:
     'v t -> 'v2 t ->
     (key -> 'v option -> 'v2 option -> 'c option) ->
-    'c t      
+    'c t
 (** [merge m1 m2 f] computes a map whose keys is a subset of keys of [m1]
     and of [m2]. The presence of each such binding, and the corresponding
     value, is determined with the function [f].
  *)
 
-val keepU: 
-    'v t -> 
-    (key -> 'v -> bool [@bs]) -> 
-    'v t
-val keep: 
-    'v t -> 
-    (key -> 'v -> bool) -> 
-    'v t      
-(** [keep m p] returns the map with all the bindings in [m]
-    that satisfy predicate [p].
-*)
+val mergeMany: 'v t -> (key * 'v) array -> 'v t
 
-val partitionU: 
-    'v t -> 
-    (key -> 'v -> bool [@bs]) -> 
+val keepU:
+    'v t ->
+    (key -> 'v -> bool [@bs]) ->
+    'v t
+val keep:
+    'v t ->
+    (key -> 'v -> bool) ->
+    'v t
+(** [keep m p] returns the map with all the bindings in [m]
+    that satisfy predicate [p]. *)
+
+val partitionU:
+    'v t ->
+    (key -> 'v -> bool [@bs]) ->
     'v t * 'v t
 val partition: 
-    'v t -> 
-    (key -> 'v -> bool) -> 
-    'v t * 'v t      
+    'v t ->
+    (key -> 'v -> bool) ->
+    'v t * 'v t
 (** [partition m p] returns a pair of maps [(m1, m2)], where
     [m1] contains all the bindings of [s] that satisfy the
     predicate [p], and [m2] is the map with all the bindings of
     [s] that do not satisfy [p].
  *)
-
-
-
-
 
 val split: key -> 'v t -> 'v t * 'v option * 'v t
 (** [split x m] returns a triple [(l, data, r)], where
@@ -138,22 +156,13 @@ val split: key -> 'v t -> 'v t * 'v option * 'v t
       or [Some v] if [m] binds [v] to [x].
  *)
 
-
-val mapU: 'v t -> ('v -> 'v2 [@bs]) ->  'v2 t
-val map: 'v t -> ('v -> 'v2) ->  'v2 t    
+val mapU: 'v t -> ('v -> 'v2 [@bs]) -> 'v2 t
+val map: 'v t -> ('v -> 'v2) -> 'v2 t
 (** [map m f] returns a map with same domain as [m], where the
-   associated value [a] of all bindings of [m] has been
-   replaced by the result of the application of [f] to [a].
-   The bindings are passed to [f] in increasing order
-   with respect to the ordering over the type of the keys. *)
+    associated value [a] of all bindings of [m] has been
+    replaced by the result of the application of [f] to [a].
+    The bindings are passed to [f] in increasing order
+    with respect to the ordering over the type of the keys. *)
 
 val mapWithKeyU: 'v t -> (key -> 'v -> 'v2 [@bs]) -> 'v2 t
-val mapWithKey: 'v t -> (key -> 'v -> 'v2) -> 'v2 t    
-
-(**/**)
-val checkInvariantInternal: _ t -> unit
-(**
-   {b raise} when invariant is not held
-*)  
-(**/**)
-
+val mapWithKey: 'v t -> (key -> 'v -> 'v2) -> 'v2 t

--- a/jscomp/others/belt_MapInt.mli
+++ b/jscomp/others/belt_MapInt.mli
@@ -121,6 +121,9 @@ val merge:
 
 val mergeMany: 'v t -> (key * 'v) array -> 'v t
 
+[@@ocaml.deprecated "Use mergeMany instead"]
+val mergeArray: 'v t -> (key * 'v) array -> 'v t
+
 val keepU:
     'v t ->
     (key -> 'v -> bool [@bs]) ->

--- a/jscomp/others/belt_MapString.ml
+++ b/jscomp/others/belt_MapString.ml
@@ -2,7 +2,7 @@
 type key = string
 module I = Belt_internalMapString
 
-# 11
+# 11 "map.cppo.ml"
 module N = Belt_internalAVLtree
 module A = Belt_Array 
 

--- a/jscomp/others/belt_MapString.ml
+++ b/jscomp/others/belt_MapString.ml
@@ -149,6 +149,8 @@ let mergeMany h arr =
   done ;
   !v 
 
+let mergeArray = mergeMany
+
 let has = I.has
 let cmpU = I.cmpU
 let cmp = I.cmp

--- a/jscomp/others/belt_MapString.ml
+++ b/jscomp/others/belt_MapString.ml
@@ -2,7 +2,7 @@
 type key = string
 module I = Belt_internalMapString
 
-# 11 "map.cppo.ml"
+# 11
 module N = Belt_internalAVLtree
 module A = Belt_Array 
 
@@ -140,7 +140,7 @@ let removeMany t keys =
   | None -> N.empty
   | Some t ->  removeMany0 t keys 0 len
 
-let mergeArray h arr =   
+let mergeMany h arr =   
   let len = A.length arr in 
   let v = ref h in  
   for i = 0 to len - 1 do 

--- a/jscomp/others/belt_MapString.mli
+++ b/jscomp/others/belt_MapString.mli
@@ -121,6 +121,9 @@ val merge:
 
 val mergeMany: 'v t -> (key * 'v) array -> 'v t
 
+[@@ocaml.deprecated "Use mergeMany instead"]
+val mergeArray: 'v t -> (key * 'v) array -> 'v t
+
 val keepU:
     'v t ->
     (key -> 'v -> bool [@bs]) ->

--- a/jscomp/others/belt_MapString.mli
+++ b/jscomp/others/belt_MapString.mli
@@ -1,90 +1,111 @@
 # 2 "map.cppo.mli"
 type key = string
-# 8 "map.cppo.mli"
+# 8
 type 'value t
 (** The type of maps from type [key] to type ['value]. *)
 
 val empty: 'v t
-val isEmpty: 'v t -> bool
-val has:  'v t -> key -> bool    
 
-val cmpU:  'v t -> 'v t -> ('v -> 'v -> int [@bs]) -> int
-val cmp:  'v t -> 'v t -> ('v -> 'v -> int) -> int
+val isEmpty: 'v t -> bool
+
+val has: 'v t -> key -> bool
+
+val cmpU: 'v t -> 'v t -> ('v -> 'v -> int [@bs]) -> int
+val cmp: 'v t -> 'v t -> ('v -> 'v -> int) -> int
 
 val eqU: 'v t -> 'v t -> ('v -> 'v -> bool [@bs]) -> bool
 val eq: 'v t -> 'v t -> ('v -> 'v -> bool) -> bool
-(** [equal m1 m2 cmp] tests whether the maps [m1] and [m2] are
+(** [eq m1 m2] tests whether the maps [m1] and [m2] are
    equal, that is, contain equal keys and associate them with
-   equal data.  [cmp] is the equality predicate used to compare
-   the data associated with the keys. *)
+   equal data. *)
 
-val forEachU: 'v t -> (key -> 'v -> unit [@bs]) ->  unit
-val forEach: 'v t -> (key -> 'v -> unit) ->  unit
+val forEachU: 'v t -> (key -> 'v -> unit [@bs]) -> unit
+val forEach: 'v t -> (key -> 'v -> unit) -> unit
 (** [forEach m f] applies [f] to all bindings in map [m].
-   [f] receives the key as first argument, and the associated value
-   as second argument.  The bindings are passed to [f] in increasing
-   order with respect to the ordering over the type of the keys. *)
+    [f] receives the key as first argument, and the associated value
+    as second argument. The bindings are passed to [f] in increasing
+    order with respect to the ordering over the type of the keys. *)
 
-val reduceU:  'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2 [@bs]) -> 'v2
-val reduce:  'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2) -> 'v2
+val reduceU: 'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2 [@bs]) -> 'v2
+val reduce: 'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2) -> 'v2
 (** [reduce m a f] computes [(f kN dN ... (f k1 d1 a)...)],
-   where [k1 ... kN] are the keys of all bindings in [m]
-   (in increasing order), and [d1 ... dN] are the associated data. *)
+    where [k1 ... kN] are the keys of all bindings in [m]
+    (in increasing order), and [d1 ... dN] are the associated data. *)
 
-val everyU:  'v t -> (key -> 'v -> bool [@bs]) -> bool
-val every:  'v t -> (key -> 'v -> bool) -> bool
+val everyU: 'v t -> (key -> 'v -> bool [@bs]) -> bool
+val every: 'v t -> (key -> 'v -> bool) -> bool
 (** [every m p] checks if all the bindings of the map
-    satisfy the predicate [p].
- *)
+    satisfy the predicate [p]. Order unspecified *)
 
-val someU:  'v t -> (key -> 'v -> bool [@bs]) -> bool
-val some:  'v t -> (key -> 'v -> bool) -> bool
+val someU: 'v t -> (key -> 'v -> bool [@bs]) -> bool
+val some: 'v t -> (key -> 'v -> bool) -> bool
 (** [some m p] checks if at least one binding of the map
-    satisfy the predicate [p].
- *)
+    satisfy the predicate [p]. Order unspecified *)
+
 val size: 'v t -> int
+
 val toList: 'v t -> (key * 'v) list
-(** In increasing order with respect *)
+(** In increasing order. *)
+
 val toArray: 'v t -> (key * 'v) array
-val ofArray: (key * 'v) array -> 'v t     
+
+val ofArray: (key * 'v) array -> 'v t
 [@@ocaml.deprecated "Use fromArray instead"]
-val fromArray: (key * 'v) array -> 'v t     
-val keysToArray: 'v t -> key array 
+
+val fromArray: (key * 'v) array -> 'v t
+
+val keysToArray: 'v t -> key array
+
 val valuesToArray: 'v t -> 'v array
-val minKey: _ t -> key option 
+
+val minKey: _ t -> key option
+
 val minKeyUndefined: _ t -> key Js.undefined
+
 val maxKey: _ t -> key option
+
 val maxKeyUndefined: _ t -> key Js.undefined
+
 val minimum: 'v t -> (key * 'v) option
+
 val minUndefined: 'v t -> (key * 'v) Js.undefined
+
 val maximum: 'v t -> (key * 'v) option
+
 val maxUndefined: 'v t -> (key * 'v) Js.undefined
+
 val get: 'v t -> key -> 'v option
+
 val getUndefined: 'v t -> key -> 'v Js.undefined
-val getWithDefault:  'v t -> key -> 'v  -> 'v
-val getExn: 'v t -> key -> 'v 
+
+val getWithDefault: 'v t -> key -> 'v -> 'v
+
+val getExn: 'v t -> key -> 'v
 
 val checkInvariantInternal: _ t -> unit
 (**
    {b raise} when invariant is not held
 *)  
 
-(****************************************************************************)
+val checkInvariantInternal: _ t -> unit
+(**
+   {b raise} when invariant is not held
+*)
 
-val remove: 'v t ->  key -> 'v t
+val remove: 'v t -> key -> 'v t
 (** [remove m x] returns a map containing the same bindings as
    [m], except for [x] which is unbound in the returned map. *)
+
 val removeMany: 'v t -> key array -> 'v t
 
-val set: 'v t ->  key -> 'v -> 'v t
+val set: 'v t -> key -> 'v -> 'v t
 (** [add m x y] returns a map containing the same bindings as
    [m], plus a binding of [x] to [y]. If [x] was already bound
    in [m], its previous binding disappears. *)
 
-val updateU: 'v t -> key -> ('v option -> 'v option [@bs]) -> 'v t 
-val update: 'v t -> key -> ('v option -> 'v option) -> 'v t 
-val mergeArray: 'v t -> (key * 'v) array -> 'v t
-    
+val updateU: 'v t -> key -> ('v option -> 'v option [@bs]) -> 'v t
+val update: 'v t -> key -> ('v option -> 'v option) -> 'v t
+
 val mergeU:
     'v t -> 'v2 t ->
     (key -> 'v option -> 'v2 option -> 'c option [@bs]) ->
@@ -92,41 +113,38 @@ val mergeU:
 val merge:
     'v t -> 'v2 t ->
     (key -> 'v option -> 'v2 option -> 'c option) ->
-    'c t      
+    'c t
 (** [merge m1 m2 f] computes a map whose keys is a subset of keys of [m1]
     and of [m2]. The presence of each such binding, and the corresponding
     value, is determined with the function [f].
  *)
 
-val keepU: 
-    'v t -> 
-    (key -> 'v -> bool [@bs]) -> 
-    'v t
-val keep: 
-    'v t -> 
-    (key -> 'v -> bool) -> 
-    'v t      
-(** [keep m p] returns the map with all the bindings in [m]
-    that satisfy predicate [p].
-*)
+val mergeMany: 'v t -> (key * 'v) array -> 'v t
 
-val partitionU: 
-    'v t -> 
-    (key -> 'v -> bool [@bs]) -> 
+val keepU:
+    'v t ->
+    (key -> 'v -> bool [@bs]) ->
+    'v t
+val keep:
+    'v t ->
+    (key -> 'v -> bool) ->
+    'v t
+(** [keep m p] returns the map with all the bindings in [m]
+    that satisfy predicate [p]. *)
+
+val partitionU:
+    'v t ->
+    (key -> 'v -> bool [@bs]) ->
     'v t * 'v t
 val partition: 
-    'v t -> 
-    (key -> 'v -> bool) -> 
-    'v t * 'v t      
+    'v t ->
+    (key -> 'v -> bool) ->
+    'v t * 'v t
 (** [partition m p] returns a pair of maps [(m1, m2)], where
     [m1] contains all the bindings of [s] that satisfy the
     predicate [p], and [m2] is the map with all the bindings of
     [s] that do not satisfy [p].
  *)
-
-
-
-
 
 val split: key -> 'v t -> 'v t * 'v option * 'v t
 (** [split x m] returns a triple [(l, data, r)], where
@@ -138,22 +156,13 @@ val split: key -> 'v t -> 'v t * 'v option * 'v t
       or [Some v] if [m] binds [v] to [x].
  *)
 
-
-val mapU: 'v t -> ('v -> 'v2 [@bs]) ->  'v2 t
-val map: 'v t -> ('v -> 'v2) ->  'v2 t    
+val mapU: 'v t -> ('v -> 'v2 [@bs]) -> 'v2 t
+val map: 'v t -> ('v -> 'v2) -> 'v2 t
 (** [map m f] returns a map with same domain as [m], where the
-   associated value [a] of all bindings of [m] has been
-   replaced by the result of the application of [f] to [a].
-   The bindings are passed to [f] in increasing order
-   with respect to the ordering over the type of the keys. *)
+    associated value [a] of all bindings of [m] has been
+    replaced by the result of the application of [f] to [a].
+    The bindings are passed to [f] in increasing order
+    with respect to the ordering over the type of the keys. *)
 
 val mapWithKeyU: 'v t -> (key -> 'v -> 'v2 [@bs]) -> 'v2 t
-val mapWithKey: 'v t -> (key -> 'v -> 'v2) -> 'v2 t    
-
-(**/**)
-val checkInvariantInternal: _ t -> unit
-(**
-   {b raise} when invariant is not held
-*)  
-(**/**)
-
+val mapWithKey: 'v t -> (key -> 'v -> 'v2) -> 'v2 t

--- a/jscomp/others/belt_MutableMap.ml
+++ b/jscomp/others/belt_MutableMap.ml
@@ -229,7 +229,7 @@ let set  m e v =
   if newRoot != oldRoot then 
     S.dataSet m newRoot
 
-let mergeArrayAux t  xs ~cmp =     
+let mergeManyAux t  xs ~cmp =     
   let v = ref t in 
   for i = 0 to A.length xs - 1 do 
     let key,value = A.getUnsafe xs i in 
@@ -239,7 +239,7 @@ let mergeArrayAux t  xs ~cmp =
 
 let mergeMany d xs =   
   let oldRoot = S.data d in 
-  let newRoot = mergeArrayAux oldRoot xs ~cmp:(S.cmp d) in 
+  let newRoot = mergeManyAux oldRoot xs ~cmp:(S.cmp d) in 
   if newRoot != oldRoot then 
     S.dataSet d newRoot
 

--- a/jscomp/others/belt_SetDict.mli
+++ b/jscomp/others/belt_SetDict.mli
@@ -22,137 +22,116 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type ('key, 'id) t
+type ('value, 'identity) t
 
-type ('key, 'id) cmp = ('key, 'id) Belt_Id.cmp
-    
+type ('value, 'id) cmp = ('value, 'id) Belt_Id.cmp
+
 val empty: ('value, 'id) t
 
-val ofArray: 'k array -> cmp:('k, 'id) cmp -> ('k, 'id) t
+val ofArray: 'value array -> cmp:('value, 'id) cmp -> ('value, 'id) t
 [@@ocaml.deprecated "Use fromArray instead"]
-val ofSortedArrayUnsafe: 'value array ->  ('value,'id) t
+
+val ofSortedArrayUnsafe: 'value array -> ('value, 'id) t
 [@@ocaml.deprecated "Use fromSortedArrayUnsafe instead"]
 
-val fromArray: 'k array -> cmp:('k, 'id) cmp -> ('k, 'id) t
+val fromArray: 'value array -> cmp:('value, 'id) cmp -> ('value, 'id) t
 
-val fromSortedArrayUnsafe: 'value array ->  ('value,'id) t
-    
+val fromSortedArrayUnsafe: 'value array -> ('value,'id) t
+
 val isEmpty: _ t -> bool
-val has:
-  ('k, 'id) t -> 'k ->
-  cmp:('k, 'id) cmp ->
-  bool
 
+val has: ('value, 'id) t -> 'value -> cmp:('value, 'id) cmp -> bool
 
-val add:   
-  ('k, 'id) t -> 'k ->
-  cmp:('k, 'id) cmp ->
-  ('k, 'id) t
+val add: ('value, 'id) t -> 'value -> cmp:('value, 'id) cmp -> ('value, 'id) t
 (** [add s x] If [x] was already in [s], [s] is returned unchanged. *)
-    
-val mergeMany:
-  ('value, 'id) t -> 'value array ->
-  cmp:('value, 'id) cmp ->
-  ('value, 'id) t 
 
-val remove:
-  ('value, 'id) t ->
-  'value ->
-  cmp:('value, 'id) cmp ->
-  ('value, 'id) t
+val mergeMany: ('value, 'id) t -> 'value array -> cmp:('value, 'id) cmp -> ('value, 'id) t 
+
+val remove: ('value, 'id) t -> 'value -> cmp:('value, 'id) cmp -> ('value, 'id) t
 (** [remove m x] If [x] was not in [m], [m] is returned reference unchanged. *)
 
-val removeMany:
-  ('value, 'id) t -> 'value array ->
-  cmp:('value, 'id) cmp ->
-  ('value, 'id) t 
+val removeMany: ('value, 'id) t -> 'value array -> cmp:('value, 'id) cmp -> ('value, 'id) t 
 
+val union: ('value, 'id) t -> ('value, 'id) t -> cmp:('value, 'id) cmp -> ('value, 'id) t
 
-val union:
-  ('value, 'id) t -> ('value, 'id) t ->
-  cmp:('value, 'id) cmp ->
-  ('value, 'id) t
-val intersect:
-  ('value, 'id) t -> ('value, 'id) t ->
-    cmp:('value, 'id) cmp ->
-  ('value, 'id) t
-    
-val diff: ('value, 'id) t -> ('value, 'id) t ->
-  cmp:('value, 'id) cmp ->
-  ('value, 'id) t
-val subset: ('value, 'id) t -> ('value, 'id) t ->
-  cmp:('value, 'id) cmp ->
-  bool     
+val intersect: ('value, 'id) t -> ('value, 'id) t -> cmp:('value, 'id) cmp -> ('value, 'id) t
 
-val cmp: ('value, 'id) t -> ('value, 'id) t ->
-  cmp:('value, 'id) cmp ->
-  int
+val diff: ('value, 'id) t -> ('value, 'id) t -> cmp:('value, 'id) cmp -> ('value, 'id) t
+
+val subset: ('value, 'id) t -> ('value, 'id) t -> cmp:('value, 'id) cmp -> bool
+(** [subset s1 s2] tests whether the set [s1] is a subset of
+   the set [s2]. *)
+
+val cmp: ('value, 'id) t -> ('value, 'id) t -> cmp:('value, 'id) cmp -> int
 (** Total ordering between sets. Can be used as the ordering function
     for doing sets of sets. *)
-val eq: ('value, 'id) t -> ('value, 'id) t ->
-  cmp:('value, 'id) cmp ->
-  bool
 
-val forEachU: ('value, 'id) t -> ('value -> unit [@bs]) ->  unit
-val forEach: ('value, 'id) t -> ('value -> unit ) ->  unit  
+val eq: ('value, 'id) t -> ('value, 'id) t -> cmp:('value, 'id) cmp -> bool
+(** [eq s1 s2] tests whether the sets [s1] and [s2] are
+   equal, that is, contain equal elements. *)
+
+val forEachU: ('value, 'id) t -> ('value -> unit [@bs]) -> unit
+val forEach: ('value, 'id) t -> ('value -> unit) -> unit
 (** [forEach s f] applies [f] in turn to all elements of [s].
     In increasing order *)
-  
-val reduceU: ('value, 'id) t -> 'a  -> ('a -> 'value -> 'a [@bs]) ->  'a
-val reduce: ('value, 'id) t -> 'a  -> ('a -> 'value -> 'a) ->  'a  
-(** In increasing order. *)
+
+val reduceU: ('value, 'id) t -> 'a -> ('a -> 'value -> 'a [@bs]) -> 'a
+val reduce: ('value, 'id) t -> 'a -> ('a -> 'value -> 'a) -> 'a
+(** Iterate in increasing order. *)
 
 val everyU: ('value, 'id) t -> ('value -> bool [@bs]) -> bool
-val every: ('value, 'id) t -> ('value -> bool) -> bool  
+val every: ('value, 'id) t -> ('value -> bool) -> bool
 (** [every p s] checks if all elements of the set
-    satisfy the predicate [p]. Order unspecified *)
+    satisfy the predicate [p]. Order unspecified. *)
 
-val someU: ('value, 'id) t ->  ('value -> bool [@bs]) -> bool
-val some: ('value, 'id) t ->  ('value -> bool) -> bool  
+val someU: ('value, 'id) t -> ('value -> bool [@bs]) -> bool
+val some: ('value, 'id) t -> ('value -> bool) -> bool
 (** [some p s] checks if at least one element of
-    the set satisfies the predicate [p]. *)
+   the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: ('value, 'id) t ->  ('value -> bool [@bs]) -> ('value, 'id) t
-val keep: ('value, 'id) t ->  ('value -> bool) -> ('value, 'id) t
-(** [keep m p] returns the set of all elements in [s]
-    that satisfy predicate [p]. *)    
+val keepU: ('value, 'id) t -> ('value -> bool [@bs]) -> ('value, 'id) t
+val keep: ('value, 'id) t -> ('value -> bool) -> ('value, 'id) t
+(** [keep p s] returns the set of all elements in [s]
+   that satisfy predicate [p]. *)
 
-val partitionU: ('value, 'id) t -> ('value -> bool [@bs]) ->  ('value, 'id) t * ('value, 'id) t
-val partition: ('value, 'id) t -> ('value -> bool ) ->  ('value, 'id) t * ('value, 'id) t                                                            
-(** [partition m p] returns a pair of sets [(s1, s2)], where
-    [s1] is the set of all the elements of [s] that satisfy the
-    predicate [p], and [s2] is the set of all the elements of
-    [s] that do not satisfy [p]. *)
+val partitionU: ('value, 'id) t -> ('value -> bool [@bs]) -> ('value, 'id) t * ('value, 'id) t
+val partition: ('value, 'id) t -> ('value -> bool) -> ('value, 'id) t * ('value, 'id) t
+(** [partition p s] returns a pair of sets [(s1, s2)], where
+   [s1] is the set of all the elements of [s] that satisfy the
+   predicate [p], and [s2] is the set of all the elements of
+   [s] that do not satisfy [p]. *)
 
-val size:  ('value, 'id) t -> int
+val size: ('value, 'id) t -> int
+
 val toList: ('value, 'id) t -> 'value list
-(** In increasing order*)
+(** In increasing order *)
+
 val toArray: ('value, 'id) t -> 'value array
 
 val minimum: ('value, 'id) t -> 'value option
+
 val minUndefined: ('value, 'id) t -> 'value Js.undefined
+
 val maximum: ('value, 'id) t -> 'value option
+
 val maxUndefined: ('value, 'id) t -> 'value Js.undefined
 
+val get: ('value, 'id) t -> 'value -> cmp:('value, 'id) cmp -> 'value option
 
+val getUndefined: ('value, 'id) t -> 'value -> cmp:('value, 'id) cmp -> 'value Js.undefined
 
-val get: ('value, 'id) t -> 'value ->
-  cmp:('value, 'id) cmp ->
-  'value option 
-val getUndefined: ('value, 'id) t -> 'value ->
-  cmp:('value, 'id) cmp ->
-  'value Js.undefined
-val getExn: ('value, 'id) t -> 'value ->
-  cmp:('value, 'id) cmp ->
-  'value 
+val getExn: ('value, 'id) t -> 'value -> cmp:('value, 'id) cmp -> 'value 
 
-val split: ('value, 'id) t -> 'value ->
-  cmp:('value, 'id) cmp ->
-  (('value, 'id) t  * ('value, 'id) t) * bool
-                                    
+val split: ('value, 'id) t -> 'value -> cmp:('value, 'id) cmp -> (('value, 'id) t * ('value, 'id) t) * bool
+(** [split x s] returns a triple [(l, present, r)], where
+      [l] is the set of elements of [s] that are
+      strictly less than [x];
+      [r] is the set of elements of [s] that are
+      strictly greater than [x];
+      [present] is [false] if [s] contains no element equal to [x],
+      or [true] if [s] contains an element equal to [x]. *)
+
 val checkInvariantInternal: _ t -> unit
 (**
    {b raise} when invariant is not held
-*)  
-  
-
+*)

--- a/jscomp/others/belt_SetInt.mli
+++ b/jscomp/others/belt_SetInt.mli
@@ -30,9 +30,9 @@
     {b See} {!Belt.Set}
 *)
 
-# 35 "set.cppo.mli"
+# 35
 type value = int
-# 39 "set.cppo.mli"
+# 39
 (** The type of the set elements. *)
 
 
@@ -41,87 +41,101 @@ type t
 
 val empty: t
 
-
 val ofArray: value array -> t
 [@@ocaml.deprecated "Use fromArray instead"]
-val ofSortedArrayUnsafe: value array -> t     
+
+val ofSortedArrayUnsafe: value array -> t
 [@@ocaml.deprecated "Use fromSortedArrayUnsafe instead"]
 
 val fromArray: value array -> t
-val fromSortedArrayUnsafe: value array -> t     
+
+val fromSortedArrayUnsafe: value array -> t
+
 val isEmpty: t -> bool
+
 val has: t -> value -> bool
-  
-val add:  t -> value -> t
-(** If [x] was already in [s], [s] is returned unchanged. *)
+
+val add: t -> value -> t
+(** [add s x] If [x] was already in [s], [s] is returned unchanged. *)
+
 val mergeMany: t -> value array -> t 
-val remove:  t -> value -> t
-(**  If [x] was not in [s], [s] is returned unchanged. *)
+
+val remove: t -> value -> t
+(** [remove m x] If [x] was not in [m], [m] is returned reference unchanged. *)
+
 val removeMany: t -> value array -> t
-  
+
 val union: t -> t -> t
+
 val intersect: t -> t -> t
+
 val diff: t -> t -> t
+
 val subset: t -> t -> bool
 (** [subset s1 s2] tests whether the set [s1] is a subset of
    the set [s2]. *)
-  
+
 val cmp: t -> t -> int
 (** Total ordering between sets. Can be used as the ordering function
-   for doing sets of sets. *)
+    for doing sets of sets. *)
 
 val eq: t -> t -> bool
 (** [eq s1 s2] tests whether the sets [s1] and [s2] are
    equal, that is, contain equal elements. *)
 
+val forEachU: t -> (value -> unit [@bs]) -> unit
+val forEach: t -> (value -> unit) -> unit
+(** [forEach s f] applies [f] in turn to all elements of [s].
+    In increasing order *)
 
-val forEachU: t -> (value -> unit [@bs]) ->  unit
-val forEach: t -> (value -> unit ) ->  unit  
-(** In increasing order*)
-
-val reduceU: t -> 'a -> ('a -> value ->  'a [@bs]) ->  'a
-val reduce: t -> 'a -> ('a -> value ->  'a ) ->  'a  
+val reduceU: t -> 'a -> ('a -> value -> 'a [@bs]) -> 'a
+val reduce: t -> 'a -> ('a -> value -> 'a) -> 'a
 (** Iterate in increasing order. *)
 
-val everyU: t -> (value -> bool [@bs]) ->  bool
-val every: t -> (value -> bool ) ->  bool  
+val everyU: t -> (value -> bool [@bs]) -> bool
+val every: t -> (value -> bool) -> bool
 (** [every p s] checks if all elements of the set
-   satisfy the predicate [p]. Order unspecified. *)
+    satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (value -> bool [@bs]) ->  bool
-val some: t -> (value -> bool ) ->  bool  
+val someU: t -> (value -> bool [@bs]) -> bool
+val some: t -> (value -> bool) -> bool
 (** [some p s] checks if at least one element of
    the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (value -> bool [@bs]) ->  t
-val keep: t -> (value -> bool ) ->  t  
+val keepU: t -> (value -> bool [@bs]) -> t
+val keep: t -> (value -> bool) -> t
 (** [keep p s] returns the set of all elements in [s]
    that satisfy predicate [p]. *)
 
-val partitionU: t -> (value -> bool [@bs]) ->  t * t
-val partition: t -> (value -> bool ) ->  t * t
+val partitionU: t -> (value -> bool [@bs]) -> t * t
+val partition: t -> (value -> bool) -> t * t
 (** [partition p s] returns a pair of sets [(s1, s2)], where
    [s1] is the set of all the elements of [s] that satisfy the
    predicate [p], and [s2] is the set of all the elements of
    [s] that do not satisfy [p]. *)
 
 val size: t -> int
+
 val toList: t -> value list
-(** In increasing order with respect *)
+(** In increasing order *)
+
 val toArray: t -> value array
 
-
 val minimum: t -> value option
+
 val minUndefined: t -> value Js.undefined
+
 val maximum: t -> value option
+
 val maxUndefined: t -> value Js.undefined
 
+val get: t -> value -> value option
 
+val getUndefined: t -> value -> value Js.undefined
 
-val get:  t -> value -> value option
-val getUndefined:  t -> value -> value Js.undefined
-val getExn: t -> value -> value    
-val split:  t -> value -> (t * t) * bool  
+val getExn: t -> value -> value
+
+val split: t -> value -> (t * t) * bool
 (** [split x s] returns a triple [(l, present, r)], where
       [l] is the set of elements of [s] that are
       strictly less than [x];
@@ -130,11 +144,7 @@ val split:  t -> value -> (t * t) * bool
       [present] is [false] if [s] contains no element equal to [x],
       or [true] if [s] contains an element equal to [x]. *)
 
-
-
 val checkInvariantInternal: t -> unit
 (**
    {b raise} when invariant is not held
-*)  
-
-
+*)

--- a/jscomp/others/belt_SetString.mli
+++ b/jscomp/others/belt_SetString.mli
@@ -30,9 +30,9 @@
     {b See} {!Belt.Set}
 *)
 
-# 33 "set.cppo.mli"
+# 33
 type value = string
-# 39 "set.cppo.mli"
+# 39
 (** The type of the set elements. *)
 
 
@@ -41,87 +41,101 @@ type t
 
 val empty: t
 
-
 val ofArray: value array -> t
 [@@ocaml.deprecated "Use fromArray instead"]
-val ofSortedArrayUnsafe: value array -> t     
+
+val ofSortedArrayUnsafe: value array -> t
 [@@ocaml.deprecated "Use fromSortedArrayUnsafe instead"]
 
 val fromArray: value array -> t
-val fromSortedArrayUnsafe: value array -> t     
+
+val fromSortedArrayUnsafe: value array -> t
+
 val isEmpty: t -> bool
+
 val has: t -> value -> bool
-  
-val add:  t -> value -> t
-(** If [x] was already in [s], [s] is returned unchanged. *)
+
+val add: t -> value -> t
+(** [add s x] If [x] was already in [s], [s] is returned unchanged. *)
+
 val mergeMany: t -> value array -> t 
-val remove:  t -> value -> t
-(**  If [x] was not in [s], [s] is returned unchanged. *)
+
+val remove: t -> value -> t
+(** [remove m x] If [x] was not in [m], [m] is returned reference unchanged. *)
+
 val removeMany: t -> value array -> t
-  
+
 val union: t -> t -> t
+
 val intersect: t -> t -> t
+
 val diff: t -> t -> t
+
 val subset: t -> t -> bool
 (** [subset s1 s2] tests whether the set [s1] is a subset of
    the set [s2]. *)
-  
+
 val cmp: t -> t -> int
 (** Total ordering between sets. Can be used as the ordering function
-   for doing sets of sets. *)
+    for doing sets of sets. *)
 
 val eq: t -> t -> bool
 (** [eq s1 s2] tests whether the sets [s1] and [s2] are
    equal, that is, contain equal elements. *)
 
+val forEachU: t -> (value -> unit [@bs]) -> unit
+val forEach: t -> (value -> unit) -> unit
+(** [forEach s f] applies [f] in turn to all elements of [s].
+    In increasing order *)
 
-val forEachU: t -> (value -> unit [@bs]) ->  unit
-val forEach: t -> (value -> unit ) ->  unit  
-(** In increasing order*)
-
-val reduceU: t -> 'a -> ('a -> value ->  'a [@bs]) ->  'a
-val reduce: t -> 'a -> ('a -> value ->  'a ) ->  'a  
+val reduceU: t -> 'a -> ('a -> value -> 'a [@bs]) -> 'a
+val reduce: t -> 'a -> ('a -> value -> 'a) -> 'a
 (** Iterate in increasing order. *)
 
-val everyU: t -> (value -> bool [@bs]) ->  bool
-val every: t -> (value -> bool ) ->  bool  
+val everyU: t -> (value -> bool [@bs]) -> bool
+val every: t -> (value -> bool) -> bool
 (** [every p s] checks if all elements of the set
-   satisfy the predicate [p]. Order unspecified. *)
+    satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (value -> bool [@bs]) ->  bool
-val some: t -> (value -> bool ) ->  bool  
+val someU: t -> (value -> bool [@bs]) -> bool
+val some: t -> (value -> bool) -> bool
 (** [some p s] checks if at least one element of
    the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (value -> bool [@bs]) ->  t
-val keep: t -> (value -> bool ) ->  t  
+val keepU: t -> (value -> bool [@bs]) -> t
+val keep: t -> (value -> bool) -> t
 (** [keep p s] returns the set of all elements in [s]
    that satisfy predicate [p]. *)
 
-val partitionU: t -> (value -> bool [@bs]) ->  t * t
-val partition: t -> (value -> bool ) ->  t * t
+val partitionU: t -> (value -> bool [@bs]) -> t * t
+val partition: t -> (value -> bool) -> t * t
 (** [partition p s] returns a pair of sets [(s1, s2)], where
    [s1] is the set of all the elements of [s] that satisfy the
    predicate [p], and [s2] is the set of all the elements of
    [s] that do not satisfy [p]. *)
 
 val size: t -> int
+
 val toList: t -> value list
-(** In increasing order with respect *)
+(** In increasing order *)
+
 val toArray: t -> value array
 
-
 val minimum: t -> value option
+
 val minUndefined: t -> value Js.undefined
+
 val maximum: t -> value option
+
 val maxUndefined: t -> value Js.undefined
 
+val get: t -> value -> value option
 
+val getUndefined: t -> value -> value Js.undefined
 
-val get:  t -> value -> value option
-val getUndefined:  t -> value -> value Js.undefined
-val getExn: t -> value -> value    
-val split:  t -> value -> (t * t) * bool  
+val getExn: t -> value -> value
+
+val split: t -> value -> (t * t) * bool
 (** [split x s] returns a triple [(l, present, r)], where
       [l] is the set of elements of [s] that are
       strictly less than [x];
@@ -130,11 +144,7 @@ val split:  t -> value -> (t * t) * bool
       [present] is [false] if [s] contains no element equal to [x],
       or [true] if [s] contains an element equal to [x]. *)
 
-
-
 val checkInvariantInternal: t -> unit
 (**
    {b raise} when invariant is not held
-*)  
-
-
+*)

--- a/jscomp/others/map.cppo.ml
+++ b/jscomp/others/map.cppo.ml
@@ -154,6 +154,8 @@ let mergeMany h arr =
   done ;
   !v 
 
+let mergeArray = mergeMany
+
 let has = I.has
 let cmpU = I.cmpU
 let cmp = I.cmp

--- a/jscomp/others/map.cppo.ml
+++ b/jscomp/others/map.cppo.ml
@@ -145,7 +145,7 @@ let removeMany t keys =
   | None -> N.empty
   | Some t ->  removeMany0 t keys 0 len
 
-let mergeArray h arr =   
+let mergeMany h arr =   
   let len = A.length arr in 
   let v = ref h in  
   for i = 0 to len - 1 do 

--- a/jscomp/others/map.cppo.mli
+++ b/jscomp/others/map.cppo.mli
@@ -4,91 +4,112 @@ type key = string
 type key = int
 #else
 [%error "unknown type"]
-#endif  
+#endif
 type 'value t
 (** The type of maps from type [key] to type ['value]. *)
 
 val empty: 'v t
-val isEmpty: 'v t -> bool
-val has:  'v t -> key -> bool    
 
-val cmpU:  'v t -> 'v t -> ('v -> 'v -> int [@bs]) -> int
-val cmp:  'v t -> 'v t -> ('v -> 'v -> int) -> int
+val isEmpty: 'v t -> bool
+
+val has: 'v t -> key -> bool
+
+val cmpU: 'v t -> 'v t -> ('v -> 'v -> int [@bs]) -> int
+val cmp: 'v t -> 'v t -> ('v -> 'v -> int) -> int
 
 val eqU: 'v t -> 'v t -> ('v -> 'v -> bool [@bs]) -> bool
 val eq: 'v t -> 'v t -> ('v -> 'v -> bool) -> bool
-(** [equal m1 m2 cmp] tests whether the maps [m1] and [m2] are
+(** [eq m1 m2] tests whether the maps [m1] and [m2] are
    equal, that is, contain equal keys and associate them with
-   equal data.  [cmp] is the equality predicate used to compare
-   the data associated with the keys. *)
+   equal data. *)
 
-val forEachU: 'v t -> (key -> 'v -> unit [@bs]) ->  unit
-val forEach: 'v t -> (key -> 'v -> unit) ->  unit
+val forEachU: 'v t -> (key -> 'v -> unit [@bs]) -> unit
+val forEach: 'v t -> (key -> 'v -> unit) -> unit
 (** [forEach m f] applies [f] to all bindings in map [m].
-   [f] receives the key as first argument, and the associated value
-   as second argument.  The bindings are passed to [f] in increasing
-   order with respect to the ordering over the type of the keys. *)
+    [f] receives the key as first argument, and the associated value
+    as second argument. The bindings are passed to [f] in increasing
+    order with respect to the ordering over the type of the keys. *)
 
-val reduceU:  'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2 [@bs]) -> 'v2
-val reduce:  'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2) -> 'v2
+val reduceU: 'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2 [@bs]) -> 'v2
+val reduce: 'v t -> 'v2 -> ('v2 -> key -> 'v -> 'v2) -> 'v2
 (** [reduce m a f] computes [(f kN dN ... (f k1 d1 a)...)],
-   where [k1 ... kN] are the keys of all bindings in [m]
-   (in increasing order), and [d1 ... dN] are the associated data. *)
+    where [k1 ... kN] are the keys of all bindings in [m]
+    (in increasing order), and [d1 ... dN] are the associated data. *)
 
-val everyU:  'v t -> (key -> 'v -> bool [@bs]) -> bool
-val every:  'v t -> (key -> 'v -> bool) -> bool
+val everyU: 'v t -> (key -> 'v -> bool [@bs]) -> bool
+val every: 'v t -> (key -> 'v -> bool) -> bool
 (** [every m p] checks if all the bindings of the map
-    satisfy the predicate [p].
- *)
+    satisfy the predicate [p]. Order unspecified *)
 
-val someU:  'v t -> (key -> 'v -> bool [@bs]) -> bool
-val some:  'v t -> (key -> 'v -> bool) -> bool
+val someU: 'v t -> (key -> 'v -> bool [@bs]) -> bool
+val some: 'v t -> (key -> 'v -> bool) -> bool
 (** [some m p] checks if at least one binding of the map
-    satisfy the predicate [p].
- *)
+    satisfy the predicate [p]. Order unspecified *)
+
 val size: 'v t -> int
+
 val toList: 'v t -> (key * 'v) list
-(** In increasing order with respect *)
+(** In increasing order. *)
+
 val toArray: 'v t -> (key * 'v) array
-val ofArray: (key * 'v) array -> 'v t     
+
+val ofArray: (key * 'v) array -> 'v t
 [@@ocaml.deprecated "Use fromArray instead"]
-val fromArray: (key * 'v) array -> 'v t     
-val keysToArray: 'v t -> key array 
+
+val fromArray: (key * 'v) array -> 'v t
+
+val keysToArray: 'v t -> key array
+
 val valuesToArray: 'v t -> 'v array
-val minKey: _ t -> key option 
+
+val minKey: _ t -> key option
+
 val minKeyUndefined: _ t -> key Js.undefined
+
 val maxKey: _ t -> key option
+
 val maxKeyUndefined: _ t -> key Js.undefined
+
 val minimum: 'v t -> (key * 'v) option
+
 val minUndefined: 'v t -> (key * 'v) Js.undefined
+
 val maximum: 'v t -> (key * 'v) option
+
 val maxUndefined: 'v t -> (key * 'v) Js.undefined
+
 val get: 'v t -> key -> 'v option
+
 val getUndefined: 'v t -> key -> 'v Js.undefined
-val getWithDefault:  'v t -> key -> 'v  -> 'v
-val getExn: 'v t -> key -> 'v 
+
+val getWithDefault: 'v t -> key -> 'v -> 'v
+
+val getExn: 'v t -> key -> 'v
 
 val checkInvariantInternal: _ t -> unit
 (**
    {b raise} when invariant is not held
 *)  
 
-(****************************************************************************)
+val checkInvariantInternal: _ t -> unit
+(**
+   {b raise} when invariant is not held
+*)
 
-val remove: 'v t ->  key -> 'v t
+val remove: 'v t -> key -> 'v t
 (** [remove m x] returns a map containing the same bindings as
    [m], except for [x] which is unbound in the returned map. *)
+
 val removeMany: 'v t -> key array -> 'v t
 
-val set: 'v t ->  key -> 'v -> 'v t
+val set: 'v t -> key -> 'v -> 'v t
 (** [add m x y] returns a map containing the same bindings as
    [m], plus a binding of [x] to [y]. If [x] was already bound
    in [m], its previous binding disappears. *)
 
-val updateU: 'v t -> key -> ('v option -> 'v option [@bs]) -> 'v t 
-val update: 'v t -> key -> ('v option -> 'v option) -> 'v t 
-val mergeArray: 'v t -> (key * 'v) array -> 'v t
-    
+val updateU: 'v t -> key -> ('v option -> 'v option [@bs]) -> 'v t
+val update: 'v t -> key -> ('v option -> 'v option) -> 'v t
+
 val mergeU:
     'v t -> 'v2 t ->
     (key -> 'v option -> 'v2 option -> 'c option [@bs]) ->
@@ -96,41 +117,38 @@ val mergeU:
 val merge:
     'v t -> 'v2 t ->
     (key -> 'v option -> 'v2 option -> 'c option) ->
-    'c t      
+    'c t
 (** [merge m1 m2 f] computes a map whose keys is a subset of keys of [m1]
     and of [m2]. The presence of each such binding, and the corresponding
     value, is determined with the function [f].
  *)
 
-val keepU: 
-    'v t -> 
-    (key -> 'v -> bool [@bs]) -> 
-    'v t
-val keep: 
-    'v t -> 
-    (key -> 'v -> bool) -> 
-    'v t      
-(** [keep m p] returns the map with all the bindings in [m]
-    that satisfy predicate [p].
-*)
+val mergeMany: 'v t -> (key * 'v) array -> 'v t
 
-val partitionU: 
-    'v t -> 
-    (key -> 'v -> bool [@bs]) -> 
+val keepU:
+    'v t ->
+    (key -> 'v -> bool [@bs]) ->
+    'v t
+val keep:
+    'v t ->
+    (key -> 'v -> bool) ->
+    'v t
+(** [keep m p] returns the map with all the bindings in [m]
+    that satisfy predicate [p]. *)
+
+val partitionU:
+    'v t ->
+    (key -> 'v -> bool [@bs]) ->
     'v t * 'v t
 val partition: 
-    'v t -> 
-    (key -> 'v -> bool) -> 
-    'v t * 'v t      
+    'v t ->
+    (key -> 'v -> bool) ->
+    'v t * 'v t
 (** [partition m p] returns a pair of maps [(m1, m2)], where
     [m1] contains all the bindings of [s] that satisfy the
     predicate [p], and [m2] is the map with all the bindings of
     [s] that do not satisfy [p].
  *)
-
-
-
-
 
 val split: key -> 'v t -> 'v t * 'v option * 'v t
 (** [split x m] returns a triple [(l, data, r)], where
@@ -142,22 +160,13 @@ val split: key -> 'v t -> 'v t * 'v option * 'v t
       or [Some v] if [m] binds [v] to [x].
  *)
 
-
-val mapU: 'v t -> ('v -> 'v2 [@bs]) ->  'v2 t
-val map: 'v t -> ('v -> 'v2) ->  'v2 t    
+val mapU: 'v t -> ('v -> 'v2 [@bs]) -> 'v2 t
+val map: 'v t -> ('v -> 'v2) -> 'v2 t
 (** [map m f] returns a map with same domain as [m], where the
-   associated value [a] of all bindings of [m] has been
-   replaced by the result of the application of [f] to [a].
-   The bindings are passed to [f] in increasing order
-   with respect to the ordering over the type of the keys. *)
+    associated value [a] of all bindings of [m] has been
+    replaced by the result of the application of [f] to [a].
+    The bindings are passed to [f] in increasing order
+    with respect to the ordering over the type of the keys. *)
 
 val mapWithKeyU: 'v t -> (key -> 'v -> 'v2 [@bs]) -> 'v2 t
-val mapWithKey: 'v t -> (key -> 'v -> 'v2) -> 'v2 t    
-
-(**/**)
-val checkInvariantInternal: _ t -> unit
-(**
-   {b raise} when invariant is not held
-*)  
-(**/**)
-
+val mapWithKey: 'v t -> (key -> 'v -> 'v2) -> 'v2 t

--- a/jscomp/others/map.cppo.mli
+++ b/jscomp/others/map.cppo.mli
@@ -125,6 +125,9 @@ val merge:
 
 val mergeMany: 'v t -> (key * 'v) array -> 'v t
 
+[@@ocaml.deprecated "Use mergeMany instead"]
+val mergeArray: 'v t -> (key * 'v) array -> 'v t
+
 val keepU:
     'v t ->
     (key -> 'v -> bool [@bs]) ->

--- a/jscomp/others/set.cppo.mli
+++ b/jscomp/others/set.cppo.mli
@@ -35,7 +35,7 @@ type value = string
 type value = int
 #else 
 [%error "unknown type"]
-#endif  
+#endif
 (** The type of the set elements. *)
 
 
@@ -44,87 +44,101 @@ type t
 
 val empty: t
 
-
 val ofArray: value array -> t
 [@@ocaml.deprecated "Use fromArray instead"]
-val ofSortedArrayUnsafe: value array -> t     
+
+val ofSortedArrayUnsafe: value array -> t
 [@@ocaml.deprecated "Use fromSortedArrayUnsafe instead"]
 
 val fromArray: value array -> t
-val fromSortedArrayUnsafe: value array -> t     
+
+val fromSortedArrayUnsafe: value array -> t
+
 val isEmpty: t -> bool
+
 val has: t -> value -> bool
-  
-val add:  t -> value -> t
-(** If [x] was already in [s], [s] is returned unchanged. *)
+
+val add: t -> value -> t
+(** [add s x] If [x] was already in [s], [s] is returned unchanged. *)
+
 val mergeMany: t -> value array -> t 
-val remove:  t -> value -> t
-(**  If [x] was not in [s], [s] is returned unchanged. *)
+
+val remove: t -> value -> t
+(** [remove m x] If [x] was not in [m], [m] is returned reference unchanged. *)
+
 val removeMany: t -> value array -> t
-  
+
 val union: t -> t -> t
+
 val intersect: t -> t -> t
+
 val diff: t -> t -> t
+
 val subset: t -> t -> bool
 (** [subset s1 s2] tests whether the set [s1] is a subset of
    the set [s2]. *)
-  
+
 val cmp: t -> t -> int
 (** Total ordering between sets. Can be used as the ordering function
-   for doing sets of sets. *)
+    for doing sets of sets. *)
 
 val eq: t -> t -> bool
 (** [eq s1 s2] tests whether the sets [s1] and [s2] are
    equal, that is, contain equal elements. *)
 
+val forEachU: t -> (value -> unit [@bs]) -> unit
+val forEach: t -> (value -> unit) -> unit
+(** [forEach s f] applies [f] in turn to all elements of [s].
+    In increasing order *)
 
-val forEachU: t -> (value -> unit [@bs]) ->  unit
-val forEach: t -> (value -> unit ) ->  unit  
-(** In increasing order*)
-
-val reduceU: t -> 'a -> ('a -> value ->  'a [@bs]) ->  'a
-val reduce: t -> 'a -> ('a -> value ->  'a ) ->  'a  
+val reduceU: t -> 'a -> ('a -> value -> 'a [@bs]) -> 'a
+val reduce: t -> 'a -> ('a -> value -> 'a) -> 'a
 (** Iterate in increasing order. *)
 
-val everyU: t -> (value -> bool [@bs]) ->  bool
-val every: t -> (value -> bool ) ->  bool  
+val everyU: t -> (value -> bool [@bs]) -> bool
+val every: t -> (value -> bool) -> bool
 (** [every p s] checks if all elements of the set
-   satisfy the predicate [p]. Order unspecified. *)
+    satisfy the predicate [p]. Order unspecified. *)
 
-val someU: t -> (value -> bool [@bs]) ->  bool
-val some: t -> (value -> bool ) ->  bool  
+val someU: t -> (value -> bool [@bs]) -> bool
+val some: t -> (value -> bool) -> bool
 (** [some p s] checks if at least one element of
    the set satisfies the predicate [p]. Oder unspecified. *)
 
-val keepU: t -> (value -> bool [@bs]) ->  t
-val keep: t -> (value -> bool ) ->  t  
+val keepU: t -> (value -> bool [@bs]) -> t
+val keep: t -> (value -> bool) -> t
 (** [keep p s] returns the set of all elements in [s]
    that satisfy predicate [p]. *)
 
-val partitionU: t -> (value -> bool [@bs]) ->  t * t
-val partition: t -> (value -> bool ) ->  t * t
+val partitionU: t -> (value -> bool [@bs]) -> t * t
+val partition: t -> (value -> bool) -> t * t
 (** [partition p s] returns a pair of sets [(s1, s2)], where
    [s1] is the set of all the elements of [s] that satisfy the
    predicate [p], and [s2] is the set of all the elements of
    [s] that do not satisfy [p]. *)
 
 val size: t -> int
+
 val toList: t -> value list
-(** In increasing order with respect *)
+(** In increasing order *)
+
 val toArray: t -> value array
 
-
 val minimum: t -> value option
+
 val minUndefined: t -> value Js.undefined
+
 val maximum: t -> value option
+
 val maxUndefined: t -> value Js.undefined
 
+val get: t -> value -> value option
 
+val getUndefined: t -> value -> value Js.undefined
 
-val get:  t -> value -> value option
-val getUndefined:  t -> value -> value Js.undefined
-val getExn: t -> value -> value    
-val split:  t -> value -> (t * t) * bool  
+val getExn: t -> value -> value
+
+val split: t -> value -> (t * t) * bool
 (** [split x s] returns a triple [(l, present, r)], where
       [l] is the set of elements of [s] that are
       strictly less than [x];
@@ -133,11 +147,7 @@ val split:  t -> value -> (t * t) * bool
       [present] is [false] if [s] contains no element equal to [x],
       or [true] if [s] contains an element equal to [x]. *)
 
-
-
 val checkInvariantInternal: t -> unit
 (**
    {b raise} when invariant is not held
-*)  
-
-
+*)

--- a/lib/js/belt_MapInt.js
+++ b/lib/js/belt_MapInt.js
@@ -152,7 +152,7 @@ function removeMany(t, keys) {
   }
 }
 
-function mergeArray(h, arr) {
+function mergeMany(h, arr) {
   var len = arr.length;
   var v = h;
   for(var i = 0 ,i_finish = len - 1 | 0; i <= i_finish; ++i){
@@ -230,6 +230,8 @@ var getWithDefault = Belt_internalMapInt.getWithDefault;
 
 var getExn = Belt_internalMapInt.getExn;
 
+var checkInvariantInternal = Belt_internalAVLtree.checkInvariantInternal;
+
 var mergeU = Belt_internalMapInt.mergeU;
 
 var merge = Belt_internalMapInt.merge;
@@ -251,8 +253,6 @@ var map = Belt_internalAVLtree.map;
 var mapWithKeyU = Belt_internalAVLtree.mapWithKeyU;
 
 var mapWithKey = Belt_internalAVLtree.mapWithKey;
-
-var checkInvariantInternal = Belt_internalAVLtree.checkInvariantInternal;
 
 exports.empty = empty;
 exports.isEmpty = isEmpty;
@@ -288,14 +288,15 @@ exports.get = get;
 exports.getUndefined = getUndefined;
 exports.getWithDefault = getWithDefault;
 exports.getExn = getExn;
+exports.checkInvariantInternal = checkInvariantInternal;
 exports.remove = remove;
 exports.removeMany = removeMany;
 exports.set = set;
 exports.updateU = updateU;
 exports.update = update;
-exports.mergeArray = mergeArray;
 exports.mergeU = mergeU;
 exports.merge = merge;
+exports.mergeMany = mergeMany;
 exports.keepU = keepU;
 exports.keep = keep;
 exports.partitionU = partitionU;
@@ -305,5 +306,4 @@ exports.mapU = mapU;
 exports.map = map;
 exports.mapWithKeyU = mapWithKeyU;
 exports.mapWithKey = mapWithKey;
-exports.checkInvariantInternal = checkInvariantInternal;
 /* No side effect */

--- a/lib/js/belt_MapInt.js
+++ b/lib/js/belt_MapInt.js
@@ -236,6 +236,8 @@ var mergeU = Belt_internalMapInt.mergeU;
 
 var merge = Belt_internalMapInt.merge;
 
+var mergeArray = mergeMany;
+
 var keepU = Belt_internalAVLtree.keepSharedU;
 
 var keep = Belt_internalAVLtree.keepShared;
@@ -297,6 +299,7 @@ exports.update = update;
 exports.mergeU = mergeU;
 exports.merge = merge;
 exports.mergeMany = mergeMany;
+exports.mergeArray = mergeArray;
 exports.keepU = keepU;
 exports.keep = keep;
 exports.partitionU = partitionU;

--- a/lib/js/belt_MapString.js
+++ b/lib/js/belt_MapString.js
@@ -152,7 +152,7 @@ function removeMany(t, keys) {
   }
 }
 
-function mergeArray(h, arr) {
+function mergeMany(h, arr) {
   var len = arr.length;
   var v = h;
   for(var i = 0 ,i_finish = len - 1 | 0; i <= i_finish; ++i){
@@ -230,6 +230,8 @@ var getWithDefault = Belt_internalMapString.getWithDefault;
 
 var getExn = Belt_internalMapString.getExn;
 
+var checkInvariantInternal = Belt_internalAVLtree.checkInvariantInternal;
+
 var mergeU = Belt_internalMapString.mergeU;
 
 var merge = Belt_internalMapString.merge;
@@ -251,8 +253,6 @@ var map = Belt_internalAVLtree.map;
 var mapWithKeyU = Belt_internalAVLtree.mapWithKeyU;
 
 var mapWithKey = Belt_internalAVLtree.mapWithKey;
-
-var checkInvariantInternal = Belt_internalAVLtree.checkInvariantInternal;
 
 exports.empty = empty;
 exports.isEmpty = isEmpty;
@@ -288,14 +288,15 @@ exports.get = get;
 exports.getUndefined = getUndefined;
 exports.getWithDefault = getWithDefault;
 exports.getExn = getExn;
+exports.checkInvariantInternal = checkInvariantInternal;
 exports.remove = remove;
 exports.removeMany = removeMany;
 exports.set = set;
 exports.updateU = updateU;
 exports.update = update;
-exports.mergeArray = mergeArray;
 exports.mergeU = mergeU;
 exports.merge = merge;
+exports.mergeMany = mergeMany;
 exports.keepU = keepU;
 exports.keep = keep;
 exports.partitionU = partitionU;
@@ -305,5 +306,4 @@ exports.mapU = mapU;
 exports.map = map;
 exports.mapWithKeyU = mapWithKeyU;
 exports.mapWithKey = mapWithKey;
-exports.checkInvariantInternal = checkInvariantInternal;
 /* No side effect */

--- a/lib/js/belt_MapString.js
+++ b/lib/js/belt_MapString.js
@@ -236,6 +236,8 @@ var mergeU = Belt_internalMapString.mergeU;
 
 var merge = Belt_internalMapString.merge;
 
+var mergeArray = mergeMany;
+
 var keepU = Belt_internalAVLtree.keepSharedU;
 
 var keep = Belt_internalAVLtree.keepShared;
@@ -297,6 +299,7 @@ exports.update = update;
 exports.mergeU = mergeU;
 exports.merge = merge;
 exports.mergeMany = mergeMany;
+exports.mergeArray = mergeArray;
 exports.keepU = keepU;
 exports.keep = keep;
 exports.partitionU = partitionU;

--- a/lib/js/belt_MutableMap.js
+++ b/lib/js/belt_MutableMap.js
@@ -333,7 +333,7 @@ function set(m, e, v) {
   }
 }
 
-function mergeArrayAux(t, xs, cmp) {
+function mergeManyAux(t, xs, cmp) {
   var v = t;
   for(var i = 0 ,i_finish = xs.length - 1 | 0; i <= i_finish; ++i){
     var match = xs[i];
@@ -344,7 +344,7 @@ function mergeArrayAux(t, xs, cmp) {
 
 function mergeMany(d, xs) {
   var oldRoot = d.data;
-  var newRoot = mergeArrayAux(oldRoot, xs, d.cmp);
+  var newRoot = mergeManyAux(oldRoot, xs, d.cmp);
   if (newRoot !== oldRoot) {
     d.data = newRoot;
     return /* () */0;


### PR DESCRIPTION
More consistency in the generated .mli for specialized Set and String, and the corresponding Dict, for maps and sets.
Renamed leftover mergeArray which should be mergeMany.