### PR TITLE
Fix startup message typo.

### DIFF
--- a/lib/bsb
+++ b/lib/bsb
@@ -243,7 +243,7 @@ if (watch_mode) {
         if (acquireBuild()) {
             logStart()
             if (reasons_to_rebuild.length === 0) {
-                console.log("Rebuilding since just get started")
+                console.log("Rebuilding since just got started")
             } else {
                 console.log("Rebuilding since", reasons_to_rebuild)
             }


### PR DESCRIPTION
'since just got started' or 'since just starting'

Signed off by: Jim Tittsler <jimt@onjapan.net>