### PR TITLE
Fix polymorphic compare on nullables.

### DIFF
--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -167,6 +167,8 @@ let unsafe_js_compare x y =
 let rec caml_compare (a : Obj.t) (b : Obj.t) : int =
   if a == b then 0 else
   (*front and formoest, we do not compare function values*)
+  if a == (Obj.repr Js_null.empty) then -1 else
+  if b == (Obj.repr Js_null.empty) then 1 else
   let a_type = Js.typeof a in 
   let b_type = Js.typeof b in 
   if a_type = "string" then
@@ -182,7 +184,6 @@ let rec caml_compare (a : Obj.t) (b : Obj.t) : int =
     | false, false -> 
       if a_type = "boolean"
       || a_type = "undefined"
-      || a == (Obj.repr Js_null.empty)
       then (* TODO: refine semantics when comparing with [null] *)
         unsafe_js_compare a b
       else if a_type = "function" || b_type = "function"

--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -185,7 +185,6 @@ let rec caml_compare (a : Obj.t) (b : Obj.t) : int =
     | false, true -> 1 
     | false, false -> 
       if a_type = "boolean"
-      || a_type = "undefined"
       then (* TODO: refine semantics when comparing with [null] *)
         unsafe_js_compare a b
       else if a_type = "function" || b_type = "function"

--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -167,8 +167,10 @@ let unsafe_js_compare x y =
 let rec caml_compare (a : Obj.t) (b : Obj.t) : int =
   if a == b then 0 else
   (*front and formoest, we do not compare function values*)
-  if a == (Obj.repr Js_null.empty) then -1 else
-  if b == (Obj.repr Js_null.empty) then 1 else
+  if a == (Obj.repr Js.null) then -1 else
+  if b == (Obj.repr Js.null) then 1 else
+  if a == (Obj.repr Js.undefined) then -1 else
+  if b == (Obj.repr Js.undefined) then 1 else
   let a_type = Js.typeof a in 
   let b_type = Js.typeof b in 
   if a_type = "string" then

--- a/jscomp/test/caml_compare_test.js
+++ b/jscomp/test/caml_compare_test.js
@@ -909,7 +909,51 @@ var suites_001 = /* :: */[
                                                                                                       ]);
                                                                                             })
                                                                                         ],
-                                                                                        /* [] */0
+                                                                                        /* :: */[
+                                                                                          /* tuple */[
+                                                                                            "File \"caml_compare_test.ml\", line 87, characters 4-11",
+                                                                                            (function () {
+                                                                                                return /* Eq */Block.__(0, [
+                                                                                                          Caml_obj.caml_compare(null, 0),
+                                                                                                          -1
+                                                                                                        ]);
+                                                                                              })
+                                                                                          ],
+                                                                                          /* :: */[
+                                                                                            /* tuple */[
+                                                                                              "File \"caml_compare_test.ml\", line 90, characters 4-11",
+                                                                                              (function () {
+                                                                                                  return /* Eq */Block.__(0, [
+                                                                                                            Caml_obj.caml_compare(0, null),
+                                                                                                            1
+                                                                                                          ]);
+                                                                                                })
+                                                                                            ],
+                                                                                            /* :: */[
+                                                                                              /* tuple */[
+                                                                                                "File \"caml_compare_test.ml\", line 93, characters 4-11",
+                                                                                                (function () {
+                                                                                                    return /* Eq */Block.__(0, [
+                                                                                                              Caml_obj.caml_compare(undefined, 0),
+                                                                                                              -1
+                                                                                                            ]);
+                                                                                                  })
+                                                                                              ],
+                                                                                              /* :: */[
+                                                                                                /* tuple */[
+                                                                                                  "File \"caml_compare_test.ml\", line 96, characters 4-11",
+                                                                                                  (function () {
+                                                                                                      return /* Eq */Block.__(0, [
+                                                                                                                Caml_obj.caml_compare(0, undefined),
+                                                                                                                1
+                                                                                                              ]);
+                                                                                                    })
+                                                                                                ],
+                                                                                                /* [] */0
+                                                                                              ]
+                                                                                            ]
+                                                                                          ]
+                                                                                        ]
                                                                                       ]
                                                                                     ]
                                                                                   ]

--- a/jscomp/test/caml_compare_test.js
+++ b/jscomp/test/caml_compare_test.js
@@ -883,7 +883,35 @@ var suites_001 = /* :: */[
                                                                                                   ]);
                                                                                         })
                                                                                     ],
-                                                                                    /* [] */0
+                                                                                    /* :: */[
+                                                                                      /* tuple */[
+                                                                                        "File \"caml_compare_test.ml\", line 81, characters 4-11",
+                                                                                        (function () {
+                                                                                            return /* Eq */Block.__(0, [
+                                                                                                      Caml_obj.caml_compare(null, /* :: */[
+                                                                                                            3,
+                                                                                                            /* [] */0
+                                                                                                          ]),
+                                                                                                      -1
+                                                                                                    ]);
+                                                                                          })
+                                                                                      ],
+                                                                                      /* :: */[
+                                                                                        /* tuple */[
+                                                                                          "File \"caml_compare_test.ml\", line 84, characters 4-11",
+                                                                                          (function () {
+                                                                                              return /* Eq */Block.__(0, [
+                                                                                                        Caml_obj.caml_compare(/* :: */[
+                                                                                                              3,
+                                                                                                              /* [] */0
+                                                                                                            ], null),
+                                                                                                        1
+                                                                                                      ]);
+                                                                                            })
+                                                                                        ],
+                                                                                        /* [] */0
+                                                                                      ]
+                                                                                    ]
                                                                                   ]
                                                                                 ]
                                                                               ]

--- a/jscomp/test/caml_compare_test.ml
+++ b/jscomp/test/caml_compare_test.ml
@@ -84,7 +84,18 @@ let suites = Mt.[
     __LOC__ , begin fun _ ->
         Eq(compare (Js.Null.return [3]) Js.null, 1)
     end;
-
+    __LOC__ , begin fun _ ->
+        Eq(compare Js.null (Js.Null.return 0), -1)
+    end;
+    __LOC__ , begin fun _ ->
+        Eq(compare (Js.Null.return 0) Js.null, 1)
+    end;
+    __LOC__ , begin fun _ ->
+        Eq(compare Js.Nullable.undefined (Js.Nullable.return 0), -1)
+    end;
+    __LOC__ , begin fun _ ->
+        Eq(compare (Js.Nullable.return 0) Js.Nullable.undefined, 1)
+    end;
 ]
 ;;
 

--- a/jscomp/test/caml_compare_test.ml
+++ b/jscomp/test/caml_compare_test.ml
@@ -77,6 +77,14 @@ let suites = Mt.[
     "eq_in_list2", (fun _ -> Eq ([[%bs.obj {x=2}]] = [[%bs.obj {x=2}]], true));
     "eq_with_list", (fun _ -> Eq ([%bs.obj {x=[0]}] = [%bs.obj {x=[0]}], true));
     "eq_with_list2", (fun _ -> Eq ([%bs.obj {x=[0]}] = [%bs.obj {x=[1]}], false));
+
+    __LOC__ , begin fun _ ->
+        Eq(compare Js.null (Js.Null.return [3]), -1)
+    end;
+    __LOC__ , begin fun _ ->
+        Eq(compare (Js.Null.return [3]) Js.null, 1)
+    end;
+
 ]
 ;;
 

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -90,7 +90,7 @@ function caml_compare(_a, _b) {
           }
         } else if (is_b_number) {
           return 1;
-        } else if (a_type === "boolean" || a_type === "undefined") {
+        } else if (a_type === "boolean") {
           var x = a;
           var y = b;
           if (x === y) {

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -70,6 +70,10 @@ function caml_compare(_a, _b) {
       return -1;
     } else if (b === null) {
       return 1;
+    } else if (a === undefined) {
+      return -1;
+    } else if (b === undefined) {
+      return 1;
     } else {
       var a_type = typeof a;
       var b_type = typeof b;

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -66,6 +66,10 @@ function caml_compare(_a, _b) {
     var a = _a;
     if (a === b) {
       return 0;
+    } else if (a === null) {
+      return -1;
+    } else if (b === null) {
+      return 1;
     } else {
       var a_type = typeof a;
       var b_type = typeof b;
@@ -82,7 +86,7 @@ function caml_compare(_a, _b) {
           }
         } else if (is_b_number) {
           return 1;
-        } else if (a_type === "boolean" || a_type === "undefined" || a === null) {
+        } else if (a_type === "boolean" || a_type === "undefined") {
           var x = a;
           var y = b;
           if (x === y) {


### PR DESCRIPTION
Polymorphic compare could crash when the second argument is null, as it would try to read the tag of null.
Added test where previously it would crash.