### PR TITLE
Small documentation fixes

### DIFF
--- a/jscomp/others/belt_List.mli
+++ b/jscomp/others/belt_List.mli
@@ -84,7 +84,7 @@ val tailExn: 'a t -> 'a t
 
 val add: 'a t -> 'a -> 'a t
 (**
-  [add xs y] adds [y] to the end of list [xs]
+  [add xs y] adds [y] to the beginning of list [xs]
   
    @example{[
      add [1] 3 = [3;1];;

--- a/jscomp/others/belt_MapDict.mli
+++ b/jscomp/others/belt_MapDict.mli
@@ -162,7 +162,7 @@ val set:
   ('a, 'b, 'id) t -> 'a -> 'b ->
   cmp:('a, 'id) cmp ->
   ('a, 'b, 'id) t
-(** [add m x y] returns a map containing the same bindings as
+(** [set m x y] returns a map containing the same bindings as
    [m], plus a binding of [x] to [y]. If [x] was already bound
    in [m], its previous binding disappears. *)
 

--- a/jscomp/others/belt_MapInt.mli
+++ b/jscomp/others/belt_MapInt.mli
@@ -99,7 +99,7 @@ val remove: 'v t -> key -> 'v t
 val removeMany: 'v t -> key array -> 'v t
 
 val set: 'v t -> key -> 'v -> 'v t
-(** [add m x y] returns a map containing the same bindings as
+(** [set m x y] returns a map containing the same bindings as
    [m], plus a binding of [x] to [y]. If [x] was already bound
    in [m], its previous binding disappears. *)
 

--- a/jscomp/others/belt_MapString.mli
+++ b/jscomp/others/belt_MapString.mli
@@ -99,7 +99,7 @@ val remove: 'v t -> key -> 'v t
 val removeMany: 'v t -> key array -> 'v t
 
 val set: 'v t -> key -> 'v -> 'v t
-(** [add m x y] returns a map containing the same bindings as
+(** [set m x y] returns a map containing the same bindings as
    [m], plus a binding of [x] to [y]. If [x] was already bound
    in [m], its previous binding disappears. *)
 

--- a/jscomp/others/belt_MutableMapInt.mli
+++ b/jscomp/others/belt_MutableMapInt.mli
@@ -115,7 +115,7 @@ val remove: 'a t -> key -> unit
 val removeMany: 'a t -> key array -> unit
     
 val set: 'a t -> key -> 'a -> unit  
-(** [add m x y] do the in-place modification, return
+(** [set m x y] do the in-place modification, return
     [m] for chaining. If [x] was already bound
    in [m], its previous binding disappears. *)
 

--- a/jscomp/others/belt_MutableMapString.mli
+++ b/jscomp/others/belt_MutableMapString.mli
@@ -115,7 +115,7 @@ val remove: 'a t -> key -> unit
 val removeMany: 'a t -> key array -> unit
     
 val set: 'a t -> key -> 'a -> unit  
-(** [add m x y] do the in-place modification, return
+(** [set m x y] do the in-place modification, return
     [m] for chaining. If [x] was already bound
    in [m], its previous binding disappears. *)
 

--- a/jscomp/others/map.cppo.mli
+++ b/jscomp/others/map.cppo.mli
@@ -103,7 +103,7 @@ val remove: 'v t -> key -> 'v t
 val removeMany: 'v t -> key array -> 'v t
 
 val set: 'v t -> key -> 'v -> 'v t
-(** [add m x y] returns a map containing the same bindings as
+(** [set m x y] returns a map containing the same bindings as
    [m], plus a binding of [x] to [y]. If [x] was already bound
    in [m], its previous binding disappears. *)
 

--- a/jscomp/others/mapm.cppo.mli
+++ b/jscomp/others/mapm.cppo.mli
@@ -118,7 +118,7 @@ val remove: 'a t -> key -> unit
 val removeMany: 'a t -> key array -> unit
     
 val set: 'a t -> key -> 'a -> unit  
-(** [add m x y] do the in-place modification, return
+(** [set m x y] do the in-place modification, return
     [m] for chaining. If [x] was already bound
    in [m], its previous binding disappears. *)
 


### PR DESCRIPTION
Minor fixes to ocamldocs:

- `Belt.List.add` adds to the beginning of the list
- Some maps docs were referencing `add` instead of `set`