### PR TITLE
Add Belt_Array.partition

### DIFF
--- a/jscomp/others/belt_Array.ml
+++ b/jscomp/others/belt_Array.ml
@@ -425,8 +425,8 @@ let partitionU a f =
       incr j
     )
   done;
-  let a1 = slice a1 ~offset:0 ~len:!i in
-  let a2 = slice a2 ~offset:0 ~len:!j in
+  truncateToLengthUnsafe a1 !i;
+  truncateToLengthUnsafe a2 !j;
   (a1, a2)
 
 let partition a f = partitionU a (fun [@bs] x -> f x)

--- a/jscomp/others/belt_Array.ml
+++ b/jscomp/others/belt_Array.ml
@@ -408,7 +408,7 @@ let cmpU a b p =
 
 let cmp a b p = cmpU a b (fun[@bs] a b -> p a b)
 
-let partition f a =
+let partitionU a f =
   let l = length a in
   let i = ref 0 in
   let j = ref 0 in
@@ -416,7 +416,7 @@ let partition f a =
   let a2 = makeUninitializedUnsafe l in
   for ii = 0 to l - 1 do
     let v = getUnsafe a ii in
-    if f v then (
+    if f v [@bs] then (
       setUnsafe a1 !i v;
       incr i
     )
@@ -429,13 +429,15 @@ let partition f a =
   let a2 = slice a2 ~offset:0 ~len:!j in
   (a1, a2)
 
+let partition a f = partitionU a (fun [@bs] x -> f x)
+
 let unzip a =
   let l = length a in
-  let a1 = makeUninitializedUnsafe l in 
-  let a2 = makeUninitializedUnsafe l in 
+  let a1 = makeUninitializedUnsafe l in
+  let a2 = makeUninitializedUnsafe l in
   for i = 0 to l - 1 do
     let (v1, v2) = getUnsafe a i in
     setUnsafe a1 i v1;
-    setUnsafe a2 i v2    
+    setUnsafe a2 i v2
   done;
   (a1, a2)

--- a/jscomp/others/belt_Array.ml
+++ b/jscomp/others/belt_Array.ml
@@ -408,6 +408,27 @@ let cmpU a b p =
 
 let cmp a b p = cmpU a b (fun[@bs] a b -> p a b)
 
+let partition f a =
+  let l = length a in
+  let i = ref 0 in
+  let j = ref 0 in
+  let a1 = makeUninitializedUnsafe l in
+  let a2 = makeUninitializedUnsafe l in
+  for ii = 0 to l - 1 do
+    let v = getUnsafe a ii in
+    if f v then (
+      setUnsafe a1 !i v;
+      incr i
+    )
+    else (
+      setUnsafe a2 !j v;
+      incr j
+    )
+  done;
+  let a1 = slice a1 ~offset:0 ~len:!i in
+  let a2 = slice a2 ~offset:0 ~len:!j in
+  (a1, a2)
+
 let unzip a =
   let l = length a in
   let a1 = makeUninitializedUnsafe l in 

--- a/jscomp/others/belt_Array.mli
+++ b/jscomp/others/belt_Array.mli
@@ -411,7 +411,16 @@ val mapWithIndex: 'a array ->  (int -> 'a -> 'b ) -> 'b array
       [|0 + 1; 1 + 2; 2 + 3|]
     ]}
 *)
-    
+
+val partition : ('a -> bool) -> 'a array -> 'a array * 'a array
+(** [partition f a] split array into tuple of two arrays based on predicate f; first of tuple where predicate vause true, second where predicate cause false
+
+    @example {[
+      predicate (fun x -> if x mod 2 = 0) [|1;2;3;4;5|] = ([|2;4|], [|1;2;3|]);;
+      predicate (fun x -> if x mod 2 <> 0) [|1;2;3;4;5|] = ([|1;2;3|], [|2;4|]);;
+    ]}
+*)
+
 val reduceU:  'b array -> 'a -> ('a -> 'b -> 'a [@bs]) ->'a
 val reduce:  'b array -> 'a -> ('a -> 'b -> 'a ) ->'a
 (** [reduce xs init f]

--- a/jscomp/others/belt_Array.mli
+++ b/jscomp/others/belt_Array.mli
@@ -412,12 +412,14 @@ val mapWithIndex: 'a array ->  (int -> 'a -> 'b ) -> 'b array
     ]}
 *)
 
-val partition : ('a -> bool) -> 'a array -> 'a array * 'a array
+
+val partitionU : 'a array -> ('a -> bool [@bs]) -> 'a array * 'a array
+val partition : 'a array ->  ('a -> bool) -> 'a array * 'a array
 (** [partition f a] split array into tuple of two arrays based on predicate f; first of tuple where predicate vause true, second where predicate cause false
 
     @example {[
-      predicate (fun x -> if x mod 2 = 0) [|1;2;3;4;5|] = ([|2;4|], [|1;2;3|]);;
-      predicate (fun x -> if x mod 2 <> 0) [|1;2;3;4;5|] = ([|1;2;3|], [|2;4|]);;
+      predicate [|1;2;3;4;5|] (fun x -> if x mod 2 = 0)  = ([|2;4|], [|1;2;3|]);;
+      predicate [|1;2;3;4;5|] (fun x -> if x mod 2 <> 0) = ([|1;2;3|], [|2;4|]);;
     ]}
 *)
 

--- a/jscomp/test/bs_array_test.js
+++ b/jscomp/test/bs_array_test.js
@@ -568,9 +568,9 @@ var a$2 = /* array */[
   5
 ];
 
-var match = Belt_Array.partition((function (x) {
+var match = Belt_Array.partition(a$2, (function (x) {
         return x % 2 === 0;
-      }), a$2);
+      }));
 
 eq("File \"bs_array_test.ml\", line 153, characters 5-12", match[0], /* array */[
       2,
@@ -583,9 +583,9 @@ eq("File \"bs_array_test.ml\", line 154, characters 5-12", match[1], /* array */
       5
     ]);
 
-var match$1 = Belt_Array.partition((function (x) {
+var match$1 = Belt_Array.partition(a$2, (function (x) {
         return x === 2;
-      }), a$2);
+      }));
 
 eq("File \"bs_array_test.ml\", line 156, characters 5-12", match$1[0], /* array */[2]);
 
@@ -596,9 +596,9 @@ eq("File \"bs_array_test.ml\", line 157, characters 5-12", match$1[1], /* array 
       5
     ]);
 
-var match$2 = Belt_Array.partition((function () {
+var match$2 = Belt_Array.partition(/* array */[], (function () {
         return false;
-      }), /* array */[]);
+      }));
 
 eq("File \"bs_array_test.ml\", line 159, characters 5-12", match$2[0], /* array */[]);
 

--- a/jscomp/test/bs_array_test.js
+++ b/jscomp/test/bs_array_test.js
@@ -568,12 +568,56 @@ var a$2 = /* array */[
   5
 ];
 
-eq("File \"bs_array_test.ml\", line 152, characters 5-12", Belt_Array.slice(a$2, 0, 2), /* array */[
+var match = Belt_Array.partition((function (x) {
+        return x % 2 === 0;
+      }), a$2);
+
+eq("File \"bs_array_test.ml\", line 153, characters 5-12", match[0], /* array */[
+      2,
+      4
+    ]);
+
+eq("File \"bs_array_test.ml\", line 154, characters 5-12", match[1], /* array */[
+      1,
+      3,
+      5
+    ]);
+
+var match$1 = Belt_Array.partition((function (x) {
+        return x === 2;
+      }), a$2);
+
+eq("File \"bs_array_test.ml\", line 156, characters 5-12", match$1[0], /* array */[2]);
+
+eq("File \"bs_array_test.ml\", line 157, characters 5-12", match$1[1], /* array */[
+      1,
+      3,
+      4,
+      5
+    ]);
+
+var match$2 = Belt_Array.partition((function () {
+        return false;
+      }), /* array */[]);
+
+eq("File \"bs_array_test.ml\", line 159, characters 5-12", match$2[0], /* array */[]);
+
+eq("File \"bs_array_test.ml\", line 160, characters 5-12", match$2[1], /* array */[]);
+
+var a$3 = /* array */[
+  1,
+  2,
+  3,
+  4,
+  5
+];
+
+eq("File \"bs_array_test.ml\", line 164, characters 5-12", Belt_Array.slice(a$3, 0, 2), /* array */[
       1,
       2
     ]);
 
-eq("File \"bs_array_test.ml\", line 153, characters 5-12", Belt_Array.slice(a$2, 0, 5), /* array */[
+eq("File \"bs_array_test.ml\", line 165, characters 5-12", Belt_Array.slice(a$3, 0, 5), /* array */[
       1,
       2,
       3,
@@ -581,7 +625,7 @@ eq("File \"bs_array_test.ml\", line 153, characters 5-12", Belt_Array.slice(a$2,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 154, characters 5-12", Belt_Array.slice(a$2, 0, 15), /* array */[
+eq("File \"bs_array_test.ml\", line 166, characters 5-12", Belt_Array.slice(a$3, 0, 15), /* array */[
       1,
       2,
       3,
@@ -589,40 +633,40 @@ eq("File \"bs_array_test.ml\", line 154, characters 5-12", Belt_Array.slice(a$2,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 155, characters 5-12", Belt_Array.slice(a$2, 5, 1), /* array */[]);
+eq("File \"bs_array_test.ml\", line 167, characters 5-12", Belt_Array.slice(a$3, 5, 1), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 156, characters 5-12", Belt_Array.slice(a$2, 4, 1), /* array */[5]);
+eq("File \"bs_array_test.ml\", line 168, characters 5-12", Belt_Array.slice(a$3, 4, 1), /* array */[5]);
 
-eq("File \"bs_array_test.ml\", line 157, characters 5-12", Belt_Array.slice(a$2, -1, 1), /* array */[5]);
+eq("File \"bs_array_test.ml\", line 169, characters 5-12", Belt_Array.slice(a$3, -1, 1), /* array */[5]);
 
-eq("File \"bs_array_test.ml\", line 158, characters 5-12", Belt_Array.slice(a$2, -1, 2), /* array */[5]);
+eq("File \"bs_array_test.ml\", line 170, characters 5-12", Belt_Array.slice(a$3, -1, 2), /* array */[5]);
 
-eq("File \"bs_array_test.ml\", line 159, characters 5-12", Belt_Array.slice(a$2, -2, 1), /* array */[4]);
+eq("File \"bs_array_test.ml\", line 171, characters 5-12", Belt_Array.slice(a$3, -2, 1), /* array */[4]);
 
-eq("File \"bs_array_test.ml\", line 160, characters 5-12", Belt_Array.slice(a$2, -2, 2), /* array */[
+eq("File \"bs_array_test.ml\", line 172, characters 5-12", Belt_Array.slice(a$3, -2, 2), /* array */[
       4,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 161, characters 5-12", Belt_Array.slice(a$2, -2, 3), /* array */[
+eq("File \"bs_array_test.ml\", line 173, characters 5-12", Belt_Array.slice(a$3, -2, 3), /* array */[
       4,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 162, characters 5-12", Belt_Array.slice(a$2, -10, 3), /* array */[
+eq("File \"bs_array_test.ml\", line 174, characters 5-12", Belt_Array.slice(a$3, -10, 3), /* array */[
       1,
       2,
       3
     ]);
 
-eq("File \"bs_array_test.ml\", line 163, characters 5-12", Belt_Array.slice(a$2, -10, 4), /* array */[
+eq("File \"bs_array_test.ml\", line 175, characters 5-12", Belt_Array.slice(a$3, -10, 4), /* array */[
       1,
       2,
       3,
       4
     ]);
 
-eq("File \"bs_array_test.ml\", line 164, characters 5-12", Belt_Array.slice(a$2, -10, 5), /* array */[
+eq("File \"bs_array_test.ml\", line 176, characters 5-12", Belt_Array.slice(a$3, -10, 5), /* array */[
       1,
       2,
       3,
@@ -630,7 +674,7 @@ eq("File \"bs_array_test.ml\", line 164, characters 5-12", Belt_Array.slice(a$2,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 165, characters 5-12", Belt_Array.slice(a$2, -10, 6), /* array */[
+eq("File \"bs_array_test.ml\", line 177, characters 5-12", Belt_Array.slice(a$3, -10, 6), /* array */[
       1,
       2,
       3,
@@ -638,17 +682,17 @@ eq("File \"bs_array_test.ml\", line 165, characters 5-12", Belt_Array.slice(a$2,
       5
     ]);
 
-eq("File \"bs_array_test.ml\", line 166, characters 5-12", Belt_Array.slice(a$2, 0, 0), /* array */[]);
+eq("File \"bs_array_test.ml\", line 178, characters 5-12", Belt_Array.slice(a$3, 0, 0), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 167, characters 5-12", Belt_Array.slice(a$2, 0, -1), /* array */[]);
+eq("File \"bs_array_test.ml\", line 179, characters 5-12", Belt_Array.slice(a$3, 0, -1), /* array */[]);
 
-var a$3 = Belt_Array.makeBy(10, (function (x) {
+var a$4 = Belt_Array.makeBy(10, (function (x) {
         return x;
       }));
 
-Belt_Array.fill(a$3, 0, 3, 0);
+Belt_Array.fill(a$4, 0, 3, 0);
 
-eq("File \"bs_array_test.ml\", line 172, characters 6-13", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 184, characters 6-13", a$4.slice(0), /* array */[
       0,
       0,
       0,
@@ -661,9 +705,9 @@ eq("File \"bs_array_test.ml\", line 172, characters 6-13", a$3.slice(0), /* arra
       9
     ]);
 
-Belt_Array.fill(a$3, 2, 8, 1);
+Belt_Array.fill(a$4, 2, 8, 1);
 
-eq("File \"bs_array_test.ml\", line 174, characters 5-12", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 186, characters 5-12", a$4.slice(0), /* array */[
       0,
       0,
       1,
@@ -676,9 +720,9 @@ eq("File \"bs_array_test.ml\", line 174, characters 5-12", a$3.slice(0), /* arra
       1
     ]);
 
-Belt_Array.fill(a$3, 8, 1, 9);
+Belt_Array.fill(a$4, 8, 1, 9);
 
-eq("File \"bs_array_test.ml\", line 176, characters 5-12", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 188, characters 5-12", a$4.slice(0), /* array */[
       0,
       0,
       1,
@@ -691,9 +735,9 @@ eq("File \"bs_array_test.ml\", line 176, characters 5-12", a$3.slice(0), /* arra
       1
     ]);
 
-Belt_Array.fill(a$3, 8, 2, 9);
+Belt_Array.fill(a$4, 8, 2, 9);
 
-eq("File \"bs_array_test.ml\", line 178, characters 5-12", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 190, characters 5-12", a$4.slice(0), /* array */[
       0,
       0,
       1,
@@ -706,9 +750,9 @@ eq("File \"bs_array_test.ml\", line 178, characters 5-12", a$3.slice(0), /* arra
       9
     ]);
 
-Belt_Array.fill(a$3, 8, 3, 12);
+Belt_Array.fill(a$4, 8, 3, 12);
 
-eq("File \"bs_array_test.ml\", line 180, characters 5-12", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 192, characters 5-12", a$4.slice(0), /* array */[
       0,
       0,
       1,
@@ -721,9 +765,9 @@ eq("File \"bs_array_test.ml\", line 180, characters 5-12", a$3.slice(0), /* arra
       12
     ]);
 
-Belt_Array.fill(a$3, -2, 3, 11);
+Belt_Array.fill(a$4, -2, 3, 11);
 
-eq("File \"bs_array_test.ml\", line 182, characters 5-12", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 194, characters 5-12", a$4.slice(0), /* array */[
       0,
       0,
       1,
@@ -736,9 +780,9 @@ eq("File \"bs_array_test.ml\", line 182, characters 5-12", a$3.slice(0), /* arra
       11
     ]);
 
-Belt_Array.fill(a$3, -3, 3, 10);
+Belt_Array.fill(a$4, -3, 3, 10);
 
-eq("File \"bs_array_test.ml\", line 184, characters 5-12", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 196, characters 5-12", a$4.slice(0), /* array */[
       0,
       0,
       1,
@@ -751,9 +795,9 @@ eq("File \"bs_array_test.ml\", line 184, characters 5-12", a$3.slice(0), /* arra
       10
     ]);
 
-Belt_Array.fill(a$3, -3, 1, 7);
+Belt_Array.fill(a$4, -3, 1, 7);
 
-eq("File \"bs_array_test.ml\", line 186, characters 5-12", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 198, characters 5-12", a$4.slice(0), /* array */[
       0,
       0,
       1,
@@ -766,9 +810,9 @@ eq("File \"bs_array_test.ml\", line 186, characters 5-12", a$3.slice(0), /* arra
       10
     ]);
 
-Belt_Array.fill(a$3, -13, 1, 7);
+Belt_Array.fill(a$4, -13, 1, 7);
 
-eq("File \"bs_array_test.ml\", line 188, characters 5-12", a$3.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 200, characters 5-12", a$4.slice(0), /* array */[
       7,
       0,
       1,
@@ -781,13 +825,13 @@ eq("File \"bs_array_test.ml\", line 188, characters 5-12", a$3.slice(0), /* arra
       10
     ]);
 
-Belt_Array.fill(a$3, -13, 12, 7);
+Belt_Array.fill(a$4, -13, 12, 7);
 
-eq("File \"bs_array_test.ml\", line 190, characters 5-12", a$3.slice(0), Belt_Array.make(10, 7));
+eq("File \"bs_array_test.ml\", line 202, characters 5-12", a$4.slice(0), Belt_Array.make(10, 7));
 
-Belt_Array.fill(a$3, 0, -1, 2);
+Belt_Array.fill(a$4, 0, -1, 2);
 
-eq("File \"bs_array_test.ml\", line 192, characters 5-12", a$3.slice(0), Belt_Array.make(10, 7));
+eq("File \"bs_array_test.ml\", line 204, characters 5-12", a$4.slice(0), Belt_Array.make(10, 7));
 
 var b$1 = /* array */[
   1,
@@ -797,7 +841,7 @@ var b$1 = /* array */[
 
 Belt_Array.fill(b$1, 0, 0, 0);
 
-eq("File \"bs_array_test.ml\", line 195, characters 5-12", b$1, /* array */[
+eq("File \"bs_array_test.ml\", line 207, characters 5-12", b$1, /* array */[
       1,
       2,
       3
@@ -805,7 +849,7 @@ eq("File \"bs_array_test.ml\", line 195, characters 5-12", b$1, /* array */[
 
 Belt_Array.fill(b$1, 4, 1, 0);
 
-eq("File \"bs_array_test.ml\", line 197, characters 5-12", b$1, /* array */[
+eq("File \"bs_array_test.ml\", line 209, characters 5-12", b$1, /* array */[
       1,
       2,
       3
@@ -819,7 +863,7 @@ var b0 = Belt_Array.make(10, 3);
 
 Belt_Array.blit(a0, 1, b0, 2, 5);
 
-eq("File \"bs_array_test.ml\", line 203, characters 5-12", b0.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 215, characters 5-12", b0.slice(0), /* array */[
       3,
       3,
       1,
@@ -834,7 +878,7 @@ eq("File \"bs_array_test.ml\", line 203, characters 5-12", b0.slice(0), /* array
 
 Belt_Array.blit(a0, -1, b0, 2, 5);
 
-eq("File \"bs_array_test.ml\", line 206, characters 5-12", b0.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 218, characters 5-12", b0.slice(0), /* array */[
       3,
       3,
       9,
@@ -849,7 +893,7 @@ eq("File \"bs_array_test.ml\", line 206, characters 5-12", b0.slice(0), /* array
 
 Belt_Array.blit(a0, -1, b0, -2, 5);
 
-eq("File \"bs_array_test.ml\", line 209, characters 5-12", b0.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 221, characters 5-12", b0.slice(0), /* array */[
       3,
       3,
       9,
@@ -864,7 +908,7 @@ eq("File \"bs_array_test.ml\", line 209, characters 5-12", b0.slice(0), /* array
 
 Belt_Array.blit(a0, -2, b0, -2, 2);
 
-eq("File \"bs_array_test.ml\", line 212, characters 5-12", b0.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 224, characters 5-12", b0.slice(0), /* array */[
       3,
       3,
       9,
@@ -879,11 +923,11 @@ eq("File \"bs_array_test.ml\", line 212, characters 5-12", b0.slice(0), /* array
 
 Belt_Array.blit(a0, -11, b0, -11, 100);
 
-eq("File \"bs_array_test.ml\", line 215, characters 5-12", b0.slice(0), a0);
+eq("File \"bs_array_test.ml\", line 227, characters 5-12", b0.slice(0), a0);
 
 Belt_Array.blit(a0, -11, b0, -11, 2);
 
-eq("File \"bs_array_test.ml\", line 217, characters 5-12", b0.slice(0), a0);
+eq("File \"bs_array_test.ml\", line 229, characters 5-12", b0.slice(0), a0);
 
 var aa = Belt_Array.makeBy(10, (function (x) {
         return x;
@@ -891,7 +935,7 @@ var aa = Belt_Array.makeBy(10, (function (x) {
 
 Belt_Array.blit(aa, -1, aa, 1, 2);
 
-eq("File \"bs_array_test.ml\", line 220, characters 5-12", aa.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 232, characters 5-12", aa.slice(0), /* array */[
       0,
       9,
       2,
@@ -906,7 +950,7 @@ eq("File \"bs_array_test.ml\", line 220, characters 5-12", aa.slice(0), /* array
 
 Belt_Array.blit(aa, -2, aa, 1, 2);
 
-eq("File \"bs_array_test.ml\", line 222, characters 5-12", aa.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 234, characters 5-12", aa.slice(0), /* array */[
       0,
       8,
       9,
@@ -921,7 +965,7 @@ eq("File \"bs_array_test.ml\", line 222, characters 5-12", aa.slice(0), /* array
 
 Belt_Array.blit(aa, -5, aa, 4, 3);
 
-eq("File \"bs_array_test.ml\", line 224, characters 5-12", aa.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 236, characters 5-12", aa.slice(0), /* array */[
       0,
       8,
       9,
@@ -936,7 +980,7 @@ eq("File \"bs_array_test.ml\", line 224, characters 5-12", aa.slice(0), /* array
 
 Belt_Array.blit(aa, 4, aa, 5, 3);
 
-eq("File \"bs_array_test.ml\", line 226, characters 5-12", aa.slice(0), /* array */[
+eq("File \"bs_array_test.ml\", line 238, characters 5-12", aa.slice(0), /* array */[
       0,
       8,
       9,
@@ -949,9 +993,9 @@ eq("File \"bs_array_test.ml\", line 226, characters 5-12", aa.slice(0), /* array
       9
     ]);
 
-eq("File \"bs_array_test.ml\", line 227, characters 5-12", Belt_Array.make(0, 3), /* array */[]);
+eq("File \"bs_array_test.ml\", line 239, characters 5-12", Belt_Array.make(0, 3), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 228, characters 5-12", Belt_Array.make(-1, 3), /* array */[]);
+eq("File \"bs_array_test.ml\", line 240, characters 5-12", Belt_Array.make(-1, 3), /* array */[]);
 
 var c = /* array */[
   0,
@@ -961,13 +1005,13 @@ var c = /* array */[
 
 Belt_Array.blit(c, 4, c, 1, 1);
 
-eq("File \"bs_array_test.ml\", line 231, characters 5-12", c, /* array */[
+eq("File \"bs_array_test.ml\", line 243, characters 5-12", c, /* array */[
       0,
       1,
       2
     ]);
 
-eq("File \"bs_array_test.ml\", line 234, characters 5-12", Belt_Array.zip(/* array */[
+eq("File \"bs_array_test.ml\", line 246, characters 5-12", Belt_Array.zip(/* array */[
           1,
           2,
           3
@@ -991,7 +1035,7 @@ eq("File \"bs_array_test.ml\", line 234, characters 5-12", Belt_Array.zip(/* arr
       ]
     ]);
 
-eq("File \"bs_array_test.ml\", line 235, characters 5-12", Belt_Array.zip(/* array */[
+eq("File \"bs_array_test.ml\", line 247, characters 5-12", Belt_Array.zip(/* array */[
           2,
           3,
           4,
@@ -1015,7 +1059,7 @@ eq("File \"bs_array_test.ml\", line 235, characters 5-12", Belt_Array.zip(/* arr
       ]
     ]);
 
-eq("File \"bs_array_test.ml\", line 236, characters 5-12", Belt_Array.zipBy(/* array */[
+eq("File \"bs_array_test.ml\", line 248, characters 5-12", Belt_Array.zipBy(/* array */[
           2,
           3,
           4,
@@ -1032,7 +1076,7 @@ eq("File \"bs_array_test.ml\", line 236, characters 5-12", Belt_Array.zipBy(/* a
       1
     ]);
 
-eq("File \"bs_array_test.ml\", line 237, characters 5-12", Belt_Array.zipBy(/* array */[
+eq("File \"bs_array_test.ml\", line 249, characters 5-12", Belt_Array.zipBy(/* array */[
           1,
           2,
           3
@@ -1051,7 +1095,7 @@ eq("File \"bs_array_test.ml\", line 237, characters 5-12", Belt_Array.zipBy(/* a
             return -x | 0;
           })));
 
-eq("File \"bs_array_test.ml\", line 238, characters 5-12", Belt_Array.unzip(/* array */[
+eq("File \"bs_array_test.ml\", line 250, characters 5-12", Belt_Array.unzip(/* array */[
           /* tuple */[
             1,
             2
@@ -1086,7 +1130,7 @@ function sumUsingForEach(xs) {
   return v[0];
 }
 
-eq("File \"bs_array_test.ml\", line 248, characters 5-12", sumUsingForEach(/* array */[
+eq("File \"bs_array_test.ml\", line 260, characters 5-12", sumUsingForEach(/* array */[
           0,
           1,
           2,
@@ -1094,7 +1138,7 @@ eq("File \"bs_array_test.ml\", line 248, characters 5-12", sumUsingForEach(/* ar
           4
         ]), 10);
 
-b("File \"bs_array_test.ml\", line 249, characters 4-11", !Belt_Array.every(/* array */[
+b("File \"bs_array_test.ml\", line 261, characters 4-11", !Belt_Array.every(/* array */[
           0,
           1,
           2,
@@ -1104,7 +1148,7 @@ b("File \"bs_array_test.ml\", line 249, characters 4-11", !Belt_Array.every(/* a
             return x > 2;
           })));
 
-b("File \"bs_array_test.ml\", line 250, characters 4-11", Belt_Array.some(/* array */[
+b("File \"bs_array_test.ml\", line 262, characters 4-11", Belt_Array.some(/* array */[
           1,
           3,
           7,
@@ -1113,7 +1157,7 @@ b("File \"bs_array_test.ml\", line 250, characters 4-11", Belt_Array.some(/* arr
             return x % 2 === 0;
           })));
 
-b("File \"bs_array_test.ml\", line 251, characters 4-11", !Belt_Array.some(/* array */[
+b("File \"bs_array_test.ml\", line 263, characters 4-11", !Belt_Array.some(/* array */[
           1,
           3,
           7
@@ -1121,14 +1165,14 @@ b("File \"bs_array_test.ml\", line 251, characters 4-11", !Belt_Array.some(/* ar
             return x % 2 === 0;
           })));
 
-b("File \"bs_array_test.ml\", line 252, characters 4-11", !Belt_Array.eq(/* array */[
+b("File \"bs_array_test.ml\", line 264, characters 4-11", !Belt_Array.eq(/* array */[
           0,
           1
         ], /* array */[1], Caml_obj.caml_equal));
 
 var c$1 = [0];
 
-b("File \"bs_array_test.ml\", line 253, characters 4-11", (Belt_Array.forEachWithIndex(/* array */[
+b("File \"bs_array_test.ml\", line 265, characters 4-11", (Belt_Array.forEachWithIndex(/* array */[
             1,
             1,
             1
@@ -1139,25 +1183,25 @@ b("File \"bs_array_test.ml\", line 253, characters 4-11", (Belt_Array.forEachWit
 
 function id$1(_, x) {
   var u = x.slice(0);
-  return eq("File \"bs_array_test.ml\", line 263, characters 5-12", Belt_Array.reverse(x), (Belt_Array.reverseInPlace(u), u));
+  return eq("File \"bs_array_test.ml\", line 275, characters 5-12", Belt_Array.reverse(x), (Belt_Array.reverseInPlace(u), u));
 }
 
-id$1("File \"bs_array_test.ml\", line 268, characters 5-12", /* array */[]);
+id$1("File \"bs_array_test.ml\", line 280, characters 5-12", /* array */[]);
 
-id$1("File \"bs_array_test.ml\", line 269, characters 5-12", /* array */[1]);
+id$1("File \"bs_array_test.ml\", line 281, characters 5-12", /* array */[1]);
 
-id$1("File \"bs_array_test.ml\", line 270, characters 5-12", /* array */[
+id$1("File \"bs_array_test.ml\", line 282, characters 5-12", /* array */[
       1,
       2
     ]);
 
-id$1("File \"bs_array_test.ml\", line 271, characters 5-12", /* array */[
+id$1("File \"bs_array_test.ml\", line 283, characters 5-12", /* array */[
       1,
       2,
       3
     ]);
 
-id$1("File \"bs_array_test.ml\", line 272, characters 5-12", /* array */[
+id$1("File \"bs_array_test.ml\", line 284, characters 5-12", /* array */[
       1,
       2,
       3,
@@ -1180,14 +1224,14 @@ function some2(xs, ys) {
     });
 }
 
-eq("File \"bs_array_test.ml\", line 282, characters 5-12", every2(/* [] */0, /* :: */[
+eq("File \"bs_array_test.ml\", line 294, characters 5-12", every2(/* [] */0, /* :: */[
             1,
             /* [] */0
           ])((function (x, y) {
             return x > y;
           })), true);
 
-eq("File \"bs_array_test.ml\", line 283, characters 5-12", every2(/* :: */[
+eq("File \"bs_array_test.ml\", line 295, characters 5-12", every2(/* :: */[
             2,
             /* :: */[
               3,
@@ -1200,7 +1244,7 @@ eq("File \"bs_array_test.ml\", line 283, characters 5-12", every2(/* :: */[
             return x > y;
           })), true);
 
-eq("File \"bs_array_test.ml\", line 284, characters 5-12", every2(/* :: */[
+eq("File \"bs_array_test.ml\", line 296, characters 5-12", every2(/* :: */[
             2,
             /* [] */0
           ], /* :: */[
@@ -1210,7 +1254,7 @@ eq("File \"bs_array_test.ml\", line 284, characters 5-12", every2(/* :: */[
             return x > y;
           })), true);
 
-eq("File \"bs_array_test.ml\", line 285, characters 5-12", every2(/* :: */[
+eq("File \"bs_array_test.ml\", line 297, characters 5-12", every2(/* :: */[
             2,
             /* :: */[
               3,
@@ -1226,7 +1270,7 @@ eq("File \"bs_array_test.ml\", line 285, characters 5-12", every2(/* :: */[
             return x > y;
           })), false);
 
-eq("File \"bs_array_test.ml\", line 286, characters 5-12", every2(/* :: */[
+eq("File \"bs_array_test.ml\", line 298, characters 5-12", every2(/* :: */[
             2,
             /* :: */[
               3,
@@ -1242,14 +1286,14 @@ eq("File \"bs_array_test.ml\", line 286, characters 5-12", every2(/* :: */[
             return x > y;
           })), true);
 
-eq("File \"bs_array_test.ml\", line 287, characters 5-12", some2(/* [] */0, /* :: */[
+eq("File \"bs_array_test.ml\", line 299, characters 5-12", some2(/* [] */0, /* :: */[
             1,
             /* [] */0
           ])((function (x, y) {
             return x > y;
           })), false);
 
-eq("File \"bs_array_test.ml\", line 288, characters 5-12", some2(/* :: */[
+eq("File \"bs_array_test.ml\", line 300, characters 5-12", some2(/* :: */[
             2,
             /* :: */[
               3,
@@ -1262,7 +1306,7 @@ eq("File \"bs_array_test.ml\", line 288, characters 5-12", some2(/* :: */[
             return x > y;
           })), true);
 
-eq("File \"bs_array_test.ml\", line 289, characters 5-12", some2(/* :: */[
+eq("File \"bs_array_test.ml\", line 301, characters 5-12", some2(/* :: */[
             2,
             /* :: */[
               3,
@@ -1278,7 +1322,7 @@ eq("File \"bs_array_test.ml\", line 289, characters 5-12", some2(/* :: */[
             return x > y;
           })), true);
 
-eq("File \"bs_array_test.ml\", line 290, characters 5-12", some2(/* :: */[
+eq("File \"bs_array_test.ml\", line 302, characters 5-12", some2(/* :: */[
             0,
             /* :: */[
               3,
@@ -1294,7 +1338,7 @@ eq("File \"bs_array_test.ml\", line 290, characters 5-12", some2(/* :: */[
             return x > y;
           })), false);
 
-eq("File \"bs_array_test.ml\", line 291, characters 5-12", some2(/* :: */[
+eq("File \"bs_array_test.ml\", line 303, characters 5-12", some2(/* :: */[
             0,
             /* :: */[
               3,
@@ -1310,7 +1354,7 @@ eq("File \"bs_array_test.ml\", line 291, characters 5-12", some2(/* :: */[
             return x > y;
           })), true);
 
-eq("File \"bs_array_test.ml\", line 296, characters 5-12", Belt_Array.concat(/* array */[], /* array */[
+eq("File \"bs_array_test.ml\", line 308, characters 5-12", Belt_Array.concat(/* array */[], /* array */[
           1,
           2,
           3
@@ -1320,9 +1364,9 @@ eq("File \"bs_array_test.ml\", line 296, characters 5-12", Belt_Array.concat(/* 
       3
     ]);
 
-eq("File \"bs_array_test.ml\", line 297, characters 5-12", Belt_Array.concat(/* array */[], /* array */[]), /* array */[]);
+eq("File \"bs_array_test.ml\", line 309, characters 5-12", Belt_Array.concat(/* array */[], /* array */[]), /* array */[]);
 
-eq("File \"bs_array_test.ml\", line 298, characters 5-12", Belt_Array.concat(/* array */[
+eq("File \"bs_array_test.ml\", line 310, characters 5-12", Belt_Array.concat(/* array */[
           3,
           2
         ], /* array */[
@@ -1337,7 +1381,7 @@ eq("File \"bs_array_test.ml\", line 298, characters 5-12", Belt_Array.concat(/* 
       3
     ]);
 
-eq("File \"bs_array_test.ml\", line 299, characters 5-12", Belt_Array.concatMany(/* array */[
+eq("File \"bs_array_test.ml\", line 311, characters 5-12", Belt_Array.concatMany(/* array */[
           /* array */[
             3,
             2
@@ -1355,7 +1399,7 @@ eq("File \"bs_array_test.ml\", line 299, characters 5-12", Belt_Array.concatMany
       3
     ]);
 
-eq("File \"bs_array_test.ml\", line 300, characters 5-12", Belt_Array.concatMany(/* array */[
+eq("File \"bs_array_test.ml\", line 312, characters 5-12", Belt_Array.concatMany(/* array */[
           /* array */[
             3,
             2
@@ -1376,7 +1420,7 @@ eq("File \"bs_array_test.ml\", line 300, characters 5-12", Belt_Array.concatMany
       0
     ]);
 
-eq("File \"bs_array_test.ml\", line 301, characters 5-12", Belt_Array.concatMany(/* array */[
+eq("File \"bs_array_test.ml\", line 313, characters 5-12", Belt_Array.concatMany(/* array */[
           /* array */[],
           /* array */[
             3,
@@ -1398,12 +1442,12 @@ eq("File \"bs_array_test.ml\", line 301, characters 5-12", Belt_Array.concatMany
       0
     ]);
 
-eq("File \"bs_array_test.ml\", line 302, characters 5-12", Belt_Array.concatMany(/* array */[
+eq("File \"bs_array_test.ml\", line 314, characters 5-12", Belt_Array.concatMany(/* array */[
           /* array */[],
           /* array */[]
         ]), /* array */[]);
 
-b("File \"bs_array_test.ml\", line 305, characters 4-11", Belt_Array.cmp(/* array */[
+b("File \"bs_array_test.ml\", line 317, characters 4-11", Belt_Array.cmp(/* array */[
           1,
           2,
           3
@@ -1414,7 +1458,7 @@ b("File \"bs_array_test.ml\", line 305, characters 4-11", Belt_Array.cmp(/* arra
           3
         ], Caml_obj.caml_compare) < 0);
 
-b("File \"bs_array_test.ml\", line 306, characters 4-11", Belt_Array.cmp(/* array */[
+b("File \"bs_array_test.ml\", line 318, characters 4-11", Belt_Array.cmp(/* array */[
           0,
           1,
           2,
@@ -1425,7 +1469,7 @@ b("File \"bs_array_test.ml\", line 306, characters 4-11", Belt_Array.cmp(/* arra
           3
         ], Caml_obj.caml_compare) > 0);
 
-b("File \"bs_array_test.ml\", line 307, characters 4-11", Belt_Array.cmp(/* array */[
+b("File \"bs_array_test.ml\", line 319, characters 4-11", Belt_Array.cmp(/* array */[
           1,
           2,
           3
@@ -1435,7 +1479,7 @@ b("File \"bs_array_test.ml\", line 307, characters 4-11", Belt_Array.cmp(/* arra
           2
         ], Caml_primitive.caml_int_compare) > 0);
 
-b("File \"bs_array_test.ml\", line 308, characters 4-11", Belt_Array.cmp(/* array */[
+b("File \"bs_array_test.ml\", line 320, characters 4-11", Belt_Array.cmp(/* array */[
           1,
           2,
           3
@@ -1445,7 +1489,7 @@ b("File \"bs_array_test.ml\", line 308, characters 4-11", Belt_Array.cmp(/* arra
           3
         ], Caml_primitive.caml_int_compare) === 0);
 
-b("File \"bs_array_test.ml\", line 309, characters 4-11", Belt_Array.cmp(/* array */[
+b("File \"bs_array_test.ml\", line 321, characters 4-11", Belt_Array.cmp(/* array */[
           1,
           2,
           4
@@ -1455,7 +1499,7 @@ b("File \"bs_array_test.ml\", line 309, characters 4-11", Belt_Array.cmp(/* arra
           3
         ], Caml_primitive.caml_int_compare) > 0);
 
-Mt.from_pair_suites("File \"bs_array_test.ml\", line 312, characters 23-30", suites[0]);
+Mt.from_pair_suites("File \"bs_array_test.ml\", line 324, characters 23-30", suites[0]);
 
 var A = 0;
 

--- a/jscomp/test/bs_array_test.ml
+++ b/jscomp/test/bs_array_test.ml
@@ -149,13 +149,13 @@ let () =
 
 let () =
   let a = [|1;2;3;4;5|] in
-  let (v0, v1) = A.partition (fun x -> x mod 2 = 0) a in
+  let (v0, v1) = A.partition a (fun x -> x mod 2 = 0) in
   eq __LOC__ v0 [|2;4|];
   eq __LOC__ v1 [|1;3;5|];
-  let (v0, v1) = A.partition (fun x -> x = 2) a in
+  let (v0, v1) = A.partition a (fun x -> x = 2) in
   eq __LOC__ v0 [|2|];
   eq __LOC__ v1 [|1;3;4;5|];
-  let (v0, v1) = A.partition (fun x -> false) [||] in
+  let (v0, v1) = A.partition [||] (fun x -> false)  in
   eq __LOC__ v0 [||];
   eq __LOC__ v1 [||]
 

--- a/jscomp/test/bs_array_test.ml
+++ b/jscomp/test/bs_array_test.ml
@@ -149,6 +149,18 @@ let () =
 
 let () =
   let a = [|1;2;3;4;5|] in
+  let (v0, v1) = A.partition (fun x -> x mod 2 = 0) a in
+  eq __LOC__ v0 [|2;4|];
+  eq __LOC__ v1 [|1;3;5|];
+  let (v0, v1) = A.partition (fun x -> x = 2) a in
+  eq __LOC__ v0 [|2|];
+  eq __LOC__ v1 [|1;3;4;5|];
+  let (v0, v1) = A.partition (fun x -> false) [||] in
+  eq __LOC__ v0 [||];
+  eq __LOC__ v1 [||]
+
+let () =
+  let a = [|1;2;3;4;5|] in
   eq __LOC__ (A.slice a ~offset:0 ~len:2) [|1;2|];
   eq __LOC__ (A.slice a ~offset:0 ~len:5) [|1;2;3;4;5|];
   eq __LOC__ (A.slice a ~offset:0 ~len:15) [|1;2;3;4;5|];

--- a/lib/js/belt_Array.js
+++ b/lib/js/belt_Array.js
@@ -541,6 +541,30 @@ function cmp(a, b, p) {
   return cmpU(a, b, Curry.__2(p));
 }
 
+function partition(f, a) {
+  var l = a.length;
+  var i = 0;
+  var j = 0;
+  var a1 = new Array(l);
+  var a2 = new Array(l);
+  for(var ii = 0 ,ii_finish = l - 1 | 0; ii <= ii_finish; ++ii){
+    var v = a[ii];
+    if (Curry._1(f, v)) {
+      a1[i] = v;
+      i = i + 1 | 0;
+    } else {
+      a2[j] = v;
+      j = j + 1 | 0;
+    }
+  }
+  var a1$1 = slice(a1, 0, i);
+  var a2$1 = slice(a2, 0, j);
+  return /* tuple */[
+          a1$1,
+          a2$1
+        ];
+}
+
 function unzip(a) {
   var l = a.length;
   var a1 = new Array(l);
@@ -593,6 +617,7 @@ exports.forEachWithIndexU = forEachWithIndexU;
 exports.forEachWithIndex = forEachWithIndex;
 exports.mapWithIndexU = mapWithIndexU;
 exports.mapWithIndex = mapWithIndex;
+exports.partition = partition;
 exports.reduceU = reduceU;
 exports.reduce = reduce;
 exports.reduceReverseU = reduceReverseU;

--- a/lib/js/belt_Array.js
+++ b/lib/js/belt_Array.js
@@ -14,7 +14,7 @@ function get(arr, i) {
 
 function getExn(arr, i) {
   if (!(i >= 0 && i < arr.length)) {
-    throw new Error("File \"belt_Array.ml\", line 25, characters 6-12");
+    throw new Error("File \"belt_Array.ml\", line 24, characters 4-10");
   }
   return arr[i];
 }
@@ -30,7 +30,7 @@ function set(arr, i, v) {
 
 function setExn(arr, i, v) {
   if (!(i >= 0 && i < arr.length)) {
-    throw new Error("File \"belt_Array.ml\", line 31, characters 4-10");
+    throw new Error("File \"belt_Array.ml\", line 29, characters 24-30");
   }
   arr[i] = v;
   return /* () */0;
@@ -541,7 +541,7 @@ function cmp(a, b, p) {
   return cmpU(a, b, Curry.__2(p));
 }
 
-function partition(f, a) {
+function partitionU(a, f) {
   var l = a.length;
   var i = 0;
   var j = 0;
@@ -549,7 +549,7 @@ function partition(f, a) {
   var a2 = new Array(l);
   for(var ii = 0 ,ii_finish = l - 1 | 0; ii <= ii_finish; ++ii){
     var v = a[ii];
-    if (Curry._1(f, v)) {
+    if (f(v)) {
       a1[i] = v;
       i = i + 1 | 0;
     } else {
@@ -563,6 +563,10 @@ function partition(f, a) {
           a1$1,
           a2$1
         ];
+}
+
+function partition(a, f) {
+  return partitionU(a, Curry.__1(f));
 }
 
 function unzip(a) {
@@ -617,6 +621,7 @@ exports.forEachWithIndexU = forEachWithIndexU;
 exports.forEachWithIndex = forEachWithIndex;
 exports.mapWithIndexU = mapWithIndexU;
 exports.mapWithIndex = mapWithIndex;
+exports.partitionU = partitionU;
 exports.partition = partition;
 exports.reduceU = reduceU;
 exports.reduce = reduce;

--- a/lib/js/belt_Array.js
+++ b/lib/js/belt_Array.js
@@ -557,11 +557,11 @@ function partitionU(a, f) {
       j = j + 1 | 0;
     }
   }
-  var a1$1 = slice(a1, 0, i);
-  var a2$1 = slice(a2, 0, j);
+  a1.length = i;
+  a2.length = j;
   return /* tuple */[
-          a1$1,
-          a2$1
+          a1,
+          a2
         ];
 }
 


### PR DESCRIPTION
This intends to fix #2753.

I've tried do to an implementation of `Array.partition` using the same style as the existing file (with unsafe set/get and refs). I tried multiple solutions for implementing `partition`, trying to make it efficient in space and time (insert tardis joke), but I didn't see a way of reducing it.

I've seen some other implementations as well, and they all do it in like 3-4 loops. So as far as I can think, this is as good as it gets? If anyone has any ideas, please let me know and I'll try to fix them.

Also please let me know if there is anything I can change with this PR.