### PR TITLE
Support large numbers in Js.Json.t with a numeric string type

### DIFF
--- a/jscomp/others/js_json.ml
+++ b/jscomp/others/js_json.ml
@@ -28,7 +28,8 @@ type t
 
 type _ kind = 
   | String : Js_string.t kind
-  | Number : float kind 
+  | Number : float kind
+  | NumberString : string kind
   | Object : t Js_dict.t kind 
   | Array : t array kind 
   | Boolean : bool kind


### PR DESCRIPTION
This isn't complete yet, but I would like to get a conversation started before trying to make too many changes.

BuckleScript supports `Int64` by splitting it into an array of two 32 bit integers `[high,low]`, you can represent this in `Js.Json.t` by either converting into a string `Int64.to_string` or you could even maintain the `[high,low]` structure in JSON. These two approaches work fine assuming you are programming against an API you have control over. However you still have to come up with a way to move these representations to whatever matches the back end programming language. Also if you want to suppport a BigInt type in BuckleScript, then you might have to come up with a different way of serializing it to JSON. It would be nice if the output of `Js.Json.stringify` would treat `Int64` as a number literal, that way we don't have to do extra work on the back end and can also match expectations of existing APIs. 

With the current `Js.Json.t`, you can safely decode a number literal to a JSON using the following function. This forces the number literal into a string, then it allows `Int64` to safely process it without losing precision.

```
let int64 json = 
  match string (Js.Json.string (Js.Json.stringify json)) with
  | s -> Int64.of_string s
  | exception DecodeError _ -> raise @@ DecodeError ("Expected int64, got " ^ Js.Json.stringify json)
```

However, we can't do the reverse. We don't have a way to encode it back to a number literal. You can either treat it as a `String`, but it will be a string literal in the JSON, or if you treat it as `Number` but you lose precision.

The proposal would be to either add a type `NumberString: string kind`, or change `Number` in `Js.Json.t` to be of type `string`. It would require updating some of the functions in Js.Json to handle the special case where the number is stored as a string and then stringify it as a number literal, but I think this is a nice solution that would improve numeric support in BuckleScript, help connect it to existing servers, and prevent the developers from coming up withsolutions on the backend to decode ad-hoc serializations of `Int64` and other large number types.