### PR TITLE
Correct Belt.html typo

### DIFF
--- a/docs/api/Belt.html
+++ b/docs/api/Belt.html
@@ -209,7 +209,7 @@
 
     Currently, both <i>Belt_Set</i> and <i>Belt.Set</i> are accessible to users for some
     technical reasons,
-    we <b>strongly recommend</b> users stick to qualified import, <i>Belt.Sort</i>, we may hide
+    we <b>strongly recommend</b> users stick to qualified import, <i>Belt.Set</i>, we may hide
     the internal, <i>i.e</i>, <i>Belt_Set</i> in the future<br>
  
                     </div>


### PR DESCRIPTION
Consistently refer to `Belt.Set` as an example of a qualified import, instead of mentioning `Belt.Sort`, which was probably a typo.

Adds a final newline when using the github editor. Think it might be useful to leave that if that's what the editor does.