### PR TITLE
Update Storage bindings to be fastpipe compatible

### DIFF
--- a/jscomp/others/dom_storage.mli
+++ b/jscomp/others/dom_storage.mli
@@ -1,11 +1,11 @@
 type t
 
-external getItem : string -> string option = "" [@@bs.send.pipe: t] [@@bs.return null_to_opt]
-external setItem : string -> string -> unit = "" [@@bs.send.pipe: t]
-external removeItem : string -> unit = "" [@@bs.send.pipe: t]
-external clear : unit = "" [@@bs.send.pipe: t]
-external key : int -> string option = "" [@@bs.send.pipe: t] [@@bs.return null_to_opt]
-external length : t -> int = "" [@@bs.get]
+external getItem : t -> string -> string option = "" [@@bs.send ][@@bs.return null_to_opt]
+external setItem : t -> string -> string -> unit = "" [@@bs.send ]
+external removeItem : t -> string -> unit = "" [@@bs.send ]
+external clear : t -> unit = "" [@@bs.send ]
+external key : t -> int -> string option = "" [@@bs.send ][@@bs.return null_to_opt]
+external length : t -> int = "" [@@bs.send ]
 
 external localStorage : t = "" [@@bs.val]
 external sessionStorage : t = "" [@@bs.val]


### PR DESCRIPTION
Puts the `t` first and removes `bs.send.pipe`

I should probably update docs etc here as well