### PR TITLE
Use `npm prefix -g` command to figure out where node_modules exist

### DIFF
--- a/jscomp/install-bsb.sh
+++ b/jscomp/install-bsb.sh
@@ -2,4 +2,5 @@
 
 # dev small utils
 # hot replace global bsb.exe for quick testing
-cp ../lib/bsb ../lib/bsb.exe ../lib/bsb_helper.exe /usr/local/lib/node_modules/bs-platform/lib/
+npm_prefix=`npm prefix -g`
+cp ../lib/bsb ../lib/bsb.exe ../lib/bsb_helper.exe $npm_prefix/lib/node_modules/bs-platform/lib/

--- a/jscomp/install-bsc.sh
+++ b/jscomp/install-bsc.sh
@@ -2,4 +2,5 @@
 
 # dev small utils
 # hot replace global bsb.exe for quick testing
-cp ../lib/bsc.exe /usr/local/lib/node_modules/bs-platform/lib/
+npm_prefix=`npm prefix -g`
+cp ../lib/bsc.exe $npm_prefix/lib/node_modules/bs-platform/lib/


### PR DESCRIPTION
Global node_modules aren't always in the same place.  By using `npm prefix -g`, you can find out exactly where they are.