### PR TITLE
fix #2864

### DIFF
--- a/jscomp/runtime/.extradepend
+++ b/jscomp/runtime/.extradepend
@@ -1,0 +1,19 @@
+caml_array.cmj: caml_builtin_exceptions.cmj
+caml_backtrace.cmj: caml_builtin_exceptions.cmj
+caml_bytes.cmj: caml_builtin_exceptions.cmj
+caml_format.cmj: curry.cmj caml_int32.cmj caml_int64.cmj caml_utils.cmj caml_builtin_exceptions.cmj
+caml_hash.cmj: caml_queue.cmj caml_hash_primitive.cmj caml_builtin_exceptions.cmj
+caml_hash_primitive.cmj: caml_int32.cmj
+caml_int32.cmj: caml_builtin_exceptions.cmj
+caml_int64.cmj: caml_int32.cmj caml_utils.cmj caml_primitive.cmj caml_builtin_exceptions.cmj
+caml_io.cmj: curry.cmj caml_builtin_exceptions.cmj
+caml_lexer.cmj: caml_builtin_exceptions.cmj
+caml_module.cmj: caml_obj.cmj caml_builtin_exceptions.cmj
+caml_obj.cmj: block.cmj caml_primitive.cmj caml_builtin_exceptions.cmj
+caml_oo.cmj: caml_array.cmj caml_builtin_exceptions.cmj
+caml_oo_curry.cmj: curry.cmj caml_oo.cmj
+caml_string.cmj: caml_builtin_exceptions.cmj
+caml_sys.cmj: caml_builtin_exceptions.cmj
+caml_weak.cmj: caml_obj.cmj caml_array.cmj js_primitive.cmj
+curry.cmj: caml_array.cmj
+js_exn.cmj: caml_exceptions.cmj

--- a/jscomp/runtime/Makefile
+++ b/jscomp/runtime/Makefile
@@ -62,7 +62,7 @@ clean::
 	$(COMPILER) $(INCLUDES) $(COMPFLAGS)  -c $<
 .ml.cmj:
 	$(COMPILER) $(INCLUDES) $(COMPFLAGS)  -c $<
-
+-include .extradepend
 -include .depend
 
 ML_SOURCES=$(addsuffix .ml, $(OTHERS))

--- a/scripts/prebuilt.js
+++ b/scripts/prebuilt.js
@@ -89,5 +89,6 @@ function buildCompiler() {
 	})
 }
 
+require('./runtimeDeps.js').create()
 buildCompiler()
 

--- a/scripts/runtimeDeps.js
+++ b/scripts/runtimeDeps.js
@@ -1,0 +1,34 @@
+
+//@ts-check
+
+var fs = require('fs')
+var path = require('path')
+
+var runtimeDir = path.join(__dirname, '..', 'jscomp', 'runtime')
+var jsDir = path.join(__dirname, '..', 'lib', 'js')
+var files = fs.readdirSync(runtimeDir, 'utf8')
+var possibleJsFiles = [... new Set(files.filter(x => x.endsWith('.ml') || x.endsWith('.mli')).map(x => x.substr(0, x.indexOf('.'))))]
+
+// possibleJsFiles.map(x=>path.join(jsDir,x + ".js")).every(x=>fs.existsSync(x))
+
+function getDeps(text) {
+    var deps = []
+    text.replace(/(\/\*[\w\W]*?\*\/|\/\/[^\n]*|[.$]r)|\brequire\s*\(\s*["']([^"']*)["']\s*\)/g, function (_, ignore, id) {
+        if (!ignore) deps.push(id);
+    });
+    return deps;
+}
+
+
+function readDeps(name) {
+    var jsFile = path.join(jsDir, name + ".js")
+    var fileContent = fs.readFileSync(jsFile, 'utf8')
+    return getDeps(fileContent).map(x => path.parse(x).name)
+}
+
+function create() {
+    var deps = possibleJsFiles.filter(x => readDeps(x).length !== 0).map(x => `${x}.cmj: ${(readDeps(x).map(x => x + '.cmj')).join(' ')}`).reduce((x, y) => x + '\n' + y)
+    fs.writeFileSync(path.join(__dirname, '..', 'jscomp', 'runtime', '.extradepend'), deps, 'utf8')
+}
+
+exports.create = create


### PR DESCRIPTION
In general,  dependency between runtime modules has to be coded manually, 
tired of such things and bugged from time to time(only possible when parallel building), added
a script to generate such dependencies based on generated js file, it is a bootstrapping process..
cc @cristianoc  