### PR TITLE
prepare consistency check for running bsb and its underlying bs-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,11 @@
 # since in relese build, user may not have the sources available
 # -B is not necessary in CI, however, when dir is not clean..
 
-NPROCS := 1
+NPROCS := 8
 KERNEL := $(shell uname -s)
 
 ifeq ($(KERNEL),Linux)
   NPROCS := $(shell grep -c '^processor' /proc/cpuinfo)
-else ifeq ($(KERNEL),Darwin
-  NPROCS := $(shell system_profiler | awk '/Number Of CPUs/{print $4}{next;}')
 endif
 
 world:

--- a/jscomp/bsb/bsb_theme_init.ml
+++ b/jscomp/bsb/bsb_theme_init.ml
@@ -56,7 +56,7 @@ let run_npm_link cwd name  =
       let (//) = Filename.concat in
       let node_bin =  "node_modules" // ".bin" in
       Bsb_build_util.mkp node_bin;
-      let p = ".." // "bs-platform" // "lib" in
+      let p = ".." // Bs_version.package_name // "lib" in
       let link a =
         Unix.symlink (p//a) (node_bin // a) in
       link "bsb" ;
@@ -64,7 +64,7 @@ let run_npm_link cwd name  =
       link "bsrefmt";
       Unix.symlink
         (Filename.dirname (Filename.dirname Sys.executable_name))
-        (Filename.concat "node_modules" "bs-platform")
+        (Filename.concat "node_modules" Bs_version.package_name)
     end
 let enter_dir cwd x action =
   Unix.chdir x ;


### PR DESCRIPTION
```
Your running bsb (/Users/hongbozhang/git/ocamlscript/lib) instance has a different version from our 
                    resolved bs-platform(/Users/hongbozhang/git/xx/node_modules/bs-platform): 1.4.1 vs 3.2.0
```