### PR TITLE
[part one] unbox option

### DIFF
--- a/jscomp/bsb/bsb_templates.ml
+++ b/jscomp/bsb/bsb_templates.ml
@@ -1286,7 +1286,7 @@ let root = OCamlRes.Res.([
        ") ;
     File  ("bsconfig.json",
       "{\n\
-      \  \"name\": \"react-template\",\n\
+      \  \"name\": \"react-lite\",\n\
       \  \"reason\": {\n\
       \    \"react-jsx\": 2\n\
       \  },\n\

--- a/jscomp/bsb/templates/react-lite/bsconfig.json
+++ b/jscomp/bsb/templates/react-lite/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-template",
+  "name": "react-lite",
   "reason": {
     "react-jsx": 2
   },

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -898,6 +898,10 @@ let rec int_comp (cmp : Lambda.comparison) ?comment  (e0 : t) (e1 : t) =
               Var(Qualified (ident,Runtime, Some "caml_equal")) 
             } , args, call_info)}
   | Ceq, _, _ -> int_equal e0 e1 
+  (* FIXME: it should not be called [int_comp] *)
+  | Cneq, Caml_block _ ,  Number _ 
+  | Cneq, Number _, Caml_block _  
+    -> caml_true
   | _ ->          
     bin ?comment (Lam_compile_util.jsop_of_comp cmp) e0 e1
 


### PR DESCRIPTION
Note the optimization like this

```
x <> None
```

it needs to be undone or depends
but the name `intcomp` is really misleading

Note the case  `intcomp` in combination of nullary constructor is (marked with simplify_constant_constructor)
```
%notequal
%equal
%bs_equal_nullable
%bs_equal_undefined
%bs_equal_null
```

For those primitives above, once one operand is immediate, we can do an address comparison