### PR TITLE
keep type information for specialization

### DIFF
--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -490,6 +490,7 @@ ocaml_typedtree_test.cmj : ../stdlib/weak.cmj ../stdlib/sys.cmj \
 of_string_test.cmj : mt.cmj
 offset.cmj : ../stdlib/string.cmj ../stdlib/set.cmj
 oo_js_test_date.cmj : mt.cmj ../runtime/js.cmj
+option_repr_test.cmj :
 optional_ffi_test.cmj : mt.cmj
 pipe_send_readline.cmj : ../runtime/js.cmj
 pipe_syntax.cmj :

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -255,6 +255,7 @@ OTHERS := test_literals a test_ari test_export2 test_internalOO test_obj_simple_
 	gpr_2682_test\
 	record_debug_test\
 	gpr_2789_test\
+	option_repr_test\
 # bs_uncurry_test
 # needs Lam to get rid of Uncurry arity first
 # simple_derive_test

--- a/jscomp/test/option_repr_test.js
+++ b/jscomp/test/option_repr_test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+
+function f0(x) {
+  var match = x[1];
+  if (match && match[0]) {
+    return 1;
+  } else {
+    return 2;
+  }
+}
+
+function f1(u) {
+  if (u) {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+
+exports.f0 = f0;
+exports.f1 = f1;
+/* No side effect */

--- a/jscomp/test/option_repr_test.ml
+++ b/jscomp/test/option_repr_test.ml
@@ -1,0 +1,16 @@
+
+type 'a u = 'a option = 
+  private 
+   | None
+   | Some  of 'a
+
+let f0 x =
+   match x with 
+  | (_, (Some true)) -> 1 
+  | (_, _ ) -> 2 
+
+
+type x = A of int * int | None
+
+type x0 = Some of int | None
+let f1 u = match u with | A _ -> 0 | None -> 1

--- a/vendor/ocaml/bytecomp/lambda.ml
+++ b/vendor/ocaml/bytecomp/lambda.ml
@@ -39,7 +39,8 @@ type tag_info =
   | Blk_extension
   | Blk_na
   | Blk_some
-
+  | Blk_some_not_nested
+    
 let default_tag_info : tag_info = Blk_na
 
 type field_dbg_info = 

--- a/vendor/ocaml/bytecomp/lambda.mli
+++ b/vendor/ocaml/bytecomp/lambda.mli
@@ -41,6 +41,7 @@ type tag_info =
   | Blk_extension
   | Blk_na
   | Blk_some
+  | Blk_some_not_nested (* ['a option] where ['a] can not inhabit a non-like value *)
     
 val default_tag_info : tag_info
 

--- a/vendor/ocaml/bytecomp/translcore.ml
+++ b/vendor/ocaml/bytecomp/translcore.ml
@@ -947,9 +947,17 @@ and transl_exp0 e =
             | _ -> (Lambda.Pt_constructor cstr.cstr_name)
             ))
       | Cstr_block n ->
-          let tag_info =
+          let tag_info : Lambda.tag_info =
             if Datarepr.constructor_has_optional_shape cstr then
-              Lambda.Blk_some
+              begin 
+                match args with
+                | [arg] when  Datarepr.cannot_inhabit_none_like_value arg.exp_type 
+                  ->
+                    (* Format.fprintf Format.err_formatter "@[special boxingl@]@."; *)
+                    Blk_some_not_nested
+                | _ ->
+                    Blk_some
+              end
             else (Lambda.Blk_constructor (cstr.cstr_name, cstr.cstr_nonconsts)) in
           begin try
             Lconst(Const_block(n,tag_info, List.map extract_constant ll))

--- a/vendor/ocaml/typing/datarepr.ml
+++ b/vendor/ocaml/typing/datarepr.ml
@@ -48,6 +48,33 @@ let constructor_has_optional_shape ({cstr_attributes = attrs} : constructor_desc
   List.exists (fun (x,_) -> x.txt = internal_optional) attrs
 
 
+(**  [Types.constructor_description]
+     records the type at the definition type so for ['a option]
+     it will always be [Tvar]
+*)
+let cannot_inhabit_none_like_value (typ : Types.type_expr) =
+  match (Btype.repr typ).desc with
+  |  Tconstr(p, _,_) ->
+      (* all built in types could not inhabit none-like values:
+         int, char, float, bool, unit, exn, array, list, nativeint,
+         int32, int64, lazy_t, bytes
+      *)
+      if Predef.type_is_builtin_path_but_option p then true
+      else false (* TODO: refine *)
+  | Ttuple _
+  | Tvariant _
+  | Tpackage _ 
+  | Tarrow _ -> true
+  | Tfield _ 
+  | Tpoly _ 
+  | Tunivar _ 
+  | Tlink _ 
+  | Tsubst _
+  | Tnil 
+  | Tvar _
+  | Tobject _ 
+    -> false
+    
 let constructor_descrs ty_res cstrs priv =
   let num_consts = ref 0 and num_nonconsts = ref 0  and num_normal = ref 0 in
   List.iter

--- a/vendor/ocaml/typing/datarepr.mli
+++ b/vendor/ocaml/typing/datarepr.mli
@@ -18,7 +18,11 @@ open Types
 
 val constructor_has_optional_shape:
   Types.constructor_description -> bool
-  
+
+
+val cannot_inhabit_none_like_value:
+  Types.type_expr -> bool
+
 val constructor_descrs:
   type_expr -> constructor_declaration list ->
   private_flag -> (Ident.t * constructor_description) list

--- a/vendor/ocaml/typing/predef.ml
+++ b/vendor/ocaml/typing/predef.ml
@@ -26,6 +26,7 @@ let wrap create s =
 let ident_create = wrap Ident.create
 let ident_create_predef_exn = wrap Ident.create_predef_exn
 
+
 let ident_int = ident_create "int"
 and ident_char = ident_create "char"
 and ident_string = ident_create "string"
@@ -41,6 +42,15 @@ and ident_int32 = ident_create "int32"
 and ident_int64 = ident_create "int64"
 and ident_lazy_t = ident_create "lazy_t"
 and ident_bytes = ident_create "bytes"
+
+
+let type_is_builtin_path_but_option p =
+  match p with
+  | Pident {stamp} ->
+      stamp >= ident_int.stamp
+      && stamp  <= ident_bytes.stamp
+      && (stamp <> ident_option.stamp)
+  | _ -> false
 
 let path_int = Pident ident_int
 and path_char = Pident ident_char

--- a/vendor/ocaml/typing/predef.mli
+++ b/vendor/ocaml/typing/predef.mli
@@ -63,3 +63,6 @@ val build_initial_env:
 
 val builtin_values: (string * Ident.t) list
 val builtin_idents: (string * Ident.t) list
+
+
+val type_is_builtin_path_but_option : Path.t -> bool


### PR DESCRIPTION
Note we need handle cases like

```ocaml
match Js.Undefined.toOption x with 
| Some "xx" -> 0 
| Some _  -> 1
| None -> 0
```
In this case, string option destructuring is a no-op, but it can not be cancelled with boxing which means regression.

- we keep Psome_unnest only erase it later
- we promote `#undefined_to_opt` to `#undefined_to_unnest_opt` (may apply to null, nullable too)

TODO:

The if_then_else should be adapted:

```js
var s = $star$opt ? $startop : false
```
The code above is no longer correct
it should be adapted to code as below:

```js
var s = $star$opt === undefined? $startop : false
```
or
```js
var s = typeof $star$opt === "undefined" ? $star$opt : false 
```
