### PR TITLE
Fix bug in windows where path has colon in command line arg

### DIFF
--- a/jscomp/core/js_packages_info.ml
+++ b/jscomp/core/js_packages_info.ml
@@ -164,6 +164,10 @@ let add_npm_package_path s (packages_info : t)  : t =
            Ext_pervasives.bad_argf "invalid module system %s" module_system), path
       | [path] ->
         NodeJS, path
+      | module_system :: path -> 
+        (match module_system_of_string module_system with 
+        | Some x -> x
+        | None -> Ext_pervasives.bad_argf "invalid module system %s" module_system), (String.concat ":" path)
       | _ ->
         Ext_pervasives.bad_argf "invalid npm package path: %s" s
     in


### PR DESCRIPTION
It's possible to get commonjs:C:\msys32\... and then this dies. This adds support for having colons after the initial one.