### PR TITLE
fix polymoprhic comparison semantics

### DIFF
--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -176,12 +176,15 @@ let rec caml_compare (a : Obj.t) (b : Obj.t) : int =
   | "string", _ -> 
       (* [b] could be [Some None] or [null] *)
       1 
+  |  _, "string" -> -1  
   | "boolean", "boolean" ->       
       Pervasives.compare (Obj.magic a : bool) (Obj.magic b)
   | "boolean", _ -> 1     
+  | _, "boolean" -> -1
   | "function", "function" -> 
       raise (Invalid_argument "compare: functional value")
   | "function", _ -> 1
+  | _, "function" -> -1 
   | "number", "number" -> 
       Pervasives.compare (Obj.magic a : int) (Obj.magic b : int)
   | "number", _ ->        

--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -143,10 +143,6 @@ module O = struct
   external get_value : Obj.t -> key -> Obj.t = ""[@@bs.get_index]
 end
 
-let unsafe_js_compare x y =
-  if x == y then 0 else
-  if Js.unsafe_lt x y then -1
-  else 1
 (** TODO: investigate total
     [compare x y] returns [0] if [x] is equal to [y],
     a negative integer if [x] is less than [y],
@@ -167,32 +163,41 @@ let unsafe_js_compare x y =
 let rec caml_compare (a : Obj.t) (b : Obj.t) : int =
   if a == b then 0 else
   (*front and formoest, we do not compare function values*)
-  if a == (Obj.repr Js.undefined) then -1 else
-  if b == (Obj.repr Js.undefined) then 1 else
-  if a == (Obj.repr Js.null) then -1 else
-  if b == (Obj.repr Js.null) then 1 else
   let a_type = Js.typeof a in 
   let b_type = Js.typeof b in 
-  if a_type = "string" then
-    Pervasives.compare (Obj.magic a : string) (Obj.magic b )
-  else 
-    let is_a_number = a_type = "number" in 
-    let is_b_number = b_type = "number" in 
-    match is_a_number , is_b_number with 
-    | true, true -> 
+  match a_type, b_type with 
+  | "undefined", _ -> - 1
+  | _, "undefined" -> 1 
+  (** [a] is of type string, b can not be None,
+      [a] could be (Some (Some x)) in that case [b] could be [Some None] or [null]
+       so [b] has to be of type string or null *)       
+  | "string", "string" ->   
+      Pervasives.compare (Obj.magic a : string) (Obj.magic b )
+  | "string", _ -> 
+      (* [b] could be [Some None] or [null] *)
+      1 
+  | "boolean", "boolean" ->       
+      Pervasives.compare (Obj.magic a : bool) (Obj.magic b)
+  | "boolean", _ -> 1     
+  | "function", "function" -> 
+      raise (Invalid_argument "compare: functional value")
+  | "function", _ -> 1
+  | "number", "number" -> 
       Pervasives.compare (Obj.magic a : int) (Obj.magic b : int)
-    | true , false -> -1 (* Integer < Block in OCaml runtime GPR #1195 *)
-    | false, true -> 1 
-    | false, false -> 
-      if a_type = "boolean"
-      then (* TODO: refine semantics when comparing with [null] *)
-        unsafe_js_compare a b
-      else if a_type = "function" || b_type = "function"
-      then raise (Invalid_argument "compare: functional value")
-      else
-        (* if #is_instance_array a then  *)
-        (*   0 *)
-        (* else  *)
+  | "number", _ ->        
+      if b == Obj.repr Js.null || Bs_obj.tag b = 256 then 1 (* Some (Some ..) < x *)
+      else 
+        -1 (* Integer < Block in OCaml runtime GPR #1195, except Some.. *)
+  | _, "number" -> 
+      if a == Obj.repr Js.null || Bs_obj.tag a = 256 then -1
+      else 1
+  | _ ->        
+      if a == Obj.repr Js.null then 
+        (** [b] could not be null otherwise would equal *)
+        if Bs_obj.tag b = 256 then 1 else -1
+     else if b == Obj.repr Js.null then 
+        if Bs_obj.tag a = 256 then -1 else 1    
+     else    
         let tag_a = Bs_obj.tag a in
         let tag_b = Bs_obj.tag b in
         (* double_array_tag: 254
@@ -202,6 +207,14 @@ let rec caml_compare (a : Obj.t) (b : Obj.t) : int =
           caml_compare (Obj.field a 0) b
         else if tag_b = 250 then
           caml_compare a (Obj.field b 0)
+        else if tag_a = 256 then   
+          if tag_b = 256 then 
+            Pervasives.compare (Obj.magic (Obj.field a 1) : int)
+             (Obj.magic (Obj.field b 1) : int)
+            (* Some None < Some (Some None)) *)
+          else  (* b could not be undefined/None *)
+             (* Some None < Some ..*) 
+             -1 
         else if tag_a = 248 (* object/exception *)  then
           Pervasives.compare (Obj.magic @@ Obj.field a 1 : int) (Obj.magic @@ Obj.field b 1 )
         else if tag_a = 251 (* abstract_tag *) then
@@ -285,6 +298,7 @@ let rec caml_equal (a : Obj.t) (b : Obj.t) : bool =
       else (* a_type = "object" || "symbol" *)
       if b_type = "number" || b_type = "undefined" || b == Obj.magic Js_null.empty then false 
       else 
+        (* [a] [b] could not be null, so it can not raise *)
         let tag_a = Bs_obj.tag a in
         let tag_b = Bs_obj.tag b in
         (* double_array_tag: 254
@@ -300,7 +314,9 @@ let rec caml_equal (a : Obj.t) (b : Obj.t) : bool =
           raise (Invalid_argument "equal: abstract value")
         else if tag_a <> tag_b then
           false
-        else
+        else if tag_a = 256 then 
+          (Obj.magic (Obj.field a 1) : int) = Obj.magic (Obj.field b 1)
+        else 
           let len_a = Bs_obj.length a in
           let len_b = Bs_obj.length b in
           if len_a = len_b then

--- a/jscomp/runtime/js_primitive.ml
+++ b/jscomp/runtime/js_primitive.ml
@@ -26,10 +26,17 @@
 
 let some ( x : Obj.t) : Obj.t = 
   if Obj.magic x =  None then 
-    Obj.repr (undefinedHeader, 0)
+    (let block = Obj.repr (undefinedHeader, 0) in
+    Obj.set_tag block 256;
+    block)
   else 
     if x != Obj.repr Js.null && fst (Obj.magic x ) == Obj.repr undefinedHeader then   
-      Obj.repr (undefinedHeader, snd (Obj.magic x) + 1)
+      (
+      let nid =   snd (Obj.magic x) + 1 in 
+      let block = Obj.repr (undefinedHeader, nid) in 
+       Obj.set_tag block 256;        
+       block
+      )
     else  x 
 
 let nullable_to_opt (type t) ( x : t Js.null_undefined) : t option = 

--- a/jscomp/test/caml_compare_test.js
+++ b/jscomp/test/caml_compare_test.js
@@ -276,62 +276,14 @@ var suites_001 = /* :: */[
                           (function () {
                               return /* Eq */Block.__(0, [
                                         true,
-                                        Caml_obj.caml_greaterthan(/* :: */[
-                                              2,
-                                              /* :: */[
-                                                6,
-                                                /* :: */[
-                                                  1,
-                                                  /* :: */[
-                                                    1,
-                                                    /* :: */[
-                                                      2,
-                                                      /* :: */[
-                                                        1,
-                                                        /* :: */[
-                                                          4,
-                                                          /* :: */[
-                                                            2,
-                                                            /* :: */[
-                                                              1,
-                                                              /* :: */[
-                                                                409,
-                                                                /* [] */0
-                                                              ]
-                                                            ]
-                                                          ]
-                                                        ]
-                                                      ]
-                                                    ]
-                                                  ]
-                                                ]
-                                              ]
+                                        Caml_obj.caml_lessthan(/* :: */[
+                                              1,
+                                              /* [] */0
                                             ], /* :: */[
-                                              2,
+                                              1,
                                               /* :: */[
-                                                6,
-                                                /* :: */[
-                                                  1,
-                                                  /* :: */[
-                                                    1,
-                                                    /* :: */[
-                                                      2,
-                                                      /* :: */[
-                                                        1,
-                                                        /* :: */[
-                                                          4,
-                                                          /* :: */[
-                                                            2,
-                                                            /* :: */[
-                                                              1,
-                                                              /* [] */0
-                                                            ]
-                                                          ]
-                                                        ]
-                                                      ]
-                                                    ]
-                                                  ]
-                                                ]
+                                                409,
+                                                /* [] */0
                                               ]
                                             ])
                                       ]);
@@ -339,48 +291,43 @@ var suites_001 = /* :: */[
                         ],
                         /* :: */[
                           /* tuple */[
-                            "File \"caml_compare_test.ml\", line 41, characters 4-11",
+                            "File \"caml_compare_test.ml\", line 40, characters 4-11",
                             (function () {
                                 return /* Eq */Block.__(0, [
-                                          false,
-                                          false
+                                          true,
+                                          Caml_obj.caml_lessthan(/* [] */0, /* :: */[
+                                                409,
+                                                /* [] */0
+                                              ])
                                         ]);
                               })
                           ],
                           /* :: */[
                             /* tuple */[
-                              "File \"caml_compare_test.ml\", line 44, characters 4-11",
+                              "File \"caml_compare_test.ml\", line 43, characters 4-11",
                               (function () {
                                   return /* Eq */Block.__(0, [
-                                            false,
-                                            false
-                                          ]);
-                                })
-                            ],
-                            /* :: */[
-                              /* tuple */[
-                                "File \"caml_compare_test.ml\", line 47, characters 4-11",
-                                (function () {
-                                    return /* Eq */Block.__(0, [
-                                              false,
-                                              Caml_obj.caml_equal(/* :: */[
-                                                    2,
+                                            true,
+                                            Caml_obj.caml_greaterthan(/* :: */[
+                                                  2,
+                                                  /* :: */[
+                                                    6,
                                                     /* :: */[
-                                                      6,
+                                                      1,
                                                       /* :: */[
                                                         1,
                                                         /* :: */[
-                                                          1,
+                                                          2,
                                                           /* :: */[
-                                                            2,
+                                                            1,
                                                             /* :: */[
-                                                              1,
+                                                              4,
                                                               /* :: */[
-                                                                4,
+                                                                2,
                                                                 /* :: */[
-                                                                  2,
+                                                                  1,
                                                                   /* :: */[
-                                                                    1,
+                                                                    409,
                                                                     /* [] */0
                                                                   ]
                                                                 ]
@@ -390,29 +337,26 @@ var suites_001 = /* :: */[
                                                         ]
                                                       ]
                                                     ]
-                                                  ], /* :: */[
-                                                    2,
+                                                  ]
+                                                ], /* :: */[
+                                                  2,
+                                                  /* :: */[
+                                                    6,
                                                     /* :: */[
-                                                      6,
+                                                      1,
                                                       /* :: */[
                                                         1,
                                                         /* :: */[
-                                                          1,
+                                                          2,
                                                           /* :: */[
-                                                            2,
+                                                            1,
                                                             /* :: */[
-                                                              1,
+                                                              4,
                                                               /* :: */[
-                                                                4,
+                                                                2,
                                                                 /* :: */[
-                                                                  2,
-                                                                  /* :: */[
-                                                                    1,
-                                                                    /* :: */[
-                                                                      409,
-                                                                      /* [] */0
-                                                                    ]
-                                                                  ]
+                                                                  1,
+                                                                  /* [] */0
                                                                 ]
                                                               ]
                                                             ]
@@ -420,7 +364,18 @@ var suites_001 = /* :: */[
                                                         ]
                                                       ]
                                                     ]
-                                                  ])
+                                                  ]
+                                                ])
+                                          ]);
+                                })
+                            ],
+                            /* :: */[
+                              /* tuple */[
+                                "File \"caml_compare_test.ml\", line 47, characters 4-11",
+                                (function () {
+                                    return /* Eq */Block.__(0, [
+                                              false,
+                                              false
                                             ]);
                                   })
                               ],
@@ -430,26 +385,34 @@ var suites_001 = /* :: */[
                                   (function () {
                                       return /* Eq */Block.__(0, [
                                                 false,
-                                                Caml_obj.caml_equal(/* :: */[
-                                                      2,
-                                                      /* :: */[
-                                                        6,
+                                                false
+                                              ]);
+                                    })
+                                ],
+                                /* :: */[
+                                  /* tuple */[
+                                    "File \"caml_compare_test.ml\", line 53, characters 4-11",
+                                    (function () {
+                                        return /* Eq */Block.__(0, [
+                                                  false,
+                                                  Caml_obj.caml_equal(/* :: */[
+                                                        2,
                                                         /* :: */[
-                                                          1,
+                                                          6,
                                                           /* :: */[
                                                             1,
                                                             /* :: */[
-                                                              2,
+                                                              1,
                                                               /* :: */[
-                                                                1,
+                                                                2,
                                                                 /* :: */[
-                                                                  4,
+                                                                  1,
                                                                   /* :: */[
-                                                                    2,
+                                                                    4,
                                                                     /* :: */[
-                                                                      1,
+                                                                      2,
                                                                       /* :: */[
-                                                                        409,
+                                                                        1,
                                                                         /* [] */0
                                                                       ]
                                                                     ]
@@ -459,26 +422,29 @@ var suites_001 = /* :: */[
                                                             ]
                                                           ]
                                                         ]
-                                                      ]
-                                                    ], /* :: */[
-                                                      2,
-                                                      /* :: */[
-                                                        6,
+                                                      ], /* :: */[
+                                                        2,
                                                         /* :: */[
-                                                          1,
+                                                          6,
                                                           /* :: */[
                                                             1,
                                                             /* :: */[
-                                                              2,
+                                                              1,
                                                               /* :: */[
-                                                                1,
+                                                                2,
                                                                 /* :: */[
-                                                                  4,
+                                                                  1,
                                                                   /* :: */[
-                                                                    2,
+                                                                    4,
                                                                     /* :: */[
-                                                                      1,
-                                                                      /* [] */0
+                                                                      2,
+                                                                      /* :: */[
+                                                                        1,
+                                                                        /* :: */[
+                                                                          409,
+                                                                          /* [] */0
+                                                                        ]
+                                                                      ]
                                                                     ]
                                                                   ]
                                                                 ]
@@ -486,420 +452,460 @@ var suites_001 = /* :: */[
                                                             ]
                                                           ]
                                                         ]
-                                                      ]
-                                                    ])
-                                              ]);
-                                    })
-                                ],
-                                /* :: */[
-                                  /* tuple */[
-                                    "cmp_id",
-                                    (function () {
-                                        return /* Eq */Block.__(0, [
-                                                  Caml_obj.caml_compare({
-                                                        x: 1,
-                                                        y: 2
-                                                      }, {
-                                                        x: 1,
-                                                        y: 2
-                                                      }),
-                                                  0
+                                                      ])
                                                 ]);
                                       })
                                   ],
                                   /* :: */[
                                     /* tuple */[
-                                      "cmp_val",
+                                      "File \"caml_compare_test.ml\", line 56, characters 4-11",
                                       (function () {
                                           return /* Eq */Block.__(0, [
-                                                    Caml_obj.caml_compare({
-                                                          x: 1
-                                                        }, {
-                                                          x: 2
-                                                        }),
-                                                    -1
+                                                    false,
+                                                    Caml_obj.caml_equal(/* :: */[
+                                                          2,
+                                                          /* :: */[
+                                                            6,
+                                                            /* :: */[
+                                                              1,
+                                                              /* :: */[
+                                                                1,
+                                                                /* :: */[
+                                                                  2,
+                                                                  /* :: */[
+                                                                    1,
+                                                                    /* :: */[
+                                                                      4,
+                                                                      /* :: */[
+                                                                        2,
+                                                                        /* :: */[
+                                                                          1,
+                                                                          /* :: */[
+                                                                            409,
+                                                                            /* [] */0
+                                                                          ]
+                                                                        ]
+                                                                      ]
+                                                                    ]
+                                                                  ]
+                                                                ]
+                                                              ]
+                                                            ]
+                                                          ]
+                                                        ], /* :: */[
+                                                          2,
+                                                          /* :: */[
+                                                            6,
+                                                            /* :: */[
+                                                              1,
+                                                              /* :: */[
+                                                                1,
+                                                                /* :: */[
+                                                                  2,
+                                                                  /* :: */[
+                                                                    1,
+                                                                    /* :: */[
+                                                                      4,
+                                                                      /* :: */[
+                                                                        2,
+                                                                        /* :: */[
+                                                                          1,
+                                                                          /* [] */0
+                                                                        ]
+                                                                      ]
+                                                                    ]
+                                                                  ]
+                                                                ]
+                                                              ]
+                                                            ]
+                                                          ]
+                                                        ])
                                                   ]);
                                         })
                                     ],
                                     /* :: */[
                                       /* tuple */[
-                                        "cmp_val2",
+                                        "cmp_id",
                                         (function () {
                                             return /* Eq */Block.__(0, [
                                                       Caml_obj.caml_compare({
-                                                            x: 2
+                                                            x: 1,
+                                                            y: 2
                                                           }, {
-                                                            x: 1
+                                                            x: 1,
+                                                            y: 2
                                                           }),
-                                                      1
+                                                      0
                                                     ]);
                                           })
                                       ],
                                       /* :: */[
                                         /* tuple */[
-                                          "cmp_empty",
+                                          "cmp_val",
                                           (function () {
                                               return /* Eq */Block.__(0, [
-                                                        Caml_obj.caml_compare(({}), ({})),
-                                                        0
+                                                        Caml_obj.caml_compare({
+                                                              x: 1
+                                                            }, {
+                                                              x: 2
+                                                            }),
+                                                        -1
                                                       ]);
                                             })
                                         ],
                                         /* :: */[
                                           /* tuple */[
-                                            "cmp_empty2",
+                                            "cmp_val2",
                                             (function () {
                                                 return /* Eq */Block.__(0, [
-                                                          Caml_obj.caml_compare(({}), ({x:1})),
-                                                          -1
+                                                          Caml_obj.caml_compare({
+                                                                x: 2
+                                                              }, {
+                                                                x: 1
+                                                              }),
+                                                          1
                                                         ]);
                                               })
                                           ],
                                           /* :: */[
                                             /* tuple */[
-                                              "cmp_swap",
+                                              "cmp_empty",
                                               (function () {
                                                   return /* Eq */Block.__(0, [
-                                                            Caml_obj.caml_compare({
-                                                                  x: 1,
-                                                                  y: 2
-                                                                }, {
-                                                                  y: 2,
-                                                                  x: 1
-                                                                }),
+                                                            Caml_obj.caml_compare(({}), ({})),
                                                             0
                                                           ]);
                                                 })
                                             ],
                                             /* :: */[
                                               /* tuple */[
-                                                "cmp_size",
+                                                "cmp_empty2",
                                                 (function () {
                                                     return /* Eq */Block.__(0, [
-                                                              Caml_obj.caml_compare(({x:1}), ({x:1, y:2})),
+                                                              Caml_obj.caml_compare(({}), ({x:1})),
                                                               -1
                                                             ]);
                                                   })
                                               ],
                                               /* :: */[
                                                 /* tuple */[
-                                                  "cmp_size2",
+                                                  "cmp_swap",
                                                   (function () {
                                                       return /* Eq */Block.__(0, [
-                                                                Caml_obj.caml_compare(({x:1, y:2}), ({x:1})),
-                                                                1
+                                                                Caml_obj.caml_compare({
+                                                                      x: 1,
+                                                                      y: 2
+                                                                    }, {
+                                                                      y: 2,
+                                                                      x: 1
+                                                                    }),
+                                                                0
                                                               ]);
                                                     })
                                                 ],
                                                 /* :: */[
                                                   /* tuple */[
-                                                    "cmp_order",
+                                                    "cmp_size",
                                                     (function () {
                                                         return /* Eq */Block.__(0, [
-                                                                  Caml_obj.caml_compare({
-                                                                        x: 0,
-                                                                        y: 1
-                                                                      }, {
-                                                                        x: 1,
-                                                                        y: 0
-                                                                      }),
+                                                                  Caml_obj.caml_compare(({x:1}), ({x:1, y:2})),
                                                                   -1
                                                                 ]);
                                                       })
                                                   ],
                                                   /* :: */[
                                                     /* tuple */[
-                                                      "cmp_order2",
+                                                      "cmp_size2",
                                                       (function () {
                                                           return /* Eq */Block.__(0, [
-                                                                    Caml_obj.caml_compare({
-                                                                          x: 1,
-                                                                          y: 0
-                                                                        }, {
-                                                                          x: 0,
-                                                                          y: 1
-                                                                        }),
+                                                                    Caml_obj.caml_compare(({x:1, y:2}), ({x:1})),
                                                                     1
                                                                   ]);
                                                         })
                                                     ],
                                                     /* :: */[
                                                       /* tuple */[
-                                                        "cmp_in_list",
+                                                        "cmp_order",
                                                         (function () {
                                                             return /* Eq */Block.__(0, [
-                                                                      Caml_obj.caml_compare(/* :: */[
-                                                                            {
-                                                                              x: 1
-                                                                            },
-                                                                            /* [] */0
-                                                                          ], /* :: */[
-                                                                            {
-                                                                              x: 2
-                                                                            },
-                                                                            /* [] */0
-                                                                          ]),
+                                                                      Caml_obj.caml_compare({
+                                                                            x: 0,
+                                                                            y: 1
+                                                                          }, {
+                                                                            x: 1,
+                                                                            y: 0
+                                                                          }),
                                                                       -1
                                                                     ]);
                                                           })
                                                       ],
                                                       /* :: */[
                                                         /* tuple */[
-                                                          "cmp_in_list2",
+                                                          "cmp_order2",
                                                           (function () {
                                                               return /* Eq */Block.__(0, [
-                                                                        Caml_obj.caml_compare(/* :: */[
-                                                                              {
-                                                                                x: 2
-                                                                              },
-                                                                              /* [] */0
-                                                                            ], /* :: */[
-                                                                              {
-                                                                                x: 1
-                                                                              },
-                                                                              /* [] */0
-                                                                            ]),
+                                                                        Caml_obj.caml_compare({
+                                                                              x: 1,
+                                                                              y: 0
+                                                                            }, {
+                                                                              x: 0,
+                                                                              y: 1
+                                                                            }),
                                                                         1
                                                                       ]);
                                                             })
                                                         ],
                                                         /* :: */[
                                                           /* tuple */[
-                                                            "cmp_with_list",
+                                                            "cmp_in_list",
                                                             (function () {
                                                                 return /* Eq */Block.__(0, [
-                                                                          Caml_obj.caml_compare({
-                                                                                x: /* :: */[
-                                                                                  0,
-                                                                                  /* [] */0
-                                                                                ]
-                                                                              }, {
-                                                                                x: /* :: */[
-                                                                                  1,
-                                                                                  /* [] */0
-                                                                                ]
-                                                                              }),
+                                                                          Caml_obj.caml_compare(/* :: */[
+                                                                                {
+                                                                                  x: 1
+                                                                                },
+                                                                                /* [] */0
+                                                                              ], /* :: */[
+                                                                                {
+                                                                                  x: 2
+                                                                                },
+                                                                                /* [] */0
+                                                                              ]),
                                                                           -1
                                                                         ]);
                                                               })
                                                           ],
                                                           /* :: */[
                                                             /* tuple */[
-                                                              "cmp_with_list2",
+                                                              "cmp_in_list2",
                                                               (function () {
                                                                   return /* Eq */Block.__(0, [
-                                                                            Caml_obj.caml_compare({
-                                                                                  x: /* :: */[
-                                                                                    1,
-                                                                                    /* [] */0
-                                                                                  ]
-                                                                                }, {
-                                                                                  x: /* :: */[
-                                                                                    0,
-                                                                                    /* [] */0
-                                                                                  ]
-                                                                                }),
+                                                                            Caml_obj.caml_compare(/* :: */[
+                                                                                  {
+                                                                                    x: 2
+                                                                                  },
+                                                                                  /* [] */0
+                                                                                ], /* :: */[
+                                                                                  {
+                                                                                    x: 1
+                                                                                  },
+                                                                                  /* [] */0
+                                                                                ]),
                                                                             1
                                                                           ]);
                                                                 })
                                                             ],
                                                             /* :: */[
                                                               /* tuple */[
-                                                                "eq_id",
+                                                                "cmp_with_list",
                                                                 (function () {
-                                                                    return /* Ok */Block.__(4, [Caml_obj.caml_equal({
-                                                                                    x: 1,
-                                                                                    y: 2
+                                                                    return /* Eq */Block.__(0, [
+                                                                              Caml_obj.caml_compare({
+                                                                                    x: /* :: */[
+                                                                                      0,
+                                                                                      /* [] */0
+                                                                                    ]
                                                                                   }, {
-                                                                                    x: 1,
-                                                                                    y: 2
-                                                                                  })]);
+                                                                                    x: /* :: */[
+                                                                                      1,
+                                                                                      /* [] */0
+                                                                                    ]
+                                                                                  }),
+                                                                              -1
+                                                                            ]);
                                                                   })
                                                               ],
                                                               /* :: */[
                                                                 /* tuple */[
-                                                                  "eq_val",
+                                                                  "cmp_with_list2",
                                                                   (function () {
                                                                       return /* Eq */Block.__(0, [
-                                                                                Caml_obj.caml_equal({
-                                                                                      x: 1
+                                                                                Caml_obj.caml_compare({
+                                                                                      x: /* :: */[
+                                                                                        1,
+                                                                                        /* [] */0
+                                                                                      ]
                                                                                     }, {
-                                                                                      x: 2
+                                                                                      x: /* :: */[
+                                                                                        0,
+                                                                                        /* [] */0
+                                                                                      ]
                                                                                     }),
-                                                                                false
+                                                                                1
                                                                               ]);
                                                                     })
                                                                 ],
                                                                 /* :: */[
                                                                   /* tuple */[
-                                                                    "eq_val2",
+                                                                    "eq_id",
                                                                     (function () {
-                                                                        return /* Eq */Block.__(0, [
-                                                                                  Caml_obj.caml_equal({
-                                                                                        x: 2
+                                                                        return /* Ok */Block.__(4, [Caml_obj.caml_equal({
+                                                                                        x: 1,
+                                                                                        y: 2
                                                                                       }, {
-                                                                                        x: 1
-                                                                                      }),
-                                                                                  false
-                                                                                ]);
+                                                                                        x: 1,
+                                                                                        y: 2
+                                                                                      })]);
                                                                       })
                                                                   ],
                                                                   /* :: */[
                                                                     /* tuple */[
-                                                                      "eq_empty",
+                                                                      "eq_val",
                                                                       (function () {
                                                                           return /* Eq */Block.__(0, [
-                                                                                    Caml_obj.caml_equal(({}), ({})),
-                                                                                    true
+                                                                                    Caml_obj.caml_equal({
+                                                                                          x: 1
+                                                                                        }, {
+                                                                                          x: 2
+                                                                                        }),
+                                                                                    false
                                                                                   ]);
                                                                         })
                                                                     ],
                                                                     /* :: */[
                                                                       /* tuple */[
-                                                                        "eq_empty2",
+                                                                        "eq_val2",
                                                                         (function () {
                                                                             return /* Eq */Block.__(0, [
-                                                                                      Caml_obj.caml_equal(({}), ({x:1})),
+                                                                                      Caml_obj.caml_equal({
+                                                                                            x: 2
+                                                                                          }, {
+                                                                                            x: 1
+                                                                                          }),
                                                                                       false
                                                                                     ]);
                                                                           })
                                                                       ],
                                                                       /* :: */[
                                                                         /* tuple */[
-                                                                          "eq_swap",
+                                                                          "eq_empty",
                                                                           (function () {
-                                                                              return /* Ok */Block.__(4, [Caml_obj.caml_equal({
-                                                                                              x: 1,
-                                                                                              y: 2
-                                                                                            }, {
-                                                                                              y: 2,
-                                                                                              x: 1
-                                                                                            })]);
+                                                                              return /* Eq */Block.__(0, [
+                                                                                        Caml_obj.caml_equal(({}), ({})),
+                                                                                        true
+                                                                                      ]);
                                                                             })
                                                                         ],
                                                                         /* :: */[
                                                                           /* tuple */[
-                                                                            "eq_size",
+                                                                            "eq_empty2",
                                                                             (function () {
                                                                                 return /* Eq */Block.__(0, [
-                                                                                          Caml_obj.caml_equal(({x:1}), ({x:1, y:2})),
+                                                                                          Caml_obj.caml_equal(({}), ({x:1})),
                                                                                           false
                                                                                         ]);
                                                                               })
                                                                           ],
                                                                           /* :: */[
                                                                             /* tuple */[
-                                                                              "eq_size2",
+                                                                              "eq_swap",
                                                                               (function () {
-                                                                                  return /* Eq */Block.__(0, [
-                                                                                            Caml_obj.caml_equal(({x:1, y:2}), ({x:1})),
-                                                                                            false
-                                                                                          ]);
+                                                                                  return /* Ok */Block.__(4, [Caml_obj.caml_equal({
+                                                                                                  x: 1,
+                                                                                                  y: 2
+                                                                                                }, {
+                                                                                                  y: 2,
+                                                                                                  x: 1
+                                                                                                })]);
                                                                                 })
                                                                             ],
                                                                             /* :: */[
                                                                               /* tuple */[
-                                                                                "eq_in_list",
+                                                                                "eq_size",
                                                                                 (function () {
                                                                                     return /* Eq */Block.__(0, [
-                                                                                              Caml_obj.caml_equal(/* :: */[
-                                                                                                    {
-                                                                                                      x: 1
-                                                                                                    },
-                                                                                                    /* [] */0
-                                                                                                  ], /* :: */[
-                                                                                                    {
-                                                                                                      x: 2
-                                                                                                    },
-                                                                                                    /* [] */0
-                                                                                                  ]),
+                                                                                              Caml_obj.caml_equal(({x:1}), ({x:1, y:2})),
                                                                                               false
                                                                                             ]);
                                                                                   })
                                                                               ],
                                                                               /* :: */[
                                                                                 /* tuple */[
-                                                                                  "eq_in_list2",
+                                                                                  "eq_size2",
                                                                                   (function () {
                                                                                       return /* Eq */Block.__(0, [
-                                                                                                Caml_obj.caml_equal(/* :: */[
-                                                                                                      {
-                                                                                                        x: 2
-                                                                                                      },
-                                                                                                      /* [] */0
-                                                                                                    ], /* :: */[
-                                                                                                      {
-                                                                                                        x: 2
-                                                                                                      },
-                                                                                                      /* [] */0
-                                                                                                    ]),
-                                                                                                true
+                                                                                                Caml_obj.caml_equal(({x:1, y:2}), ({x:1})),
+                                                                                                false
                                                                                               ]);
                                                                                     })
                                                                                 ],
                                                                                 /* :: */[
                                                                                   /* tuple */[
-                                                                                    "eq_with_list",
+                                                                                    "eq_in_list",
                                                                                     (function () {
                                                                                         return /* Eq */Block.__(0, [
-                                                                                                  Caml_obj.caml_equal({
-                                                                                                        x: /* :: */[
-                                                                                                          0,
-                                                                                                          /* [] */0
-                                                                                                        ]
-                                                                                                      }, {
-                                                                                                        x: /* :: */[
-                                                                                                          0,
-                                                                                                          /* [] */0
-                                                                                                        ]
-                                                                                                      }),
-                                                                                                  true
+                                                                                                  Caml_obj.caml_equal(/* :: */[
+                                                                                                        {
+                                                                                                          x: 1
+                                                                                                        },
+                                                                                                        /* [] */0
+                                                                                                      ], /* :: */[
+                                                                                                        {
+                                                                                                          x: 2
+                                                                                                        },
+                                                                                                        /* [] */0
+                                                                                                      ]),
+                                                                                                  false
                                                                                                 ]);
                                                                                       })
                                                                                   ],
                                                                                   /* :: */[
                                                                                     /* tuple */[
-                                                                                      "eq_with_list2",
+                                                                                      "eq_in_list2",
                                                                                       (function () {
                                                                                           return /* Eq */Block.__(0, [
-                                                                                                    Caml_obj.caml_equal({
-                                                                                                          x: /* :: */[
-                                                                                                            0,
-                                                                                                            /* [] */0
-                                                                                                          ]
-                                                                                                        }, {
-                                                                                                          x: /* :: */[
-                                                                                                            1,
-                                                                                                            /* [] */0
-                                                                                                          ]
-                                                                                                        }),
-                                                                                                    false
+                                                                                                    Caml_obj.caml_equal(/* :: */[
+                                                                                                          {
+                                                                                                            x: 2
+                                                                                                          },
+                                                                                                          /* [] */0
+                                                                                                        ], /* :: */[
+                                                                                                          {
+                                                                                                            x: 2
+                                                                                                          },
+                                                                                                          /* [] */0
+                                                                                                        ]),
+                                                                                                    true
                                                                                                   ]);
                                                                                         })
                                                                                     ],
                                                                                     /* :: */[
                                                                                       /* tuple */[
-                                                                                        "File \"caml_compare_test.ml\", line 81, characters 4-11",
+                                                                                        "eq_with_list",
                                                                                         (function () {
                                                                                             return /* Eq */Block.__(0, [
-                                                                                                      Caml_obj.caml_compare(null, /* :: */[
-                                                                                                            3,
-                                                                                                            /* [] */0
-                                                                                                          ]),
-                                                                                                      -1
+                                                                                                      Caml_obj.caml_equal({
+                                                                                                            x: /* :: */[
+                                                                                                              0,
+                                                                                                              /* [] */0
+                                                                                                            ]
+                                                                                                          }, {
+                                                                                                            x: /* :: */[
+                                                                                                              0,
+                                                                                                              /* [] */0
+                                                                                                            ]
+                                                                                                          }),
+                                                                                                      true
                                                                                                     ]);
                                                                                           })
                                                                                       ],
                                                                                       /* :: */[
                                                                                         /* tuple */[
-                                                                                          "File \"caml_compare_test.ml\", line 84, characters 4-11",
+                                                                                          "eq_with_list2",
                                                                                           (function () {
                                                                                               return /* Eq */Block.__(0, [
-                                                                                                        Caml_obj.caml_compare(/* :: */[
-                                                                                                              3,
-                                                                                                              /* [] */0
-                                                                                                            ], null),
-                                                                                                        1
+                                                                                                        Caml_obj.caml_equal({
+                                                                                                              x: /* :: */[
+                                                                                                                0,
+                                                                                                                /* [] */0
+                                                                                                              ]
+                                                                                                            }, {
+                                                                                                              x: /* :: */[
+                                                                                                                1,
+                                                                                                                /* [] */0
+                                                                                                              ]
+                                                                                                            }),
+                                                                                                        false
                                                                                                       ]);
                                                                                             })
                                                                                         ],
@@ -908,7 +914,10 @@ var suites_001 = /* :: */[
                                                                                             "File \"caml_compare_test.ml\", line 87, characters 4-11",
                                                                                             (function () {
                                                                                                 return /* Eq */Block.__(0, [
-                                                                                                          Caml_obj.caml_compare(null, 0),
+                                                                                                          Caml_obj.caml_compare(null, /* :: */[
+                                                                                                                3,
+                                                                                                                /* [] */0
+                                                                                                              ]),
                                                                                                           -1
                                                                                                         ]);
                                                                                               })
@@ -918,7 +927,10 @@ var suites_001 = /* :: */[
                                                                                               "File \"caml_compare_test.ml\", line 90, characters 4-11",
                                                                                               (function () {
                                                                                                   return /* Eq */Block.__(0, [
-                                                                                                            Caml_obj.caml_compare(0, null),
+                                                                                                            Caml_obj.caml_compare(/* :: */[
+                                                                                                                  3,
+                                                                                                                  /* [] */0
+                                                                                                                ], null),
                                                                                                             1
                                                                                                           ]);
                                                                                                 })
@@ -928,7 +940,7 @@ var suites_001 = /* :: */[
                                                                                                 "File \"caml_compare_test.ml\", line 93, characters 4-11",
                                                                                                 (function () {
                                                                                                     return /* Eq */Block.__(0, [
-                                                                                                              Caml_obj.caml_compare(undefined, 0),
+                                                                                                              Caml_obj.caml_compare(null, 0),
                                                                                                               -1
                                                                                                             ]);
                                                                                                   })
@@ -938,12 +950,34 @@ var suites_001 = /* :: */[
                                                                                                   "File \"caml_compare_test.ml\", line 96, characters 4-11",
                                                                                                   (function () {
                                                                                                       return /* Eq */Block.__(0, [
-                                                                                                                Caml_obj.caml_compare(0, undefined),
+                                                                                                                Caml_obj.caml_compare(0, null),
                                                                                                                 1
                                                                                                               ]);
                                                                                                     })
                                                                                                 ],
-                                                                                                /* [] */0
+                                                                                                /* :: */[
+                                                                                                  /* tuple */[
+                                                                                                    "File \"caml_compare_test.ml\", line 99, characters 4-11",
+                                                                                                    (function () {
+                                                                                                        return /* Eq */Block.__(0, [
+                                                                                                                  Caml_obj.caml_compare(undefined, 0),
+                                                                                                                  -1
+                                                                                                                ]);
+                                                                                                      })
+                                                                                                  ],
+                                                                                                  /* :: */[
+                                                                                                    /* tuple */[
+                                                                                                      "File \"caml_compare_test.ml\", line 102, characters 4-11",
+                                                                                                      (function () {
+                                                                                                          return /* Eq */Block.__(0, [
+                                                                                                                    Caml_obj.caml_compare(0, undefined),
+                                                                                                                    1
+                                                                                                                  ]);
+                                                                                                        })
+                                                                                                    ],
+                                                                                                    /* [] */0
+                                                                                                  ]
+                                                                                                ]
                                                                                               ]
                                                                                             ]
                                                                                           ]

--- a/jscomp/test/caml_compare_test.ml
+++ b/jscomp/test/caml_compare_test.ml
@@ -35,6 +35,12 @@ let suites = Mt.[
         Eq(true, [2;6;1;1;2;1;4;2;1] < [2;6;1;1;2;1;4;2;1;409])
     end;
     __LOC__ , begin fun _ -> 
+        Eq(true, [1] < [1;409])
+    end;
+    __LOC__ , begin fun _ -> 
+        Eq(true, [] < [409])
+    end;
+    __LOC__ , begin fun _ -> 
         Eq(true,  [2;6;1;1;2;1;4;2;1;409] > [2;6;1;1;2;1;4;2;1])
     end;
     

--- a/jscomp/test/option_repr_test.js
+++ b/jscomp/test/option_repr_test.js
@@ -132,6 +132,14 @@ function ltx(a, b) {
   }
 }
 
+function gtx(a, b) {
+  if (Caml_obj.caml_greaterthan(a, b)) {
+    return Caml_obj.caml_lessthan(b, a);
+  } else {
+    return false;
+  }
+}
+
 function eqx(a, b) {
   if (Caml_obj.caml_equal(a, b)) {
     return Caml_obj.caml_equal(b, a);
@@ -154,23 +162,46 @@ function all_true(xs) {
               }));
 }
 
-var xs_000 = ltx(Js_primitive.some(undefined), 3);
+var xs_000 = gtx(Js_primitive.some(null), Js_primitive.some(undefined));
+
+var xs = /* :: */[
+  xs_000,
+  /* [] */0
+];
+
+b("File \"option_repr_test.ml\", line 118, characters 5-12", Belt_List.every(xs, (function (x) {
+            return x;
+          })));
+
+var xs_000$1 = ltx(Js_primitive.some(undefined), 3);
 
 var xs_001 = /* :: */[
   ltx(Js_primitive.some(undefined), Js_primitive.some(Js_primitive.some(undefined))),
   /* :: */[
     ltx(Js_primitive.some(undefined), "3"),
     /* :: */[
-      ltx(undefined, Js_primitive.some(undefined)),
+      ltx(Js_primitive.some(undefined), true),
       /* :: */[
-        ltx(undefined, null),
+        ltx(Js_primitive.some(undefined), false),
         /* :: */[
-          ltx(undefined, (function (x) {
-                  return x;
-                })),
+          ltx(false, true),
           /* :: */[
-            ltx(null, 3),
-            /* [] */0
+            ltx(false, true),
+            /* :: */[
+              ltx(undefined, Js_primitive.some(undefined)),
+              /* :: */[
+                ltx(undefined, null),
+                /* :: */[
+                  ltx(undefined, (function (x) {
+                          return x;
+                        })),
+                  /* :: */[
+                    ltx(null, 3),
+                    /* [] */0
+                  ]
+                ]
+              ]
+            ]
           ]
         ]
       ]
@@ -178,16 +209,16 @@ var xs_001 = /* :: */[
   ]
 ];
 
-var xs = /* :: */[
-  xs_000,
+var xs$1 = /* :: */[
+  xs_000$1,
   xs_001
 ];
 
-b("File \"option_repr_test.ml\", line 117, characters 5-12", Belt_List.every(xs, (function (x) {
+b("File \"option_repr_test.ml\", line 124, characters 5-12", Belt_List.every(xs$1, (function (x) {
             return x;
           })));
 
-var xs_000$1 = eqx(undefined, undefined);
+var xs_000$2 = eqx(undefined, undefined);
 
 var xs_001$1 = /* :: */[
   neqx(undefined, null),
@@ -203,12 +234,12 @@ var xs_001$1 = /* :: */[
   ]
 ];
 
-var xs$1 = /* :: */[
-  xs_000$1,
+var xs$2 = /* :: */[
+  xs_000$2,
   xs_001$1
 ];
 
-b("File \"option_repr_test.ml\", line 129, characters 5-12", Belt_List.every(xs$1, (function (x) {
+b("File \"option_repr_test.ml\", line 140, characters 5-12", Belt_List.every(xs$2, (function (x) {
             return x;
           })));
 
@@ -251,6 +282,7 @@ exports.length_10_id = length_10_id;
 exports.f13 = f13$1;
 exports.none_arg = none_arg;
 exports.ltx = ltx;
+exports.gtx = gtx;
 exports.eqx = eqx;
 exports.neqx = neqx;
 exports.all_true = all_true;

--- a/jscomp/test/option_repr_test.js
+++ b/jscomp/test/option_repr_test.js
@@ -124,6 +124,94 @@ b("File \"option_repr_test.ml\", line 95, characters 4-11", Caml_obj.caml_lessth
 
 console.log(6, undefined);
 
+function ltx(a, b) {
+  if (Caml_obj.caml_lessthan(a, b)) {
+    return Caml_obj.caml_greaterthan(b, a);
+  } else {
+    return false;
+  }
+}
+
+function eqx(a, b) {
+  if (Caml_obj.caml_equal(a, b)) {
+    return Caml_obj.caml_equal(b, a);
+  } else {
+    return false;
+  }
+}
+
+function neqx(a, b) {
+  if (Caml_obj.caml_notequal(a, b)) {
+    return Caml_obj.caml_notequal(b, a);
+  } else {
+    return false;
+  }
+}
+
+function all_true(xs) {
+  return Belt_List.every(xs, (function (x) {
+                return x;
+              }));
+}
+
+var xs_000 = ltx(Js_primitive.some(undefined), 3);
+
+var xs_001 = /* :: */[
+  ltx(Js_primitive.some(undefined), Js_primitive.some(Js_primitive.some(undefined))),
+  /* :: */[
+    ltx(Js_primitive.some(undefined), "3"),
+    /* :: */[
+      ltx(undefined, Js_primitive.some(undefined)),
+      /* :: */[
+        ltx(undefined, null),
+        /* :: */[
+          ltx(undefined, (function (x) {
+                  return x;
+                })),
+          /* :: */[
+            ltx(null, 3),
+            /* [] */0
+          ]
+        ]
+      ]
+    ]
+  ]
+];
+
+var xs = /* :: */[
+  xs_000,
+  xs_001
+];
+
+b("File \"option_repr_test.ml\", line 117, characters 5-12", Belt_List.every(xs, (function (x) {
+            return x;
+          })));
+
+var xs_000$1 = eqx(undefined, undefined);
+
+var xs_001$1 = /* :: */[
+  neqx(undefined, null),
+  /* :: */[
+    eqx(Js_primitive.some(undefined), Js_primitive.some(undefined)),
+    /* :: */[
+      eqx(Js_primitive.some(Js_primitive.some(undefined)), Js_primitive.some(Js_primitive.some(undefined))),
+      /* :: */[
+        neqx(Js_primitive.some(Js_primitive.some(Js_primitive.some(undefined))), Js_primitive.some(Js_primitive.some(undefined))),
+        /* [] */0
+      ]
+    ]
+  ]
+];
+
+var xs$1 = /* :: */[
+  xs_000$1,
+  xs_001$1
+];
+
+b("File \"option_repr_test.ml\", line 129, characters 5-12", Belt_List.every(xs$1, (function (x) {
+            return x;
+          })));
+
 Mt.from_pair_suites("option_repr_test.ml", suites[0]);
 
 var f7 = undefined;
@@ -162,4 +250,8 @@ exports.length_8_id = length_8_id;
 exports.length_10_id = length_10_id;
 exports.f13 = f13$1;
 exports.none_arg = none_arg;
+exports.ltx = ltx;
+exports.eqx = eqx;
+exports.neqx = neqx;
+exports.all_true = all_true;
 /* ff Not a pure module */

--- a/jscomp/test/option_repr_test.ml
+++ b/jscomp/test/option_repr_test.ml
@@ -109,17 +109,28 @@ let _ = log3 ~req:(`Int 6) ?opt:none_arg ()
 
 
 let ltx a b =  a < b && b > a 
-
+let gtx a b = a > b && b < a 
 let eqx a b = a = b && b = a
 let neqx a b = a <> b && b <> a 
 
 let all_true xs = Belt.List.every xs (fun x -> x)
+
+;; b __LOC__ 
+  @@ all_true 
+  [ 
+    gtx (Some (Some Js.null)) (Some None)
+  ]
+  
 ;; b __LOC__ 
   @@ all_true
   [
     ltx (Some None)  (Some (Some 3));    
     ltx (Some None) (Some (Some None));
     ltx (Some None) (Some (Some "3"));
+    ltx (Some None) (Some (Some true));
+    ltx (Some None) (Some (Some false));
+    ltx (Some false) (Some (true));    
+    ltx (Some (Some false)) (Some (Some (true)));
     ltx None (Some None);
     ltx None (Some Js.null);
     ltx None (Some (fun x -> x  ));

--- a/jscomp/test/option_repr_test.ml
+++ b/jscomp/test/option_repr_test.ml
@@ -107,4 +107,32 @@ external log3 :
 let none_arg = None
 let _ = log3 ~req:(`Int 6) ?opt:none_arg ()
 
+
+let ltx a b =  a < b && b > a 
+
+let eqx a b = a = b && b = a
+let neqx a b = a <> b && b <> a 
+
+let all_true xs = Belt.List.every xs (fun x -> x)
+;; b __LOC__ 
+  @@ all_true
+  [
+    ltx (Some None)  (Some (Some 3));    
+    ltx (Some None) (Some (Some None));
+    ltx (Some None) (Some (Some "3"));
+    ltx None (Some None);
+    ltx None (Some Js.null);
+    ltx None (Some (fun x -> x  ));
+    ltx (Some Js.null) (Some (Js.Null.return 3));
+  ]
+
+;; b __LOC__   
+  @@ all_true [
+    eqx None None;
+    neqx None (Some Js.null);
+    eqx (Some None) (Some None);
+    eqx (Some (Some None)) (Some (Some None));
+    neqx (Some (Some (Some None))) (Some (Some None))
+  ]
+  
 ;; Mt.from_pair_suites __FILE__ !suites

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -75,8 +75,9 @@ function caml_compare(_a, _b) {
             if (b_type === "boolean") {
               return Caml_primitive.caml_bool_compare(a, b);
             } else {
-              return 1;
+              exit = 1;
             }
+            break;
         case "function" : 
             if (b_type === "function") {
               throw [
@@ -84,8 +85,9 @@ function caml_compare(_a, _b) {
                     "compare: functional value"
                   ];
             } else {
-              return 1;
+              exit = 1;
             }
+            break;
         case "number" : 
             if (b_type === "number") {
               return Caml_primitive.caml_int_compare(a, b);
@@ -105,179 +107,192 @@ function caml_compare(_a, _b) {
           exit = 1;
       }
       if (exit === 1) {
-        if (b_type === "undefined") {
-          return 1;
-        } else if (a_type === "number") {
-          if (b === null || b.tag === 256) {
-            return 1;
-          } else {
-            return -1;
-          }
-        } else if (b_type === "number") {
-          if (a === null || a.tag === 256) {
-            return -1;
-          } else {
-            return 1;
-          }
-        } else if (a === null) {
-          if (b.tag === 256) {
-            return 1;
-          } else {
-            return -1;
-          }
-        } else if (b === null) {
-          if (a.tag === 256) {
-            return -1;
-          } else {
-            return 1;
-          }
-        } else {
-          var tag_a = a.tag | 0;
-          var tag_b = b.tag | 0;
-          if (tag_a === 250) {
-            _a = a[0];
-            continue ;
-          } else if (tag_b === 250) {
-            _b = b[0];
-            continue ;
-          } else if (tag_a === 256) {
-            if (tag_b === 256) {
-              return Caml_primitive.caml_int_compare(a[1], b[1]);
-            } else {
+        switch (b_type) {
+          case "string" : 
               return -1;
-            }
-          } else if (tag_a === 248) {
-            return Caml_primitive.caml_int_compare(a[1], b[1]);
-          } else if (tag_a === 251) {
-            throw [
-                  Caml_builtin_exceptions.invalid_argument,
-                  "equal: abstract value"
-                ];
-          } else if (tag_a !== tag_b) {
-            if (tag_a < tag_b) {
-              return -1;
-            } else {
+          case "undefined" : 
               return 1;
-            }
-          } else {
-            var len_a = a.length | 0;
-            var len_b = b.length | 0;
-            if (len_a === len_b) {
-              if (Array.isArray(a)) {
-                var a$1 = a;
-                var b$1 = b;
-                var _i = 0;
-                var same_length = len_a;
-                while(true) {
-                  var i = _i;
-                  if (i === same_length) {
-                    return 0;
-                  } else {
-                    var res = caml_compare(a$1[i], b$1[i]);
-                    if (res !== 0) {
-                      return res;
-                    } else {
-                      _i = i + 1 | 0;
-                      continue ;
-                    }
-                  }
-                };
+          default:
+            if (a_type === "boolean") {
+              return 1;
+            } else if (b_type === "boolean") {
+              return -1;
+            } else if (a_type === "function") {
+              return 1;
+            } else if (b_type === "function") {
+              return -1;
+            } else if (a_type === "number") {
+              if (b === null || b.tag === 256) {
+                return 1;
               } else {
-                var a$2 = a;
-                var b$2 = b;
-                var min_key_lhs = [undefined];
-                var min_key_rhs = [undefined];
-                var do_key = function (param, key) {
-                  var min_key = param[2];
-                  var b = param[1];
-                  if (!b.hasOwnProperty(key) || caml_compare(param[0][key], b[key]) > 0) {
-                    var match = min_key[0];
-                    if (match !== undefined && key >= match) {
-                      return 0;
-                    } else {
-                      min_key[0] = key;
-                      return /* () */0;
-                    }
-                  } else {
-                    return 0;
-                  }
-                };
-                var partial_arg = /* tuple */[
-                  a$2,
-                  b$2,
-                  min_key_rhs
-                ];
-                var do_key_a = (function(partial_arg){
-                return function do_key_a(param) {
-                  return do_key(partial_arg, param);
-                }
-                }(partial_arg));
-                var partial_arg$1 = /* tuple */[
-                  b$2,
-                  a$2,
-                  min_key_lhs
-                ];
-                var do_key_b = (function(partial_arg$1){
-                return function do_key_b(param) {
-                  return do_key(partial_arg$1, param);
-                }
-                }(partial_arg$1));
-                for_in(a$2, do_key_a);
-                for_in(b$2, do_key_b);
-                var match = min_key_lhs[0];
-                var match$1 = min_key_rhs[0];
-                if (match !== undefined) {
-                  if (match$1 !== undefined) {
-                    return Caml_primitive.caml_string_compare(match, match$1);
-                  } else {
-                    return -1;
-                  }
-                } else if (match$1 !== undefined) {
-                  return 1;
-                } else {
-                  return 0;
-                }
+                return -1;
               }
-            } else if (len_a < len_b) {
-              var a$3 = a;
-              var b$3 = b;
-              var _i$1 = 0;
-              var short_length = len_a;
-              while(true) {
-                var i$1 = _i$1;
-                if (i$1 === short_length) {
+            } else if (b_type === "number") {
+              if (a === null || a.tag === 256) {
+                return -1;
+              } else {
+                return 1;
+              }
+            } else if (a === null) {
+              if (b.tag === 256) {
+                return 1;
+              } else {
+                return -1;
+              }
+            } else if (b === null) {
+              if (a.tag === 256) {
+                return -1;
+              } else {
+                return 1;
+              }
+            } else {
+              var tag_a = a.tag | 0;
+              var tag_b = b.tag | 0;
+              if (tag_a === 250) {
+                _a = a[0];
+                continue ;
+              } else if (tag_b === 250) {
+                _b = b[0];
+                continue ;
+              } else if (tag_a === 256) {
+                if (tag_b === 256) {
+                  return Caml_primitive.caml_int_compare(a[1], b[1]);
+                } else {
+                  return -1;
+                }
+              } else if (tag_a === 248) {
+                return Caml_primitive.caml_int_compare(a[1], b[1]);
+              } else if (tag_a === 251) {
+                throw [
+                      Caml_builtin_exceptions.invalid_argument,
+                      "equal: abstract value"
+                    ];
+              } else if (tag_a !== tag_b) {
+                if (tag_a < tag_b) {
                   return -1;
                 } else {
-                  var res$1 = caml_compare(a$3[i$1], b$3[i$1]);
-                  if (res$1 !== 0) {
-                    return res$1;
-                  } else {
-                    _i$1 = i$1 + 1 | 0;
-                    continue ;
-                  }
-                }
-              };
-            } else {
-              var a$4 = a;
-              var b$4 = b;
-              var _i$2 = 0;
-              var short_length$1 = len_b;
-              while(true) {
-                var i$2 = _i$2;
-                if (i$2 === short_length$1) {
                   return 1;
-                } else {
-                  var res$2 = caml_compare(a$4[i$2], b$4[i$2]);
-                  if (res$2 !== 0) {
-                    return res$2;
-                  } else {
-                    _i$2 = i$2 + 1 | 0;
-                    continue ;
-                  }
                 }
-              };
+              } else {
+                var len_a = a.length | 0;
+                var len_b = b.length | 0;
+                if (len_a === len_b) {
+                  if (Array.isArray(a)) {
+                    var a$1 = a;
+                    var b$1 = b;
+                    var _i = 0;
+                    var same_length = len_a;
+                    while(true) {
+                      var i = _i;
+                      if (i === same_length) {
+                        return 0;
+                      } else {
+                        var res = caml_compare(a$1[i], b$1[i]);
+                        if (res !== 0) {
+                          return res;
+                        } else {
+                          _i = i + 1 | 0;
+                          continue ;
+                        }
+                      }
+                    };
+                  } else {
+                    var a$2 = a;
+                    var b$2 = b;
+                    var min_key_lhs = [undefined];
+                    var min_key_rhs = [undefined];
+                    var do_key = function (param, key) {
+                      var min_key = param[2];
+                      var b = param[1];
+                      if (!b.hasOwnProperty(key) || caml_compare(param[0][key], b[key]) > 0) {
+                        var match = min_key[0];
+                        if (match !== undefined && key >= match) {
+                          return 0;
+                        } else {
+                          min_key[0] = key;
+                          return /* () */0;
+                        }
+                      } else {
+                        return 0;
+                      }
+                    };
+                    var partial_arg = /* tuple */[
+                      a$2,
+                      b$2,
+                      min_key_rhs
+                    ];
+                    var do_key_a = (function(partial_arg){
+                    return function do_key_a(param) {
+                      return do_key(partial_arg, param);
+                    }
+                    }(partial_arg));
+                    var partial_arg$1 = /* tuple */[
+                      b$2,
+                      a$2,
+                      min_key_lhs
+                    ];
+                    var do_key_b = (function(partial_arg$1){
+                    return function do_key_b(param) {
+                      return do_key(partial_arg$1, param);
+                    }
+                    }(partial_arg$1));
+                    for_in(a$2, do_key_a);
+                    for_in(b$2, do_key_b);
+                    var match = min_key_lhs[0];
+                    var match$1 = min_key_rhs[0];
+                    if (match !== undefined) {
+                      if (match$1 !== undefined) {
+                        return Caml_primitive.caml_string_compare(match, match$1);
+                      } else {
+                        return -1;
+                      }
+                    } else if (match$1 !== undefined) {
+                      return 1;
+                    } else {
+                      return 0;
+                    }
+                  }
+                } else if (len_a < len_b) {
+                  var a$3 = a;
+                  var b$3 = b;
+                  var _i$1 = 0;
+                  var short_length = len_a;
+                  while(true) {
+                    var i$1 = _i$1;
+                    if (i$1 === short_length) {
+                      return -1;
+                    } else {
+                      var res$1 = caml_compare(a$3[i$1], b$3[i$1]);
+                      if (res$1 !== 0) {
+                        return res$1;
+                      } else {
+                        _i$1 = i$1 + 1 | 0;
+                        continue ;
+                      }
+                    }
+                  };
+                } else {
+                  var a$4 = a;
+                  var b$4 = b;
+                  var _i$2 = 0;
+                  var short_length$1 = len_b;
+                  while(true) {
+                    var i$2 = _i$2;
+                    if (i$2 === short_length$1) {
+                      return 1;
+                    } else {
+                      var res$2 = caml_compare(a$4[i$2], b$4[i$2]);
+                      if (res$2 !== 0) {
+                        return res$2;
+                      } else {
+                        _i$2 = i$2 + 1 | 0;
+                        continue ;
+                      }
+                    }
+                  };
+                }
+              }
             }
-          }
         }
       }
       

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -66,45 +66,71 @@ function caml_compare(_a, _b) {
     var a = _a;
     if (a === b) {
       return 0;
-    } else if (a === undefined) {
-      return -1;
-    } else if (b === undefined) {
-      return 1;
-    } else if (a === null) {
-      return -1;
-    } else if (b === null) {
-      return 1;
     } else {
       var a_type = typeof a;
       var b_type = typeof b;
-      if (a_type === "string") {
-        return Caml_primitive.caml_string_compare(a, b);
-      } else {
-        var is_a_number = a_type === "number";
-        var is_b_number = b_type === "number";
-        if (is_a_number) {
-          if (is_b_number) {
-            return Caml_primitive.caml_int_compare(a, b);
+      var exit = 0;
+      switch (a_type) {
+        case "boolean" : 
+            if (b_type === "boolean") {
+              return Caml_primitive.caml_bool_compare(a, b);
+            } else {
+              return 1;
+            }
+        case "function" : 
+            if (b_type === "function") {
+              throw [
+                    Caml_builtin_exceptions.invalid_argument,
+                    "compare: functional value"
+                  ];
+            } else {
+              return 1;
+            }
+        case "number" : 
+            if (b_type === "number") {
+              return Caml_primitive.caml_int_compare(a, b);
+            } else {
+              exit = 1;
+            }
+            break;
+        case "string" : 
+            if (b_type === "string") {
+              return Caml_primitive.caml_string_compare(a, b);
+            } else {
+              return 1;
+            }
+        case "undefined" : 
+            return -1;
+        default:
+          exit = 1;
+      }
+      if (exit === 1) {
+        if (b_type === "undefined") {
+          return 1;
+        } else if (a_type === "number") {
+          if (b === null || b.tag === 256) {
+            return 1;
           } else {
             return -1;
           }
-        } else if (is_b_number) {
-          return 1;
-        } else if (a_type === "boolean") {
-          var x = a;
-          var y = b;
-          if (x === y) {
-            return 0;
-          } else if (x < y) {
+        } else if (b_type === "number") {
+          if (a === null || a.tag === 256) {
             return -1;
           } else {
             return 1;
           }
-        } else if (a_type === "function" || b_type === "function") {
-          throw [
-                Caml_builtin_exceptions.invalid_argument,
-                "compare: functional value"
-              ];
+        } else if (a === null) {
+          if (b.tag === 256) {
+            return 1;
+          } else {
+            return -1;
+          }
+        } else if (b === null) {
+          if (a.tag === 256) {
+            return -1;
+          } else {
+            return 1;
+          }
         } else {
           var tag_a = a.tag | 0;
           var tag_b = b.tag | 0;
@@ -114,6 +140,12 @@ function caml_compare(_a, _b) {
           } else if (tag_b === 250) {
             _b = b[0];
             continue ;
+          } else if (tag_a === 256) {
+            if (tag_b === 256) {
+              return Caml_primitive.caml_int_compare(a[1], b[1]);
+            } else {
+              return -1;
+            }
           } else if (tag_a === 248) {
             return Caml_primitive.caml_int_compare(a[1], b[1]);
           } else if (tag_a === 251) {
@@ -248,6 +280,7 @@ function caml_compare(_a, _b) {
           }
         }
       }
+      
     }
   };
 }
@@ -289,6 +322,8 @@ function caml_equal(_a, _b) {
                 ];
           } else if (tag_a !== tag_b) {
             return false;
+          } else if (tag_a === 256) {
+            return a[1] === b[1];
           } else {
             var len_a = a.length | 0;
             var len_b = b.length | 0;

--- a/lib/js/js_primitive.js
+++ b/lib/js/js_primitive.js
@@ -5,15 +5,20 @@ var undefinedHeader = /* array */[];
 
 function some(x) {
   if (x === undefined) {
-    return /* tuple */[
-            undefinedHeader,
-            0
-          ];
+    var block = /* tuple */[
+      undefinedHeader,
+      0
+    ];
+    block.tag = 256;
+    return block;
   } else if (x !== null && x[0] === undefinedHeader) {
-    return /* tuple */[
-            undefinedHeader,
-            x[1] + 1 | 0
-          ];
+    var nid = x[1] + 1 | 0;
+    var block$1 = /* tuple */[
+      undefinedHeader,
+      nid
+    ];
+    block$1.tag = 256;
+    return block$1;
   } else {
     return x;
   }


### PR DESCRIPTION
by introducing a tag 256 to makes it easier to fix polymoprhic comparison semantics

conclusion: `None, Some None, Some (Some (None)) ...` such group is strictly smaller than value outside of this group. In that case we need check comparison between `Some None` and `(Some null)`
todo: caml_equal