### PR TITLE
Fix react-lite template script path

### DIFF
--- a/jscomp/bsb/templates/react-lite/index.html
+++ b/jscomp/bsb/templates/react-lite/index.html
@@ -10,7 +10,7 @@
   Component 2:
   <div id="index2"></div>
 
-  <script src="./loader.js" type="module" data-main="./src/index.bs.js"></script>
+  <script src="./loader.js" type="module" data-main="./src/Index.bs.js"></script>
   <script src="./watcher.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
This to make sure it works on a case-sensitive filesystem (aka linux) 