### PR TITLE
Quote each entry in ppx-flags in bsconfig.json

### DIFF
--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -24,10 +24,17 @@
 
 let flag_concat flag xs = 
   xs 
-  |> Ext_list.flat_map (fun x -> [flag ; Filename.quote x])
+  |> Ext_list.flat_map (fun x -> [flag ; x])
   |> String.concat Ext_string.single_space
 let (//) = Ext_path.combine
 
+
+let ppx_flags xs =
+  xs
+  |> List.map Filename.quote
+  |> flag_concat "-ppx"
+
+let include_dirs = flag_concat "-I"
 
 
 (* we use lazy $src_root_dir *)

--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -24,7 +24,7 @@
 
 let flag_concat flag xs = 
   xs 
-  |> Ext_list.flat_map (fun x -> [flag ; x])
+  |> Ext_list.flat_map (fun x -> [flag ; Filename.quote x])
   |> String.concat Ext_string.single_space
 let (//) = Ext_path.combine
 

--- a/jscomp/bsb/bsb_build_util.mli
+++ b/jscomp/bsb/bsb_build_util.mli
@@ -22,15 +22,25 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-(** 
+(**
+Build quoted commandline arguments for bsc.exe for the given ppx flags
+
 Use:
 {[
-flag_concat "-ppx" [ppxs]
+ppx_flags [ppxs]
 ]}
 *)
-val flag_concat : string -> string list -> string
+val ppx_flags : string list -> string
 
+(**
+Build unquoted command line arguments for bsc.exe for the given include dirs
 
+Use:
+{[
+include_dirs [dirs]
+]}
+*)
+val include_dirs : string list -> string
 
 
 val mkp : string -> unit

--- a/jscomp/bsb/bsb_merlin_gen.ml
+++ b/jscomp/bsb/bsb_merlin_gen.ml
@@ -135,7 +135,7 @@ let merlin_file_gen ~cwd
     | [] -> ()
     | _ -> 
 
-      Buffer.add_string buffer (merlin_flg ^ Bsb_build_util.flag_concat "-I" external_includes
+      Buffer.add_string buffer (merlin_flg ^ Bsb_build_util.include_dirs external_includes
       ));
     *)
     external_includes 

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -45,7 +45,6 @@ let merge_module_info_map acc sources : Bsb_db.t =
 let bsc_exe = "bsc.exe"
 let bsb_helper_exe = "bsb_helper.exe"
 let dash_i = "-I"
-let dash_ppx = "-ppx"
 
 
 
@@ -78,16 +77,16 @@ let output_ninja_and_namespace_map
   let bsc = bsc_dir // bsc_exe in   (* The path to [bsc.exe] independent of config  *)
   let bsdep = bsc_dir // bsb_helper_exe in (* The path to [bsb_heler.exe] *)
   let cwd_lib_bs = cwd // Bsb_config.lib_bs in 
-  let ppx_flags = Bsb_build_util.flag_concat dash_ppx ppx_flags in
+  let ppx_flags = Bsb_build_util.ppx_flags ppx_flags in
   let bsc_flags =  String.concat Ext_string.single_space bsc_flags in
   let refmt_flags = String.concat Ext_string.single_space refmt_flags in
   let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in
   let bs_package_includes = 
-    Bsb_build_util.flag_concat dash_i @@ Ext_list.map 
+    Bsb_build_util.include_dirs @@ Ext_list.map 
       (fun (x : Bsb_config_types.dependency) -> x.package_install_path) bs_dependencies
   in
   let bs_package_dev_includes = 
-    Bsb_build_util.flag_concat dash_i @@ Ext_list.map 
+    Bsb_build_util.include_dirs @@ Ext_list.map 
       (fun (x : Bsb_config_types.dependency) -> x.package_install_path) bs_dev_dependencies
   in  
   let has_reason_files = ref false in 
@@ -166,7 +165,7 @@ let output_ninja_and_namespace_map
   let emit_bsc_lib_includes source_dirs = 
     Bsb_ninja_util.output_kv
       Bsb_build_schemas.bsc_lib_includes 
-      (Bsb_build_util.flag_concat dash_i @@ 
+      (Bsb_build_util.include_dirs @@ 
        (all_includes 
           (if namespace = None then source_dirs 
            else Filename.current_dir_name :: source_dirs) ))  oc 
@@ -203,7 +202,7 @@ let output_ninja_and_namespace_map
         String_map.iter (fun k _ -> if String_map.mem k lib then failwith ("conflict files found:" ^ k)) c ;
         Bsb_ninja_util.output_kv 
           (Bsb_dir_index.(string_of_bsb_dev_include (of_int i)))
-          (Bsb_build_util.flag_concat dash_i @@ source_dirs.(i)) oc
+          (Bsb_build_util.include_dirs @@ source_dirs.(i)) oc
       done  ;
       bs_groups,source_dirs.((Bsb_dir_index.lib_dir_index:>int)), static_resources
   in

--- a/lib/bsb.ml
+++ b/lib/bsb.ml
@@ -5825,7 +5825,7 @@ end = struct
 
 let flag_concat flag xs = 
   xs 
-  |> Ext_list.flat_map (fun x -> [flag ; x])
+  |> Ext_list.flat_map (fun x -> [flag ; Filename.quote x])
   |> String.concat Ext_string.single_space
 let (//) = Ext_path.combine
 


### PR DESCRIPTION
This fixes #1704 by running `Filename.quote` on each entry in the `ppx-flags` array.

Since the fix is applied to `Bsb_build_util.flag_concat`, it should also fix potential issues with include paths containing spaces. I couldn't find any existing tests or any hints as to how this could be tested, so I would appreciate some ideas or pointers.

It's unfortunately a breaking change since people who today have entered e.g. `ppx-flags: ["graphql_ppx/ppx\\ -ast-out"]` will get doubly escaped backslashes.