### PR TITLE
tentative fix for #2983

### DIFF
--- a/jscomp/bsb/bsb_config_parse.ml
+++ b/jscomp/bsb/bsb_config_parse.ml
@@ -124,7 +124,7 @@ let interpret_json
   : Bsb_config_types.t =
 
   let reason_react_jsx = ref None in 
-  let config_json = (cwd // Literals.bsconfig_json) in
+  let config_json = cwd // Literals.bsconfig_json in
   let refmt_flags = ref Bsb_default.refmt_flags in
   let bs_external_includes = ref [] in 
   (** we should not resolve it too early,

--- a/jscomp/bsb/bsb_default.ml
+++ b/jscomp/bsb/bsb_default.ml
@@ -26,9 +26,8 @@
 (* for default warning flags, please see bsb_warning.ml *)
 let bsc_flags =
   [
-    "-no-alias-deps";
     "-color"; "always"
-  ]
+  ] 
 
 
 let refmt_flags = ["--print"; "binary"]

--- a/jscomp/bsb/bsb_log.ml
+++ b/jscomp/bsb/bsb_log.ml
@@ -22,11 +22,29 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-let color_enabled = ref (Unix.isatty Unix.stdout)
+
+
+let ninja_ansi_forced = lazy 
+  (try Sys.getenv "NINJA_ANSI_FORCED" with 
+    Not_found  ->""
+  )  
+let color_enabled = lazy (Unix.isatty Unix.stdout)
+
+(* same logic as [ninja.exe] *)
+let get_color_enabled () = 
+  let colorful = 
+    match ninja_ansi_forced with 
+    | lazy "1" -> true     
+    | lazy ("0" | "false") -> false
+    | _ ->
+      Lazy.force color_enabled  in 
+  colorful 
+
+
 
 let color_functions : Format.formatter_tag_functions = {
-  mark_open_tag = (fun s ->  if !color_enabled then  Ext_color.ansi_of_tag s else Ext_string.empty) ;
-  mark_close_tag = (fun _ ->  if !color_enabled then Ext_color.reset_lit else Ext_string.empty);
+  mark_open_tag = (fun s ->  if get_color_enabled () then  Ext_color.ansi_of_tag s else Ext_string.empty) ;
+  mark_close_tag = (fun _ ->  if get_color_enabled () then Ext_color.reset_lit else Ext_string.empty);
   print_open_tag = (fun _ -> ());
   print_close_tag = (fun _ -> ())
 }

--- a/jscomp/bsb/bsb_log.mli
+++ b/jscomp/bsb/bsb_log.mli
@@ -22,7 +22,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-val color_enabled : bool ref 
 
 val setup : unit -> unit 
 

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -54,10 +54,6 @@ let bsb_main_flags : (string * Arg.spec * string) list=
     " Print version and exit";
     "-verbose", Arg.Unit Bsb_log.verbose,
     " Set the output(from bsb) to be verbose";
-    "-color", Arg.Set Bsb_log.color_enabled,
-    " forced color output";
-    "-no-color", Arg.Clear Bsb_log.color_enabled,
-    " forced no color output";
     "-w", Arg.Set watch_mode,
     " Watch mode" ;     
     "-clean-world", Arg.Unit (fun _ -> 

--- a/jscomp/core/js_main.ml
+++ b/jscomp/core/js_main.ml
@@ -242,6 +242,8 @@ let _ =
   Clflags.debug := true;
   Clflags.record_event_when_debug := false;
   Clflags.binary_annotations := true; 
+  Clflags.transparent_modules := true;
+  (* Turn on [-no-alias-deps] by default *)
   Oprint.out_ident := Outcome_printer_ns.out_ident;
   Bs_conditional_initial.setup_env ();
   try

--- a/jscomp/test/bigarray_test.js
+++ b/jscomp/test/bigarray_test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Bigarray = require("../../lib/js/bigarray.js");
 var Caml_int32 = require("../../lib/js/caml_int32.js");
 var Caml_missing_polyfill = require("../../lib/js/caml_missing_polyfill.js");
 
@@ -43,4 +42,4 @@ exports.sum = sum;
 exports.init = init;
 exports.init2 = init2;
 exports.init3 = init3;
-/* Bigarray Not a pure module */
+/* No side effect */

--- a/lib/bsb
+++ b/lib/bsb
@@ -96,11 +96,24 @@ for (var i = 2; i < process_argv.length; ++i) {
     }
 }
 
-var tty = require('tty')
-if(tty.isatty(1)){
-    process.env.NINJA_ANSI_FORCED = '1'
+
+if(
+    process.env.NINJA_ANSI_FORCED === undefined 
+  ){
+
+    if(require ('tty').isatty(1)){
+        process.env.NINJA_ANSI_FORCED = '1'
+    }
+    
+} else {
+    dlog(`NINJA_ANSI_FORCED: "${process.env.NINJA_ANSI_FORCED}"`)
 }
 
+// Note the watch mode flag `-w` is not very useful to bsb.exe
+// A trick is played that for such flags `bsb.exe -make-world -w`
+// it will exit ignoreing `-make-world` since it will be triggered
+// again in bsb
+// The following process atm only spawned `bsb.exe` directly
 try {
     child_process.execFileSync(bsb_exe, delegate_args, { stdio: 'inherit' })
 } catch (e) {


### PR DESCRIPTION
Note the fix is not ideal.
In a clean slate, to get colorless output,
people need run `bsb -clean-world` first to remove those colors, and `bsb -no-color --`, the `--` is needed to trigger the build

cc @Khady 