### PR TITLE
Support npm namespaced packages in the loader

### DIFF
--- a/jscomp/bsb/templates/react-lite/loader.js
+++ b/jscomp/bsb/templates/react-lite/loader.js
@@ -249,6 +249,7 @@ function getParentModulePromise(id, parent) {
  */
 function getPackageName(id) {
     var index = id.indexOf('/')
+    if (id[0] === '@') index = id.indexOf('/', index + 1)
     if (index === -1) {
         return id
     }


### PR DESCRIPTION
The correct package name for `@astrada/bs-css-core/lib/js/src/Css.js` is `@astrada/bs-css-core` but `getPackageName` was returning `@astrada` and the package was failing to load.

I'd also like to say a big thank you for writing this and including it. I've always hated using bundlers in development mode. This loader is a much better development experience 👍 