### PR TITLE
Add development server (optional) to Reason React template

### DIFF
--- a/jscomp/bsb/templates/react/README.md
+++ b/jscomp/bsb/templates/react/README.md
@@ -9,9 +9,17 @@ npm start
 npm run webpack
 ```
 
-After you see the webpack compilation succeed (the `npm run webpack` step), open up `src/index.html` (**no server needed!**). Then modify whichever `.re` file in `src` and refresh the page to see the changes.
+After you see the webpack compilation succeed (the `npm run webpack` step), open up `build/index.html` (**no server needed!**). Then modify whichever `.re` file in `src` and refresh the page to see the changes.
 
 **For more elaborate ReasonReact examples**, please see https://github.com/reasonml-community/reason-react-example
+
+## Run Project with Server
+
+To run with the webpack development server run `npm run server` and view in the browser at http://localhost:8000. Running in this environment provides hot reloading and support for routing; just edit and save the file and the browser will automatically refresh.
+
+Note that any hot reload on a route will fall back to the root (`/`), so `ReasonReact.Router.dangerouslyGetInitialUrl` will likely be needed alongside the `ReasonReact.Router.watchUrl` logic to handle routing correctly on hot reload refreshes or simply opening the app at a URL that is not the root.
+
+To use a port other than 8000 set the `PORT` environment variable (`PORT=8080 npm run server`).
 
 ## Build for Production
 
@@ -20,6 +28,8 @@ npm run build
 npm run webpack:production
 ```
 
-This will replace the development artifact `build/Index.js` for an optimized version.
+This will replace the development artifact `build/Index.js` for an optimized version as well as copy `src/index.html` into `build/`. You can then deploy the contents of the `build` directory (`index.html` and `Index.js`).
+
+If you make use of routing (via `ReasonReact.Router` or similar logic) ensure that server-side routing handles your routes or that 404's are directed back to `index.html` (which is how the dev server is set up).
 
 **To enable dead code elimination**, change `bsconfig.json`'s `package-specs` `module` from `"commonjs"` to `"es6"`. Then re-run the above 2 commands. This will allow Webpack to remove unused code.

--- a/jscomp/bsb/templates/react/package.json
+++ b/jscomp/bsb/templates/react/package.json
@@ -7,7 +7,8 @@
     "clean": "bsb -clean-world",
     "test": "echo \"Error: no test specified\" && exit 1",
     "webpack": "webpack -w",
-    "webpack:production": "NODE_ENV=production webpack"
+    "webpack:production": "NODE_ENV=production webpack",
+    "server": "webpack-dev-server"
   },
   "keywords": [
     "BuckleScript"
@@ -21,7 +22,9 @@
   },
   "devDependencies": {
     "bs-platform": "^${bsb:bs-version}",
+    "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.0.1",
-    "webpack-cli": "^3.1.1"
+    "webpack-cli": "^3.1.1",
+    "webpack-dev-server": "^3.1.8"
   }
 }

--- a/jscomp/bsb/templates/react/src/index.html
+++ b/jscomp/bsb/templates/react/src/index.html
@@ -10,6 +10,6 @@
   Component 2:
   <div id="index2"></div>
 
-  <script src="../build/Index.js"></script>
+  <script src="Index.js"></script>
 </body>
 </html>

--- a/jscomp/bsb/templates/react/webpack.config.js
+++ b/jscomp/bsb/templates/react/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const outputDir = path.join(__dirname, "build/");
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const outputDir = path.join(__dirname, 'build/');
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -11,4 +12,16 @@ module.exports = {
     publicPath: outputDir,
     filename: 'Index.js',
   },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: 'src/index.html',
+      inject: false
+    })
+  ],
+  devServer: {
+    compress: true,
+    contentBase: outputDir,
+    port: process.env.PORT || 8000,
+    historyApiFallback: true
+  }
 };


### PR DESCRIPTION
This adds a dev server via [webpack-dev-server](https://github.com/webpack/webpack-dev-server) to the Reason React template (`npm run server`). This enables hot reloading and routing (not just hash changes, but the History API as well). While the server option is added, the simpler server-less development can still be used. The other benefit from moving is that all of the build assets needed to run in a production environment (mainly the addition of `index.html`, which is now copied over) are contained within the `/build` folder.

Obviously this adds a few development dependencies (webpack-dev-server and [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)), but I think providing this as an option is helpful, especially for people that make use of routing libraries [`ReasonReact.Router`](https://reasonml.github.io/reason-react/docs/en/router).

**Key Changes**
- Optional development server (`npm run server`)
- Server allows for hot reloading and routing
- Server-less builds still work by opening `build/index.html`
- The development server provides the structure for the `ReasonReact.Router` module to handle page refreshes, making it easier to develop when using routing
