### PR TITLE
Upgrade `webpack-cli` to fix broken `npm run webpack`

### DIFF
--- a/jscomp/bsb/templates/react/package.json
+++ b/jscomp/bsb/templates/react/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "bs-platform": "^${bsb:bs-version}",
     "webpack": "^4.0.1",
-    "webpack-cli": "^2.0.10"
+    "webpack-cli": "^3.1.1"
   }
 }


### PR DESCRIPTION
If you run `npm run webpack` with the `react` template, it throws an error:

`TypeError: Cannot read property 'properties' of undefined`
`describe: optionsSchema.definitions.output.properties.path.description`

A recent update went out with breaking changes, `webpack-cli` needs to be upgraded to `3.1.1` to fix the issue. 

See related discussion here: [#8082](https://github.com/webpack/webpack/issues/8082)

This PR simply applies the needed `webpack-cli` update. I tested it out, the script works as expected again.