### PR TITLE
[Belt] Add List.filter/WithIndex with deprecation warning and point to List.keep/WithIndex

### DIFF
--- a/jscomp/others/belt_List.ml
+++ b/jscomp/others/belt_List.ml
@@ -743,6 +743,8 @@ let rec keepU xs p  =
 
 let keep xs p = keepU xs (fun[@bs] x -> p x)
 
+let filter = keep
+
 let keepWithIndexU xs p =
   let rec auxKeepWithIndex xs p i =
     match xs with
@@ -759,6 +761,8 @@ let keepWithIndexU xs p =
   in auxKeepWithIndex xs p 0
 
 let keepWithIndex xs p = keepWithIndexU xs (fun [@bs] x i -> p x i)
+
+let filterWithIndex = keepWithIndex
 
 let rec keepMapU xs p  =
   match xs with

--- a/jscomp/others/belt_List.mli
+++ b/jscomp/others/belt_List.mli
@@ -574,6 +574,7 @@ val keep: 'a t ->  ('a -> bool) -> 'a t
     ]}
 *)
 
+[@@deprecated "This function will soon be deprecated. Please, use `List.keep` instead."]
 val filter: 'a t ->  ('a -> bool) -> 'a t
 (** [filter  xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
 
@@ -594,6 +595,7 @@ val keepWithIndex: 'a t ->  ('a -> int -> bool) -> 'a t
     ]}
 *)
 
+[@@deprecated "This function will soon be deprecated. Please, use `List.keepWithIndex` instead."]
 val filterWithIndex: 'a t ->  ('a -> int -> bool) -> 'a t
 (** [filterWithIndex xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
 

--- a/jscomp/others/belt_List.mli
+++ b/jscomp/others/belt_List.mli
@@ -574,12 +574,31 @@ val keep: 'a t ->  ('a -> bool) -> 'a t
     ]}
 *)
 
+val filter: 'a t ->  ('a -> bool) -> 'a t
+(** [filter  xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
+
+    @example {[
+      filter [1;2;3;4] (fun x -> x mod 2 = 0) =
+      [2;4]
+    ]}
+*)
+
 val keepWithIndexU: 'a t ->  ('a -> int -> bool [@bs]) -> 'a t
 val keepWithIndex: 'a t ->  ('a -> int -> bool) -> 'a t
 (** [keepWithIndex xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
 
     @example {[
       keepWithIndex [1;2;3;4] (fun _x i -> i mod 2 = 0)
+      =
+      [1;3]
+    ]}
+*)
+
+val filterWithIndex: 'a t ->  ('a -> int -> bool) -> 'a t
+(** [filterWithIndex xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
+
+    @example {[
+      filterWithIndex [1;2;3;4] (fun _x i -> i mod 2 = 0)
       =
       [1;3]
     ]}

--- a/jscomp/test/bs_list_test.ml
+++ b/jscomp/test/bs_list_test.ml
@@ -106,13 +106,20 @@ let () =
   N.keep [1;2;3;4] mod2 =~ [2;4];
   N.keep [1;3;41] mod2 =~ [];
   N.keep [] mod2 =~ [];
-  N.keep  [2;2;2;4;6] mod2 =~ [2;2;2;4;6]
+  N.keep  [2;2;2;4;6] mod2 =~ [2;2;2;4;6];
+  N.filter [1;2;3;4] mod2 =~ [2;4];
+  N.filter [1;3;41] mod2 =~ [];
+  N.filter [] mod2 =~ [];
+  N.filter  [2;2;2;4;6] mod2 =~ [2;2;2;4;6]
 
 let () =
   let (=~) = eq "FILTER2" in
   N.keepWithIndex [] evenIndex =~ [];
   N.keepWithIndex [1;2;3;4] evenIndex =~ [1;3];
-  N.keepWithIndex [0;1;2;3;4;5;6;7] evenIndex =~ [0;2;4;6]
+  N.keepWithIndex [0;1;2;3;4;5;6;7] evenIndex =~ [0;2;4;6];
+  N.filterWithIndex [] evenIndex =~ [];
+  N.filterWithIndex [1;2;3;4] evenIndex =~ [1;3];
+  N.filterWithIndex [0;1;2;3;4;5;6;7] evenIndex =~ [0;2;4;6]
 
 let id : int -> int = fun  x -> x 
 

--- a/jscomp/test/bs_list_test.ml
+++ b/jscomp/test/bs_list_test.ml
@@ -106,20 +106,13 @@ let () =
   N.keep [1;2;3;4] mod2 =~ [2;4];
   N.keep [1;3;41] mod2 =~ [];
   N.keep [] mod2 =~ [];
-  N.keep  [2;2;2;4;6] mod2 =~ [2;2;2;4;6];
-  N.filter [1;2;3;4] mod2 =~ [2;4];
-  N.filter [1;3;41] mod2 =~ [];
-  N.filter [] mod2 =~ [];
-  N.filter  [2;2;2;4;6] mod2 =~ [2;2;2;4;6]
+  N.keep  [2;2;2;4;6] mod2 =~ [2;2;2;4;6]
 
 let () =
   let (=~) = eq "FILTER2" in
   N.keepWithIndex [] evenIndex =~ [];
   N.keepWithIndex [1;2;3;4] evenIndex =~ [1;3];
-  N.keepWithIndex [0;1;2;3;4;5;6;7] evenIndex =~ [0;2;4;6];
-  N.filterWithIndex [] evenIndex =~ [];
-  N.filterWithIndex [1;2;3;4] evenIndex =~ [1;3];
-  N.filterWithIndex [0;1;2;3;4;5;6;7] evenIndex =~ [0;2;4;6]
+  N.keepWithIndex [0;1;2;3;4;5;6;7] evenIndex =~ [0;2;4;6]
 
 let id : int -> int = fun  x -> x 
 


### PR DESCRIPTION
Hi, I found this pretty confusing since the native `List` OCaml does contain a `filter` method, I guess every js dev would expect `Belt.List` to have exactly that naming as well.

This also came up during @ryyppy workshop in Alicante and I noticed some people were confused as well.

For now can we consider to have an alias to that fns? @IwanKaramazow also mentioned to me something about a deprecation flag in OCaml but I have literally no idea how to do that 😄 