### PR TITLE
fix *predef* Some

### DIFF
--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -203,7 +203,8 @@ syntax/ast_derive.cmx : ext/string_map.cmx ext/literals.cmx \
 syntax/ast_comb.cmx : ext/ext_list.cmx syntax/ast_literal.cmx \
     syntax/ast_compatible.cmx syntax/ast_comb.cmi
 syntax/ast_core_type.cmx : ext/ext_list.cmx syntax/bs_syntaxerr.cmx \
-    syntax/ast_compatible.cmx syntax/ast_comb.cmx syntax/ast_core_type.cmi
+    syntax/ast_literal.cmx syntax/ast_compatible.cmx syntax/ast_comb.cmx \
+    syntax/ast_core_type.cmi
 syntax/bs_ast_invariant.cmx : ext/literals.cmx ext/hash_set_poly.cmx \
     ext/ext_string.cmx common/bs_warnings.cmx syntax/bs_ast_iterator.cmx \
     syntax/ast_core_type.cmx syntax/bs_ast_invariant.cmi

--- a/jscomp/syntax/ast_core_type.ml
+++ b/jscomp/syntax/ast_core_type.ml
@@ -30,15 +30,12 @@ type t = Parsetree.core_type
 
 
 
-let predef_option : Longident.t =
-  Ldot (Lident "*predef*", "option")
-
 
 
 let lift_option_type ({ptyp_loc} as ty:t) : t =
   {ptyp_desc =
      Ptyp_constr(
-       {txt = predef_option;
+       {txt = Ast_literal.predef_option;
         loc = ptyp_loc}
         , [ty]);
         ptyp_loc = ptyp_loc;

--- a/jscomp/syntax/ast_literal.ml
+++ b/jscomp/syntax/ast_literal.ml
@@ -25,6 +25,18 @@
 open Ast_helper
 
 
+let predef_prefix_ident : Longident.t = Lident "*predef*"
+
+let predef_option : Longident.t =
+  Ldot (predef_prefix_ident, "option")
+
+let predef_some : Longident.t =   
+  Ldot (predef_prefix_ident, "Some")
+
+let predef_none : Longident.t = 
+  Ldot (predef_prefix_ident, "None")
+
+
 module Lid = struct 
   type t = Longident.t 
   let val_unit : t = Lident "()"

--- a/jscomp/syntax/ast_literal.mli
+++ b/jscomp/syntax/ast_literal.mli
@@ -24,6 +24,11 @@
 
 
 type 'a  lit = ?loc: Location.t -> unit -> 'a
+
+val predef_option : Longident.t 
+val predef_some : Longident.t 
+val predef_none : Longident.t 
+
 module Lid : sig
   type t = Longident.t 
   val val_unit : t 

--- a/jscomp/syntax/ast_util.ml
+++ b/jscomp/syntax/ast_util.ml
@@ -662,9 +662,7 @@ and check_pat (pat : Parsetree.pattern) =
 let convertBsErrorFunction loc  (self : Bs_ast_mapper.mapper) attrs (cases : Parsetree.case list ) =
   let txt  = "match" in 
   let txt_expr = Exp.ident ~loc {txt = Lident txt; loc} in 
-  let none = Exp.constraint_ ~loc 
-      (Exp.construct ~loc {txt = Lident "None" ; loc} None) 
-      (Ast_core_type.lift_option_type (Typ.any ~loc ())) in
+  let none = Exp.construct ~loc {txt = Ast_literal.predef_none ; loc} None in
   let () = checkCases cases in  
   let cases = self.cases self cases in 
   Ast_compatible.fun_ ~attrs ~loc ( Pat.var ~loc  {txt; loc })
@@ -682,14 +680,9 @@ let convertBsErrorFunction loc  (self : Bs_ast_mapper.mapper) attrs (cases : Par
            let pc_rhs = x.pc_rhs in 
            let  loc  = pc_rhs.pexp_loc in
            {
-             x with pc_rhs = 
-                      Exp.constraint_ ~loc 
-                        (Exp.construct ~loc {txt = Lident "Some";loc} (Some pc_rhs))
-                        (Ast_core_type.lift_option_type (Typ.any ~loc ())  )
-           }
-
-         ) )
-    )
+             x with pc_rhs = Exp.construct ~loc {txt = Ast_literal.predef_some;loc} (Some pc_rhs)
+                        
+           })))
     (Some none))
     
                        

--- a/lib/bsdep.ml
+++ b/lib/bsdep.ml
@@ -26410,6 +26410,11 @@ module Ast_literal : sig
 
 
 type 'a  lit = ?loc: Location.t -> unit -> 'a
+
+val predef_option : Longident.t 
+val predef_some : Longident.t 
+val predef_none : Longident.t 
+
 module Lid : sig
   type t = Longident.t 
   val val_unit : t 
@@ -26469,6 +26474,18 @@ end = struct
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 open Ast_helper
+
+
+let predef_prefix_ident : Longident.t = Lident "*predef*"
+
+let predef_option : Longident.t =
+  Ldot (predef_prefix_ident, "option")
+
+let predef_some : Longident.t =   
+  Ldot (predef_prefix_ident, "Some")
+
+let predef_none : Longident.t = 
+  Ldot (predef_prefix_ident, "None")
 
 
 module Lid = struct 
@@ -27037,15 +27054,12 @@ type t = Parsetree.core_type
 
 
 
-let predef_option : Longident.t =
-  Ldot (Lident "*predef*", "option")
-
 
 
 let lift_option_type ({ptyp_loc} as ty:t) : t =
   {ptyp_desc =
      Ptyp_constr(
-       {txt = predef_option;
+       {txt = Ast_literal.predef_option;
         loc = ptyp_loc}
         , [ty]);
         ptyp_loc = ptyp_loc;
@@ -35235,9 +35249,7 @@ and check_pat (pat : Parsetree.pattern) =
 let convertBsErrorFunction loc  (self : Bs_ast_mapper.mapper) attrs (cases : Parsetree.case list ) =
   let txt  = "match" in 
   let txt_expr = Exp.ident ~loc {txt = Lident txt; loc} in 
-  let none = Exp.constraint_ ~loc 
-      (Exp.construct ~loc {txt = Lident "None" ; loc} None) 
-      (Ast_core_type.lift_option_type (Typ.any ~loc ())) in
+  let none = Exp.construct ~loc {txt = Ast_literal.predef_none ; loc} None in
   let () = checkCases cases in  
   let cases = self.cases self cases in 
   Ast_compatible.fun_ ~attrs ~loc ( Pat.var ~loc  {txt; loc })
@@ -35255,14 +35267,9 @@ let convertBsErrorFunction loc  (self : Bs_ast_mapper.mapper) attrs (cases : Par
            let pc_rhs = x.pc_rhs in 
            let  loc  = pc_rhs.pexp_loc in
            {
-             x with pc_rhs = 
-                      Exp.constraint_ ~loc 
-                        (Exp.construct ~loc {txt = Lident "Some";loc} (Some pc_rhs))
-                        (Ast_core_type.lift_option_type (Typ.any ~loc ())  )
-           }
-
-         ) )
-    )
+             x with pc_rhs = Exp.construct ~loc {txt = Ast_literal.predef_some;loc} (Some pc_rhs)
+                        
+           })))
     (Some none))
     
                        

--- a/lib/bsppx.ml
+++ b/lib/bsppx.ml
@@ -8352,6 +8352,11 @@ module Ast_literal : sig
 
 
 type 'a  lit = ?loc: Location.t -> unit -> 'a
+
+val predef_option : Longident.t 
+val predef_some : Longident.t 
+val predef_none : Longident.t 
+
 module Lid : sig
   type t = Longident.t 
   val val_unit : t 
@@ -8411,6 +8416,18 @@ end = struct
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 open Ast_helper
+
+
+let predef_prefix_ident : Longident.t = Lident "*predef*"
+
+let predef_option : Longident.t =
+  Ldot (predef_prefix_ident, "option")
+
+let predef_some : Longident.t =   
+  Ldot (predef_prefix_ident, "Some")
+
+let predef_none : Longident.t = 
+  Ldot (predef_prefix_ident, "None")
 
 
 module Lid = struct 
@@ -8979,15 +8996,12 @@ type t = Parsetree.core_type
 
 
 
-let predef_option : Longident.t =
-  Ldot (Lident "*predef*", "option")
-
 
 
 let lift_option_type ({ptyp_loc} as ty:t) : t =
   {ptyp_desc =
      Ptyp_constr(
-       {txt = predef_option;
+       {txt = Ast_literal.predef_option;
         loc = ptyp_loc}
         , [ty]);
         ptyp_loc = ptyp_loc;
@@ -17240,9 +17254,7 @@ and check_pat (pat : Parsetree.pattern) =
 let convertBsErrorFunction loc  (self : Bs_ast_mapper.mapper) attrs (cases : Parsetree.case list ) =
   let txt  = "match" in 
   let txt_expr = Exp.ident ~loc {txt = Lident txt; loc} in 
-  let none = Exp.constraint_ ~loc 
-      (Exp.construct ~loc {txt = Lident "None" ; loc} None) 
-      (Ast_core_type.lift_option_type (Typ.any ~loc ())) in
+  let none = Exp.construct ~loc {txt = Ast_literal.predef_none ; loc} None in
   let () = checkCases cases in  
   let cases = self.cases self cases in 
   Ast_compatible.fun_ ~attrs ~loc ( Pat.var ~loc  {txt; loc })
@@ -17260,14 +17272,9 @@ let convertBsErrorFunction loc  (self : Bs_ast_mapper.mapper) attrs (cases : Par
            let pc_rhs = x.pc_rhs in 
            let  loc  = pc_rhs.pexp_loc in
            {
-             x with pc_rhs = 
-                      Exp.constraint_ ~loc 
-                        (Exp.construct ~loc {txt = Lident "Some";loc} (Some pc_rhs))
-                        (Ast_core_type.lift_option_type (Typ.any ~loc ())  )
-           }
-
-         ) )
-    )
+             x with pc_rhs = Exp.construct ~loc {txt = Ast_literal.predef_some;loc} (Some pc_rhs)
+                        
+           })))
     (Some none))
     
                        

--- a/vendor/ocaml/bytecomp/translcore.ml
+++ b/vendor/ocaml/bytecomp/translcore.ml
@@ -942,7 +942,9 @@ and transl_exp0 e =
           Lconst(Const_pointer (n,
             match lid.txt with
             | Lident ("false"|"true") -> Pt_builtin_boolean
-            | Lident "None" when Datarepr.constructor_has_optional_shape cstr
+            | Lident "None"
+            | Ldot (Lident "*predef*", "None")
+               when Datarepr.constructor_has_optional_shape cstr
               -> Pt_shape_none
             | _ -> (Lambda.Pt_constructor cstr.cstr_name)
             ))


### PR DESCRIPTION
TODO: checkout why ast_util module using (*predef*, None/Some) won’t work
Done