### PR TITLE
Fix webpack-dev-server script in `react` template

### DIFF
--- a/jscomp/bsb/templates/react/webpack.config.js
+++ b/jscomp/bsb/templates/react/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin')
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const outputDir = path.join(__dirname, 'build/');
 
 const isProd = process.env.NODE_ENV === 'production';
@@ -9,8 +9,7 @@ module.exports = {
   mode: isProd ? 'production' : 'development',
   output: {
     path: outputDir,
-    publicPath: outputDir,
-    filename: 'Index.js',
+    filename: 'Index.js'
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Fix the `server` script to run webpack-dev-server properly.

Previously, running `webpack-dev-server` would only work if you were also running the `wepback` script in another terminal tab.

After this change, simply running `yarn server` should be enough to get it working!

I ran `pack-templates.sh` to update the `bsb_templates.ml` file and it moved quite a bit of stuff around. Not sure why it did that, maybe `ocp-ocamlres` is not deterministic? I verified my changes are also in there, though.

### Testing Steps

1. Make sure there's no `build/` folder
2. Run `yarn/npm server`
4. Open `localhost:8000`
4. You should see the example components render as expected!
5. Make sure `yarn/npm webpack` is still working as expected
6. Make sure `yarn/npm webpack:production` is still working as expected
