### PR TITLE
Fix typos in docs referring to array instead of string

### DIFF
--- a/docs/api/Js.String.html
+++ b/docs/api/Js.String.html
@@ -96,7 +96,7 @@
 
 <pre><span class="keyword">module</span> String: <code class="type"><a href="Js_string.html">Js_string</a></code></pre><div class="info module top">
                     <div class="not-examples">
-                    Provide bindings to Js array<br>
+                    Provide bindings to Js string<br>
  
                     </div>
                     

--- a/docs/api/Js.html
+++ b/docs/api/Js.html
@@ -301,7 +301,6 @@ Provide utilities for dealing with Js exceptions<br>
                 </div> 
 <pre><span class="keyword">module</span> <a href="Js.String.html">String</a>: <code class="type"><a href="Js_string.html">Js_string</a></code></pre> <div class="info">                     
                 <div class="not-examples">
-                    Provide bindings to Js array<br>
  
                 </div>
                 </div> <br>

--- a/docs/api/index_modules.html
+++ b/docs/api/index_modules.html
@@ -1591,7 +1591,7 @@ and subsequent uses will ocntinue the search from the previous <a href="Js_re.ht
 <tr><td><a href="Js.String.html">String</a> [<a href="Js.html">Js</a>]</td>
 <td> <div class="info">                     
                 <div class="not-examples">
-                    Provide bindings to Js array<br>
+                    Provide bindings to Js string<br>
  
                 </div>
                 </div> </td></tr>


### PR DESCRIPTION
I noticed a few spots in the docs referring to arrays instead of strings.