### PR TITLE
Actually remove bs.send.pipe from js_typed_array2

### DIFF
--- a/jscomp/others/js_typed_array2.cppo.ml
+++ b/jscomp/others/js_typed_array2.cppo.ml
@@ -49,8 +49,8 @@ module ArrayBuffer = struct
 
   external byteLength : t -> int = "" [@@bs.get]
 
-  external slice : start:int -> end_:int -> array_buffer = "" [@@bs.send.pipe: t]
-  external sliceFrom : int -> array_buffer = "slice" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> array_buffer = "" [@@bs.send]
+  external sliceFrom : t -> int -> array_buffer = "slice" [@@bs.send]
 end
 
 #define COMMON_EXTERNALS(moduleName, eltType)\
@@ -66,86 +66,86 @@ end
   external byteLength : t -> int = "" [@@bs.get]\
   external byteOffset : t -> int = "" [@@bs.get]\
   \
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]\
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]\
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]\
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]\
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)\
   \
   (* Array interface(-ish) *)\
   external length : t -> int = "" [@@bs.get]\
   \
   (* Mutator functions *)\
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]\
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]\
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]\
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]\
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]\
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]\
   \
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]\
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]\
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]\
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]\
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]\
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]\
   \
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]\
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]\
   \
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]\
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]\
+  external sortInPlace : t -> t = "sort" [@@bs.send]\
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]\
   \
   (* Accessor functions *)\
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)\
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)\
   \
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]\
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]\
+  external indexOf : t -> elt  -> int = "" [@@bs.send]\
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]\
   \
-  external join : string = "" [@@bs.send.pipe: t]\
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]\
+  external join : t -> string = "" [@@bs.send]\
+  external joinWith : t -> string -> string = "join" [@@bs.send]\
   \
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]\
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]\
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]\
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]\
   \
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]\
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]\
   (** [start] is inclusive, [end_] exclusive *)\
-  external copy : t = "slice" [@@bs.send.pipe: t]\
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]\
+  external copy : t -> t = "slice" [@@bs.send]\
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]\
   \
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]\
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]\
   (** [start] is inclusive, [end_] exclusive *)\
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]\
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]\
   \
-  external toString : string = "" [@@bs.send.pipe: t]\
-  external toLocaleString : string = "" [@@bs.send.pipe: t]\
+  external toString : t -> string = "" [@@bs.send]\
+  external toLocaleString : t -> string = "" [@@bs.send]\
   \
   (* Iteration functions *)\
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)\
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]\
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]\
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]\
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]\
   \
   (** should we use [bool] or [boolan] seems they are intechangeable here *)\
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]\
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]\
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]\
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]\
   \
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]\
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]\
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]\
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]\
   \
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]\
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]\
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]\
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]\
   \
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]\
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]\
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]\
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]\
   \
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)\
   \
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]\
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]\
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]\
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]\
   \
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]\
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]\
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]\
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]\
   \
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]\
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]\
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]\
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]\
   \
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]\
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]\
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]\
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]\
   \
   external _BYTES_PER_ELEMENT: int = STRINGIFY(moduleName.BYTES_PER_ELEMENT) [@@bs.val]\
   \
@@ -163,7 +163,7 @@ end
   (* *Array.of is redundant, use make *)
 
   (* commented out until bs has a plan for iterators
-  external values : elt array_iter = "" [@@bs.send.pipe: t]
+  external values : t -> elt array_iter = "" [@@bs.send]
   *)
 
 module Int8Array = struct

--- a/jscomp/others/js_typed_array2.ml
+++ b/jscomp/others/js_typed_array2.ml
@@ -50,15 +50,15 @@ module ArrayBuffer = struct
 
   external byteLength : t -> int = "" [@@bs.get]
 
-  external slice : start:int -> end_:int -> array_buffer = "" [@@bs.send.pipe: t]
-  external sliceFrom : int -> array_buffer = "slice" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> array_buffer = "" [@@bs.send]
+  external sliceFrom : t -> int -> array_buffer = "slice" [@@bs.send]
 end
 
 
   
 # 165 "others/js_typed_array2.cppo.ml"
   (* commented out until bs has a plan for iterators
-  external values : elt array_iter = "" [@@bs.send.pipe: t]
+  external values : t -> elt array_iter = "" [@@bs.send]
   *)
 
 module Int8Array = struct
@@ -77,86 +77,86 @@ module Int8Array = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Int8Array.BYTES_PER_ELEMENT" [@@bs.val]
   
@@ -192,86 +192,86 @@ module Uint8Array = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Uint8Array.BYTES_PER_ELEMENT" [@@bs.val]
   
@@ -306,86 +306,86 @@ module Uint8ClampedArray = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Uint8ClampedArray.BYTES_PER_ELEMENT" [@@bs.val]
   
@@ -420,86 +420,86 @@ module Int16Array = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Int16Array.BYTES_PER_ELEMENT" [@@bs.val]
   
@@ -534,86 +534,86 @@ module Uint16Array = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Uint16Array.BYTES_PER_ELEMENT" [@@bs.val]
   
@@ -648,86 +648,86 @@ module Int32Array = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Int32Array.BYTES_PER_ELEMENT" [@@bs.val]
   
@@ -762,86 +762,86 @@ module Uint32Array = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Uint32Array.BYTES_PER_ELEMENT" [@@bs.val]
   
@@ -879,86 +879,86 @@ module Float32Array = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Float32Array.BYTES_PER_ELEMENT" [@@bs.val]
   
@@ -993,86 +993,86 @@ module Float64Array = struct
   external byteLength : t -> int = "" [@@bs.get]
   external byteOffset : t -> int = "" [@@bs.get]
   
-  external setArray : elt array -> unit = "set" [@@bs.send.pipe: t]
-  external setArrayOffset : elt array -> int -> unit = "set" [@@bs.send.pipe: t]
+  external setArray : t -> elt array -> unit = "set" [@@bs.send]
+  external setArrayOffset : t -> elt array -> int -> unit = "set" [@@bs.send]
   (* There's also an overload for typed arrays, but don't know how to model that without subtyping *)
   
   (* Array interface(-ish) *)
   external length : t -> int = "" [@@bs.get]
   
   (* Mutator functions *)
-  external copyWithin : to_:int -> t = "" [@@bs.send.pipe: t]
-  external copyWithinFrom : to_:int -> from:int -> t = "copyWithin" [@@bs.send.pipe: t]
-  external copyWithinFromRange : to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send.pipe: t]
+  external copyWithin : t -> to_:int -> t = "" [@@bs.send]
+  external copyWithinFrom : t -> to_:int -> from:int -> t = "copyWithin" [@@bs.send]
+  external copyWithinFromRange : t -> to_:int -> start:int -> end_:int -> t = "copyWithin" [@@bs.send]
   
-  external fillInPlace : elt -> t = "fill" [@@bs.send.pipe: t]
-  external fillFromInPlace : elt -> from:int -> t = "fill" [@@bs.send.pipe: t]
-  external fillRangeInPlace : elt -> start:int -> end_:int -> t = "fill" [@@bs.send.pipe: t]
+  external fillInPlace : t -> elt -> t = "fill" [@@bs.send]
+  external fillFromInPlace : t -> elt -> from:int -> t = "fill" [@@bs.send]
+  external fillRangeInPlace : t -> elt -> start:int -> end_:int -> t = "fill" [@@bs.send]
   
-  external reverseInPlace : t = "reverse" [@@bs.send.pipe: t]
+  external reverseInPlace : t -> t = "reverse" [@@bs.send]
   
-  external sortInPlace : t = "sort" [@@bs.send.pipe: t]
-  external sortInPlaceWith : (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send.pipe: t]
+  external sortInPlace : t -> t = "sort" [@@bs.send]
+  external sortInPlaceWith : t -> (elt -> elt -> int [@bs]) -> t = "sort" [@@bs.send]
   
   (* Accessor functions *)
-  external includes : elt -> bool = "" [@@bs.send.pipe: t] (** ES2016 *)
+  external includes : t -> elt -> bool = "" [@@bs.send] (** ES2016 *)
   
-  external indexOf : elt  -> int = "" [@@bs.send.pipe: t]
-  external indexOfFrom : elt -> from:int -> int = "indexOf" [@@bs.send.pipe: t]
+  external indexOf : t -> elt  -> int = "" [@@bs.send]
+  external indexOfFrom : t -> elt -> from:int -> int = "indexOf" [@@bs.send]
   
-  external join : string = "" [@@bs.send.pipe: t]
-  external joinWith : string -> string = "join" [@@bs.send.pipe: t]
+  external join : t -> string = "" [@@bs.send]
+  external joinWith : t -> string -> string = "join" [@@bs.send]
   
-  external lastIndexOf : elt -> int = "" [@@bs.send.pipe: t]
-  external lastIndexOfFrom : elt -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+  external lastIndexOf : t -> elt -> int = "" [@@bs.send]
+  external lastIndexOfFrom : t -> elt -> from:int -> int = "lastIndexOf" [@@bs.send]
   
-  external slice : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external slice : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external copy : t = "slice" [@@bs.send.pipe: t]
-  external sliceFrom : int -> t = "slice" [@@bs.send.pipe: t]
+  external copy : t -> t = "slice" [@@bs.send]
+  external sliceFrom : t -> int -> t = "slice" [@@bs.send]
   
-  external subarray : start:int -> end_:int -> t = "" [@@bs.send.pipe: t]
+  external subarray : t -> start:int -> end_:int -> t = "" [@@bs.send]
   (** [start] is inclusive, [end_] exclusive *)
-  external subarrayFrom : int -> t = "subarray" [@@bs.send.pipe: t]
+  external subarrayFrom : t -> int -> t = "subarray" [@@bs.send]
   
-  external toString : string = "" [@@bs.send.pipe: t]
-  external toLocaleString : string = "" [@@bs.send.pipe: t]
+  external toString : t -> string = "" [@@bs.send]
+  external toLocaleString : t -> string = "" [@@bs.send]
   
   (* Iteration functions *)
   (* commented out until bs has a plan for iterators
-  external entries : (int * elt) array_iter = "" [@@bs.send.pipe: t]
+  external entries : t -> (int * elt) array_iter = "" [@@bs.send]
   *)
-  external every : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external everyi : (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send.pipe: t]
+  external every : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external everyi : t -> (elt -> int -> bool [@bs]) -> bool = "every" [@@bs.send]
   
   (** should we use [bool] or [boolan] seems they are intechangeable here *)
-  external filter : (elt -> bool [@bs]) -> t = "" [@@bs.send.pipe: t]
-  external filteri : (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send.pipe: t]
+  external filter : t -> (elt -> bool [@bs]) -> t = "" [@@bs.send]
+  external filteri : t -> (elt -> int  -> bool [@bs]) -> t = "filter" [@@bs.send]
   
-  external find : (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send.pipe: t]
-  external findi : (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send.pipe: t]
+  external find : t -> (elt -> bool [@bs]) -> elt Js.undefined = "" [@@bs.send]
+  external findi : t -> (elt -> int -> bool [@bs]) -> elt Js.undefined  = "find" [@@bs.send]
   
-  external findIndex : (elt -> bool [@bs]) -> int = "" [@@bs.send.pipe: t]
-  external findIndexi : (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: t]
+  external findIndex : t -> (elt -> bool [@bs]) -> int = "" [@@bs.send]
+  external findIndexi : t -> (elt -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send]
   
-  external forEach : (elt -> unit [@bs]) -> unit = "" [@@bs.send.pipe: t]
-  external forEachi : (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: t]
+  external forEach : t -> (elt -> unit [@bs]) -> unit = "" [@@bs.send]
+  external forEachi : t -> (elt -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send]
   
   (* commented out until bs has a plan for iterators
-  external keys : int array_iter = "" [@@bs.send.pipe: t]
+  external keys : t -> int array_iter = "" [@@bs.send]
   *)
   
-  external map : (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send.pipe: t]
-  external mapi : (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send.pipe: t]
+  external map : t -> (elt  -> 'b [@bs]) -> 'b typed_array = "" [@@bs.send]
+  external mapi : t -> (elt -> int ->  'b [@bs]) -> 'b typed_array = "map" [@@bs.send]
   
-  external reduce :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reducei : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: t]
+  external reduce : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reducei : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send]
   
-  external reduceRight :  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: t]
-  external reduceRighti : ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: t]
+  external reduceRight : t ->  ('b -> elt  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send]
+  external reduceRighti : t -> ('b -> elt -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send]
   
-  external some : (elt  -> bool [@bs]) -> bool = "" [@@bs.send.pipe: t]
-  external somei : (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send.pipe: t]
+  external some : t -> (elt  -> bool [@bs]) -> bool = "" [@@bs.send]
+  external somei : t -> (elt  -> int -> bool [@bs]) -> bool = "some" [@@bs.send]
   
   external _BYTES_PER_ELEMENT: int = "Float64Array.BYTES_PER_ELEMENT" [@@bs.val]
   


### PR DESCRIPTION
#3297 only took care of the cppo generation part like js_typed_array. This actually makes the semantic changes.