### PR TITLE
[Super errors] Simplify super_typecore logic

### DIFF
--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -178,15 +178,13 @@ let print_expr_type_clash env trace ppf =
 (* taken from https://github.com/BuckleScript/ocaml/blob/d4144647d1bf9bc7dc3aadc24c25a7efa3a67915/typing/typecore.ml#L3769 *)
 (* modified branches are commented *)
 let report_error env ppf = function
-  | Typecore.Polymorphic_label lid ->
-      fprintf ppf "@[The record field %a is polymorphic.@ %s@]"
-        longident lid "You cannot instantiate it in a pattern."
-  | Constructor_arity_mismatch(lid, expected, provided) ->
+  | Typecore.Constructor_arity_mismatch(lid, expected, provided) ->
       (* modified *)
       fprintf ppf
        "@[This variant constructor, %a, expects %i %s; here, we've %sfound %i.@]"
        longident lid expected (if expected == 1 then "argument" else "arguments") (if provided < expected then "only " else "") provided
   | Label_mismatch(lid, trace) ->
+      (* modified *)
       super_report_unification_error ppf env trace
         (function ppf ->
            fprintf ppf "The record field %a@ belongs to the type"
@@ -194,28 +192,19 @@ let report_error env ppf = function
         (function ppf ->
            fprintf ppf "but is mixed here with fields of type")
   | Pattern_type_clash trace ->
+      (* modified *)
       super_report_unification_error ppf env trace
         (function ppf ->
           fprintf ppf "This pattern matches values of type")
         (function ppf ->
           fprintf ppf "but a pattern was expected which matches values of type")
   | Or_pattern_type_clash (id, trace) ->
+      (* modified *)
       super_report_unification_error ppf env trace
         (function ppf ->
           fprintf ppf "The variable %s on the left-hand side of this or-pattern has type" (Ident.name id))
         (function ppf ->
           fprintf ppf "but on the right-hand side it has type")
-  | Multiply_bound_variable name ->
-      fprintf ppf "Variable %s is bound several times in this matching" name
-  | Orpat_vars 
-#if OCAML_VERSION  =~ ">4.03.0" then 
-    (id, _)
-#else
-    id 
-#end    
-    ->
-      fprintf ppf "Variable %s must occur on both sides of this | pattern"
-        (Ident.name id)
   | Expr_type_clash trace ->
       (* modified *)
       fprintf ppf "@[<v>";
@@ -254,105 +243,8 @@ let report_error env ppf = function
             type_expr typ
             "It is not a function."
       end
-  | Apply_wrong_label (l, ty) ->
-      let print_label ppf = function
-        | 
-#if OCAML_VERSION =~ ">4.03.0" then
-          Asttypes.Nolabel
-#else
-          "" 
-#end           
-              -> fprintf ppf "without label"
-        | l ->
-            fprintf ppf "with label %s" (prefixed_label_name l)
-      in
-      reset_and_mark_loops ty;
-      fprintf ppf
-        "@[<v>@[<2>The function applied to this argument has type@ %a@]@.\
-          This argument cannot be applied %a@]"
-        type_expr ty print_label l
-  | Label_multiply_defined s ->
-      fprintf ppf "The record field label %s is defined several times" s
-  | Label_missing labels ->
-      let print_labels ppf =
-        List.iter (fun lbl -> fprintf ppf "@ %s" (Ident.name lbl)) in
-      fprintf ppf "@[<hov>Some record fields are undefined:%a@]"
-        print_labels labels
-  | Label_not_mutable lid ->
-      fprintf ppf "The record field %a is not mutable" longident lid
-  | Wrong_name 
-#if OCAML_VERSION =~ ">4.03.0" then
-    (eorp, ty, kind, p, lid,_)
-#else
-    (eorp, ty, kind, p, lid)
-#end    
-     as foo ->
-      (* forwarded *)
-      Typecore.report_error env ppf foo
-      (* reset_and_mark_loops ty;
-      fprintf ppf "@[@[<2>%s type@ %a@]@ "
-        eorp type_expr ty;
-      fprintf ppf "The %s %a does not belong to type %a@]"
-        (if kind = "record" then "field" else "constructor")
-        longident lid (*kind*) path p;
-      if kind = "record" then Label.spellcheck ppf env p lid
-                         else Constructor.spellcheck ppf env p lid *)
-  | Name_type_mismatch (kind, lid, tp, tpl) ->
-      let name = if kind = "record" then "field" else "constructor" in
-      Printtyp.report_ambiguous_type_error ppf env tp tpl
-        (function ppf ->
-           fprintf ppf "The %s %a@ belongs to the %s type"
-             name longident lid kind)
-        (function ppf ->
-           fprintf ppf "The %s %a@ belongs to one of the following %s types:"
-             name longident lid kind)
-        (function ppf ->
-           fprintf ppf "but a %s was expected belonging to the %s type"
-             name kind)
-  | Invalid_format msg ->
-      fprintf ppf "%s" msg
-  | Undefined_method 
-#if OCAML_VERSION =~ ">4.03.0" then
-    (ty, me,_) 
-#else    
-    (ty, me)     
-#end
-    ->
-      reset_and_mark_loops ty;
-      fprintf ppf
-        "@[<v>@[This expression has type@;<1 2>%a@]@,\
-         It has no method %s@]" type_expr ty me
-  | Undefined_inherited_method 
-#if OCAML_VERSION =~ ">4.03.0" then
-    (me, _)
-#else
-    me 
-#end    
-    ->
-      fprintf ppf "This expression has no method %s" me
-  | Virtual_class cl ->
-      fprintf ppf "Cannot instantiate the virtual class %a"
-        longident cl
-  | Unbound_instance_variable 
-#if OCAML_VERSION  =~ ">4.03.0" then
-    (v,_)
-#else    
-    v 
-#end    
-    ->
-      fprintf ppf "Unbound instance variable %s" v
-  | Instance_variable_not_mutable (b, v) ->
-      if b then
-        fprintf ppf "The instance variable %s is not mutable" v
-      else
-        fprintf ppf "The value %s is not an instance variable" v
-  | Not_subtype(tr1, tr2) ->
-      Printtyp.report_subtyping_error ppf env tr1 "is not a subtype of" tr2
-  | Outside_class ->
-      fprintf ppf "This object duplication occurs outside a method definition"
-  | Value_multiply_overridden v ->
-      fprintf ppf "The instance variable %s is overridden several times" v
   | Coercion_failure (ty, ty', trace, b) ->
+      (* modified *)
       super_report_unification_error ppf env trace
         (function ppf ->
            let ty, ty' = Printtyp.prepare_expansion (ty, ty') in
@@ -377,86 +269,21 @@ let report_error env ppf = function
         fprintf ppf "the expected type is@ %a@]"
           type_expr ty
       end
-  | Abstract_wrong_label (l, ty) ->
-      let label_mark = function
-#if OCAML_VERSION =~ ">4.03.0" then
-        | Asttypes.Nolabel -> 
-#else
-        | "" ->
-#end        
-         "but its first argument is not labelled"
-        |  l -> sprintf "but its first argument is labelled %s"
-          (prefixed_label_name l) in
-      reset_and_mark_loops ty;
-      fprintf ppf "@[<v>@[<2>This function should have type@ %a@]@,%s@]"
-      type_expr ty (label_mark l)
-  | Scoping_let_module(id, ty) ->
-      reset_and_mark_loops ty;
-      fprintf ppf
-       "This `let module' expression has type@ %a@ " type_expr ty;
-      fprintf ppf
-       "In this type, the locally bound module name %s escapes its scope" id
-  | Masked_instance_variable lid ->
-      fprintf ppf
-        "The instance variable %a@ \
-         cannot be accessed from the definition of another instance variable"
-        longident lid
-  | Private_type ty ->
-      fprintf ppf "Cannot create values of the private type %a" type_expr ty
-  | Private_label (lid, ty) ->
-      fprintf ppf "Cannot assign field %a of the private type %a"
-        longident lid type_expr ty
-  | Not_a_variant_type lid ->
-      fprintf ppf "The type %a@ is not a variant type" longident lid
-  | Incoherent_label_order ->
-      fprintf ppf "This function is applied to arguments@ ";
-      fprintf ppf "in an order different from other calls.@ ";
-      fprintf ppf "This is only allowed when the real type is known."
   | Less_general (kind, trace) ->
+      (* modified *)
       super_report_unification_error ppf env trace
         (fun ppf -> fprintf ppf "This %s has type" kind)
         (fun ppf -> fprintf ppf "which is less general than")
-  | Modules_not_allowed ->
-      fprintf ppf "Modules are not allowed in this pattern."
-  | Cannot_infer_signature ->
-      fprintf ppf
-        "The signature for this packaged module couldn't be inferred."
-  | Not_a_packed_module ty ->
-      fprintf ppf
-        "This expression is packed module, but the expected type is@ %a"
-        type_expr ty
   | Recursive_local_constraint trace ->
+      (* modified *)
       super_report_unification_error ppf env trace
         (function ppf ->
            fprintf ppf "Recursive local constraint when unifying")
         (function ppf ->
            fprintf ppf "with")
-  | Unexpected_existential ->
-      fprintf ppf
-        "Unexpected existential"
-  | Unqualified_gadt_pattern (tpath, name) ->
-      fprintf ppf "@[The GADT constructor %s of type %a@ %s.@]"
-        name Printtyp.path tpath
-        "must be qualified in this pattern"
-  | Invalid_interval ->
-      fprintf ppf "@[Only character intervals are supported in patterns.@]"
-  | Invalid_for_loop_index ->
-      fprintf ppf
-        "@[Invalid for-loop index: only variables and _ are allowed.@]"
-  | No_value_clauses ->
-      fprintf ppf
-        "None of the patterns in this 'match' expression match values."
-  | Exception_pattern_below_toplevel ->
-      fprintf ppf
-        "@[Exception patterns must be at the top level of a match case.@]"
-#if OCAML_VERSION =~ ">4.03.0" then 
-    | (Inlined_record_escape|Inlined_record_expected|
-       Invalid_extension_constructor_payload|Not_an_extension_constructor|
-       Illegal_letrec_pat|Illegal_letrec_expr|Illegal_class_expr|
-       Unrefuted_pattern _|Literal_overflow _|Unknown_literal (_, _))
-        -> 
-        fprintf ppf "TODO" (* TODO**)
-#end
+  | anythingElse ->
+      Typecore.super_report_error_no_wrap_printing_env env ppf anythingElse
+
 let report_error env ppf err =
   Printtyp.wrap_printing_env env (fun () -> report_error env ppf err)
 

--- a/vendor/ocaml/typing/typecore.ml
+++ b/vendor/ocaml/typing/typecore.ml
@@ -3976,6 +3976,10 @@ let report_error env ppf = function
       fprintf ppf
         "@[Exception patterns must be at the top level of a match case.@]"
 
+#if true then
+let super_report_error_no_wrap_printing_env = report_error
+#end
+
 let report_error env ppf err =
   wrap_printing_env env (fun () -> report_error env ppf err)
 

--- a/vendor/ocaml/typing/typecore.mli
+++ b/vendor/ocaml/typing/typecore.mli
@@ -116,6 +116,10 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
+#if true then
+val super_report_error_no_wrap_printing_env: Env.t -> formatter -> error -> unit
+#end
+
 val report_error: Env.t -> formatter -> error -> unit
  (* Deprecated.  Use Location.{error_of_exn, report_error}. *)
 


### PR DESCRIPTION
This exposes the first `report_error` binding from the vendored `typecore.ml` (the binding is shadowed afterward). This allows us to avoid copy pasting the whole error pattern matching logic, which differs enough between compiler versions to be annoying to cppo.

I have a similar `typecore.ml` patch for the 4.06 compiler