### PR TITLE
Revert "[compiler] export unwrapped report_error"

### DIFF
--- a/vendor/ocaml/typing/typecore.ml
+++ b/vendor/ocaml/typing/typecore.ml
@@ -3983,10 +3983,6 @@ let super_report_error_no_wrap_printing_env = report_error
 let report_error env ppf err =
   wrap_printing_env env (fun () -> report_error env ppf err)
 
-#if true then
-let super_report_error_no_wrap_printing_env = report_error
-#end  
-
 let () =
   Location.register_error_of_exn
     (function

--- a/vendor/ocaml/typing/typecore.mli
+++ b/vendor/ocaml/typing/typecore.mli
@@ -116,10 +116,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-#if true then
-val super_report_error_no_wrap_printing_env: Env.t -> formatter -> error -> unit
-#end
-
 val report_error: Env.t -> formatter -> error -> unit
  (* Deprecated.  Use Location.{error_of_exn, report_error}. *)
 


### PR DESCRIPTION
I'm not sure why this is here, but the changes already got in, in
164758af4802ca6624dc3648d46b32f559cdfe69. And I think this commit didn't
get applied in an idempotent way?

Now we ended up with two `#if` lol