### PR TITLE
[Super errors] Put the exposed #if back into typecore.mli

### DIFF
--- a/vendor/ocaml/typing/typecore.mli
+++ b/vendor/ocaml/typing/typecore.mli
@@ -116,6 +116,10 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
+#if true then
+val super_report_error_no_wrap_printing_env: Env.t -> formatter -> error -> unit
+#end
+
 val report_error: Env.t -> formatter -> error -> unit
  (* Deprecated.  Use Location.{error_of_exn, report_error}. *)
 


### PR DESCRIPTION
9c4e02ed8021c796db307681a32f87a785d6f0b5 is a revert of 164758af4802ca6624dc3648d46b32f559cdfe69. But I noticed just now that typecore.mli correctly added the #if only once (contrary to typecore.ml). So I'm adding the #if back into the interface file.