### PR TITLE
Fix issue with currying arity 0 functions

### DIFF
--- a/jscomp/runtime/curry.ml
+++ b/jscomp/runtime/curry.ml
@@ -63,6 +63,7 @@ external apply8 : ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8) 
 (* Intenral use *)  
 let curry_1 o a0 arity =
   match arity with
+  | 0
   | 1 -> apply1 (Obj.magic o) a0
   | 2 -> apply2 (Obj.magic o) a0
   | 3 -> apply3 (Obj.magic o) a0

--- a/lib/js/curry.js
+++ b/lib/js/curry.js
@@ -27,6 +27,7 @@ function app(_f, _args) {
 
 function curry_1(o, a0, arity) {
   switch (arity) {
+    case 0 : 
     case 1 : 
         return o(a0);
     case 2 : 


### PR DESCRIPTION
Fixes #3362

Fixes an issue with currying 0 arity functions. The issue is reproduced in this repo: https://github.com/baldurh/bs-platform-arity-test

Note:
This is my first PR to the bucklescript project. I wasn’t sure whether I should commit some of the generated files that were changed or not. Please let me know if this needs some additional changes.