### PR TITLE
Belt bsppx

### DIFF
--- a/jscomp/main/native_ppx_main.ml
+++ b/jscomp/main/native_ppx_main.ml
@@ -73,11 +73,8 @@ let structure_item_mapper (self : mapper) (str : Parsetree.structure_item) =
 #if OCAML_VERSION =~ ">4.03.0" then
       _rf,
 #end
-    (_ :: _ as tdcls )) (* [ {ptype_attributes} as tdcl ] *)->
+    (_ :: _ as tdcls )) ->
       Ast_tdcls.handleTdclsInStru self str tdcls
-  (* | Pstr_primitive prim when Ast_attributes.external_needs_to_be_encoded prim.pval_attributes
-      ->
-      Ast_external.handleExternalInStru self prim str *)
   | _ -> default_str_mapper self str
 
 let signature_item_mapper (self : mapper) (sigi : Parsetree.signature_item) =

--- a/jscomp/main/native_ppx_main.ml
+++ b/jscomp/main/native_ppx_main.ml
@@ -26,16 +26,76 @@
 type mapper = Bs_ast_mapper.mapper 
 
 let default_expr_mapper = Bs_ast_mapper.default_mapper.expr
+let default_typ_mapper = Bs_ast_mapper.default_mapper.typ
+let default_str_mapper = Bs_ast_mapper.default_mapper.structure_item
+let default_sig_mapper = Bs_ast_mapper.default_mapper.signature_item
 
 let expr_mapper (self : mapper) ( e : Parsetree.expression) = 
   match e.pexp_desc with 
   | Pexp_apply(fn, args) -> 
     Ast_exp_apply.app_exp_mapper e self fn args 
-  | _  -> default_expr_mapper self e 
+  | Pexp_constant (
+#if OCAML_VERSION =~ ">4.03.0" then
+    Pconst_string
+#else
+    Const_string
+#end
+    (s, (Some delim)))
+  ->
+    Ast_utf8_string_interp.transform e s delim
+  | Pexp_fun (arg_label, _, pat , body)
+    when Ast_compatible.is_arg_label_simple arg_label ->
+    begin match Ext_list.exclude_with_val
+          e.pexp_attributes
+          Ast_attributes.is_bs with
+      | None -> default_expr_mapper self e
+      | Some pexp_attributes -> default_expr_mapper self {e with pexp_attributes = pexp_attributes}
+    end
+  | _  -> default_expr_mapper self e
+
+let typ_mapper (self : mapper) (typ : Parsetree.core_type) =
+  match typ with
+  | {ptyp_attributes ;
+     ptyp_desc = Ptyp_arrow (label, args, body);
+     ptyp_loc = loc
+    } ->
+    begin match Ext_list.exclude_with_val
+          ptyp_attributes
+          Ast_attributes.is_bs with
+      | None -> default_typ_mapper self typ
+      | Some ptyp_attributes -> default_typ_mapper self {typ with ptyp_attributes = ptyp_attributes}
+    end
+  | _ -> default_typ_mapper self typ
+
+let structure_item_mapper (self : mapper) (str : Parsetree.structure_item) =
+  match str.pstr_desc with
+  | Pstr_type (
+#if OCAML_VERSION =~ ">4.03.0" then
+      _rf,
+#end
+    (_ :: _ as tdcls )) (* [ {ptype_attributes} as tdcl ] *)->
+      Ast_tdcls.handleTdclsInStru self str tdcls
+  (* | Pstr_primitive prim when Ast_attributes.external_needs_to_be_encoded prim.pval_attributes
+      ->
+      Ast_external.handleExternalInStru self prim str *)
+  | _ -> default_str_mapper self str
+
+let signature_item_mapper (self : mapper) (sigi : Parsetree.signature_item) =
+  match sigi.psig_desc with
+  | Psig_type (
+#if OCAML_VERSION =~ ">4.03.0" then
+      _rf,
+#end
+       (_ :: _ as tdcls)) ->  (*FIXME: check recursive handling*)
+      Ast_tdcls.handleTdclsInSigi self sigi tdcls
+  | _ -> default_sig_mapper self sigi
 
 let my_mapper : mapper = {
   Bs_ast_mapper.default_mapper with 
-  expr = expr_mapper
+  expr = expr_mapper;
+  typ = typ_mapper;
+  signature_item =  signature_item_mapper;
+  structure_item = structure_item_mapper;
 }
 
 let () = 

--- a/jscomp/syntax/ast_attributes.ml
+++ b/jscomp/syntax/ast_attributes.ml
@@ -353,6 +353,15 @@ let is_bs (attr : attr) =
   | {Location.txt = "bs"; _}, _ -> true
   | _ -> false
 
+let is_optional (attr : attr) =
+  match attr with
+  | {Location.txt = "bs.optional"; _}, _ -> true
+  | _ -> false
+
+let is_bs_as (attr : attr) =
+  match attr with
+  | {Location.txt = "bs.as"; _}, _ -> true
+  | _ -> false
 
 let bs_get : attr
   =  {txt = "bs.get"; loc = locg}, Ast_payload.empty

--- a/jscomp/syntax/ast_attributes.mli
+++ b/jscomp/syntax/ast_attributes.mli
@@ -99,6 +99,8 @@ val iter_process_derive_type :
 
 val bs : attr
 val is_bs : attr -> bool
+val is_optional : attr -> bool
+val is_bs_as : attr -> bool
 
 
 

--- a/jscomp/syntax/ast_compatible.ml
+++ b/jscomp/syntax/ast_compatible.ml
@@ -129,6 +129,24 @@ let fun_
     pexp_desc = Pexp_fun(no_label,None, pat, exp)
   }
 
+let opt_label s =
+#if OCAML_VERSION =~ ">4.03.0" then
+  Asttypes.Optional s
+#else
+  "?" ^ s
+#end
+
+let label_fun
+  ?(loc = default_loc)
+  ?(attrs = [])
+  ~label
+  pat
+  exp =
+  {
+    pexp_loc = loc;
+    pexp_attributes = attrs;
+    pexp_desc = Pexp_fun(label, None, pat, exp)
+  }
 
 #if OCAML_VERSION =~ ">4.03.0" then 
 

--- a/jscomp/syntax/ast_compatible.mli
+++ b/jscomp/syntax/ast_compatible.mli
@@ -119,21 +119,12 @@ val fun_ :
   expression -> 
   expression
 
-val opt_label : string ->
-#if OCAML_VERSION =~ ">4.03.0" then
-  Asttypes.arg_label
-#else
-  string
-#end
+val opt_label : string -> Asttypes.arg_label
 
 val label_fun :
   ?loc:Location.t ->
   ?attrs:attrs ->
-#if OCAML_VERSION =~ ">4.03.0" then
   label:Asttypes.arg_label ->
-#else
-  label:string ->
-#end
   pattern ->
   expression ->
   expression

--- a/jscomp/syntax/ast_compatible.mli
+++ b/jscomp/syntax/ast_compatible.mli
@@ -119,8 +119,27 @@ val fun_ :
   expression -> 
   expression
 
-val is_arg_label_simple : 
-  arg_label -> bool   
+val opt_label : string ->
+#if OCAML_VERSION =~ ">4.03.0" then
+  Asttypes.arg_label
+#else
+  string
+#end
+
+val label_fun :
+  ?loc:Location.t ->
+  ?attrs:attrs ->
+#if OCAML_VERSION =~ ">4.03.0" then
+  label:Asttypes.arg_label ->
+#else
+  label:string ->
+#end
+  pattern ->
+  expression ->
+  expression
+
+val is_arg_label_simple :
+  arg_label -> bool
 
 val arrow :
   ?loc:Location.t -> 

--- a/jscomp/syntax/ast_compatible.mli
+++ b/jscomp/syntax/ast_compatible.mli
@@ -119,12 +119,12 @@ val fun_ :
   expression -> 
   expression
 
-val opt_label : string -> Asttypes.arg_label
+val opt_label : string -> arg_label
 
 val label_fun :
   ?loc:Location.t ->
   ?attrs:attrs ->
-  label:Asttypes.arg_label ->
+  label:arg_label ->
   pattern ->
   expression ->
   expression

--- a/jscomp/syntax/ast_exp_apply.ml
+++ b/jscomp/syntax/ast_exp_apply.ml
@@ -209,8 +209,11 @@ let app_exp_mapper
           Ast_attributes.is_bs with
       | None -> default_expr_mapper self e
       | Some pexp_attributes ->
+#if BS_NATIVE then
+        {e with pexp_attributes }
+#else
         {e with pexp_desc = Ast_util.uncurry_fn_apply e.pexp_loc self fn (check_and_discard args) ;
                 pexp_attributes }
       
   
-  
+#end

--- a/jscomp/syntax/ast_tdcls.ml
+++ b/jscomp/syntax/ast_tdcls.ml
@@ -52,10 +52,6 @@ let turn_bs_optional_into_optional (tdcls : Parsetree.type_declaration list) =
      {tdcl with ptype_kind = Ptype_record (List.map (fun ({Parsetree.pld_type; pld_loc; pld_attributes} as dcl : Parsetree.label_declaration) ->
            let has_optional_field = Ast_attributes.has_bs_optional pld_attributes in
            if has_optional_field then
-           (* @Incomplete remove ALL attributes when we might want to only remove the bs.optional.
-
-                      Ben - June 8th 2018
-            *)
              { dcl with
                Parsetree.pld_type = {dcl.pld_type with ptyp_desc =
                 Ptyp_constr(

--- a/jscomp/syntax/ast_tdcls.ml
+++ b/jscomp/syntax/ast_tdcls.ml
@@ -44,6 +44,34 @@ let newTdcls
          else x )
       
 
+#if BS_NATIVE then
+
+let turn_bs_optional_into_optional (tdcls : Parsetree.type_declaration list) =
+   List.map (fun tdcl -> match tdcl.Parsetree.ptype_kind with
+   | Ptype_record labels ->
+     {tdcl with ptype_kind = Ptype_record (List.map (fun ({Parsetree.pld_type; pld_loc; pld_attributes} as dcl : Parsetree.label_declaration) ->
+           let has_optional_field = Ast_attributes.has_bs_optional pld_attributes in
+           if has_optional_field then
+           (* @Incomplete remove ALL attributes when we might want to only remove the bs.optional.
+
+                      Ben - June 8th 2018
+            *)
+             { dcl with
+               Parsetree.pld_type = {dcl.pld_type with ptyp_desc =
+                Ptyp_constr(
+                  {txt = Lident "option";
+                   loc = pld_loc}
+                   , [pld_type]);
+                   ptyp_loc = pld_loc;
+               };
+               pld_attributes = Ext_list.exclude pld_attributes (fun x -> (Ast_attributes.is_optional x) || (Ast_attributes.is_bs_as x))
+             }
+           else dcl
+         ) labels)}
+   | _ -> tdcl) tdcls
+
+#end
+
 
 let handleTdclsInSigi
     (self : Bs_ast_mapper.mapper)
@@ -59,7 +87,11 @@ let handleTdclsInSigi
     let newTdclsNewAttrs = self.type_declaration_list self originalTdclsNewAttrs in
     let kind = Ast_derive_abstract.isAbstract actions in
     if kind <> Not_abstract then
+#if BS_NATIVE then
+      let  codes = Native_ast_derive_abstract.handleTdclsInSig ~light:(kind = Light_abstract) originalTdclsNewAttrs in
+#else
       let  codes = Ast_derive_abstract.handleTdclsInSig ~light:(kind = Light_abstract) originalTdclsNewAttrs in
+#end
       Ast_signature.fuseAll ~loc
         (
           Sig.include_ ~loc
@@ -67,7 +99,11 @@ let handleTdclsInSigi
                (Mty.typeof_ ~loc
                   (Mod.constraint_ ~loc
                      (Mod.structure ~loc [
+#if BS_NATIVE then
+                         Ast_compatible.rec_type_str ~loc (turn_bs_optional_into_optional newTdclsNewAttrs)
+#else
                          Ast_compatible.rec_type_str ~loc newTdclsNewAttrs
+#end
                          ] )
                      (Mty.signature ~loc [])) ) )
           :: (* include module type of struct [processed_code for checking like invariance ]end *)
@@ -105,7 +141,14 @@ let handleTdclsInStru
     in
     let kind = Ast_derive_abstract.isAbstract actions in 
     if kind <> Not_abstract then
-      let codes = 
+#if BS_NATIVE then
+      let (codes, codes_sig) = Native_ast_derive_abstract.handleTdclsInStr ~light:(kind = Light_abstract) originalTdclsNewAttrs in
+       (* the codes_sig will hide the implementation of the type that is a record. *)
+       Ast_structure.constraint_ ~loc
+         (self.structure self codes)
+         (self.signature self codes_sig)
+#else
+      let codes =
           Ast_derive_abstract.handleTdclsInStr ~light:(kind = Light_abstract) originalTdclsNewAttrs in
       (* use [tdcls2] avoid nonterminating *)
       Ast_structure.fuseAll ~loc
@@ -113,6 +156,8 @@ let handleTdclsInStru
           Ast_structure.constraint_ ~loc [newStr] []
           :: (* [include struct end : sig end] for error checking *)
           self.structure self codes)
+#end
+
     else
       Ast_structure.fuseAll ~loc
         (newStr ::

--- a/jscomp/syntax/native_ast_derive_abstract.ml
+++ b/jscomp/syntax/native_ast_derive_abstract.ml
@@ -57,8 +57,7 @@ let handleTdcl light (tdcl : Parsetree.type_declaration) =
               Parsetree.label_declaration) (acc, maker, labels) ->
            let prim = [label_name] in
            let is_optional = Ast_attributes.has_bs_optional pld_attributes in
-           (* Add the question mark back because that's how ocaml 4.02.3 determines if the argument
-             label is for a optional argument vs a named argument. *)
+
            let newLabel = if is_optional then {pld_name with txt = Ast_compatible.opt_label pld_name.Asttypes.txt} else pld_name in
 
             let maker, getter_type =

--- a/jscomp/syntax/native_ast_derive_abstract.ml
+++ b/jscomp/syntax/native_ast_derive_abstract.ml
@@ -1,0 +1,211 @@
+module U = Ast_derive_util
+open Ast_helper
+type tdcls = Parsetree.type_declaration list
+
+let deprecated name =
+  Ast_attributes.deprecated
+    ("use " ^ name ^ "Get instead or use {abstract = light} explicitly")
+
+let strip_option arg_name =
+   if arg_name.[0] = '?' then
+     String.sub arg_name 1 (String.length arg_name - 1)
+   else arg_name
+
+let handleTdcl light (tdcl : Parsetree.type_declaration) =
+   let core_type = U.core_type_of_type_declaration tdcl in
+   let loc = tdcl.ptype_loc in
+   let type_name = tdcl.ptype_name.txt in
+   match tdcl.ptype_kind with
+   | Ptype_record label_declarations ->
+     let is_private = tdcl.ptype_private = Private in
+     let (has_optional_field, new_label_declarations) =
+       Ext_list.fold_right label_declarations (false, []) (fun ({pld_type; pld_loc; pld_attributes} as dcl : Parsetree.label_declaration) (has_optional_field, acc) ->
+           let has_optional_field_local = Ast_attributes.has_bs_optional pld_attributes in
+           let acc = if has_optional_field_local then
+             { dcl with
+              pld_type = {
+                dcl.pld_type with
+                ptyp_desc = Ptyp_constr({txt = Lident "option"; loc = pld_loc}, [pld_type]);
+                ptyp_loc = pld_loc;
+              };
+              pld_attributes = Ext_list.exclude pld_attributes (fun x -> (Ast_attributes.is_optional x) || (Ast_attributes.is_bs_as x))
+            } :: acc
+           else dcl :: acc in
+             (has_optional_field || has_optional_field_local, acc)
+         ) in
+     let newTdcl = {
+       tdcl with
+       ptype_kind = Ptype_record new_label_declarations;
+       ptype_attributes = [];
+     } in
+     let setter_accessor, makeType, labels =
+       Ext_list.fold_right
+         label_declarations
+         ([],
+          (if has_optional_field then
+             Ast_compatible.arrow ~loc  (Ast_literal.type_unit ()) core_type
+           else  core_type),
+          [])
+         (fun
+           ({pld_name =
+               {txt = label_name; loc = label_loc} as pld_name;
+             pld_type;
+             pld_mutable;
+             pld_attributes;
+             pld_loc
+            }:
+              Parsetree.label_declaration) (acc, maker, labels) ->
+           let prim = [label_name] in
+           let is_optional = Ast_attributes.has_bs_optional pld_attributes in
+           (* Add the question mark back because that's how ocaml 4.02.3 determines if the argument
+             label is for a optional argument vs a named argument. *)
+           let newLabel = if is_optional then {pld_name with txt = Ast_compatible.opt_label pld_name.Asttypes.txt} else pld_name in
+
+            let maker, getter_type =
+              if is_optional then
+                let maker_optional_type = Ast_core_type.lift_option_type pld_type in
+                let getter_optional_type = {
+                  Parsetree.ptyp_desc =
+                   Ptyp_constr(
+                     {txt = Lident "option";
+                      loc = pld_loc
+                     }, [pld_type]);
+                  ptyp_loc = pld_loc;
+                  ptyp_attributes = [];
+                } in
+                Ast_compatible.opt_arrow ~loc:pld_loc label_name
+#if OCAML_VERSION =~ "<4.03.0" then
+                  maker_optional_type
+#else             pld_type
+#end
+                maker,
+                Ast_compatible.arrow ~loc  core_type getter_optional_type
+              else
+                Ast_compatible.label_arrow ~loc:pld_loc label_name pld_type maker,
+                Ast_compatible.arrow ~loc  core_type pld_type
+           in
+           let makeGetter light deprec pld_name =
+             Str.value Nonrecursive [
+                 Vb.mk
+                   ~loc:pld_loc
+                   ~attrs:(if deprec then deprecated (pld_name.Asttypes.txt) :: []
+                     else [])
+                   (Pat.var {pld_name with txt = if light then label_name else label_name ^ "Get"})
+                   (Exp.constraint_ (Ast_compatible.fun_ ~loc:pld_loc
+                       (Pat.var {Location.txt = "o"; loc = pld_loc})
+                       (Exp.field (Exp.ident {Location.txt = Longident.Lident "o"; loc = pld_loc}) {txt = Longident.Lident pld_name.Location.txt; loc = pld_loc})) getter_type)]
+             in
+             let acc = if not light then
+               makeGetter true true pld_name :: makeGetter false false pld_name  :: acc
+             else  makeGetter true false pld_name :: acc in
+           let is_current_field_mutable = pld_mutable = Mutable in
+           let acc =
+             if is_current_field_mutable then
+               let setter_type =
+                (Ast_compatible.arrow core_type
+                   (Ast_compatible.arrow
+                      pld_type (* setter *)
+                      (Ast_literal.type_unit ()))) in
+               let variable = (Exp.ident {Location.txt = Longident.Lident "v"; loc = pld_loc}) in
+               let setter = Str.value Nonrecursive [
+                 Vb.mk
+                   (Pat.var {loc = label_loc; txt = label_name ^ "Set"})
+                   (Exp.constraint_ (Ast_compatible.fun_ ~loc:pld_loc
+                       (Pat.var {Location.txt = "o"; loc = pld_loc})
+                       (Ast_compatible.fun_ ~loc:pld_loc
+                         (Pat.var {Location.txt = "v"; loc = pld_loc})
+                         (Exp.setfield
+                           (Exp.ident {Location.txt = Longident.Lident "o"; loc = pld_loc})
+                           {txt = Longident.Lident pld_name.Location.txt; loc = pld_loc}
+                           (if is_optional then Exp.construct {txt=Lident "Some"; loc = pld_loc} (Some variable) else variable))))
+                       setter_type)
+                   ]
+                 in
+               setter :: acc
+             else acc in
+           acc,
+           maker,
+           newLabel::labels
+         )
+     in
+     newTdcl,
+     (if is_private then
+        setter_accessor
+      else
+        let my_loc = match labels with
+        | [] -> !default_loc
+        | { Asttypes.loc = label_loc } :: _ -> label_loc
+        in
+        let maker_body = Exp.record (Ext_list.fold_right labels [] (fun ({ Asttypes.txt; loc = label_loc }) rest ->
+           let field_name = {Asttypes.txt = Longident.Lident (strip_option txt); loc = label_loc} in
+           (field_name, Exp.ident field_name) :: rest
+         )) None in
+        (* This is to support bs.optional, which makes certain args of the function optional so we
+           add a unit at the end to prevent auto-currying issues. *)
+        let body_with_extra_unit_fun = (if has_optional_field then
+           (Ast_compatible.fun_ ~loc:my_loc
+             (Pat.var ({txt = "()"; loc = my_loc})) maker_body)
+         else maker_body) in
+
+        let myMaker =
+         Str.value Nonrecursive [
+           Vb.mk
+             (Pat.var {loc; txt = type_name})
+             (Exp.constraint_ (
+               Ext_list.fold_right
+                 labels
+                 body_with_extra_unit_fun
+                 (fun arg_name rest ->
+                   (Ast_compatible.label_fun ~label:arg_name.Asttypes.txt ~loc:my_loc
+                     (Pat.var ({arg_name with txt = strip_option arg_name.Asttypes.txt})) rest))
+                 ) makeType)
+         ]
+         in
+        (myMaker :: setter_accessor))
+
+    | Ptype_abstract
+   | Ptype_variant _
+   | Ptype_open ->
+     (* Looks obvious that it does not make sense to warn *)
+     (* U.notApplicable tdcl.ptype_loc derivingName;  *)
+     tdcl, []
+
+let code_sig_transform sigi = match sigi with
+  | {Parsetree.pstr_loc; pstr_desc =
+      Pstr_value (_, (({
+        pvb_pat = {ppat_desc = Ppat_var name};
+        pvb_expr = {pexp_desc = Pexp_constraint (_, typ)}
+      } as _makerVb) :: []))
+    } ->
+    Sig.value (Val.mk ~loc:pstr_loc name typ)
+  | _ -> Sig.type_ []
+
+let handleTdclsInStr ~light tdcls =
+  let tdcls, tdcls_sig, code, code_sig =
+    Ext_list.fold_right tdcls ([],[], [], []) (fun tdcl (tdcls, tdcls_sig, sts, code_sig)  ->
+        match handleTdcl light tdcl with
+          ntdcl, value_descriptions ->
+          let open Parsetree in
+          (
+            ntdcl::tdcls,
+            {ntdcl with ptype_kind = Ptype_abstract }::tdcls_sig,
+            Ext_list.map_append value_descriptions sts (fun x -> x),
+            Ext_list.map_append value_descriptions code_sig code_sig_transform
+          )
+      )  in
+  (Ast_compatible.rec_type_str tdcls :: code,
+   Ast_compatible.rec_type_sig tdcls_sig :: code_sig)
+  (* still need perform transformation for non-abstract type*)
+
+let handleTdclsInSig ~light tdcls =
+  let tdcls_sig, code =
+    Ext_list.fold_right tdcls ([], []) (fun tdcl (tdcls_sig, sts)  ->
+        match handleTdcl light tdcl with
+          ntdcl, value_descriptions ->
+          let open Parsetree in
+          (
+            {ntdcl with ptype_kind = Ptype_abstract }::tdcls_sig,
+            Ext_list.map_append value_descriptions sts code_sig_transform
+          )
+      )  in
+   Ast_compatible.rec_type_sig tdcls_sig :: code

--- a/jscomp/syntax/native_ast_derive_abstract.ml
+++ b/jscomp/syntax/native_ast_derive_abstract.ml
@@ -55,7 +55,6 @@ let handleTdcl light (tdcl : Parsetree.type_declaration) =
              pld_loc
             }:
               Parsetree.label_declaration) (acc, maker, labels) ->
-           let prim = [label_name] in
            let is_optional = Ast_attributes.has_bs_optional pld_attributes in
 
            let newLabel = if is_optional then {pld_name with txt = Ast_compatible.opt_label pld_name.Asttypes.txt} else pld_name in


### PR DESCRIPTION
This adds support for `|.`, `bs.deriving` (and the `light` version) and `@bs` uncurried calls (which we simply filter out and do nothing about, so that belt compiles without any changes to its ppxes).

I merged all the changes into the ppx code directly. Most of it is simply hiding features away when compiling to native (like `bs.obj` for example). The's a bit that's different for `bs.deriving`, because in JS we can simply make the constructor an external function that returns an `bs.obj` under the hood. We don't have `bs.obj` in native, so we use a record and generate a constructor for the record. We also can't erase the record type at the same level: we have to generate a signature literal for the module inside the implementation file, so that even inside your own code you cannot "know" that the implementation uses a record, and so you're forced to use the getters/setters.

I also pulled out some JS-specific pattern matching in functions called `the_original_function_name_helper` which I guarded against `BS_NATIVE`. I didn't touch their implementation though the diff is awful, sorry about that.

I added some super simple test case also, to make sure this runs correctly.

Step 1 towards https://github.com/BuckleScript/bucklescript/pull/3353.