### PR TITLE
attempting to allow extended, but closed polyvariants

### DIFF
--- a/jscomp/syntax/external_process.ml
+++ b/jscomp/syntax/external_process.ml
@@ -102,6 +102,7 @@ let get_arg_type
     | `String ->
       begin match ptyp_desc with
         | Ptyp_variant ( row_fields, Closed, None)
+        | Ptyp_variant ( row_fields, Closed, Some [])
           ->
           Ast_polyvar.map_row_fields_into_strings ptyp.ptyp_loc row_fields
         | _ ->

--- a/jscomp/test/poly_variant_test.ml
+++ b/jscomp/test/poly_variant_test.ml
@@ -26,8 +26,7 @@ function hey_int (option){
  }
 |}]
 
-type u = [`on_closed | `on_open | `in_ 
-            (* [@bs.as "in"] TODO: warning test  *)]
+type u = [`on_closed | `on_open | `in_ [@bs.as "in"]]
 (* indeed we have a warning here*)
 (* TODO: add warning test 
 *)

--- a/jscomp/test/poly_variant_test.ml
+++ b/jscomp/test/poly_variant_test.ml
@@ -65,7 +65,7 @@ let ww =
 let () =
   eq __LOC__ vv [|3;0;4|];
   eq __LOC__ (test_int_type `again, test_int_type `hey) (5,6);
-  eq __LOC__ uu [|"on_open"; "on_closed"; "in"|]
+  eq __LOC__ uu [|"on_open"; "on_closed"; "in"|];
   eq __LOC__ ww [|"on_open"; "on_closed"; "in"|]
 
 

--- a/jscomp/test/poly_variant_test.ml
+++ b/jscomp/test/poly_variant_test.ml
@@ -48,7 +48,7 @@ external test_int_type :
   "hey_int" [@@bs.val]
 
 external test_string_extended_closed :
-  flag:([> u] [@bs.string]) -> string  =
+  flag:([< u] [@bs.string]) -> string  =
   "hey_string" [@@bs.val]
 
 let uu =

--- a/jscomp/test/poly_variant_test.ml
+++ b/jscomp/test/poly_variant_test.ml
@@ -47,6 +47,10 @@ external test_int_type :
                 [@bs.int])  -> int  = 
   "hey_int" [@@bs.val]
 
+external test_string_extended_closed :
+  flag:([> u] [@bs.string]) -> string  =
+  "hey_string" [@@bs.val]
+
 let uu =
   [| test_string_type ~flag: `on_open; test_string_type ~flag: `on_closed; 
      test_string_type ~flag: `in_ |]
@@ -54,10 +58,15 @@ let uu =
 let vv = 
   [| test_int_type `on_open; test_int_type `on_closed; test_int_type `in_ |]
 
-let () = 
+let ww =
+  [| test_string_extended_closed ~flag: `on_open; test_string_extended_closed ~flag: `on_closed;
+     test_string_extended_closed ~flag: `in_ |]
+
+let () =
   eq __LOC__ vv [|3;0;4|];
   eq __LOC__ (test_int_type `again, test_int_type `hey) (5,6);
   eq __LOC__ uu [|"on_open"; "on_closed"; "in"|]
+  eq __LOC__ ww [|"on_open"; "on_closed"; "in"|]
 
 
 let option = `on_closed 

--- a/jscomp/test/poly_variant_test.mli
+++ b/jscomp/test/poly_variant_test.mli
@@ -1,5 +1,5 @@
 
-
+type u = [`on_closed | `on_open | `in_[@bs.as "in"]]
 
 external test_string_type : flag:([`on_closed | `on_open | `in_ [@bs.as "in"]]
                 [@bs.string]) -> string  = 
@@ -15,8 +15,13 @@ external test_int_type :
      [@bs.int]) -> int  = 
   "hey_int" [@@bs.val]
 
+external test_string_extended_closed :
+  flag:([< u] [@bs.string]) -> string  =
+  "hey_string" [@@bs.val]
+
 val uu : string array
 val vv : int array
+val ww : string array
 
 type readline
 


### PR DESCRIPTION
This is my first time attempting to work on any internal code on BuckleScript, so I'm not sure I did this correctly.

I'm trying to add support for extended polymorphic variants in `@bs.string` based on the signature information at https://github.com/ocaml/merlin/blob/master/orig/ocaml_402/parsing/parsetree.mli#L86

I'm also not sure I wrote the tests correctly, so any suggestions there are greatly appreciated.

I'm hoping this runs on the CI if I open as a PR because I don't have my local environment setup to run tests currently.