### PR TITLE
in watch mode, clear the screen upon each rebuild

### DIFF
--- a/lib/bsb
+++ b/lib/bsb
@@ -21,6 +21,7 @@ var LAST_SUCCESS_BUILD_STAMP = 0
  */
 var wsClients = []
 var watch_mode = false
+var watch_clear = false
 var verbose = false
 /**
  * @type {string | undefined}
@@ -119,6 +120,9 @@ for (var i = 2; i < process_argv.length; ++i) {
         delegate_args.push(current)
         if (current === '-w') {
             watch_mode = true
+        } else if (current === '-wc') {
+            watch_mode = true
+            watch_clear = true
         } else if (current === "-verbose") {
             verbose = true
 
@@ -394,6 +398,7 @@ if (watch_mode) {
             dlog(`Event ${event} ${reason}`);
             reasons_to_rebuild.push([event, reason])
             if (needRebuild()) {
+                if (watch_clear) console.clear()
                 build()
             }
         }

--- a/lib/bsb.ml
+++ b/lib/bsb.ml
@@ -17015,6 +17015,7 @@ let generate_theme_with_path = ref None
 let regen = "-regen"
 let separator = "--"
 let watch_mode = ref false
+let watch_clear = ref false
 let make_world = ref false 
 let set_make_world () = make_world := true
 let bs_version_string = Bs_version.version
@@ -17034,6 +17035,8 @@ let bsb_main_flags : (string * Arg.spec * string) list=
     " Set the output(from bsb) to be verbose";
     "-w", Arg.Set watch_mode,
     " Watch mode" ;     
+    "-wc", Arg.Set watch_clear,
+    " Watch mode, and clear the screen upon rebuild" ;     
     "-clean-world", Arg.Unit (fun _ -> 
         Bsb_clean.clean_bs_deps bsc_dir cwd),
     " Clean all bs dependencies";
@@ -17149,7 +17152,7 @@ let () =
                      [bsb -clean-world]
                      [bsb -regen ]
                   *)
-                  if !watch_mode then begin
+                  if !watch_mode || !watch_clear then begin
                     watch_exit ()
                   end 
                 | make_world, force_regenerate ->
@@ -17157,7 +17160,7 @@ let () =
                   if make_world then begin
                     Bsb_world.make_world_deps cwd config_opt
                   end;
-                  if !watch_mode then begin
+                  if !watch_mode || !watch_clear then begin
                     watch_exit ()
                     (* ninja is not triggered in this case
                        There are several cases we wish ninja will not be triggered.
@@ -17177,7 +17180,7 @@ let () =
             (* [-make-world] should never be combined with [-package-specs] *)
             if !make_world then
               Bsb_world.make_world_deps cwd config_opt ;
-            if !watch_mode then watch_exit ()
+            if !watch_mode || !watch_clear then watch_exit ()
             else ninja_command_exit  vendor_ninja ninja_args 
           end
       end


### PR DESCRIPTION
existing behaviour of -w is not changed

new command -wc clears the screen upon rebuild.

in package.json i bind "npm run startclear" to "bsb -make-world -wc" so the screen refreshes each time watch decides to rebuild.
