### PR TITLE
in watch mode, clear the screen upon rebuilding

### DIFF
--- a/lib/bsb
+++ b/lib/bsb
@@ -394,7 +394,7 @@ if (watch_mode) {
             dlog(`Event ${event} ${reason}`);
             reasons_to_rebuild.push([event, reason])
             if (needRebuild()) {
-                console.clear()
+                if (! process.env.BS_WATCHNOCLEAR) console.clear()
                 build()
             }
         }

--- a/lib/bsb
+++ b/lib/bsb
@@ -394,6 +394,7 @@ if (watch_mode) {
             dlog(`Event ${event} ${reason}`);
             reasons_to_rebuild.push([event, reason])
             if (needRebuild()) {
+                console.clear()
                 build()
             }
         }


### PR DESCRIPTION
Without a screen refresh, watch mode fills the terminal with a scroll of build errors and warnings. It is not easy to see where the most recent build started; scanning upwards for ">>>> Start compiling" is cognitively taxing. So now we clear the screen each time watch mode decides to rebuild. Thanks @varunpatro for working with me on this. This pull request is a one-line change, but it took a while to get here!