### PR TITLE
add submodule explaination to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,12 @@ Prerequisites:
 node scripts/buildocaml.js
 ```
 
+The codebase recently moved from keeping its version of OCaml in a subtree to using git submodules. If you run into error on this step, executing the following can help:
+
+```
+git submodule update --init
+```
+
 ### Build everything in dev mode using vendored compiler
 
 ```


### PR DESCRIPTION
This provides additional explanation on how to setup submodules. I assume that on clean clones this just works, but if not then maybe it makes sense to add it to the node script or as it's own step.

Addresses #3443