### PR TITLE
point react-hooks template to alpha version so that it can be release…

### DIFF
--- a/jscomp/bsb/bsb_templates.ml
+++ b/jscomp/bsb/bsb_templates.ml
@@ -819,7 +819,7 @@ let root = OCamlRes.Res.([
       \  \"dependencies\": {\n\
       \    \"react\": \"^16.8.1\",\n\
       \    \"react-dom\": \"^16.8.1\",\n\
-      \    \"reason-react\": \">=0.7.0\"\n\
+      \    \"reason-react\": \"0.7.0-alpha.0\"\n\
       \  },\n\
       \  \"devDependencies\": {\n\
       \    \"bs-platform\": \"^${bsb:bs-version}\",\n\

--- a/jscomp/bsb/templates/react-hooks/package.json
+++ b/jscomp/bsb/templates/react-hooks/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
-    "reason-react": ">=0.7.0"
+    "reason-react": "0.7.0-alpha.0"
   },
   "devDependencies": {
     "bs-platform": "^${bsb:bs-version}",


### PR DESCRIPTION
…d safely

I will bump to 0.7.0 proper after it lands. This is to unblock release here.