### PR TITLE
[react jsx ppx] treat default arguments correctly

### DIFF
--- a/lib/4.02.3/reactjs_jsx_ppx_v2.ml
+++ b/lib/4.02.3/reactjs_jsx_ppx_v2.ml
@@ -653,8 +653,8 @@ let jsxMapper () =
               })
             ]
           ) in
-          let expression = match (label, default) with
-          | (label, Some default) when isOptional label -> Exp.match_ expression [
+          let expression = match (default) with
+          | (Some default) -> Exp.match_ expression [
             Exp.case
               (Pat.construct {loc; txt=Lident "Some"} (Some (Pat.var ~loc {txt = labelString; loc})))
               (Exp.ident ~loc {txt = (Lident labelString); loc});
@@ -662,7 +662,7 @@ let jsxMapper () =
               (Pat.construct {loc; txt=Lident "None"} None)
               default
           ]
-          | _ -> expression in
+          | None -> expression in
           let letExpression = Vb.mk
             (Pat.var ~loc {txt = alias; loc})
              expression in

--- a/lib/4.02.3/reactjs_jsx_ppx_v3.ml
+++ b/lib/4.02.3/reactjs_jsx_ppx_v3.ml
@@ -653,8 +653,8 @@ let jsxMapper () =
               })
             ]
           ) in
-          let expression = match (label, default) with
-          | (label, Some default) when isOptional label -> Exp.match_ expression [
+          let expression = match (default) with
+          | (Some default) -> Exp.match_ expression [
             Exp.case
               (Pat.construct {loc; txt=Lident "Some"} (Some (Pat.var ~loc {txt = labelString; loc})))
               (Exp.ident ~loc {txt = (Lident labelString); loc});
@@ -662,7 +662,7 @@ let jsxMapper () =
               (Pat.construct {loc; txt=Lident "None"} None)
               default
           ]
-          | _ -> expression in
+          | None -> expression in
           let letExpression = Vb.mk
             (Pat.var ~loc {txt = alias; loc})
              expression in

--- a/lib/4.06.1/reactjs_jsx_ppx_v2.ml
+++ b/lib/4.06.1/reactjs_jsx_ppx_v2.ml
@@ -647,8 +647,8 @@ let jsxMapper () =
               })
             ]
           ) in
-          let expression = match (label, default) with
-          | (label, Some default) when isOptional label -> Exp.match_ expression [
+          let expression = match (default) with
+          | (Some default) -> Exp.match_ expression [
             Exp.case
               (Pat.construct {loc; txt=Lident "Some"} (Some (Pat.var ~loc {txt = labelString; loc})))
               (Exp.ident ~loc {txt = (Lident labelString); loc});
@@ -656,7 +656,7 @@ let jsxMapper () =
               (Pat.construct {loc; txt=Lident "None"} None)
               default
           ]
-          | _ -> expression in
+          | None -> expression in
           let letExpression = Vb.mk
             (Pat.var ~loc {txt = alias; loc})
              expression in

--- a/lib/4.06.1/reactjs_jsx_ppx_v3.ml
+++ b/lib/4.06.1/reactjs_jsx_ppx_v3.ml
@@ -647,8 +647,8 @@ let jsxMapper () =
               })
             ]
           ) in
-          let expression = match (label, default) with
-          | (label, Some default) when isOptional label -> Exp.match_ expression [
+          let expression = match (default) with
+          | (Some default) -> Exp.match_ expression [
             Exp.case
               (Pat.construct {loc; txt=Lident "Some"} (Some (Pat.var ~loc {txt = labelString; loc})))
               (Exp.ident ~loc {txt = (Lident labelString); loc});
@@ -656,7 +656,7 @@ let jsxMapper () =
               (Pat.construct {loc; txt=Lident "None"} None)
               default
           ]
-          | _ -> expression in
+          | None -> expression in
           let letExpression = Vb.mk
             (Pat.var ~loc {txt = alias; loc})
              expression in


### PR DESCRIPTION
Before we were ignoring all default arguments because they aren't considered optional arguments. Don't even need to run this check really.