### PR TITLE
Add .gitignore to reason hooks template

### DIFF
--- a/jscomp/bsb/templates/react-hooks/.gitignore
+++ b/jscomp/bsb/templates/react-hooks/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.merlin
+.bsb.lock
+npm-debug.log
+/lib/bs/
+/node_modules/


### PR DESCRIPTION
I'm new to Reason+Bucklescript so I'm not sure if this is everything that's needed for a good `.gitignore` template. Happy to address any feedback you may have!

Thanks!

Closes https://github.com/BuckleScript/bucklescript/issues/3490