### PR TITLE
fix webpack file serving for direct route access

### DIFF
--- a/jscomp/bsb/templates/react-hooks/src/index.html
+++ b/jscomp/bsb/templates/react-hooks/src/index.html
@@ -11,6 +11,6 @@
   Component 2:
   <div id="index2"></div>
 
-  <script src="Index.js"></script>
+  <script src="/Index.js"></script>
 </body>
 </html>

--- a/jscomp/bsb/templates/react-hooks/webpack.config.js
+++ b/jscomp/bsb/templates/react-hooks/webpack.config.js
@@ -9,7 +9,8 @@ module.exports = {
   mode: isProd ? 'production' : 'development',
   output: {
     path: outputDir,
-    filename: 'Index.js'
+    filename: 'Index.js',
+    publicPath: '/'
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
with this config you can open up any route directly `localhost:3000/foo/bar` in the browser
without it you would get a not found