### PR TITLE
Double quote -ppx argument to solve windows issue (#3588)

### DIFF
--- a/jscomp/bsb/bsb_merlin_gen.ml
+++ b/jscomp/bsb/bsb_merlin_gen.ml
@@ -132,7 +132,7 @@ let merlin_file_gen ~cwd
        (match reason_react_jsx with 
         | None -> built_in_ppx
         | Some opt ->
-          Printf.sprintf "'%s -bs-jsx %d'" built_in_ppx
+          Printf.sprintf "\"%s -bs-jsx %d\"" built_in_ppx
             (match opt with Jsx_v2 -> 2 | Jsx_v3 -> 3)
        )
       );


### PR DESCRIPTION
This pr contains the change discussed in https://github.com/BuckleScript/bucklescript/issues/3588.
Had some roadblocks in testing, sending pr to get further on the issue.
I did change to double quotes in the .merlin file manually on my mac, the merlin extension in vscode had no problems after.
I haven't gotten merlin functioning on windows, but at least in the windows case, this does solve the problem with reason-language-server. 
I don't have access to linux, assume it to be similar to mac.