### PR TITLE
React PPX: Show warning 26 on unused props with default value

### DIFF
--- a/jscomp/syntax/reactjs_jsx_ppx.cppo.ml
+++ b/jscomp/syntax/reactjs_jsx_ppx.cppo.ml
@@ -789,8 +789,8 @@ let jsxMapper () =
           let expression = match (default) with
           | (Some default) -> Exp.match_ expression [
             Exp.case
-              (Pat.construct {loc; txt=Lident "Some"} (Some (Pat.var ~loc {txt = "$value"; loc})))
-              (Exp.ident ~loc {txt = (Lident "$value"); loc});
+              (Pat.construct {loc; txt=Lident "Some"} (Some (Pat.var ~loc {txt = labelString; loc})))
+              (Exp.ident ~loc {txt = (Lident labelString); loc = { loc with Location.loc_ghost = true }});
             Exp.case
               (Pat.construct {loc; txt=Lident "None"} None)
               default

--- a/jscomp/syntax/reactjs_jsx_ppx.cppo.ml
+++ b/jscomp/syntax/reactjs_jsx_ppx.cppo.ml
@@ -789,8 +789,8 @@ let jsxMapper () =
           let expression = match (default) with
           | (Some default) -> Exp.match_ expression [
             Exp.case
-              (Pat.construct {loc; txt=Lident "Some"} (Some (Pat.var ~loc {txt = labelString; loc})))
-              (Exp.ident ~loc {txt = (Lident labelString); loc});
+              (Pat.construct {loc; txt=Lident "Some"} (Some (Pat.var ~loc {txt = "$value"; loc})))
+              (Exp.ident ~loc {txt = (Lident "$value"); loc});
             Exp.case
               (Pat.construct {loc; txt=Lident "None"} None)
               default


### PR DESCRIPTION
It seems that the usage of the same identifier as the prop in the `match` statement used for props with default values makes the compiler ignore the unused variable warnings.

This change fixes it by using a different identifier (`$value`), which is intentionally invalid so it doesn't clash with any user generated ids.

cc @rickyvetter 