### PR TITLE
improve OCaml version file error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ jscomp/outcome_printer/reason_syntax_util.mli
 jscomp/bin/all_ounit_tests.ml
 native/
 vendor/ocaml
+OCAML_VERSION
+ocaml/VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,3 @@ jscomp/outcome_printer/reason_syntax_util.mli
 jscomp/bin/all_ounit_tests.ml
 native/
 vendor/ocaml
-OCAML_VERSION
-ocaml/VERSION

--- a/scripts/buildocaml.js
+++ b/scripts/buildocaml.js
@@ -29,6 +29,10 @@ function getVersionPrefix() {
     cached = version.substr(0, version.indexOf("+"));
     return cached;
   }
+
+  console.error(`cannot find '${file}'`);
+  console.error("You should create OCAML_VERSION or ocaml/VERSION file to specify OCaml version like '4.02.3+buckle-master'");
+  console.error("For example, run `opam switch show > OCAML_VERSION`");
   throw new Error("version file not found");
 }
 exports.getVersionPrefix = getVersionPrefix;

--- a/scripts/buildocaml.js
+++ b/scripts/buildocaml.js
@@ -30,10 +30,17 @@ function getVersionPrefix() {
     cached = version.substr(0, version.indexOf("+"));
     return cached;
   }
-  console.error(`cannot find '${file}'`);
+  console.warn(`cannot find '${file}'`);
 
-  console.error("You should create OCAML_VERSION or ocaml/VERSION file to specify OCaml version like '4.02.3+buckle-master'");
-  console.error("For example, run `opam switch show > OCAML_VERSION`");
+  console.warn("You should create OCAML_VERSION or ocaml/VERSION file to specify OCaml version like '4.02.3+buckle-master'");
+  console.warn(`for example,
+bucklescript>cat ocaml/VERSION 
+4.02.3+BS
+
+# The version string is the first line of this file.
+# It must be in the format described in stdlib/sys.mli
+`);
+
   throw new Error("version file not found");
 }
 exports.getVersionPrefix = getVersionPrefix;

--- a/scripts/buildocaml.js
+++ b/scripts/buildocaml.js
@@ -22,6 +22,7 @@ function getVersionPrefix() {
     cached = version.substr(0, version.indexOf("+"));
     return cached;
   }
+  console.error(`cannot find '${file}'`);
 
   file = path.join(__dirname, "..", "OCAML_VERSION");
   if (fs.existsSync(file)) {
@@ -29,8 +30,8 @@ function getVersionPrefix() {
     cached = version.substr(0, version.indexOf("+"));
     return cached;
   }
-
   console.error(`cannot find '${file}'`);
+
   console.error("You should create OCAML_VERSION or ocaml/VERSION file to specify OCaml version like '4.02.3+buckle-master'");
   console.error("For example, run `opam switch show > OCAML_VERSION`");
   throw new Error("version file not found");

--- a/scripts/buildocaml.js
+++ b/scripts/buildocaml.js
@@ -22,7 +22,7 @@ function getVersionPrefix() {
     cached = version.substr(0, version.indexOf("+"));
     return cached;
   }
-  console.error(`cannot find '${file}'`);
+  console.warn(`cannot find '${file}'`);
 
   file = path.join(__dirname, "..", "OCAML_VERSION");
   if (fs.existsSync(file)) {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -357,7 +357,7 @@ function provideCompiler() {
     var releaseNinja = require("./ninjaFactory.js").libNinja({
       ocamlopt: "ocamlopt.opt",
       ext: ".exe",
-      INCL: require("./buildocaml.js").getVersionPrefix()
+      INCL: ocamlVersion
     });
 
     var filePath = path.join(lib_dir, "release.ninja");

--- a/scripts/prebuilt.js
+++ b/scripts/prebuilt.js
@@ -8,7 +8,7 @@ var root_config = { cwd: root, stdio: [0, 1, 2] }
 process.env.BS_RELEASE_BUILD = 'true'
 
 
-var version = require('./buildocaml.js').getVersionPrefix()
+var ocamlVersion = require('./buildocaml.js').getVersionPrefix()
 var fs = require('fs')
 var hostPlatform = 'darwin'
 
@@ -19,9 +19,9 @@ function buildCompiler() {
   // delete process.env.OCAMLLIB
   var prebuilt = 'prebuilt.ninja'
   var content = require('./ninjaFactory.js').libNinja({
-    ocamlopt : is_windows?`ocamlopt.opt.exe`:`../native/${version}/bin/ocamlopt.opt`,
+    ocamlopt : is_windows?`ocamlopt.opt.exe`:`../native/${ocamlVersion}/bin/ocamlopt.opt`,
     ext : sys_extension,
-    INCL : version
+    INCL : ocamlVersion
   })
   
   fs.writeFileSync(path.join(root,'lib',prebuilt),content,'ascii')


### PR DESCRIPTION
Currently, we get an error when running `yarn`:

```shell-session
$ yarn
yarn install v1.16.0
[1/4] Resolving packages...
success Already up-to-date.
$ node scripts/install.js
/path/to/bucklescript/scripts/buildocaml.js:32
  throw new Error("version file not found");
  ^

Error: version file not found
    at ......
```
Newbie, like me, cannot understand what to do.
So this pr is the improvement to show tender message:
```shell-session
$ yarn
yarn install v1.16.0
[1/4] Resolving packages...
success Already up-to-date.
$ node scripts/install.js
cannot find '/path/to/ocaml/VERSION'
cannot find '/path/to/bucklescript/OCAML_VERSION'
You should create OCAML_VERSION or ocaml/VERSION file to specify OCaml version like '4.02.3+buckle-master'
For example, run `opam switch show > OCAML_VERSION`
/path/to/bucklescript/scripts/buildocaml.js:36
  throw new Error("version file not found");
  ^

Error: version file not found
    at ......
````