### PR TITLE
Exit code from bsb in watch mode should be 0 instead of 2

### DIFF
--- a/lib/bsb
+++ b/lib/bsb
@@ -176,7 +176,7 @@ if (watch_mode) {
      */
     var watchers = [];
 
-    function onUncaughtException (err){
+    function onUncaughtException(err){
         console.error("Uncaught Exception", err)
         process.exit(1)
     }
@@ -184,9 +184,11 @@ if (watch_mode) {
         try {
             fs.unlinkSync(lockFileName)
         } catch (err) {
-
+            process.exitCode = 1
         }
-        process.exit(2)
+    }
+    function exitProcess() {
+        process.exit(0)
     }
 
     /**
@@ -205,18 +207,21 @@ if (watch_mode) {
             }
 
             process.on('exit', onExit)
-            // Ctrl+C
-            process.on('SIGINT', onExit)
-            // kill pid
-            process.on('SIGUSR1', onExit)
-            process.on('SIGUSR2', onExit)
-            process.on('SIGTERM', onExit)
-            process.on('SIGHUP', onExit)
             process.on('uncaughtException', onUncaughtException)
-            process.stdin.on('close', onExit)
+
+            // OS signal handlers
+            // Ctrl+C
+            process.on('SIGINT', exitProcess)
+            // kill pid
+            process.on('SIGUSR1', exitProcess)
+            process.on('SIGUSR2', exitProcess)
+            process.on('SIGTERM', exitProcess)
+            process.on('SIGHUP', exitProcess)
+
+            process.stdin.on('close', exitProcess)
             // close when stdin stops
             if (os.platform() !== "win32") {
-                process.stdin.on('end', onExit)
+                process.stdin.on('end', exitProcess)
                 process.stdin.resume()
             }
 


### PR DESCRIPTION
Hi everyone,

I was having some issues with some of our npm scripts where I was constantly getting termination errors when running a command like `bsb -make-world -w`. It turns out that the *bsb* script returns `2` after it's started in watch mode and it receives an external interrupt like `Ctrl+C` to terminate. 

This should't be the correct behavior since any script that terminates gracefully should have a exit code of `0`.

This PR fixes that behavior, and now it should be possible to build scripts that rely on logic like `bsb -make-world -w && do_something_after_clean_exit || do_something_on_error`.

The changes are quite simple, all the OS signal handlers (*SIGINT*, *SIGUSR*, etc) now simply call a function that exits the process (basically it's just a wrapper around `process.exit(0)`). 

This differs from the previous implementation where all event handlers called the same `onExit` function . The issue with that approach is that by calling `process.exit()` inside `onExit` would also emit an *exit* event on itself. This meant that the function was executed twice (assuming it was triggered by one of the signal handlers in first place) and in the second time it ran the function was trying to remove a lock file that wasn't there anymore. 

With the current implementation the `onExit` function is called exactly once. If for some reason there's a issue during the removal of the lock file than the exit code is set to `1` to indicate an improper shutdown.

Hopefully someone find this useful and I wasn't the only one annoyed with the current behavior 😄 