### PR TITLE
fix regression of genType.import & add backtrace support in compiler debug mode

### DIFF
--- a/jscomp/build_tests/case3/.gitignore
+++ b/jscomp/build_tests/case3/.gitignore
@@ -24,3 +24,4 @@ lib/bs
 .vscode
 .merlin
 .bsb.lock
+*.bs.js

--- a/jscomp/build_tests/case3/input.js
+++ b/jscomp/build_tests/case3/input.js
@@ -1,3 +1,16 @@
-var p = require("child_process");
+//@ts-check
 
-var o = p.spawnSync(`bsb`, { encoding: "utf8", cwd: __dirname });
+var p = require("child_process");
+var fs = require("fs");
+var path = require("path");
+var assert = require("assert");
+p.spawnSync(`bsb`, {
+  encoding: "utf8",
+  cwd: __dirname,
+  stdio: [0, 1, 2]
+});
+
+var o = fs.readFileSync(path.join(__dirname, "src", "hello.bs.js"), "ascii");
+assert.ok(/HelloGen.f/.test(o))
+
+

--- a/jscomp/build_tests/case3/src/hello.re
+++ b/jscomp/build_tests/case3/src/hello.re
@@ -1,0 +1,3 @@
+
+[@genType.import "hh"]
+external f : int => int = "f";

--- a/jscomp/build_tests/hyphen2/input.js
+++ b/jscomp/build_tests/hyphen2/input.js
@@ -1,3 +1,3 @@
 var p  = require('child_process')
 
-p.execSync(`bsb`)
+p.execSync(`bsb`,{cwd:__dirname,stdio:[0,1,2]})

--- a/jscomp/common/bs_warnings.ml
+++ b/jscomp/common/bs_warnings.ml
@@ -43,8 +43,7 @@ let warning_formatter = Format.err_formatter
 
 let print_string_warning (loc : Location.t) x =   
   if loc.loc_ghost then 
-    Format.fprintf warning_formatter "File %s@." 
-      (Js_config.get_current_file ())
+    Format.fprintf warning_formatter "File %s@."  !Location.input_name      
   else 
     Location.print warning_formatter loc ; 
   Format.fprintf warning_formatter "@{<error>Warning@}: %s@." x 

--- a/jscomp/common/js_config.ml
+++ b/jscomp/common/js_config.ml
@@ -71,19 +71,14 @@ let no_builtin_ppx_mli = ref false
 
 (** TODO: will flip the option when it is ready *)
 let no_warn_unimplemented_external = ref false 
-let current_file = ref ""
+
 let debug_file = ref ""
 
-let set_current_file f  = current_file := f
-let get_current_file () = !current_file
 
-let iset_debug_file _ = ()
 let set_debug_file  f = debug_file := f
-let get_debug_file  () = !debug_file
-
 
 let is_same_file () =
-  !debug_file <> "" &&  !debug_file = !current_file
+  !debug_file <> "" &&  !debug_file = !Location.input_name
 
 let tool_name = "BuckleScript"
 

--- a/jscomp/common/js_config.mli
+++ b/jscomp/common/js_config.mli
@@ -73,14 +73,11 @@ val get_check_div_by_zero : unit -> bool
 
 
 
-(** Debugging utilies *)
-val set_current_file : string -> unit 
-val get_current_file : unit -> string
 
 
-val iset_debug_file : string -> unit
+
 val set_debug_file : string -> unit
-val get_debug_file : unit -> string
+
 
 val is_same_file : unit -> bool 
 

--- a/jscomp/core/bs_conditional_initial.ml
+++ b/jscomp/core/bs_conditional_initial.ml
@@ -25,9 +25,9 @@
 
 let setup_env () =
 #if undefined BS_RELEASE_BUILD then
+    Printexc.record_backtrace true;
     (match Ext_sys.getenv_opt "BS_DEBUG_FILE" with 
-     | None -> 
-       Js_config.set_debug_file "caml_obj.ml"
+     | None -> ()       
      | Some s -> 
        Js_config.set_debug_file s 
     );

--- a/jscomp/core/js_cmj_load.ml
+++ b/jscomp/core/js_cmj_load.ml
@@ -43,7 +43,7 @@ let find_cmj file : string * Js_cmj_format.t =
             | exception _ 
               -> 
               Ext_log.warn __LOC__ 
-                "@[%s corrupted in database, when looking %s while compiling %s please update @]"           file target (Js_config.get_current_file ())  ;
+                "@[%s corrupted in database, when looking %s while compiling %s please update @]"  file target !Location.input_name  ;
               Js_cmj_format.no_pure_dummy; (* FIXME *)
             | v ->  v 
             (* see {!Js_packages_info.string_of_module_id} *)

--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -137,7 +137,7 @@ let after_parsing_impl ppf sourcefile outputprefix ast =
               try
                 Lam_compile_main.lambda_as_module
                   finalenv  
-                  sourcefile  outputprefix lambda  with
+                  outputprefix lambda  with
               | e -> 
                 (* Save to a file instead so that it will not scare user *)
                 (if Js_config.get_diagnose () then

--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -45,7 +45,7 @@ let after_parsing_sig ppf sourcefile outputprefix ast  =
     begin 
 
       if Js_config.get_diagnose () then
-        Format.fprintf Format.err_formatter "Building %s@." sourcefile;    
+        Format.fprintf Format.err_formatter "Building %s@." !Location.input_name;    
       let modulename = module_of_filename ppf sourcefile outputprefix in
       Lam_compile_env.reset () ;
       let initial_env = Compmisc.initial_env () in
@@ -108,7 +108,7 @@ let after_parsing_impl ppf sourcefile outputprefix ast =
     begin
 
       if Js_config.get_diagnose () then
-        Format.fprintf Format.err_formatter "Building %s@." sourcefile;      
+        Format.fprintf Format.err_formatter "Building %s@." !Location.input_name;      
       let modulename = Compenv.module_of_filename ppf sourcefile outputprefix in
       Lam_compile_env.reset () ;
       let env = Compmisc.initial_env() in

--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -28,12 +28,12 @@ let print_if ppf flag printer arg =
 
 
 
-let after_parsing_sig ppf sourcefile outputprefix ast  =
+let after_parsing_sig ppf  outputprefix ast  =
   if !Js_config.binary_ast then
     begin 
       Binary_ast.write_ast
         Mli
-        ~fname:sourcefile
+        ~sourcefile:!Location.input_name
         ~output:(outputprefix ^ if !Js_config.is_reason  then Literals.suffix_reiast else Literals.suffix_mliast)
         (* to support relocate to another directory *)
         ast 
@@ -46,7 +46,7 @@ let after_parsing_sig ppf sourcefile outputprefix ast  =
 
       if Js_config.get_diagnose () then
         Format.fprintf Format.err_formatter "Building %s@." !Location.input_name;    
-      let modulename = module_of_filename ppf sourcefile outputprefix in
+      let modulename = module_of_filename ppf !Location.input_name outputprefix in
       Lam_compile_env.reset () ;
       let initial_env = Compmisc.initial_env () in
       Env.set_unit_name modulename;
@@ -74,30 +74,28 @@ let after_parsing_sig ppf sourcefile outputprefix ast  =
 #else
         let sg = Env.save_signature ?check_exists:(if !Js_config.force_cmi then None else Some ()) sg modulename (outputprefix ^ ".cmi") in
 #end        
-        Typemod.save_signature modulename tsg outputprefix sourcefile
+        Typemod.save_signature modulename tsg outputprefix !Location.input_name
           initial_env sg ;
       end
     end
 let interface ppf sourcefile outputprefix =
-  Js_config.set_current_file sourcefile ; 
   Compmisc.init_path false;
   Ocaml_parse.parse_interface ppf sourcefile
   |> print_if ppf Clflags.dump_parsetree Printast.interface
   |> print_if ppf Clflags.dump_source Pprintast.signature 
-  |> after_parsing_sig ppf sourcefile outputprefix 
+  |> after_parsing_sig ppf  outputprefix 
 
-let interface_mliast ppf sourcefile outputprefix  = 
-  Js_config.set_current_file sourcefile ; 
+let interface_mliast ppf fname outputprefix  = 
   Compmisc.init_path false;
-  Binary_ast.read_ast Mli sourcefile 
+  Binary_ast.read_ast Mli fname 
   |> print_if ppf Clflags.dump_parsetree Printast.interface
   |> print_if ppf Clflags.dump_source Pprintast.signature 
-  |> after_parsing_sig ppf sourcefile outputprefix 
+  |> after_parsing_sig ppf  outputprefix 
 
-let after_parsing_impl ppf sourcefile outputprefix ast =
+let after_parsing_impl ppf  outputprefix ast =
   
   if !Js_config.binary_ast then
-    Binary_ast.write_ast ~fname:sourcefile 
+    Binary_ast.write_ast ~sourcefile:!Location.input_name 
       Ml ~output:(outputprefix ^ 
         if !Js_config.is_reason then  Literals.suffix_reast else Literals.suffix_mlast
         )
@@ -109,14 +107,14 @@ let after_parsing_impl ppf sourcefile outputprefix ast =
 
       if Js_config.get_diagnose () then
         Format.fprintf Format.err_formatter "Building %s@." !Location.input_name;      
-      let modulename = Compenv.module_of_filename ppf sourcefile outputprefix in
+      let modulename = Compenv.module_of_filename ppf !Location.input_name outputprefix in
       Lam_compile_env.reset () ;
       let env = Compmisc.initial_env() in
       Env.set_unit_name modulename;
-      try
+      
         let (typedtree, coercion, finalenv, current_signature) =
           ast 
-          |> Typemod.type_implementation_more ?check_exists:(if !Js_config.force_cmi then None else Some ()) sourcefile outputprefix modulename env 
+          |> Typemod.type_implementation_more ?check_exists:(if !Js_config.force_cmi then None else Some ()) !Location.input_name outputprefix modulename env 
           |> print_if ppf Clflags.dump_typedtree
             (fun fmt (ty,co,_,_) -> Printtyped.implementation_with_coercion fmt  (ty,co))
         in
@@ -134,46 +132,27 @@ let after_parsing_impl ppf sourcefile outputprefix ast =
 #end              
                -> 
               ignore (print_if ppf Clflags.dump_rawlambda Printlambda.lambda lambda);
-              try
                 Lam_compile_main.lambda_as_module
                   finalenv  
-                  outputprefix lambda  with
-              | e -> 
-                (* Save to a file instead so that it will not scare user *)
-                (if Js_config.get_diagnose () then
-                   begin              
-                     let file = "bsc.dump" in
-                     Ext_pervasives.with_file_as_chan file
-                       (fun ch -> output_string ch @@             
-                         Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()));
-                     Ext_log.err __LOC__
-                       "Compilation fatal error, stacktrace saved into %s when compiling %s"
-                       file sourcefile;
-                   end;            
-                 raise e)             
+                  outputprefix lambda
             );
 
         end;
         Stypes.dump (Some (outputprefix ^ ".annot"));
-      with x ->
-        Stypes.dump (Some (outputprefix ^ ".annot"));
-        raise x
     end
 let implementation ppf sourcefile outputprefix =
   Compmisc.init_path false;
-  Js_config.set_current_file sourcefile ; 
   Ocaml_parse.parse_implementation ppf sourcefile
   |> print_if ppf Clflags.dump_parsetree Printast.implementation
   |> print_if ppf Clflags.dump_source Pprintast.structure
-  |> after_parsing_impl ppf sourcefile outputprefix 
+  |> after_parsing_impl ppf outputprefix 
 
-let implementation_mlast ppf sourcefile outputprefix = 
+let implementation_mlast ppf fname outputprefix = 
   Compmisc.init_path false;
-  Js_config.set_current_file sourcefile ; 
-  Binary_ast.read_ast Ml sourcefile
+  Binary_ast.read_ast Ml fname
   |> print_if ppf Clflags.dump_parsetree Printast.implementation
   |> print_if ppf Clflags.dump_source Pprintast.structure
-  |> after_parsing_impl ppf sourcefile outputprefix 
+  |> after_parsing_impl ppf  outputprefix 
 
 
 
@@ -209,5 +188,5 @@ let implementation_map ppf sourcefile outputprefix =
   ml_ast
   |> print_if ppf Clflags.dump_parsetree Printast.implementation
   |> print_if ppf Clflags.dump_source Pprintast.structure
-  |> after_parsing_impl ppf sourcefile outputprefix 
+  |> after_parsing_impl ppf outputprefix 
 

--- a/jscomp/core/js_implementation.mli
+++ b/jscomp/core/js_implementation.mli
@@ -39,11 +39,16 @@ val interface : Format.formatter -> string -> string -> unit
 
 val interface_mliast : Format.formatter -> string -> string  -> unit
   
-val after_parsing_sig : Format.formatter -> string -> string -> Parsetree.signature -> unit
 
-val after_parsing_impl : Format.formatter -> string -> string -> Parsetree.structure -> unit
+
+val after_parsing_impl : 
+  Format.formatter -> 
+  string ->
+  Parsetree.structure ->
+  unit
 (** [after_parsing_impl ppf sourcefile outputprefix ast ]
     Make sure you need run {!Compmisc.init_path} for set up
+    Used in eval
 *)
 
 val implementation : Format.formatter -> string -> string -> unit

--- a/jscomp/core/js_pass_debug.ml
+++ b/jscomp/core/js_pass_debug.ml
@@ -41,7 +41,7 @@ let dump name (prog : J.program) =
           incr log_counter ; 
           Ext_log.dwarn ~__POS__ "\n@[[TIME:]%s: %f@]@." name (Sys.time () *. 1000.);          
           Ext_pervasives.with_file_as_chan       
-            (Ext_filename.new_extension (Js_config.get_current_file()) 
+            (Ext_filename.new_extension !Location.input_name
              (Printf.sprintf ".%02d.%s.jsx"  !log_counter name)
             ) (fun chan -> Js_dump_program.dump_program prog chan )
         end in

--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -293,7 +293,6 @@ let (//) = Filename.concat
 
 let lambda_as_module 
     finalenv 
-    (filename : string) 
     (output_prefix : string)
     (lam : Lambda.lambda) = 
   let lambda_output = 

--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -121,7 +121,7 @@ let _d  = fun env s lam ->
 #if undefined BS_RELEASE_BUILD then 
     Lam_util.dump env s lam ;
     Ext_log.dwarn ~__POS__ "START CHECKING PASS %s@." s;
-    ignore @@ Lam_check.check (Js_config.get_current_file ()) lam;
+    ignore @@ Lam_check.check !Location.input_name lam;
     Ext_log.dwarn ~__POS__ "FINISH CHECKING PASS %s@." s;
 #end
     lam
@@ -198,7 +198,7 @@ let compile
     |> (fun lam -> 
        let () = 
         Ext_log.dwarn ~__POS__ "Before coercion: %a@." Lam_stats.print meta in 
-      Lam_check.check (Js_config.get_current_file ()) lam
+      Lam_check.check !Location.input_name lam
     ) 
 #end    
   in

--- a/jscomp/core/lam_compile_main.mli
+++ b/jscomp/core/lam_compile_main.mli
@@ -45,7 +45,6 @@ val compile :
 
 val lambda_as_module :  
   Env.t ->
-  string -> 
   string ->
   Lambda.lambda -> 
   unit

--- a/jscomp/core/lam_util.ml
+++ b/jscomp/core/lam_util.ml
@@ -236,7 +236,7 @@ let dump env ext  lam =
         Ext_log.dwarn ~__POS__ "\n@[[TIME:]%s: %f@]@." ext (Sys.time () *. 1000.);
         Lam_print.seriaize env 
           (Ext_filename.new_extension
-             (Js_config.get_current_file ())
+             !Location.input_name
            (Printf.sprintf ".%02d%s.lam" !log_counter ext)
           ) lam;
       end

--- a/jscomp/core/ocaml_options.ml
+++ b/jscomp/core/ocaml_options.ml
@@ -264,13 +264,6 @@ let print_version_string () =
 let print_standard_library () = 
   print_string Bs_conditional_initial.standard_library; print_newline(); exit 0
 
-let print_version_and_library compiler =
-  Printf.printf "The OCaml %s, version " compiler;
-  print_string bs_version_string; print_newline();
-  print_string "Standard library directory: ";
-  print_string Bs_conditional_initial.standard_library; print_newline();
-  exit 0 
-
 let ocaml_options = 
   let set r () = r := true in 
   let unset r () = r := false in 
@@ -309,7 +302,8 @@ let ocaml_options =
   let _strict_formats = set Clflags.strict_formats in 
   let _unsafe = set Clflags.fast in 
   (* let _unsafe_string = set unsafe_string in  *)
-  let _v () = print_version_and_library "compiler" in 
+  (* let _v () = print_version_and_library "compiler" in  *)
+  let _v = print_version_string in 
   let _version = print_version_string in 
   let _vnum = print_version_string in 
   let _w = (Warnings.parse_options false) in

--- a/jscomp/core/ocaml_parse.ml
+++ b/jscomp/core/ocaml_parse.ml
@@ -46,7 +46,9 @@ let parse_implementation ppf sourcefile =
 
 let parse_implementation_from_string  str = 
   let lb = Lexing.from_string str in
-  Location.init lb "//toplevel//";
+  let fname =  "//toplevel//" in 
+  Location.input_name := fname;
+  Location.init lb fname;
   Ppx_entry.rewrite_implementation (Parse.implementation lb)
 
 

--- a/jscomp/depends/binary_ast.ml
+++ b/jscomp/depends/binary_ast.ml
@@ -46,7 +46,7 @@ let magic_sep_char = '\n'
    1. for performance , easy skipping and calcuate the length 
    2. cut dependency, otherwise its type is {!Ast_extract.String_set.t}
 *)      
-let write_ast (type t) ~(fname : string) ~output (kind : t Ml_binary.kind) ( pt : t) : unit =
+let write_ast (type t) ~(sourcefile : string) ~output (kind : t Ml_binary.kind) ( pt : t) : unit =
   let oc = open_out_bin output in 
   let output_set = Ast_extract.read_parse_and_extract kind pt in
   let buf = Ext_buffer.create 1000 in
@@ -59,6 +59,6 @@ let write_ast (type t) ~(fname : string) ~output (kind : t Ml_binary.kind) ( pt 
     ) output_set ;  
   output_binary_int oc (Ext_buffer.length buf);  
   Ext_buffer.output_buffer oc buf;
-  Ml_binary.write_ast kind fname pt oc;
+  Ml_binary.write_ast kind sourcefile pt oc;
   close_out oc 
 

--- a/jscomp/depends/binary_ast.mli
+++ b/jscomp/depends/binary_ast.mli
@@ -43,5 +43,5 @@ val magic_sep_char : char
    Use case cat - | fan -printer -impl -
    redirect the standard input to fan
  *)
-val write_ast : fname:string -> output:string -> 'a Ml_binary.kind -> 'a -> unit
+val write_ast : sourcefile:string -> output:string -> 'a Ml_binary.kind -> 'a -> unit
 

--- a/jscomp/syntax/ast_external_process.ml
+++ b/jscomp/syntax/ast_external_process.ml
@@ -277,7 +277,7 @@ let parse_external_attributes
         if txt = Literals.gentype_import then 
           let bundle = 
               "./" ^ Ext_filename.new_extension
-                (Filename.basename (Js_config.get_current_file ()))  ".gen"
+                (Filename.basename !Location.input_name)  ".gen"
             in 
             attr::attrs, 
             {st with external_module_name = Some { bundle; module_bind_name = Phint_nothing}}          

--- a/jscomp/syntax/ast_reason_pp.ml
+++ b/jscomp/syntax/ast_reason_pp.ml
@@ -31,7 +31,7 @@ exception Pp_error
 *)
 let pp (sourcefile : string) =
   
-  Location.input_name := sourcefile;
+  
   let tmpfile = Filename.temp_file "ocamlpp" "" in
   let pp = (*TODO: check to avoid double quoting *)
     Ext_filename.maybe_quote 

--- a/jscomp/test/build.ninja
+++ b/jscomp/test/build.ninja
@@ -218,6 +218,7 @@ build test/functor_ffi.cmi test/functor_ffi.cmj : cc test/functor_ffi.ml | $stdl
 build test/functor_inst.cmi test/functor_inst.cmj : cc test/functor_inst.ml | $stdlib
 build test/gbk.cmi test/gbk.cmj : cc test/gbk.ml | $stdlib
 build test/genlex_test.cmi test/genlex_test.cmj : cc test/genlex_test.ml | test/mt.cmj $stdlib
+build test/gentTypeReTest.cmi test/gentTypeReTest.cmj : cc test/gentTypeReTest.re | $stdlib
 build test/global_exception_regression_test.cmi test/global_exception_regression_test.cmj : cc test/global_exception_regression_test.ml | test/mt.cmj $stdlib
 build test/global_mangles.cmi test/global_mangles.cmj : cc test/global_mangles.ml | $stdlib
 build test/global_module_alias_test.cmi test/global_module_alias_test.cmj : cc test/global_module_alias_test.ml | test/mt.cmj $stdlib

--- a/jscomp/test/gentTypeReTest.js
+++ b/jscomp/test/gentTypeReTest.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var GentTypeReTestGen = require("./gentTypeReTest.gen");
+
+function f(prim) {
+  return GentTypeReTestGen.f(prim);
+}
+
+exports.f = f;
+/* ./gentTypeReTest.gen Not a pure module */

--- a/jscomp/test/gentTypeReTest.re
+++ b/jscomp/test/gentTypeReTest.re
@@ -1,0 +1,5 @@
+
+
+
+[@genType.import "hh"]
+external f : int => int = "f";

--- a/lib/4.02.3/bsdep.ml
+++ b/lib/4.02.3/bsdep.ml
@@ -29719,14 +29719,11 @@ val get_check_div_by_zero : unit -> bool
 
 
 
-(** Debugging utilies *)
-val set_current_file : string -> unit 
-val get_current_file : unit -> string
 
 
-val iset_debug_file : string -> unit
+
 val set_debug_file : string -> unit
-val get_debug_file : unit -> string
+
 
 val is_same_file : unit -> bool 
 
@@ -29824,19 +29821,14 @@ let no_builtin_ppx_mli = ref false
 
 (** TODO: will flip the option when it is ready *)
 let no_warn_unimplemented_external = ref false 
-let current_file = ref ""
+
 let debug_file = ref ""
 
-let set_current_file f  = current_file := f
-let get_current_file () = !current_file
 
-let iset_debug_file _ = ()
 let set_debug_file  f = debug_file := f
-let get_debug_file  () = !debug_file
-
 
 let is_same_file () =
-  !debug_file <> "" &&  !debug_file = !current_file
+  !debug_file <> "" &&  !debug_file = !Location.input_name
 
 let tool_name = "BuckleScript"
 
@@ -29952,8 +29944,7 @@ let warning_formatter = Format.err_formatter
 
 let print_string_warning (loc : Location.t) x =   
   if loc.loc_ghost then 
-    Format.fprintf warning_formatter "File %s@." 
-      (Js_config.get_current_file ())
+    Format.fprintf warning_formatter "File %s@."  !Location.input_name      
   else 
     Location.print warning_formatter loc ; 
   Format.fprintf warning_formatter "@{<error>Warning@}: %s@." x 

--- a/lib/4.02.3/bsdep.ml
+++ b/lib/4.02.3/bsdep.ml
@@ -35568,7 +35568,7 @@ let parse_external_attributes
         if txt = Literals.gentype_import then 
           let bundle = 
               "./" ^ Ext_filename.new_extension
-                (Filename.basename (Js_config.get_current_file ()))  ".gen"
+                (Filename.basename !Location.input_name)  ".gen"
             in 
             attr::attrs, 
             {st with external_module_name = Some { bundle; module_bind_name = Phint_nothing}}          

--- a/lib/4.02.3/bsppx.ml
+++ b/lib/4.02.3/bsppx.ml
@@ -17684,7 +17684,7 @@ let parse_external_attributes
         if txt = Literals.gentype_import then 
           let bundle = 
               "./" ^ Ext_filename.new_extension
-                (Filename.basename (Js_config.get_current_file ()))  ".gen"
+                (Filename.basename !Location.input_name)  ".gen"
             in 
             attr::attrs, 
             {st with external_module_name = Some { bundle; module_bind_name = Phint_nothing}}          

--- a/lib/4.02.3/bsppx.ml
+++ b/lib/4.02.3/bsppx.ml
@@ -271,229 +271,6 @@ let print_config oc =
 
 end
 module Config = Config_whole_compiler 
-module Js_config : sig 
-#1 "js_config.mli"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-
-
-
-
-(* val get_packages_info :
-   unit -> Js_packages_info.t *)
-
-
-(** set/get header *)
-val no_version_header : bool ref 
-
-
-(** return [package_name] and [path] 
-    when in script mode: 
-*)
-
-(* val get_current_package_name_and_path : 
-  Js_packages_info.module_system -> 
-  Js_packages_info.info_query *)
-
-
-(* val set_package_name : string -> unit  
-val get_package_name : unit -> string option *)
-
-(** cross module inline option *)
-val cross_module_inline : bool ref
-val set_cross_module_inline : bool -> unit
-val get_cross_module_inline : unit -> bool
-  
-(** diagnose option *)
-val diagnose : bool ref 
-val get_diagnose : unit -> bool 
-val set_diagnose : bool -> unit 
-
-
-(** options for builtin ppx *)
-val no_builtin_ppx_ml : bool ref 
-val no_builtin_ppx_mli : bool ref 
-
-
-
-val no_warn_unimplemented_external : bool ref 
-
-(** check-div-by-zero option *)
-val check_div_by_zero : bool ref 
-val get_check_div_by_zero : unit -> bool 
-
-
-
-
-
-(** Debugging utilies *)
-val set_current_file : string -> unit 
-val get_current_file : unit -> string
-
-
-val iset_debug_file : string -> unit
-val set_debug_file : string -> unit
-val get_debug_file : unit -> string
-
-val is_same_file : unit -> bool 
-
-val tool_name : string
-
-
-val sort_imports : bool ref 
-
-val syntax_only  : bool ref
-val binary_ast : bool ref
-
-
-val bs_suffix : bool ref
-val debug : bool ref
-
-val cmi_only  : bool ref
-val force_cmi : bool ref 
-val force_cmj : bool ref
-
-val jsx_version : int ref
-val refmt : string option ref
-val is_reason : bool ref 
-end = struct
-#1 "js_config.ml"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-
-
-
-
-
-(* let add_npm_package_path s =
-  match !packages_info  with
-  | Empty ->
-    Ext_pervasives.bad_argf "please set package name first using -bs-package-name ";
-  | NonBrowser(name,  envs) ->
-    let env, path =
-      match Ext_string.split ~keep_empty:false s ':' with
-      | [ package_name; path]  ->
-        (match Js_packages_info.module_system_of_string package_name with
-         | Some x -> x
-         | None ->
-           Ext_pervasives.bad_argf "invalid module system %s" package_name), path
-      | [path] ->
-        NodeJS, path
-      | _ ->
-        Ext_pervasives.bad_argf "invalid npm package path: %s" s
-    in
-    packages_info := NonBrowser (name,  ((env,path) :: envs)) *)
-(** Browser is not set via command line only for internal use *)
-
-
-let no_version_header = ref false
-
-let cross_module_inline = ref false
-
-let get_cross_module_inline () = !cross_module_inline
-let set_cross_module_inline b =
-  cross_module_inline := b
-
-
-let diagnose = ref false
-let get_diagnose () = !diagnose
-let set_diagnose b = diagnose := b
-
-let (//) = Filename.concat
-
-(* let get_packages_info () = !packages_info *)
-
-let no_builtin_ppx_ml = ref false
-let no_builtin_ppx_mli = ref false
-
-
-(** TODO: will flip the option when it is ready *)
-let no_warn_unimplemented_external = ref false 
-let current_file = ref ""
-let debug_file = ref ""
-
-let set_current_file f  = current_file := f
-let get_current_file () = !current_file
-
-let iset_debug_file _ = ()
-let set_debug_file  f = debug_file := f
-let get_debug_file  () = !debug_file
-
-
-let is_same_file () =
-  !debug_file <> "" &&  !debug_file = !current_file
-
-let tool_name = "BuckleScript"
-
-let check_div_by_zero = ref true
-let get_check_div_by_zero () = !check_div_by_zero
-
-
-
-
-let sort_imports = ref true
-
-let syntax_only = ref false
-let binary_ast = ref false
-
-let bs_suffix = ref false 
-
-let debug = ref false
-
-let cmi_only = ref false  
-let force_cmi = ref false
-let force_cmj = ref false
-
-let jsx_version = ref (-1)
-
-let refmt = ref None
-
-let is_reason = ref false
-end
 module Clflags : sig 
 #1 "clflags.mli"
 (***********************************************************************)
@@ -2761,6 +2538,221 @@ let raise_errorf ?(loc = none) ?(sub = []) ?(if_highlight = "") =
     ~before:print_phanton_error_prefix
     (fun msg -> raise (Error ({loc; msg; sub; if_highlight})))
 
+end
+module Js_config : sig 
+#1 "js_config.mli"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+
+
+(* val get_packages_info :
+   unit -> Js_packages_info.t *)
+
+
+(** set/get header *)
+val no_version_header : bool ref 
+
+
+(** return [package_name] and [path] 
+    when in script mode: 
+*)
+
+(* val get_current_package_name_and_path : 
+  Js_packages_info.module_system -> 
+  Js_packages_info.info_query *)
+
+
+(* val set_package_name : string -> unit  
+val get_package_name : unit -> string option *)
+
+(** cross module inline option *)
+val cross_module_inline : bool ref
+val set_cross_module_inline : bool -> unit
+val get_cross_module_inline : unit -> bool
+  
+(** diagnose option *)
+val diagnose : bool ref 
+val get_diagnose : unit -> bool 
+val set_diagnose : bool -> unit 
+
+
+(** options for builtin ppx *)
+val no_builtin_ppx_ml : bool ref 
+val no_builtin_ppx_mli : bool ref 
+
+
+
+val no_warn_unimplemented_external : bool ref 
+
+(** check-div-by-zero option *)
+val check_div_by_zero : bool ref 
+val get_check_div_by_zero : unit -> bool 
+
+
+
+
+
+
+
+
+val set_debug_file : string -> unit
+
+
+val is_same_file : unit -> bool 
+
+val tool_name : string
+
+
+val sort_imports : bool ref 
+
+val syntax_only  : bool ref
+val binary_ast : bool ref
+
+
+val bs_suffix : bool ref
+val debug : bool ref
+
+val cmi_only  : bool ref
+val force_cmi : bool ref 
+val force_cmj : bool ref
+
+val jsx_version : int ref
+val refmt : string option ref
+val is_reason : bool ref 
+end = struct
+#1 "js_config.ml"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+
+
+
+(* let add_npm_package_path s =
+  match !packages_info  with
+  | Empty ->
+    Ext_pervasives.bad_argf "please set package name first using -bs-package-name ";
+  | NonBrowser(name,  envs) ->
+    let env, path =
+      match Ext_string.split ~keep_empty:false s ':' with
+      | [ package_name; path]  ->
+        (match Js_packages_info.module_system_of_string package_name with
+         | Some x -> x
+         | None ->
+           Ext_pervasives.bad_argf "invalid module system %s" package_name), path
+      | [path] ->
+        NodeJS, path
+      | _ ->
+        Ext_pervasives.bad_argf "invalid npm package path: %s" s
+    in
+    packages_info := NonBrowser (name,  ((env,path) :: envs)) *)
+(** Browser is not set via command line only for internal use *)
+
+
+let no_version_header = ref false
+
+let cross_module_inline = ref false
+
+let get_cross_module_inline () = !cross_module_inline
+let set_cross_module_inline b =
+  cross_module_inline := b
+
+
+let diagnose = ref false
+let get_diagnose () = !diagnose
+let set_diagnose b = diagnose := b
+
+let (//) = Filename.concat
+
+(* let get_packages_info () = !packages_info *)
+
+let no_builtin_ppx_ml = ref false
+let no_builtin_ppx_mli = ref false
+
+
+(** TODO: will flip the option when it is ready *)
+let no_warn_unimplemented_external = ref false 
+
+let debug_file = ref ""
+
+
+let set_debug_file  f = debug_file := f
+
+let is_same_file () =
+  !debug_file <> "" &&  !debug_file = !Location.input_name
+
+let tool_name = "BuckleScript"
+
+let check_div_by_zero = ref true
+let get_check_div_by_zero () = !check_div_by_zero
+
+
+
+
+let sort_imports = ref true
+
+let syntax_only = ref false
+let binary_ast = ref false
+
+let bs_suffix = ref false 
+
+let debug = ref false
+
+let cmi_only = ref false  
+let force_cmi = ref false
+let force_cmj = ref false
+
+let jsx_version = ref (-1)
+
+let refmt = ref None
+
+let is_reason = ref false
 end
 (** Interface as module  *)
 module Asttypes
@@ -12005,8 +11997,7 @@ let warning_formatter = Format.err_formatter
 
 let print_string_warning (loc : Location.t) x =   
   if loc.loc_ghost then 
-    Format.fprintf warning_formatter "File %s@." 
-      (Js_config.get_current_file ())
+    Format.fprintf warning_formatter "File %s@."  !Location.input_name      
   else 
     Location.print warning_formatter loc ; 
   Format.fprintf warning_formatter "@{<error>Warning@}: %s@." x 

--- a/lib/4.02.3/unstable/all_ounit_tests.ml
+++ b/lib/4.02.3/unstable/all_ounit_tests.ml
@@ -7360,14 +7360,11 @@ val get_check_div_by_zero : unit -> bool
 
 
 
-(** Debugging utilies *)
-val set_current_file : string -> unit 
-val get_current_file : unit -> string
 
 
-val iset_debug_file : string -> unit
+
 val set_debug_file : string -> unit
-val get_debug_file : unit -> string
+
 
 val is_same_file : unit -> bool 
 
@@ -7465,19 +7462,14 @@ let no_builtin_ppx_mli = ref false
 
 (** TODO: will flip the option when it is ready *)
 let no_warn_unimplemented_external = ref false 
-let current_file = ref ""
+
 let debug_file = ref ""
 
-let set_current_file f  = current_file := f
-let get_current_file () = !current_file
 
-let iset_debug_file _ = ()
 let set_debug_file  f = debug_file := f
-let get_debug_file  () = !debug_file
-
 
 let is_same_file () =
-  !debug_file <> "" &&  !debug_file = !current_file
+  !debug_file <> "" &&  !debug_file = !Location.input_name
 
 let tool_name = "BuckleScript"
 

--- a/lib/4.02.3/unstable/bspack.ml
+++ b/lib/4.02.3/unstable/bspack.ml
@@ -8125,14 +8125,11 @@ val get_check_div_by_zero : unit -> bool
 
 
 
-(** Debugging utilies *)
-val set_current_file : string -> unit 
-val get_current_file : unit -> string
 
 
-val iset_debug_file : string -> unit
+
 val set_debug_file : string -> unit
-val get_debug_file : unit -> string
+
 
 val is_same_file : unit -> bool 
 
@@ -8230,19 +8227,14 @@ let no_builtin_ppx_mli = ref false
 
 (** TODO: will flip the option when it is ready *)
 let no_warn_unimplemented_external = ref false 
-let current_file = ref ""
+
 let debug_file = ref ""
 
-let set_current_file f  = current_file := f
-let get_current_file () = !current_file
 
-let iset_debug_file _ = ()
 let set_debug_file  f = debug_file := f
-let get_debug_file  () = !debug_file
-
 
 let is_same_file () =
-  !debug_file <> "" &&  !debug_file = !current_file
+  !debug_file <> "" &&  !debug_file = !Location.input_name
 
 let tool_name = "BuckleScript"
 

--- a/lib/4.02.3/unstable/native_ppx.ml
+++ b/lib/4.02.3/unstable/native_ppx.ml
@@ -16804,7 +16804,7 @@ let parse_external_attributes
         if txt = Literals.gentype_import then 
           let bundle = 
               "./" ^ Ext_filename.new_extension
-                (Filename.basename (Js_config.get_current_file ()))  ".gen"
+                (Filename.basename !Location.input_name)  ".gen"
             in 
             attr::attrs, 
             {st with external_module_name = Some { bundle; module_bind_name = Phint_nothing}}          

--- a/lib/4.02.3/unstable/native_ppx.ml
+++ b/lib/4.02.3/unstable/native_ppx.ml
@@ -11657,14 +11657,11 @@ val get_check_div_by_zero : unit -> bool
 
 
 
-(** Debugging utilies *)
-val set_current_file : string -> unit 
-val get_current_file : unit -> string
 
 
-val iset_debug_file : string -> unit
+
 val set_debug_file : string -> unit
-val get_debug_file : unit -> string
+
 
 val is_same_file : unit -> bool 
 
@@ -11762,19 +11759,14 @@ let no_builtin_ppx_mli = ref false
 
 (** TODO: will flip the option when it is ready *)
 let no_warn_unimplemented_external = ref false 
-let current_file = ref ""
+
 let debug_file = ref ""
 
-let set_current_file f  = current_file := f
-let get_current_file () = !current_file
 
-let iset_debug_file _ = ()
 let set_debug_file  f = debug_file := f
-let get_debug_file  () = !debug_file
-
 
 let is_same_file () =
-  !debug_file <> "" &&  !debug_file = !current_file
+  !debug_file <> "" &&  !debug_file = !Location.input_name
 
 let tool_name = "BuckleScript"
 
@@ -11890,8 +11882,7 @@ let warning_formatter = Format.err_formatter
 
 let print_string_warning (loc : Location.t) x =   
   if loc.loc_ghost then 
-    Format.fprintf warning_formatter "File %s@." 
-      (Js_config.get_current_file ())
+    Format.fprintf warning_formatter "File %s@."  !Location.input_name      
   else 
     Location.print warning_formatter loc ; 
   Format.fprintf warning_formatter "@{<error>Warning@}: %s@." x 


### PR DESCRIPTION
cc @cristianoc in case you came across a regression after this release
Note after integration of reason instead of using pp, we should update the sourcefile accordingly to avoid the temporary name used