### PR TITLE
Esy monorepo support

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -8,7 +8,7 @@
     "ocaml": "4.02.3000+BS"
   },
   "resolutions": {
-    "ocaml": "ulrikstrid/ocaml:package.json#d8d514004"
+    "ocaml": "bucklescript/ocaml:package.json#698e60f3cd2f442f2013e79860ce2f7b0a9624cb"
   },
   "esy": {
     "buildsInSource": true,

--- a/esy.json
+++ b/esy.json
@@ -8,7 +8,7 @@
     "ocaml": "4.02.3000+BS"
   },
   "resolutions": {
-    "ocaml": "ulrikstrid/ocaml:package.json#e433d5b3fbe8963ac98257d1ed3b32c01515e07d"
+    "ocaml": "ulrikstrid/ocaml:package.json#d8d514004"
   },
   "esy": {
     "buildsInSource": true,

--- a/jscomp/bsb/bsb_pkg.ml
+++ b/jscomp/bsb/bsb_pkg.ml
@@ -106,7 +106,7 @@ let resolve_bs_package ~cwd (package : t) =
  * npm_config_prefix, bs_custom_resolution allows these to specify the
  * exact location of build cache, but on a per-package basis. Implemented as
  * environment lookup to avoid invasive changes to bsconfig and mandates. *)
-let custom_resolution =
+let custom_resolution () =
  match Sys.getenv "bs_custom_resolution" with
   | exception Not_found  -> false
   | "true"  -> true
@@ -126,7 +126,7 @@ let pkg_name_as_variable pkg =
   |> Str.global_replace regex_hyphen "_"
 
 let resolve_bs_package ~cwd (pkg : t) =
-  if custom_resolution then
+  if custom_resolution () then
   begin
     Bsb_log.info "@{<info>Using Custom Resolution@}@.";
     let custom_pkg_loc = pkg_name_as_variable pkg ^ "__install" in

--- a/jscomp/bsb/bsb_pkg.ml
+++ b/jscomp/bsb/bsb_pkg.ml
@@ -101,7 +101,65 @@ let resolve_bs_package ~cwd (package : t) =
       end;
     x
 
+(* Some package managers will implement "postinstall" caches, that do not
+ * keep their build artifacts in the local node_modules. Similar to
+ * npm_config_prefix, bs_custom_resolution allows these to specify the
+ * exact location of build cache, but on a per-package basis. Implemented as
+ * environment lookup to avoid invasive changes to bsconfig and mandates. *)
+let custom_resolution =
+ match Sys.getenv "bs_custom_resolution" with
+  | exception Not_found  -> false
+  | "true"  -> true
+  | _ -> false
 
+let regex_at = Str.regexp "@"
+let regex_unders = Str.regexp "_+"
+let regex_slash = Str.regexp "\\/"
+let regex_dot = Str.regexp "\\."
+let regex_hyphen = Str.regexp "-"
+let pkg_name_as_variable pkg =
+  Bsb_pkg_types.to_string pkg
+  |> Str.replace_first regex_at ""
+  |> Str.global_replace regex_unders "\\0_"
+  |> Str.global_replace regex_slash "__slash__"
+  |> Str.global_replace regex_dot "__dot__"
+  |> Str.global_replace regex_hyphen "_"
+
+let resolve_bs_package ~cwd (pkg : t) =
+  if custom_resolution then
+  begin
+    Bsb_log.info "@{<info>Using Custom Resolution@}@.";
+    let custom_pkg_loc = pkg_name_as_variable pkg ^ "__install" in
+    match Sys.getenv custom_pkg_loc with
+    | exception Not_found ->
+        begin
+          Bsb_log.error
+            "@{<error>Custom resolution of package %s does not exist in var %s @}@."
+            (Bsb_pkg_types.to_string pkg)
+            custom_pkg_loc;
+          Bsb_exception.package_not_found ~pkg ~json:None
+        end
+    | path when not (Sys.file_exists path) ->
+        begin
+          Bsb_log.error
+            "@{<error>Custom resolution of package %s does not exist on disk: %s=%s @}@."
+            (Bsb_pkg_types.to_string pkg)
+            custom_pkg_loc
+            path;
+          Bsb_exception.package_not_found ~pkg ~json:None
+        end
+    | path ->
+      begin
+        Bsb_log.info
+          "@{<info>Custom Resolution of package %s in var %s found at %s@}@."
+          (Bsb_pkg_types.to_string pkg)
+          custom_pkg_loc
+          path;
+        path
+      end
+    end
+  else
+    resolve_bs_package ~cwd pkg
 
 
 (** The package does not need to be a bspackage

--- a/jscomp/bsb/bsb_pkg.ml
+++ b/jscomp/bsb/bsb_pkg.ml
@@ -82,25 +82,6 @@ let cache : string Coll.t = Coll.create 0
 let to_list cb  =   
   Coll.to_list cache  cb 
   
-(** TODO: collect all warnings and print later *)
-let resolve_bs_package ~cwd (package : t) =
-  match Coll.find_opt cache package with
-  | None ->
-    let result = resolve_bs_package_aux ~cwd package in
-    Bsb_log.info "@{<info>Package@} %a -> %s@." Bsb_pkg_types.print package result ;
-    Coll.add cache package result ;
-    result
-  | Some x
-    ->
-    let result = resolve_bs_package_aux ~cwd package in
-    if result <> x then
-      begin
-        Bsb_log.warn
-          "@{<warning>Duplicated package:@} %a %s (chosen) vs %s in %s @." 
-            Bsb_pkg_types.print package x result cwd;
-      end;
-    x
-
 (* Some package managers will implement "postinstall" caches, that do not
  * keep their build artifacts in the local node_modules. Similar to
  * npm_config_prefix, bs_custom_resolution allows these to specify the
@@ -125,41 +106,56 @@ let pkg_name_as_variable pkg =
   |> Str.global_replace regex_dot "__dot__"
   |> Str.global_replace regex_hyphen "_"
 
-let resolve_bs_package ~cwd (pkg : t) =
+let resolve_bs_package ~cwd (package : t) =
   if custom_resolution () then
   begin
     Bsb_log.info "@{<info>Using Custom Resolution@}@.";
-    let custom_pkg_loc = pkg_name_as_variable pkg ^ "__install" in
+    let custom_pkg_loc = pkg_name_as_variable package ^ "__install" in
     match Sys.getenv custom_pkg_loc with
     | exception Not_found ->
         begin
           Bsb_log.error
             "@{<error>Custom resolution of package %s does not exist in var %s @}@."
-            (Bsb_pkg_types.to_string pkg)
+            (Bsb_pkg_types.to_string package)
             custom_pkg_loc;
-          Bsb_exception.package_not_found ~pkg ~json:None
+          Bsb_exception.package_not_found ~pkg:package ~json:None
         end
     | path when not (Sys.file_exists path) ->
         begin
           Bsb_log.error
             "@{<error>Custom resolution of package %s does not exist on disk: %s=%s @}@."
-            (Bsb_pkg_types.to_string pkg)
+            (Bsb_pkg_types.to_string package)
             custom_pkg_loc
             path;
-          Bsb_exception.package_not_found ~pkg ~json:None
+          Bsb_exception.package_not_found ~pkg:package ~json:None
         end
     | path ->
       begin
         Bsb_log.info
           "@{<info>Custom Resolution of package %s in var %s found at %s@}@."
-          (Bsb_pkg_types.to_string pkg)
+          (Bsb_pkg_types.to_string package)
           custom_pkg_loc
           path;
         path
       end
     end
   else
-    resolve_bs_package ~cwd pkg
+    match Coll.find_opt cache package with
+    | None ->
+      let result = resolve_bs_package_aux ~cwd package in
+      Bsb_log.info "@{<info>Package@} %a -> %s@." Bsb_pkg_types.print package result ;
+      Coll.add cache package result ;
+      result
+    | Some x
+      ->
+      let result = resolve_bs_package_aux ~cwd package in
+      if result <> x then
+        begin
+          Bsb_log.warn
+            "@{<warning>Duplicated package:@} %a %s (chosen) vs %s in %s @." 
+              Bsb_pkg_types.print package x result cwd;
+        end;
+      x
 
 
 (** The package does not need to be a bspackage

--- a/jscomp/bsb/bsb_pkg.ml
+++ b/jscomp/bsb/bsb_pkg.ml
@@ -106,6 +106,7 @@ let pkg_name_as_variable pkg =
   |> Str.global_replace regex_dot "__dot__"
   |> Str.global_replace regex_hyphen "_"
 
+(** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =
   if custom_resolution () then
   begin

--- a/jscomp/bsb/bsb_pkg.ml
+++ b/jscomp/bsb/bsb_pkg.ml
@@ -92,20 +92,19 @@ let custom_resolution = lazy
   | exception Not_found  -> false
   | "true"  -> true
   | _ -> false)
- 
 
-let regex_at = Str.regexp "@"
-let regex_unders = Str.regexp "_+"
-let regex_slash = Str.regexp "\\/"
-let regex_dot = Str.regexp "\\."
-let regex_hyphen = Str.regexp "-"
-let pkg_name_as_variable pkg =
-  Bsb_pkg_types.to_string pkg
-  |> Str.replace_first regex_at ""
-  |> Str.global_replace regex_unders "\\0_"
-  |> Str.global_replace regex_slash "__slash__"
-  |> Str.global_replace regex_dot "__dot__"
-  |> Str.global_replace regex_hyphen "_"
+let pkg_name_as_variable package =
+  Bsb_pkg_types.to_string package
+  |> fun s -> Ext_string.split s '@'
+  |> String.concat ""
+  |> fun s -> Ext_string.split s '_'
+  |> String.concat "__"
+  |> fun s -> Ext_string.split s '/'
+  |> String.concat "__slash__"
+  |> fun s -> Ext_string.split s '.'
+  |> String.concat "__dot__"
+  |> fun s -> Ext_string.split s '-'
+  |> String.concat "_"
 
 (** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =

--- a/lib/4.02.3/bsb.ml
+++ b/lib/4.02.3/bsb.ml
@@ -8572,6 +8572,7 @@ let pkg_name_as_variable pkg =
   |> Str.global_replace regex_dot "__dot__"
   |> Str.global_replace regex_hyphen "_"
 
+(** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =
   if custom_resolution () then
   begin

--- a/lib/4.02.3/bsb.ml
+++ b/lib/4.02.3/bsb.ml
@@ -8572,7 +8572,7 @@ let resolve_bs_package ~cwd (package : t) =
  * npm_config_prefix, bs_custom_resolution allows these to specify the
  * exact location of build cache, but on a per-package basis. Implemented as
  * environment lookup to avoid invasive changes to bsconfig and mandates. *)
-let custom_resolution =
+let custom_resolution () =
  match Sys.getenv "bs_custom_resolution" with
   | exception Not_found  -> false
   | "true"  -> true
@@ -8592,7 +8592,7 @@ let pkg_name_as_variable pkg =
   |> Str.global_replace regex_hyphen "_"
 
 let resolve_bs_package ~cwd (pkg : t) =
-  if custom_resolution then
+  if custom_resolution () then
   begin
     Bsb_log.info "@{<info>Using Custom Resolution@}@.";
     let custom_pkg_loc = pkg_name_as_variable pkg ^ "__install" in

--- a/lib/4.02.3/bsb.ml
+++ b/lib/4.02.3/bsb.ml
@@ -8567,6 +8567,65 @@ let resolve_bs_package ~cwd (package : t) =
       end;
     x
 
+(* Some package managers will implement "postinstall" caches, that do not
+ * keep their build artifacts in the local node_modules. Similar to
+ * npm_config_prefix, bs_custom_resolution allows these to specify the
+ * exact location of build cache, but on a per-package basis. Implemented as
+ * environment lookup to avoid invasive changes to bsconfig and mandates. *)
+let custom_resolution =
+ match Sys.getenv "bs_custom_resolution" with
+  | exception Not_found  -> false
+  | "true"  -> true
+  | _ -> false
+
+let regex_at = Str.regexp "@"
+let regex_unders = Str.regexp "_+"
+let regex_slash = Str.regexp "\\/"
+let regex_dot = Str.regexp "\\."
+let regex_hyphen = Str.regexp "-"
+let pkg_name_as_variable pkg =
+  Bsb_pkg_types.to_string pkg
+  |> Str.replace_first regex_at ""
+  |> Str.global_replace regex_unders "\\0_"
+  |> Str.global_replace regex_slash "__slash__"
+  |> Str.global_replace regex_dot "__dot__"
+  |> Str.global_replace regex_hyphen "_"
+
+let resolve_bs_package ~cwd (pkg : t) =
+  if custom_resolution then
+  begin
+    Bsb_log.info "@{<info>Using Custom Resolution@}@.";
+    let custom_pkg_loc = pkg_name_as_variable pkg ^ "__install" in
+    match Sys.getenv custom_pkg_loc with
+    | exception Not_found ->
+        begin
+          Bsb_log.error
+            "@{<error>Custom resolution of package %s does not exist in var %s @}@."
+            (Bsb_pkg_types.to_string pkg)
+            custom_pkg_loc;
+          Bsb_exception.package_not_found ~pkg ~json:None
+        end
+    | path when not (Sys.file_exists path) ->
+        begin
+          Bsb_log.error
+            "@{<error>Custom resolution of package %s does not exist on disk: %s=%s @}@."
+            (Bsb_pkg_types.to_string pkg)
+            custom_pkg_loc
+            path;
+          Bsb_exception.package_not_found ~pkg ~json:None
+        end
+    | path ->
+      begin
+        Bsb_log.info
+          "@{<info>Custom Resolution of package %s in var %s found at %s@}@."
+          (Bsb_pkg_types.to_string pkg)
+          custom_pkg_loc
+          path;
+        path
+      end
+    end
+  else
+    resolve_bs_package ~cwd pkg
 
 
 

--- a/lib/4.02.3/bsb.ml
+++ b/lib/4.02.3/bsb.ml
@@ -8558,20 +8558,19 @@ let custom_resolution = lazy
   | exception Not_found  -> false
   | "true"  -> true
   | _ -> false)
- 
 
-let regex_at = Str.regexp "@"
-let regex_unders = Str.regexp "_+"
-let regex_slash = Str.regexp "\\/"
-let regex_dot = Str.regexp "\\."
-let regex_hyphen = Str.regexp "-"
-let pkg_name_as_variable pkg =
-  Bsb_pkg_types.to_string pkg
-  |> Str.replace_first regex_at ""
-  |> Str.global_replace regex_unders "\\0_"
-  |> Str.global_replace regex_slash "__slash__"
-  |> Str.global_replace regex_dot "__dot__"
-  |> Str.global_replace regex_hyphen "_"
+let pkg_name_as_variable package =
+  Bsb_pkg_types.to_string package
+  |> fun s -> Ext_string.split s '@'
+  |> String.concat ""
+  |> fun s -> Ext_string.split s '_'
+  |> String.concat "__"
+  |> fun s -> Ext_string.split s '/'
+  |> String.concat "__slash__"
+  |> fun s -> Ext_string.split s '.'
+  |> String.concat "__dot__"
+  |> fun s -> Ext_string.split s '-'
+  |> String.concat "_"
 
 (** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =

--- a/lib/4.02.3/bsb.ml
+++ b/lib/4.02.3/bsb.ml
@@ -8547,17 +8547,18 @@ let cache : string Coll.t = Coll.create 0
 
 let to_list cb  =   
   Coll.to_list cache  cb 
-
+  
 (* Some package managers will implement "postinstall" caches, that do not
  * keep their build artifacts in the local node_modules. Similar to
  * npm_config_prefix, bs_custom_resolution allows these to specify the
  * exact location of build cache, but on a per-package basis. Implemented as
  * environment lookup to avoid invasive changes to bsconfig and mandates. *)
-let custom_resolution () =
- match Sys.getenv "bs_custom_resolution" with
+let custom_resolution = lazy
+  (match Sys.getenv "bs_custom_resolution" with
   | exception Not_found  -> false
   | "true"  -> true
-  | _ -> false
+  | _ -> false)
+ 
 
 let regex_at = Str.regexp "@"
 let regex_unders = Str.regexp "_+"
@@ -8574,11 +8575,12 @@ let pkg_name_as_variable pkg =
 
 (** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =
-  if custom_resolution () then
+  if Lazy.force custom_resolution then
   begin
     Bsb_log.info "@{<info>Using Custom Resolution@}@.";
     let custom_pkg_loc = pkg_name_as_variable package ^ "__install" in
-    match Sys.getenv custom_pkg_loc with
+    let custom_pkg_location = lazy (Sys.getenv custom_pkg_loc) in
+    match Lazy.force custom_pkg_location with
     | exception Not_found ->
         begin
           Bsb_log.error
@@ -8623,7 +8625,6 @@ let resolve_bs_package ~cwd (package : t) =
               Bsb_pkg_types.print package x result cwd;
         end;
       x
-
 
 
 (** The package does not need to be a bspackage

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -8542,6 +8542,7 @@ let pkg_name_as_variable pkg =
   |> Str.global_replace regex_dot "__dot__"
   |> Str.global_replace regex_hyphen "_"
 
+(** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =
   if custom_resolution () then
   begin

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -8528,20 +8528,19 @@ let custom_resolution = lazy
   | exception Not_found  -> false
   | "true"  -> true
   | _ -> false)
- 
 
-let regex_at = Str.regexp "@"
-let regex_unders = Str.regexp "_+"
-let regex_slash = Str.regexp "\\/"
-let regex_dot = Str.regexp "\\."
-let regex_hyphen = Str.regexp "-"
-let pkg_name_as_variable pkg =
-  Bsb_pkg_types.to_string pkg
-  |> Str.replace_first regex_at ""
-  |> Str.global_replace regex_unders "\\0_"
-  |> Str.global_replace regex_slash "__slash__"
-  |> Str.global_replace regex_dot "__dot__"
-  |> Str.global_replace regex_hyphen "_"
+let pkg_name_as_variable package =
+  Bsb_pkg_types.to_string package
+  |> fun s -> Ext_string.split s '@'
+  |> String.concat ""
+  |> fun s -> Ext_string.split s '_'
+  |> String.concat "__"
+  |> fun s -> Ext_string.split s '/'
+  |> String.concat "__slash__"
+  |> fun s -> Ext_string.split s '.'
+  |> String.concat "__dot__"
+  |> fun s -> Ext_string.split s '-'
+  |> String.concat "_"
 
 (** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -8542,7 +8542,7 @@ let resolve_bs_package ~cwd (package : t) =
  * npm_config_prefix, bs_custom_resolution allows these to specify the
  * exact location of build cache, but on a per-package basis. Implemented as
  * environment lookup to avoid invasive changes to bsconfig and mandates. *)
-let custom_resolution =
+let custom_resolution () =
  match Sys.getenv "bs_custom_resolution" with
   | exception Not_found  -> false
   | "true"  -> true
@@ -8562,7 +8562,7 @@ let pkg_name_as_variable pkg =
   |> Str.global_replace regex_hyphen "_"
 
 let resolve_bs_package ~cwd (pkg : t) =
-  if custom_resolution then
+  if custom_resolution () then
   begin
     Bsb_log.info "@{<info>Using Custom Resolution@}@.";
     let custom_pkg_loc = pkg_name_as_variable pkg ^ "__install" in

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -8537,6 +8537,65 @@ let resolve_bs_package ~cwd (package : t) =
       end;
     x
 
+(* Some package managers will implement "postinstall" caches, that do not
+ * keep their build artifacts in the local node_modules. Similar to
+ * npm_config_prefix, bs_custom_resolution allows these to specify the
+ * exact location of build cache, but on a per-package basis. Implemented as
+ * environment lookup to avoid invasive changes to bsconfig and mandates. *)
+let custom_resolution =
+ match Sys.getenv "bs_custom_resolution" with
+  | exception Not_found  -> false
+  | "true"  -> true
+  | _ -> false
+
+let regex_at = Str.regexp "@"
+let regex_unders = Str.regexp "_+"
+let regex_slash = Str.regexp "\\/"
+let regex_dot = Str.regexp "\\."
+let regex_hyphen = Str.regexp "-"
+let pkg_name_as_variable pkg =
+  Bsb_pkg_types.to_string pkg
+  |> Str.replace_first regex_at ""
+  |> Str.global_replace regex_unders "\\0_"
+  |> Str.global_replace regex_slash "__slash__"
+  |> Str.global_replace regex_dot "__dot__"
+  |> Str.global_replace regex_hyphen "_"
+
+let resolve_bs_package ~cwd (pkg : t) =
+  if custom_resolution then
+  begin
+    Bsb_log.info "@{<info>Using Custom Resolution@}@.";
+    let custom_pkg_loc = pkg_name_as_variable pkg ^ "__install" in
+    match Sys.getenv custom_pkg_loc with
+    | exception Not_found ->
+        begin
+          Bsb_log.error
+            "@{<error>Custom resolution of package %s does not exist in var %s @}@."
+            (Bsb_pkg_types.to_string pkg)
+            custom_pkg_loc;
+          Bsb_exception.package_not_found ~pkg ~json:None
+        end
+    | path when not (Sys.file_exists path) ->
+        begin
+          Bsb_log.error
+            "@{<error>Custom resolution of package %s does not exist on disk: %s=%s @}@."
+            (Bsb_pkg_types.to_string pkg)
+            custom_pkg_loc
+            path;
+          Bsb_exception.package_not_found ~pkg ~json:None
+        end
+    | path ->
+      begin
+        Bsb_log.info
+          "@{<info>Custom Resolution of package %s in var %s found at %s@}@."
+          (Bsb_pkg_types.to_string pkg)
+          custom_pkg_loc
+          path;
+        path
+      end
+    end
+  else
+    resolve_bs_package ~cwd pkg
 
 
 

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -8517,25 +8517,6 @@ let cache : string Coll.t = Coll.create 0
 
 let to_list cb  =   
   Coll.to_list cache  cb 
-  
-(** TODO: collect all warnings and print later *)
-let resolve_bs_package ~cwd (package : t) =
-  match Coll.find_opt cache package with
-  | None ->
-    let result = resolve_bs_package_aux ~cwd package in
-    Bsb_log.info "@{<info>Package@} %a -> %s@." Bsb_pkg_types.print package result ;
-    Coll.add cache package result ;
-    result
-  | Some x
-    ->
-    let result = resolve_bs_package_aux ~cwd package in
-    if result <> x then
-      begin
-        Bsb_log.warn
-          "@{<warning>Duplicated package:@} %a %s (chosen) vs %s in %s @." 
-            Bsb_pkg_types.print package x result cwd;
-      end;
-    x
 
 (* Some package managers will implement "postinstall" caches, that do not
  * keep their build artifacts in the local node_modules. Similar to
@@ -8561,41 +8542,56 @@ let pkg_name_as_variable pkg =
   |> Str.global_replace regex_dot "__dot__"
   |> Str.global_replace regex_hyphen "_"
 
-let resolve_bs_package ~cwd (pkg : t) =
+let resolve_bs_package ~cwd (package : t) =
   if custom_resolution () then
   begin
     Bsb_log.info "@{<info>Using Custom Resolution@}@.";
-    let custom_pkg_loc = pkg_name_as_variable pkg ^ "__install" in
+    let custom_pkg_loc = pkg_name_as_variable package ^ "__install" in
     match Sys.getenv custom_pkg_loc with
     | exception Not_found ->
         begin
           Bsb_log.error
             "@{<error>Custom resolution of package %s does not exist in var %s @}@."
-            (Bsb_pkg_types.to_string pkg)
+            (Bsb_pkg_types.to_string package)
             custom_pkg_loc;
-          Bsb_exception.package_not_found ~pkg ~json:None
+          Bsb_exception.package_not_found ~pkg:package ~json:None
         end
     | path when not (Sys.file_exists path) ->
         begin
           Bsb_log.error
             "@{<error>Custom resolution of package %s does not exist on disk: %s=%s @}@."
-            (Bsb_pkg_types.to_string pkg)
+            (Bsb_pkg_types.to_string package)
             custom_pkg_loc
             path;
-          Bsb_exception.package_not_found ~pkg ~json:None
+          Bsb_exception.package_not_found ~pkg:package ~json:None
         end
     | path ->
       begin
         Bsb_log.info
           "@{<info>Custom Resolution of package %s in var %s found at %s@}@."
-          (Bsb_pkg_types.to_string pkg)
+          (Bsb_pkg_types.to_string package)
           custom_pkg_loc
           path;
         path
       end
     end
   else
-    resolve_bs_package ~cwd pkg
+    match Coll.find_opt cache package with
+    | None ->
+      let result = resolve_bs_package_aux ~cwd package in
+      Bsb_log.info "@{<info>Package@} %a -> %s@." Bsb_pkg_types.print package result ;
+      Coll.add cache package result ;
+      result
+    | Some x
+      ->
+      let result = resolve_bs_package_aux ~cwd package in
+      if result <> x then
+        begin
+          Bsb_log.warn
+            "@{<warning>Duplicated package:@} %a %s (chosen) vs %s in %s @." 
+              Bsb_pkg_types.print package x result cwd;
+        end;
+      x
 
 
 


### PR DESCRIPTION
This patch is basically taken from this commit https://github.com/esy-ocaml/bucklescript/commit/2b4bc2a07b3b9ee24bc1f5d877ab98f6446ab4e4

This allows us to find bs-platform via a env variable. Users can also supply paths to dependencies in a monorepo style by setting `package_name__install` to the path.

When this is merged we need 2 things:
1. A possibility to write outside of our dependencies sources as `esy` doesn't allow us to modify the soruces except for .merlin files.
2. A way to find sources that do not supply the environment variable mentioned above. We might want to solve this problem by reading the file `_esy/default/installation.json` as that will include all sources.