### PR TITLE
Fixes #3843

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -29,7 +29,6 @@ var sys_extension = config.sys_extension;
 process.env.BS_RELEASE_BUILD = "true";
 
 var ninja_bin_output = path.join(root_dir, "lib", "ninja.exe");
-var preBuiltCompilerArtifacts = ["bsc", "bsb", "bsb_helper", "bsppx", "refmt"];
 
 /**
  * Make sure `ninja_bin_output` exists
@@ -37,82 +36,82 @@ var preBuiltCompilerArtifacts = ["bsc", "bsb", "bsb_helper", "bsppx", "refmt"];
  * This is less problematic since `ninja.exe` is very stable
  */
 function provideNinja() {
-    var vendor_ninja_version = "1.9.0.git";
-    var ninja_source_dir = path.join(root_dir, "vendor", "ninja");
-    function build_ninja() {
-        console.log(`building ninja`);
-        cp.execSync(`tar xzvf ../ninja.tar.gz`, {
-            cwd: ninja_source_dir,
-            stdio: [0, 1, 2]
-        });
-        console.log("No prebuilt Ninja, building Ninja now");
-        var build_ninja_command = "./configure.py --bootstrap";
-        cp.execSync(build_ninja_command, {
-            cwd: ninja_source_dir,
-            stdio: [0, 1, 2]
-        });
-        fs.renameSync(path.join(ninja_source_dir, "ninja"), ninja_bin_output);
-        console.log("ninja binary is ready: ", ninja_bin_output);
-    }
+  var vendor_ninja_version = "1.9.0.git";
+  var ninja_source_dir = path.join(root_dir, "vendor", "ninja");
+  function build_ninja() {
+    console.log(`building ninja`);
+    cp.execSync(`tar xzvf ../ninja.tar.gz`, {
+      cwd: ninja_source_dir,
+      stdio: [0, 1, 2]
+    });
+    console.log("No prebuilt Ninja, building Ninja now");
+    var build_ninja_command = "./configure.py --bootstrap";
+    cp.execSync(build_ninja_command, {
+      cwd: ninja_source_dir,
+      stdio: [0, 1, 2]
+    });
+    fs.renameSync(path.join(ninja_source_dir, "ninja"), ninja_bin_output);
+    console.log("ninja binary is ready: ", ninja_bin_output);
+  }
 
-    // sanity check to make sure the binary actually runs. Used for Linux. Too many variants
-    /**
-     *
-     * @param {string} binary_path
-     */
-    function test_ninja_compatible(binary_path) {
-        var version;
-        try {
-            version = cp
-                .execSync(JSON.stringify(binary_path) + " --version", {
-                    encoding: "utf8",
-                    stdio: ["pipe", "pipe", "ignore"] // execSync outputs to stdout even if we catch the error. Silent it here
-                })
-                .trim();
-        } catch (e) {
-            console.log("ninja not compatible?", String(e));
-            return false;
-        }
-        return version === vendor_ninja_version;
+  // sanity check to make sure the binary actually runs. Used for Linux. Too many variants
+  /**
+   *
+   * @param {string} binary_path
+   */
+  function test_ninja_compatible(binary_path) {
+    var version;
+    try {
+      version = cp
+        .execSync(JSON.stringify(binary_path) + " --version", {
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "ignore"] // execSync outputs to stdout even if we catch the error. Silent it here
+        })
+        .trim();
+    } catch (e) {
+      console.log("ninja not compatible?", String(e));
+      return false;
     }
+    return version === vendor_ninja_version;
+  }
 
-    var ninja_os_path = path.join(
-        ninja_source_dir,
-        "snapshot",
-        "ninja" + sys_extension
+  var ninja_os_path = path.join(
+    ninja_source_dir,
+    "snapshot",
+    "ninja" + sys_extension
+  );
+  if (
+    fs.existsSync(ninja_bin_output) &&
+    test_ninja_compatible(ninja_bin_output)
+  ) {
+    console.log(
+      "ninja binary is already cached and installed: ",
+      ninja_bin_output
     );
-    if (
-        fs.existsSync(ninja_bin_output) &&
-        test_ninja_compatible(ninja_bin_output)
-    ) {
-        console.log(
-            "ninja binary is already cached and installed: ",
-            ninja_bin_output
-        );
-        return;
+    return;
+  }
+  if (fs.existsSync(ninja_os_path)) {
+    if (fs.copyFileSync) {
+      // ninja binary size is small
+      fs.copyFileSync(ninja_os_path, ninja_bin_output);
+    } else {
+      fs.renameSync(ninja_os_path, ninja_bin_output);
     }
-    if (fs.existsSync(ninja_os_path)) {
-        if (fs.copyFileSync) {
-            // ninja binary size is small
-            fs.copyFileSync(ninja_os_path, ninja_bin_output);
-        } else {
-            fs.renameSync(ninja_os_path, ninja_bin_output);
-        }
-        if (test_ninja_compatible(ninja_bin_output)) {
-            console.log("ninja binary is copied from pre-distribution");
-            return;
-        }
+    if (test_ninja_compatible(ninja_bin_output)) {
+      console.log("ninja binary is copied from pre-distribution");
+      return;
     }
-    build_ninja();
+  }
+  build_ninja();
 }
 /**
  *
  * @param {NodeJS.ErrnoException} err
  */
 function throwWhenError(err) {
-    if (err !== null) {
-        throw err;
-    }
+  if (err !== null) {
+    throw err;
+  }
 }
 /**
  *
@@ -120,10 +119,10 @@ function throwWhenError(err) {
  * @param {string} target
  */
 function poorCopyFile(file, target) {
-    var stat = fs.statSync(file);
-    fs.createReadStream(file).pipe(
-        fs.createWriteStream(target, { mode: stat.mode })
-    );
+  var stat = fs.statSync(file);
+  fs.createReadStream(file).pipe(
+    fs.createWriteStream(target, { mode: stat.mode })
+  );
 }
 /**
  * @type {(x:string,y:string)=>void}
@@ -131,17 +130,17 @@ function poorCopyFile(file, target) {
  */
 var installTrytoCopy;
 if (fs.copyFile !== undefined) {
-    installTrytoCopy = function (x, y) {
-        fs.copyFile(x, y, throwWhenError);
-    };
+  installTrytoCopy = function(x, y) {
+    fs.copyFile(x, y, throwWhenError);
+  };
 } else if (is_windows) {
-    installTrytoCopy = function (x, y) {
-        fs.rename(x, y, throwWhenError);
-    };
+  installTrytoCopy = function(x, y) {
+    fs.rename(x, y, throwWhenError);
+  };
 } else {
-    installTrytoCopy = function (x, y) {
-        poorCopyFile(x, y);
-    };
+  installTrytoCopy = function(x, y) {
+    poorCopyFile(x, y);
+  };
 }
 
 /**
@@ -151,20 +150,20 @@ if (fs.copyFile !== undefined) {
  * @param {string} dest
  */
 function installDirBy(src, dest, filter) {
-    fs.readdir(src, function (err, files) {
-        if (err === null) {
-            files.forEach(function (file) {
-                if (filter(file)) {
-                    var x = path.join(src, file);
-                    var y = path.join(dest, file);
-                    // console.log(x, '----->', y )
-                    installTrytoCopy(x, y);
-                }
-            });
-        } else {
-            throw err;
+  fs.readdir(src, function(err, files) {
+    if (err === null) {
+      files.forEach(function(file) {
+        if (filter(file)) {
+          var x = path.join(src, file);
+          var y = path.join(dest, file);
+          // console.log(x, '----->', y )
+          installTrytoCopy(x, y);
         }
-    });
+      });
+    } else {
+      throw err;
+    }
+  });
 }
 
 /**
@@ -173,28 +172,28 @@ function installDirBy(src, dest, filter) {
  * TODO: `mkdirSync` may fail
  */
 function ensureExists(dir) {
-    if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir);
-    }
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir);
+  }
 }
 
 /**
  * @param {string} stdlib
  */
 function install(stdlib) {
-    installDirBy(runtime_dir, ocaml_dir, function (file) {
-        var y = path.parse(file);
-        return y.name === "js" || y.ext.includes("cm");
-    });
-    installDirBy(others_dir, ocaml_dir, function (file) {
-        var y = path.parse(file);
-        return y.ext === ".ml" || y.ext === ".mli" || y.ext.includes("cm");
-    });
-    var stdlib_dir = path.join(jscomp_dir, stdlib);
-    installDirBy(stdlib_dir, ocaml_dir, function (file) {
-        var y = path.parse(file);
-        return y.ext === ".ml" || y.ext === ".mli" || y.ext.includes("cm");
-    });
+  installDirBy(runtime_dir, ocaml_dir, function(file) {
+    var y = path.parse(file);
+    return y.name === "js" || y.ext.includes("cm");
+  });
+  installDirBy(others_dir, ocaml_dir, function(file) {
+    var y = path.parse(file);
+    return y.ext === ".ml" || y.ext === ".mli" || y.ext.includes("cm");
+  });
+  var stdlib_dir = path.join(jscomp_dir, stdlib);
+  installDirBy(stdlib_dir, ocaml_dir, function(file) {
+    var y = path.parse(file);
+    return y.ext === ".ml" || y.ext === ".mli" || y.ext.includes("cm");
+  });
 }
 
 /**
@@ -251,41 +250,41 @@ function copyPrebuiltCompilers() {
  * @returns {string|undefined}
  */
 function checkPrebuiltBscCompiler() {
-    if (process.env.BS_TRAVIS_CI) {
-        return;
-    }
-    try {
-        var version = String(
-            cp.execFileSync(path.join(lib_dir, "bsc" + sys_extension), ["-v"])
-        );
+  if(process.env.BS_TRAVIS_CI){
+    return ;
+  }
+  try {
+    var version = String(
+      cp.execFileSync(path.join(lib_dir, "bsc" + sys_extension), ["-v"])
+    );
 
-        var myOCamlVersion = version.substr(
-            version.indexOf(":") + 1,
-            version.lastIndexOf(" ") - version.indexOf(":") - 1
-        );
-        console.log("checkoutput:", version, "ocaml version", myOCamlVersion);
-        console.log("Prebuilt compiler works good");
+    var myOCamlVersion = version.substr(
+      version.indexOf(":") + 1,
+      version.lastIndexOf(" ") - version.indexOf(":") - 1
+    );
+    console.log("checkoutput:", version, "ocaml version", myOCamlVersion);
+    console.log("Prebuilt compiler works good");
 
-        return myOCamlVersion;
-    } catch (e) {
-        console.log("No working prebuilt buckleScript compiler");
-        if (is_windows) {
-            throw new Error("no prebuilt bsc compiler on windows");
-        }
-        return;
+    return myOCamlVersion;
+  } catch (e) {
+    console.log("No working prebuilt buckleScript compiler");
+    if (is_windows) {
+      throw new Error("no prebuilt bsc compiler on windows");
     }
+    return;
+  }
 }
 /**
  *
  * @param {string} stdlib
  */
 function buildLibs(stdlib) {
-    ensureExists(lib_dir);
-    ensureExists(ocaml_dir);
-    ensureExists(path.join(lib_dir, "js"));
-    ensureExists(path.join(lib_dir, "es6"));
-    process.env.NINJA_IGNORE_GENERATOR = "true";
-    var releaseNinja = `
+  ensureExists(lib_dir);
+  ensureExists(ocaml_dir);
+  ensureExists(path.join(lib_dir, "js"));
+  ensureExists(path.join(lib_dir, "es6"));
+  process.env.NINJA_IGNORE_GENERATOR = "true";
+  var releaseNinja = `
 stdlib = ${stdlib}
 subninja runtime/release.ninja
 subninja others/release.ninja
@@ -293,71 +292,71 @@ subninja $stdlib/release.ninja
 ${process.env.BS_TRAVIS_CI ? "subninja test/build.ninja\n" : "\n"}
 build all: phony runtime others $stdlib
 `;
-    var filePath = path.join(jscomp_dir, "release.ninja");
-    fs.writeFileSync(filePath, releaseNinja, "ascii");
-    var cleanArgs = ["-f", "release.ninja", "-t", "clean"];
-    cp.execFileSync(ninja_bin_output, cleanArgs, {
-        cwd: jscomp_dir,
-        stdio: [0, 1, 2],
-        shell: false
-    });
-    var buildArgs = ["-f", "release.ninja"];
-    if (process.env.BS_TRAVIS_CI) {
-        buildArgs.push("--verbose");
-    }
-    cp.execFileSync(ninja_bin_output, buildArgs, {
-        cwd: jscomp_dir,
-        stdio: [0, 1, 2],
-        shell: false
-    });
-    fs.unlinkSync(filePath);
-    console.log("Build finished");
+  var filePath = path.join(jscomp_dir, "release.ninja");
+  fs.writeFileSync(filePath, releaseNinja, "ascii");
+  var cleanArgs = ["-f", "release.ninja", "-t", "clean"];
+  cp.execFileSync(ninja_bin_output, cleanArgs, {
+    cwd: jscomp_dir,
+    stdio: [0, 1, 2],
+    shell: false
+  });
+  var buildArgs = ["-f", "release.ninja"];
+  if (process.env.BS_TRAVIS_CI) {
+    buildArgs.push("--verbose");
+  }
+  cp.execFileSync(ninja_bin_output, buildArgs, {
+    cwd: jscomp_dir,
+    stdio: [0, 1, 2],
+    shell: false
+  });
+  fs.unlinkSync(filePath);
+  console.log("Build finished");
 }
 
 /**
  * @returns {string}
  */
 function provideCompiler() {
-    var myVersion = checkPrebuiltBscCompiler();
-    if (myVersion !== undefined) {
-        copyPrebuiltCompilers();
-        return myVersion;
+  var myVersion = checkPrebuiltBscCompiler();
+  if (myVersion !== undefined) {
+    copyPrebuiltCompilers();
+    return myVersion;
+  } else {
+    myVersion = require("./buildocaml.js").getVersionPrefix();
+    var ocamlopt =
+      process.env.ESY === "true"
+        ? "ocamlopt.opt"
+        : path.join(
+            __dirname,
+            "..",
+            "native",
+            myVersion,
+            "bin",
+            "ocamlopt.opt"
+          );
+    if (!fs.existsSync(ocamlopt)) {
+      require("./buildocaml.js").build(true);
     } else {
-        myVersion = require("./buildocaml.js").getVersionPrefix();
-        var ocamlopt =
-            process.env.ESY === "true"
-                ? "ocamlopt.opt"
-                : path.join(
-                    __dirname,
-                    "..",
-                    "native",
-                    myVersion,
-                    "bin",
-                    "ocamlopt.opt"
-                );
-        if (!fs.existsSync(ocamlopt)) {
-            require("./buildocaml.js").build(true);
-        } else {
-            console.log(ocamlopt, "is already there");
-        }
-        // Note this ninja file only works under *nix due to the suffix
-        // under windows require '.exe'
-        var releaseNinja = require("./ninjaFactory.js").libNinja({
-            ocamlopt: ocamlopt,
-            ext: ".exe",
-            INCL: myVersion,
-            isWin: is_windows
-        });
-
-        var filePath = path.join(lib_dir, "release.ninja");
-        fs.writeFileSync(filePath, releaseNinja, "ascii");
-        cp.execFileSync(ninja_bin_output, ["-f", "release.ninja"], {
-            cwd: lib_dir,
-            stdio: [0, 1, 2]
-        });
-        fs.unlinkSync(filePath);
-        return myVersion;
+      console.log(ocamlopt, "is already there");
     }
+    // Note this ninja file only works under *nix due to the suffix
+    // under windows require '.exe'
+    var releaseNinja = require("./ninjaFactory.js").libNinja({
+      ocamlopt: ocamlopt,
+      ext: ".exe",
+      INCL: myVersion,
+      isWin: is_windows
+    });
+
+    var filePath = path.join(lib_dir, "release.ninja");
+    fs.writeFileSync(filePath, releaseNinja, "ascii");
+    cp.execFileSync(ninja_bin_output, ["-f", "release.ninja"], {
+      cwd: lib_dir,
+      stdio: [0, 1, 2]
+    });
+    fs.unlinkSync(filePath);
+    return myVersion;
+  }
 }
 
 provideNinja();

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -29,6 +29,7 @@ var sys_extension = config.sys_extension;
 process.env.BS_RELEASE_BUILD = "true";
 
 var ninja_bin_output = path.join(root_dir, "lib", "ninja.exe");
+var preBuiltCompilerArtifacts = ["bsc", "bsb", "bsb_helper", "bsppx", "refmt"];
 
 /**
  * Make sure `ninja_bin_output` exists
@@ -36,82 +37,82 @@ var ninja_bin_output = path.join(root_dir, "lib", "ninja.exe");
  * This is less problematic since `ninja.exe` is very stable
  */
 function provideNinja() {
-  var vendor_ninja_version = "1.9.0.git";
-  var ninja_source_dir = path.join(root_dir, "vendor", "ninja");
-  function build_ninja() {
-    console.log(`building ninja`);
-    cp.execSync(`tar xzvf ../ninja.tar.gz`, {
-      cwd: ninja_source_dir,
-      stdio: [0, 1, 2]
-    });
-    console.log("No prebuilt Ninja, building Ninja now");
-    var build_ninja_command = "./configure.py --bootstrap";
-    cp.execSync(build_ninja_command, {
-      cwd: ninja_source_dir,
-      stdio: [0, 1, 2]
-    });
-    fs.renameSync(path.join(ninja_source_dir, "ninja"), ninja_bin_output);
-    console.log("ninja binary is ready: ", ninja_bin_output);
-  }
-
-  // sanity check to make sure the binary actually runs. Used for Linux. Too many variants
-  /**
-   *
-   * @param {string} binary_path
-   */
-  function test_ninja_compatible(binary_path) {
-    var version;
-    try {
-      version = cp
-        .execSync(JSON.stringify(binary_path) + " --version", {
-          encoding: "utf8",
-          stdio: ["pipe", "pipe", "ignore"] // execSync outputs to stdout even if we catch the error. Silent it here
-        })
-        .trim();
-    } catch (e) {
-      console.log("ninja not compatible?", String(e));
-      return false;
+    var vendor_ninja_version = "1.9.0.git";
+    var ninja_source_dir = path.join(root_dir, "vendor", "ninja");
+    function build_ninja() {
+        console.log(`building ninja`);
+        cp.execSync(`tar xzvf ../ninja.tar.gz`, {
+            cwd: ninja_source_dir,
+            stdio: [0, 1, 2]
+        });
+        console.log("No prebuilt Ninja, building Ninja now");
+        var build_ninja_command = "./configure.py --bootstrap";
+        cp.execSync(build_ninja_command, {
+            cwd: ninja_source_dir,
+            stdio: [0, 1, 2]
+        });
+        fs.renameSync(path.join(ninja_source_dir, "ninja"), ninja_bin_output);
+        console.log("ninja binary is ready: ", ninja_bin_output);
     }
-    return version === vendor_ninja_version;
-  }
 
-  var ninja_os_path = path.join(
-    ninja_source_dir,
-    "snapshot",
-    "ninja" + sys_extension
-  );
-  if (
-    fs.existsSync(ninja_bin_output) &&
-    test_ninja_compatible(ninja_bin_output)
-  ) {
-    console.log(
-      "ninja binary is already cached and installed: ",
-      ninja_bin_output
+    // sanity check to make sure the binary actually runs. Used for Linux. Too many variants
+    /**
+     *
+     * @param {string} binary_path
+     */
+    function test_ninja_compatible(binary_path) {
+        var version;
+        try {
+            version = cp
+                .execSync(JSON.stringify(binary_path) + " --version", {
+                    encoding: "utf8",
+                    stdio: ["pipe", "pipe", "ignore"] // execSync outputs to stdout even if we catch the error. Silent it here
+                })
+                .trim();
+        } catch (e) {
+            console.log("ninja not compatible?", String(e));
+            return false;
+        }
+        return version === vendor_ninja_version;
+    }
+
+    var ninja_os_path = path.join(
+        ninja_source_dir,
+        "snapshot",
+        "ninja" + sys_extension
     );
-    return;
-  }
-  if (fs.existsSync(ninja_os_path)) {
-    if (fs.copyFileSync) {
-      // ninja binary size is small
-      fs.copyFileSync(ninja_os_path, ninja_bin_output);
-    } else {
-      fs.renameSync(ninja_os_path, ninja_bin_output);
+    if (
+        fs.existsSync(ninja_bin_output) &&
+        test_ninja_compatible(ninja_bin_output)
+    ) {
+        console.log(
+            "ninja binary is already cached and installed: ",
+            ninja_bin_output
+        );
+        return;
     }
-    if (test_ninja_compatible(ninja_bin_output)) {
-      console.log("ninja binary is copied from pre-distribution");
-      return;
+    if (fs.existsSync(ninja_os_path)) {
+        if (fs.copyFileSync) {
+            // ninja binary size is small
+            fs.copyFileSync(ninja_os_path, ninja_bin_output);
+        } else {
+            fs.renameSync(ninja_os_path, ninja_bin_output);
+        }
+        if (test_ninja_compatible(ninja_bin_output)) {
+            console.log("ninja binary is copied from pre-distribution");
+            return;
+        }
     }
-  }
-  build_ninja();
+    build_ninja();
 }
 /**
  *
  * @param {NodeJS.ErrnoException} err
  */
 function throwWhenError(err) {
-  if (err !== null) {
-    throw err;
-  }
+    if (err !== null) {
+        throw err;
+    }
 }
 /**
  *
@@ -119,10 +120,10 @@ function throwWhenError(err) {
  * @param {string} target
  */
 function poorCopyFile(file, target) {
-  var stat = fs.statSync(file);
-  fs.createReadStream(file).pipe(
-    fs.createWriteStream(target, { mode: stat.mode })
-  );
+    var stat = fs.statSync(file);
+    fs.createReadStream(file).pipe(
+        fs.createWriteStream(target, { mode: stat.mode })
+    );
 }
 /**
  * @type {(x:string,y:string)=>void}
@@ -130,17 +131,17 @@ function poorCopyFile(file, target) {
  */
 var installTrytoCopy;
 if (fs.copyFile !== undefined) {
-  installTrytoCopy = function(x, y) {
-    fs.copyFile(x, y, throwWhenError);
-  };
+    installTrytoCopy = function (x, y) {
+        fs.copyFile(x, y, throwWhenError);
+    };
 } else if (is_windows) {
-  installTrytoCopy = function(x, y) {
-    fs.rename(x, y, throwWhenError);
-  };
+    installTrytoCopy = function (x, y) {
+        fs.rename(x, y, throwWhenError);
+    };
 } else {
-  installTrytoCopy = function(x, y) {
-    poorCopyFile(x, y);
-  };
+    installTrytoCopy = function (x, y) {
+        poorCopyFile(x, y);
+    };
 }
 
 /**
@@ -150,20 +151,20 @@ if (fs.copyFile !== undefined) {
  * @param {string} dest
  */
 function installDirBy(src, dest, filter) {
-  fs.readdir(src, function(err, files) {
-    if (err === null) {
-      files.forEach(function(file) {
-        if (filter(file)) {
-          var x = path.join(src, file);
-          var y = path.join(dest, file);
-          // console.log(x, '----->', y )
-          installTrytoCopy(x, y);
+    fs.readdir(src, function (err, files) {
+        if (err === null) {
+            files.forEach(function (file) {
+                if (filter(file)) {
+                    var x = path.join(src, file);
+                    var y = path.join(dest, file);
+                    // console.log(x, '----->', y )
+                    installTrytoCopy(x, y);
+                }
+            });
+        } else {
+            throw err;
         }
-      });
-    } else {
-      throw err;
-    }
-  });
+    });
 }
 
 /**
@@ -172,76 +173,119 @@ function installDirBy(src, dest, filter) {
  * TODO: `mkdirSync` may fail
  */
 function ensureExists(dir) {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
-  }
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+    }
 }
 
 /**
  * @param {string} stdlib
  */
 function install(stdlib) {
-  installDirBy(runtime_dir, ocaml_dir, function(file) {
-    var y = path.parse(file);
-    return y.name === "js" || y.ext.includes("cm");
-  });
-  installDirBy(others_dir, ocaml_dir, function(file) {
-    var y = path.parse(file);
-    return y.ext === ".ml" || y.ext === ".mli" || y.ext.includes("cm");
-  });
-  var stdlib_dir = path.join(jscomp_dir, stdlib);
-  installDirBy(stdlib_dir, ocaml_dir, function(file) {
-    var y = path.parse(file);
-    return y.ext === ".ml" || y.ext === ".mli" || y.ext.includes("cm");
-  });
+    installDirBy(runtime_dir, ocaml_dir, function (file) {
+        var y = path.parse(file);
+        return y.name === "js" || y.ext.includes("cm");
+    });
+    installDirBy(others_dir, ocaml_dir, function (file) {
+        var y = path.parse(file);
+        return y.ext === ".ml" || y.ext === ".mli" || y.ext.includes("cm");
+    });
+    var stdlib_dir = path.join(jscomp_dir, stdlib);
+    installDirBy(stdlib_dir, ocaml_dir, function (file) {
+        var y = path.parse(file);
+        return y.ext === ".ml" || y.ext === ".mli" || y.ext.includes("cm");
+    });
+}
+
+/**
+ *
+ * @param {string} sys_extension
+ *
+ */
+function copyPrebuiltCompilersForUnix(sys_extension) {
+    var output = `
+rule cp 
+    command = cp $in $out
+`;
+    output += preBuiltCompilerArtifacts
+        .map(function (x) {
+            return `build ${x}.exe: cp ${x}${sys_extension}`;
+        })
+        .join("\n");
+    output += "\n";
+
+    var filePath = path.join(lib_dir, "copy.ninja");
+    fs.writeFileSync(filePath, output, "ascii");
+    cp.execFileSync(ninja_bin_output, ["-f", "copy.ninja"], {
+        cwd: lib_dir,
+        stdio: [0, 1, 2]
+    });
+    fs.unlinkSync(filePath);
+}
+
+/**
+ *
+ * @param {string} sys_extension
+ *
+ */
+function copyPrebuiltCompilersForWindows(sys_extension) {
+    preBuiltCompilerArtifacts
+        .forEach(function (x) {
+            fs.copyFileSync(path.join(lib_dir, `${x}${sys_extension}`), path.join((lib_dir), `${x}.exe`));
+        });
 }
 
 function copyPrebuiltCompilers() {
-  ["bsc", "bsb", "bsb_helper", "bsppx", "refmt"]
-  .forEach(function (x) {
-    fs.copyFileSync(path.join(lib_dir, `${x}${sys_extension}`), path.join((lib_dir), `${x}.exe`));
-  });
+    switch (sys_extension) {
+        case ".win32":
+            copyPrebuiltCompilersForWindows(sys_extension);
+            break;
+
+        default:
+            copyPrebuiltCompilersForUnix(sys_extension);
+            break;
+    }
 }
 
 /**
  * @returns {string|undefined}
  */
 function checkPrebuiltBscCompiler() {
-  if(process.env.BS_TRAVIS_CI){
-    return ;
-  }
-  try {
-    var version = String(
-      cp.execFileSync(path.join(lib_dir, "bsc" + sys_extension), ["-v"])
-    );
-
-    var myOCamlVersion = version.substr(
-      version.indexOf(":") + 1,
-      version.lastIndexOf(" ") - version.indexOf(":") - 1
-    );
-    console.log("checkoutput:", version, "ocaml version", myOCamlVersion);
-    console.log("Prebuilt compiler works good");
-
-    return myOCamlVersion;
-  } catch (e) {
-    console.log("No working prebuilt buckleScript compiler");
-    if (is_windows) {
-      throw new Error("no prebuilt bsc compiler on windows");
+    if (process.env.BS_TRAVIS_CI) {
+        return;
     }
-    return;
-  }
+    try {
+        var version = String(
+            cp.execFileSync(path.join(lib_dir, "bsc" + sys_extension), ["-v"])
+        );
+
+        var myOCamlVersion = version.substr(
+            version.indexOf(":") + 1,
+            version.lastIndexOf(" ") - version.indexOf(":") - 1
+        );
+        console.log("checkoutput:", version, "ocaml version", myOCamlVersion);
+        console.log("Prebuilt compiler works good");
+
+        return myOCamlVersion;
+    } catch (e) {
+        console.log("No working prebuilt buckleScript compiler");
+        if (is_windows) {
+            throw new Error("no prebuilt bsc compiler on windows");
+        }
+        return;
+    }
 }
 /**
  *
  * @param {string} stdlib
  */
 function buildLibs(stdlib) {
-  ensureExists(lib_dir);
-  ensureExists(ocaml_dir);
-  ensureExists(path.join(lib_dir, "js"));
-  ensureExists(path.join(lib_dir, "es6"));
-  process.env.NINJA_IGNORE_GENERATOR = "true";
-  var releaseNinja = `
+    ensureExists(lib_dir);
+    ensureExists(ocaml_dir);
+    ensureExists(path.join(lib_dir, "js"));
+    ensureExists(path.join(lib_dir, "es6"));
+    process.env.NINJA_IGNORE_GENERATOR = "true";
+    var releaseNinja = `
 stdlib = ${stdlib}
 subninja runtime/release.ninja
 subninja others/release.ninja
@@ -249,71 +293,71 @@ subninja $stdlib/release.ninja
 ${process.env.BS_TRAVIS_CI ? "subninja test/build.ninja\n" : "\n"}
 build all: phony runtime others $stdlib
 `;
-  var filePath = path.join(jscomp_dir, "release.ninja");
-  fs.writeFileSync(filePath, releaseNinja, "ascii");
-  var cleanArgs = ["-f", "release.ninja", "-t", "clean"];
-  cp.execFileSync(ninja_bin_output, cleanArgs, {
-    cwd: jscomp_dir,
-    stdio: [0, 1, 2],
-    shell: false
-  });
-  var buildArgs = ["-f", "release.ninja"];
-  if (process.env.BS_TRAVIS_CI) {
-    buildArgs.push("--verbose");
-  }
-  cp.execFileSync(ninja_bin_output, buildArgs, {
-    cwd: jscomp_dir,
-    stdio: [0, 1, 2],
-    shell: false
-  });
-  fs.unlinkSync(filePath);
-  console.log("Build finished");
+    var filePath = path.join(jscomp_dir, "release.ninja");
+    fs.writeFileSync(filePath, releaseNinja, "ascii");
+    var cleanArgs = ["-f", "release.ninja", "-t", "clean"];
+    cp.execFileSync(ninja_bin_output, cleanArgs, {
+        cwd: jscomp_dir,
+        stdio: [0, 1, 2],
+        shell: false
+    });
+    var buildArgs = ["-f", "release.ninja"];
+    if (process.env.BS_TRAVIS_CI) {
+        buildArgs.push("--verbose");
+    }
+    cp.execFileSync(ninja_bin_output, buildArgs, {
+        cwd: jscomp_dir,
+        stdio: [0, 1, 2],
+        shell: false
+    });
+    fs.unlinkSync(filePath);
+    console.log("Build finished");
 }
 
 /**
  * @returns {string}
  */
 function provideCompiler() {
-  var myVersion = checkPrebuiltBscCompiler();
-  if (myVersion !== undefined) {
-    copyPrebuiltCompilers();
-    return myVersion;
-  } else {
-    myVersion = require("./buildocaml.js").getVersionPrefix();
-    var ocamlopt =
-      process.env.ESY === "true"
-        ? "ocamlopt.opt"
-        : path.join(
-            __dirname,
-            "..",
-            "native",
-            myVersion,
-            "bin",
-            "ocamlopt.opt"
-          );
-    if (!fs.existsSync(ocamlopt)) {
-      require("./buildocaml.js").build(true);
+    var myVersion = checkPrebuiltBscCompiler();
+    if (myVersion !== undefined) {
+        copyPrebuiltCompilers();
+        return myVersion;
     } else {
-      console.log(ocamlopt, "is already there");
-    }
-    // Note this ninja file only works under *nix due to the suffix
-    // under windows require '.exe'
-    var releaseNinja = require("./ninjaFactory.js").libNinja({
-      ocamlopt: ocamlopt,
-      ext: ".exe",
-      INCL: myVersion,
-      isWin: is_windows
-    });
+        myVersion = require("./buildocaml.js").getVersionPrefix();
+        var ocamlopt =
+            process.env.ESY === "true"
+                ? "ocamlopt.opt"
+                : path.join(
+                    __dirname,
+                    "..",
+                    "native",
+                    myVersion,
+                    "bin",
+                    "ocamlopt.opt"
+                );
+        if (!fs.existsSync(ocamlopt)) {
+            require("./buildocaml.js").build(true);
+        } else {
+            console.log(ocamlopt, "is already there");
+        }
+        // Note this ninja file only works under *nix due to the suffix
+        // under windows require '.exe'
+        var releaseNinja = require("./ninjaFactory.js").libNinja({
+            ocamlopt: ocamlopt,
+            ext: ".exe",
+            INCL: myVersion,
+            isWin: is_windows
+        });
 
-    var filePath = path.join(lib_dir, "release.ninja");
-    fs.writeFileSync(filePath, releaseNinja, "ascii");
-    cp.execFileSync(ninja_bin_output, ["-f", "release.ninja"], {
-      cwd: lib_dir,
-      stdio: [0, 1, 2]
-    });
-    fs.unlinkSync(filePath);
-    return myVersion;
-  }
+        var filePath = path.join(lib_dir, "release.ninja");
+        fs.writeFileSync(filePath, releaseNinja, "ascii");
+        cp.execFileSync(ninja_bin_output, ["-f", "release.ninja"], {
+            cwd: lib_dir,
+            stdio: [0, 1, 2]
+        });
+        fs.unlinkSync(filePath);
+        return myVersion;
+    }
 }
 
 provideNinja();

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -196,44 +196,11 @@ function install(stdlib) {
   });
 }
 
-/**
- *
- * @param {string} sys_extension
- *
- */
-function createCopyNinja(sys_extension) {
-  var output = "";
-  switch (sys_extension) {
-    case ".win32":
-      output += `
-rule cp
-    command = cmd /q /c copy $in $out 1>nul
-`;
-      break;
-    default:
-      output += `
-rule cp 
-    command = cp $in $out
-`;
-      break;
-  }
-  output += ["bsc", "bsb", "bsb_helper", "bsppx", "refmt"]
-    .map(function(x) {
-      return `build ${x}.exe: cp ${x}${sys_extension}`;
-    })
-    .join("\n");
-  output += "\n";
-  return output;
-}
-
 function copyPrebuiltCompilers() {
-  var filePath = path.join(lib_dir, "copy.ninja");
-  fs.writeFileSync(filePath, createCopyNinja(sys_extension), "ascii");
-  cp.execFileSync(ninja_bin_output, ["-f", "copy.ninja"], {
-    cwd: lib_dir,
-    stdio: [0, 1, 2]
+  ["bsc", "bsb", "bsb_helper", "bsppx", "refmt"]
+  .forEach(function (x) {
+    fs.copyFileSync(path.join(lib_dir, `${x}${sys_extension}`), path.join((lib_dir), `${x}.exe`));
   });
-  fs.unlinkSync(filePath);
 }
 
 /**


### PR DESCRIPTION
Fixes #3843 by using nodejs fs.copyFileSync to copy pre-built compilers instead of using ninja.exe. Since ninja.exe is classed as trojan by many anti-virus software.