### PR TITLE
Add Belt.Option.forEach

### DIFF
--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -22,6 +22,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+let forEachU opt f = match opt with
+  | Some x -> (f x [@bs])
+  | None  -> ()
+
+let forEach opt f = forEachU opt (fun[@bs] x -> f x)
 
 let getExn = function
   | Some x -> x

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -27,6 +27,21 @@
     Utilities for option data type
 *)
 
+val forEachU : 'a option -> ('a -> unit [@bs]) -> unit
+(** Uncurried version of [forEach] *)
+
+val forEach : 'a option -> ('a -> unit) -> unit
+(**
+  [forEach optionValue f]
+  
+  If [optionValue] is [Some value], it calls [f value]; otherwise returns [()]
+  
+  @example {[
+    forEach (Some "thing")(fun x -> Js.log x);; (* logs "thing" *)
+    forEach None (fun x -> Js.log x);; (* returns () *)
+  ]}
+*)
+
 val getExn : 'a option -> 'a
 (** [getExn optionalValue]
   Returns [value] if [optionalValue] is [Some value], otherwise raises [getExn]

--- a/lib/js/belt_Option.js
+++ b/lib/js/belt_Option.js
@@ -3,6 +3,18 @@
 var Curry = require("./curry.js");
 var Caml_option = require("./caml_option.js");
 
+function forEachU(opt, f) {
+  if (opt !== undefined) {
+    return f(Caml_option.valFromOption(opt));
+  } else {
+    return /* () */0;
+  }
+}
+
+function forEach(opt, f) {
+  return forEachU(opt, Curry.__1(f));
+}
+
 function getExn(param) {
   if (param !== undefined) {
     return Caml_option.valFromOption(param);
@@ -95,6 +107,8 @@ function cmp(a, b, f) {
   return cmpU(a, b, Curry.__2(f));
 }
 
+exports.forEachU = forEachU;
+exports.forEach = forEach;
 exports.getExn = getExn;
 exports.mapWithDefaultU = mapWithDefaultU;
 exports.mapWithDefault = mapWithDefault;


### PR DESCRIPTION
A very simple extension of the `Belt.Option` module. I use this `apply` method a lot in some codebases. When an option is `Some` its content is called as the parameter of a given function. 

I think it is very useful, as there are often functions like React's (reducer) `dispatch` function, or even just a logging statement, which all return `unit`.

[Reason Try Example](https://reasonml.github.io/en/try?rrjsx=true&reason=LYewJgrgNgpgBAFwJ4Ad4HkUIJYgHZwC8cA3gFBxywJwCGKKUSAqgFxwAUIWueHA5LQCUAGk4A6OIKFEAfHAh5sCGYXmLlAbgpUYNeoyTsuPfAOFjBchUpXWNCbQF9tZUJFhxMOfO2+8iUh1qOgYmZkCTBDEAM1VZHUoAZwB3ZQBjAAtObjtySkoAHzgAZRBgGA4AD3i4GI5JGsS4YoA5fHg1TiFmlzJgvVDDSNzY2oNwqLEGuBrrepqhZ1d-fHEJpA4yio4AIgRM7DwAc13RWesAKSTxKBBj6qElslW8dbDN9rwYMSqrm7uD0W2iAA)