### PR TITLE
Take notes of changes between 4.02 and 4.06

### DIFF
--- a/jscomp/test/flattern_order_test.ml
+++ b/jscomp/test/flattern_order_test.ml
@@ -1,6 +1,6 @@
 
-#if OCAML_VERSION =~ "<4.03.0" then
-let rec xs = 
+#if OCAML_VERSION =~ "<4.03.0"  then
+let rec xs =  (* such recursive value not allowed in 4.06 *)
   let rec ys = 1 :: ys 
   and _zs () = (List.hd ys, List.hd (fst xs))  in
   (* and us = 3 in  *)
@@ -40,4 +40,4 @@ let v = ref 0
 let rec obj = 
     { get = (fun _ -> !v);
       set = (fun i -> v := i )
-    }    
+    }    (* should generate `obj_get`, obj_set` meaningful names*)

--- a/jscomp/test/fun_pattern_match.ml
+++ b/jscomp/test/fun_pattern_match.ml
@@ -38,6 +38,7 @@ and ticker = {
 
 let f3  =     
   (fun {rank = lhs; _} {rank = rhs} -> 
+  (* generate curried version when pattern match against arguments *)
   match lhs, rhs with
   | Ranked x , Ranked y -> Pervasives.compare x y 
   | _ -> assert false

--- a/jscomp/test/global_module_alias_test.ml
+++ b/jscomp/test/global_module_alias_test.ml
@@ -88,7 +88,7 @@ let () =
 
 
 let () = 
-  let module V = (val  (xx () ) : S) in 
+  let module V = (val  (xx () ) : S) in (* xx () not inlined in 4.06 *) 
   eq __LOC__ (V.length [1;2;3]) 3 ;
   eq __LOC__ !v 15;
   let module H = (val (f ()) : S) in 

--- a/jscomp/test/js_re_test.ml
+++ b/jscomp/test/js_re_test.ml
@@ -79,8 +79,7 @@ let suites = Mt.[
   );
   "t_lastIndex", (fun _ ->
     let re = [%re "/na/g"] in
-    let _ = re |. Js.Re.exec_ "banana" in
-
+    let _ = re |. Js.Re.exec_ "banana" in     (* Caml_option.null_to_opt post operation is not dropped in 4.06 which seems to be reduandant *)
     Eq(4,  re |. Js.Re.lastIndex)
   );
   "t_setLastIndex", (fun _ ->

--- a/jscomp/test/recursive_module.ml
+++ b/jscomp/test/recursive_module.ml
@@ -11,7 +11,7 @@ module  rec Int32 : sig
   external set : t -> int -> int -> unit = "" [@@js.set_index]
   external create : int array -> t = "Int32Array" [@@js.new]
   external of_buffer : buffer -> t = "Int32Array" [@@js.new]
-end = Int32
+end = Int32 (* Int32 is compiled away in 4.06 *)
 
 module Xx : sig
   val f : int -> int -> int 


### PR DESCRIPTION
- See if we could optimize away `Sys.backend_type = Other “BS”`
- (XX: S ) -> include XX is coerced twice