### PR TITLE
Use folders from esy ocaml for snapshots

### DIFF
--- a/4061.json
+++ b/4061.json
@@ -2,7 +2,7 @@
   "source": "./esy.json",
   "override": {
     "resolutions": {
-      "ocaml": "bucklescript/ocaml:package.json#4582c3fcce632aaa0f9794f5518bf5d9ad4a6385"
+      "ocaml": "ulrikstrid/ocaml:package.json#68e181a3a44f0b6be1b1ab1e585d2c9f2718c37b"
     }
   }
 }

--- a/jscomp/snapshot.ninja
+++ b/jscomp/snapshot.ninja
@@ -5,14 +5,12 @@ rule bspack
     generator = true
 
 
-NATIVE_OCAML_PATH=$native_ocaml_path
-
-OCAML_SRC_UTILS=$NATIVE_OCAML_PATH/utils
-OCAML_SRC_PARSING=$NATIVE_OCAML_PATH/parsing
-OCAML_SRC_TYPING=$NATIVE_OCAML_PATH/typing
-OCAML_SRC_BYTECOMP=$NATIVE_OCAML_PATH/bytecomp
-OCAML_SRC_DRIVER=$NATIVE_OCAML_PATH/driver
-OCAML_SRC_TOOLS=$NATIVE_OCAML_PATH/tools   
+OCAML_SRC_UTILS=$native_ocaml_path/utils
+OCAML_SRC_PARSING=$native_ocaml_path/parsing
+OCAML_SRC_TYPING=$native_ocaml_path/typing
+OCAML_SRC_BYTECOMP=$native_ocaml_path/bytecomp
+OCAML_SRC_DRIVER=$native_ocaml_path/driver
+OCAML_SRC_TOOLS=$native_ocaml_path/tools   
 includes = -I stubs -I ext -I common -I syntax -I depends -I core -I super_errors -I outcome_printer -I bsb -I ounit -I ounit_tests -I main
 SNAP=../lib/$snapshot_path
 

--- a/jscomp/snapshot.ninja
+++ b/jscomp/snapshot.ninja
@@ -5,7 +5,7 @@ rule bspack
     generator = true
 
 
-NATIVE_OCAML_PATH=../ocaml/
+NATIVE_OCAML_PATH=$native_ocaml_path
 
 OCAML_SRC_UTILS=$NATIVE_OCAML_PATH/utils
 OCAML_SRC_PARSING=$NATIVE_OCAML_PATH/parsing
@@ -71,4 +71,3 @@ build $SNAP/unstable/js_compiler.ml: bspack | ./bin/bspack.exe
 #     command = $ocamlopt -w -a  unix.cmxa str.cmxa  ./stubs/ext_basic_hash_stubs.c $in -o $out
 #  only check if it compiles     
 # build $SNAP/unstable/bsb_native.exe: bsbnative ./bin/bsb_native.ml
-

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -1413,6 +1413,11 @@ build all: phony runtime others $stdlib test
       `
 ${getVendorConfigNinja()}
 stdlib = ${version6() ? `stdlib-406` : `stdlib-402`}
+native_ocaml_path = ${
+        process.env.ESY === "true"
+          ? path.join(process.env.OCAMLLIB, "/../..")
+          : "../ocaml/"
+      }
 snapshot_path = ${require("./buildocaml.js").getVersionPrefix()}
 subninja compiler.ninja
 subninja snapshot.ninja


### PR DESCRIPTION
Sets a `native_ocaml_path` that can point either to the esy installed `ocaml` or the one from git submodules depending on if we're have the `ESY` environment variable.

The resolution should be changed when bucklescript/ocaml#38 lands.