### PR TITLE
fix SPA mode regression for hooks template

### DIFF
--- a/jscomp/bsb/templates/react-hooks/README.md
+++ b/jscomp/bsb/templates/react-hooks/README.md
@@ -22,6 +22,8 @@ Open a new web page to `http://localhost:8000/`. Change any `.re` file in `src` 
 
 **How come we don't need any bundler during development**? We highly encourage you to open up `index.html` to check for yourself!
 
+If you start handling routes via `ReasonReactRouter` change the server script in package.json to `moduleserve ./ --port 8000 --spa` to make sure your routes don't result in a 404 not found error. With the added `--spa` flag your routes will return the index.html on page load and you can handle them client-side.
+
 # Features Used
 
 |                           | Blinking Greeting | Reducer from ReactJS Docs | Fetch Dog Pictures | Reason Using JS Using Reason |

--- a/jscomp/bsb/templates/react-hooks/index.html
+++ b/jscomp/bsb/templates/react-hooks/index.html
@@ -15,7 +15,7 @@
   </script>
 
   <!-- This is https://github.com/marijnh/moduleserve, the secret sauce that allows us not need to bundle things during development, and have instantaneous iteration feedback, without any hot-reloading or extra build pipeline needed. -->
-  <script src="/moduleserve/load.js" data-module="./src/Index.bs.js"></script>
+  <script src="/moduleserve/load.js" data-module="/src/Index.bs.js"></script>
   <!-- Our little watcher. Super clean. Check it out! -->
   <script src="./watcher.js"></script>
 </body>

--- a/jscomp/bsb/templates/react-hooks/package.json
+++ b/jscomp/bsb/templates/react-hooks/package.json
@@ -5,7 +5,7 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w -ws _ ",
     "clean": "bsb -clean-world",
-    "server": "moduleserve ./ --port 8000 --spa",
+    "server": "moduleserve ./ --port 8000",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/jscomp/bsb/templates/react-hooks/package.json
+++ b/jscomp/bsb/templates/react-hooks/package.json
@@ -5,7 +5,7 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w -ws _ ",
     "clean": "bsb -clean-world",
-    "server": "moduleserve ./ --port 8000",
+    "server": "moduleserve ./ --port 8000 --spa",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "bs-platform": "^${bsb:bs-version}",
-    "moduleserve": "^0.8.4"
+    "moduleserve": "^0.9.0"
   }
 }


### PR DESCRIPTION
When running the server with the `--spa` flag every file path where no file can be found automatically will fall back to serving the index.html. This option allows you to implement routing for Single Page Applications.