### PR TITLE
Add spacing to variant formatter

### DIFF
--- a/lib/js/caml_chrome_debugger.js
+++ b/lib/js/caml_chrome_debugger.js
@@ -63,7 +63,11 @@ var variantCustomFormatter = function (data,recordVariant){
      ... listToArray(data)
    ]
  } else {
-     return ["ol", olStyle, ...data.map(function (cur) { return showObject(cur) })]
+    let spacedData = [];
+    data.forEach(cur => {
+      spacedData.push(["span", {"style": "margin-right: 12px"}, showObject(cur)]);
+    })
+     return ["ol", olStyle, ...spacedData]
  }
 
 };


### PR DESCRIPTION
Fixes #3838 

**Problem**

Origninally the `variantCustomFormatter` in `canl_chrome_debugger` just mapped over the objects in the variant and called `showObject` resulting in no spacing between them which made debugging harder because if the two objects where `1` and `2` they would appear as `12`. 

**Solution**

Mapping over the data and placing `span` elements between each call to `showObject` in order to provide some spacing. The `12px` was used as this is the same as `olStyles` left padding. 

Example Reason Code: 

```reason
[%%debugger.chrome]

type y = A(int, int, int, int);
type x = B(int, int, y, y);

type reco = {
  x: int,
  y: int,
  z: x
};

let record = {
  x: 3,
  y: 2,
  z: B(0, 0, A(1, 2, 3, 4), A(1, 2, 3, 4))
};

Js.log(record);
```

Output: 

<img width="291" alt="Screenshot 2019-11-08 at 16 16 09" src="https://user-images.githubusercontent.com/20166594/68492539-3eeceb80-0243-11ea-804b-a0f4f8c80fe0.png">


