### PR TITLE
Tweak grammar

### DIFF
--- a/jscomp/syntax/ast_external_process.ml
+++ b/jscomp/syntax/ast_external_process.ml
@@ -331,11 +331,11 @@ let parse_external_attributes
             | "bs.new" -> {st with new_name = name_from_payload_or_prim ~loc payload}
             | "bs.set_index" -> 
               if String.length prim_name_check <> 0 then 
-                Location.raise_errorf ~loc "[@@bs.set_index] expect external names to be empty string";
+                Location.raise_errorf ~loc "[@@bs.set_index] this particular external's name needs to be a placeholder empty string";
               {st with set_index = true}
             | "bs.get_index"->               
               if String.length prim_name_check <> 0 then
-                Location.raise_errorf ~loc "[@@bs.get_index] expect external names to be empty string";
+                Location.raise_errorf ~loc "[@@bs.get_index] this particular external's name needs to be a placeholder empty string";
               {st with get_index = true}
             | "bs.obj" -> {st with mk_obj = true}
             | "bs.return" ->


### PR DESCRIPTION
This is in light of general bs.val external names needing to be named
now. This message makes it less confusing while refactoring both bs.val
and bs.get/set externals