### PR TITLE
Add esy sandbox for bspack

### DIFF
--- a/bspack.json
+++ b/bspack.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "esy": {
+    "buildsInSource": true,
+    "build": [
+      [
+        "ocamlopt",
+        "-g",
+        "-w",
+        "-40-30-3",
+        "#{self.root / 'jscomp' / 'stubs' / 'ext_basic_hash_stubs.c'}",
+        "unix.cmxa",
+        "#{self.root / 'lib' / '4.06.1' / 'unstable' / 'bspack.ml'}",
+        "-o",
+        "#{self.install / 'bin' / 'bspack.exe'}"
+      ]
+    ]
+  },
+  "dependencies": {
+    "ocaml": "ulrikstrid/ocaml#copy-folder-on-install"
+  }
+}


### PR DESCRIPTION
This PR adds a esy sandbox for bspack.

To use it locally you can run `esy @bspack x bspack.exe`.

But the most important thing is probably to make it usable from other projects more easily. This can be done as follows: `"bspack": "bucklescript/bucklescript:bspack.json"` and then `bspack.exe` should be available in build scripts.