### PR TITLE
Use setImmediate for rebuilding in on_change callback

### DIFF
--- a/lib/bsb
+++ b/lib/bsb
@@ -400,6 +400,9 @@ if (watch_mode) {
         if (validEvent(event, reason)) {
             dlog(`Event ${event} ${reason}`);
             reasons_to_rebuild.push([event, reason])
+            // Some editors are using temporary files to store edits.
+            // This results in two sync change events: change + rename and two sync builds. 
+            // Using setImmediate will ensure that only one build done.
             setImmediate(() => {
                 if (needRebuild()) {
                     if (process.env.BS_WATCH_CLEAR && console.clear) {console.clear()}

--- a/lib/bsb
+++ b/lib/bsb
@@ -400,10 +400,12 @@ if (watch_mode) {
         if (validEvent(event, reason)) {
             dlog(`Event ${event} ${reason}`);
             reasons_to_rebuild.push([event, reason])
-            if (needRebuild()) {
-                if (process.env.BS_WATCH_CLEAR && console.clear) {console.clear()}
-                build()
-            }
+            setImmediate(() => {
+                if (needRebuild()) {
+                    if (process.env.BS_WATCH_CLEAR && console.clear) {console.clear()}
+                    build()
+                }
+            })
         }
 
     }


### PR DESCRIPTION
Some editors are using temporary files to store edits. This results in two sync change events: change + rename and two sync builds. Using setImmediate will ensure that only one build done.