### PR TITLE
Make node process exit return 'a instead of unit

### DIFF
--- a/jscomp/others/node_process.ml
+++ b/jscomp/others/node_process.ml
@@ -37,7 +37,7 @@ type t =
 
 external process : t = "process" [@@bs.module]
 external argv : string array = "argv" [@@bs.module "process"]
-external exit : int -> unit = "exit" [@@bs.module "process"]
+external exit : int -> 'a = "exit" [@@bs.module "process"]
 external cwd : unit -> string = "cwd" [@@bs.module "process"]
 (** The process.uptime() method returns the number of seconds 
    the current Node.js process has been running.) *)

--- a/jscomp/others/node_process.mli
+++ b/jscomp/others/node_process.mli
@@ -35,7 +35,7 @@ type t =
 
 external process : t = "process" [@@bs.module] 
 external argv : string array = "argv" [@@bs.module "process"]
-external exit : int -> unit = "exit" [@@bs.module "process"]
+external exit : int -> 'a = "exit" [@@bs.module "process"]
 external cwd : unit -> string = "cwd" [@@bs.module "process"]
 (** The process.uptime() method returns the number of seconds 
    the current Node.js process has been running.) *)


### PR DESCRIPTION
Hi,

I've just noticed that the `exit` function in Node process returns `unit`.
Since this function terminates the process, I would expect that `'a` is more appropriate here.

What do you think?

Sander