### PR TITLE
fix SPA mode watcher path in react-hooks template

### DIFF
--- a/jscomp/bsb/templates/react-hooks/index.html
+++ b/jscomp/bsb/templates/react-hooks/index.html
@@ -17,6 +17,6 @@
   <!-- This is https://github.com/marijnh/moduleserve, the secret sauce that allows us not need to bundle things during development, and have instantaneous iteration feedback, without any hot-reloading or extra build pipeline needed. -->
   <script src="/moduleserve/load.js" data-module="/src/Index.bs.js"></script>
   <!-- Our little watcher. Super clean. Check it out! -->
-  <script src="./watcher.js"></script>
+  <script src="/watcher.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Using relative path for watcher.js in SPA mode cause wrong fall back when you have more than one level path (example: http://localhost:8000/my_path/bar)