### PR TITLE
Allow to customize WebSocket Host and Port in bsb script

### DIFF
--- a/lib/bsb
+++ b/lib/bsb
@@ -29,8 +29,8 @@ var verbose = false
  */
 var postBuild = undefined
 var useWebSocket = false
-var webSocketHost = 'localhost'
-var webSocketPort = 9999
+var webSocketHost = process.env.BSB_WEBSOCKET_HOST || 'localhost'
+var webSocketPort = process.env.BSB_WEBSOCKET_PORT || 9999
 
 /**
  * @returns {string}


### PR DESCRIPTION
I need this to use "bsb -ws" because I can only test my website over network and can't use localhost so I need to customize HOST IP, port is optional but added anyway.

Thanks for considering this patch.

Edit: I don't know much of BuckleScript internals or how it is built. I just made the change that solved my problem. If it needs to be done another way, let me know. And sorry for that.