### PR TITLE
docs: update README in basic reason template

### DIFF
--- a/jscomp/bsb/templates/basic-reason/README.md
+++ b/jscomp/bsb/templates/basic-reason/README.md
@@ -3,16 +3,25 @@
 Hello! This project allows you to quickly get started with Reason and BuckleScript. If you wanted a more sophisticated version, try the `react` template (`bsb -theme react -init .`).
 
 # Build
-```
+
+```bash
+# for yarn
+yarn build
+
+# for npm
 npm run build
 ```
 
 # Build + Watch
 
-```
+```bash
+# for yarn
+yarn
+
+# for npm
 npm run start
 ```
 
-
 # Editor
-If you use `vscode`, Press `Windows + Shift + B` it will build automatically
+
+If you're using VS Code, press <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>B</kbd> or <kbd>Windows</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd> to build the project automatically.


### PR DESCRIPTION
This PR makes a few minor changes to the `README.md` in the basic reason template to:

- include commands for both `npm` and `yarn`
- include keyboard shortcuts for both Windows and Mac