### PR TITLE
Fix yarn start command

### DIFF
--- a/jscomp/bsb/templates/basic-reason/README.md
+++ b/jscomp/bsb/templates/basic-reason/README.md
@@ -16,7 +16,7 @@ npm run build
 
 ```bash
 # for yarn
-yarn
+yarn start
 
 # for npm
 npm run start


### PR DESCRIPTION
Saw this tweet and looks like I found a little bug

https://twitter.com/jsjoeio/status/1224124605784305665

`yarn` does `yarn install` by default, not `start`