### PR TITLE
add new binary locations to esy manifest

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -25,7 +25,6 @@
       ["cp", "-r", "-f", "#{self.root / 'lib'}", "#{self.install}"],
       ["cp", "-r", "-f", "#{self.root / 'scripts'}", "#{self.install}"],
       ["cp", "-r", "-f", "#{self.root / 'vendor'}", "#{self.install}"],
-      ["cp", "-r", "-f", "#{self.root / 'ocaml'}", "#{self.lib}"],
       ["cp", "-r", "-f", "#{self.root / 'darwin'}", "#{self.bin}"],
       ["cp", "-r", "-f", "#{self.root / 'freebsd'}", "#{self.bin}"],
       ["cp", "-r", "-f", "#{self.root / 'linux'}", "#{self.bin}"],
@@ -45,10 +44,6 @@
       "ESY": "true"
     },
     "exportedEnv": {
-      "OCAMLLIB": {
-        "val": "#{self.lib / 'ocaml' }",
-        "scope": "global"
-      },
       "CAML_LD_LIBRARY_PATH": {
         "val": "#{self.lib / 'ocaml'  / 'stublibs' : self.lib / 'ocaml'  : $CAML_LD_LIBRARY_PATH}",
         "scope": "global"

--- a/esy.json
+++ b/esy.json
@@ -24,7 +24,15 @@
       ["cp", "-r", "-f", "#{self.root / 'jscomp' / 'bin'}", "#{self.install}"],
       ["cp", "-r", "-f", "#{self.root / 'lib'}", "#{self.install}"],
       ["cp", "-r", "-f", "#{self.root / 'scripts'}", "#{self.install}"],
-      ["cp", "-r", "-f", "#{self.root / 'vendor'}", "#{self.install}"]
+      ["cp", "-r", "-f", "#{self.root / 'vendor'}", "#{self.install}"],
+      ["cp", "-r", "-f", "#{self.root / 'darwin'}", "#{self.bin}"],
+      ["cp", "-r", "-f", "#{self.root / 'freebsd'}", "#{self.bin}"],
+      ["cp", "-r", "-f", "#{self.root / 'linux'}", "#{self.bin}"],
+      ["cp", "-r", "-f", "#{self.root / 'win32'}", "#{self.bin}"],
+      ["cp", "-f", "#{self.root / 'bsb'}", "#{self.bin}"],
+      ["cp", "-f", "#{self.root / 'bsc'}", "#{self.bin}"],
+      ["cp", "-f", "#{self.root / 'bsrefmt'}", "#{self.bin}"],
+      ["cp", "-f", "#{self.root / 'lib/bstracing'}", "#{self.bin}"]
     ],
     "buildDev": [
       ["echo", "config"],

--- a/esy.json
+++ b/esy.json
@@ -25,6 +25,7 @@
       ["cp", "-r", "-f", "#{self.root / 'lib'}", "#{self.install}"],
       ["cp", "-r", "-f", "#{self.root / 'scripts'}", "#{self.install}"],
       ["cp", "-r", "-f", "#{self.root / 'vendor'}", "#{self.install}"],
+      ["cp", "-r", "-f", "#{self.root / 'ocaml'}", "#{self.lib}"],
       ["cp", "-r", "-f", "#{self.root / 'darwin'}", "#{self.bin}"],
       ["cp", "-r", "-f", "#{self.root / 'freebsd'}", "#{self.bin}"],
       ["cp", "-r", "-f", "#{self.root / 'linux'}", "#{self.bin}"],


### PR DESCRIPTION
024695f6e799f7d88ad0bd7a354d7dd5e1d486ae and a couple subsequent changes moved around the binaries so they were no longer visible in esy builds (which automatically exposes /bin and /lib but nothing else). This makes sure they are available.