### PR TITLE
change for_in impl for arrays

### DIFF
--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -140,10 +140,13 @@ let caml_lazy_make (fn : _ -> _) =
    whose tag is 0, we optimize that case
 *)
 let caml_update_dummy : _ -> _ -> unit= [%raw{|function (x, y) {
-  var set = function (k) {
-    x[k] = y[k]
+  if (Array.isArray(y)) {
+    for (var k = 0; k < y.length; k++) {
+      x[k] = y[k]
+    }
+  } else {
+    for (var k in y) { x[k] = y[k] }
   }
-  for_in(y, set)
 }|}]
   
 (* Caml_obj_extern.set_length x   (Caml_obj_extern.length y) *)

--- a/lib/es6/caml_obj.js
+++ b/lib/es6/caml_obj.js
@@ -4,8 +4,15 @@ import * as Block from "./block.js";
 import * as Caml_primitive from "./caml_primitive.js";
 import * as Caml_builtin_exceptions from "./caml_builtin_exceptions.js";
 
-var for_in = (function(o,foo){
-        for (var x in o) { foo(x) }});
+var for_in = (function (o, foo) {
+      if (Array.isArray(o)) {
+        for (var x = 0; x < o.length; x++) {
+          foo(x)
+        }
+      } else {
+        for (var x in o) { foo(x) }
+      }
+    });
 
 function caml_obj_block(tag, size) {
   var v = new Array(size);
@@ -54,11 +61,12 @@ function caml_lazy_make(fn) {
   return block;
 }
 
-var caml_update_dummy = (function(x,y){
-  for (var k in y){
+var caml_update_dummy = (function (x, y) {
+  var set = function (k) {
     x[k] = y[k]
   }
-  });
+  for_in(y, set)
+});
 
 function caml_compare(_a, _b) {
   while(true) {

--- a/lib/es6/caml_obj.js
+++ b/lib/es6/caml_obj.js
@@ -62,10 +62,13 @@ function caml_lazy_make(fn) {
 }
 
 var caml_update_dummy = (function (x, y) {
-  var set = function (k) {
-    x[k] = y[k]
+  if (Array.isArray(y)) {
+    for (var k = 0; k < y.length; k++) {
+      x[k] = y[k]
+    }
+  } else {
+    for (var k in y) { x[k] = y[k] }
   }
-  for_in(y, set)
 });
 
 function caml_compare(_a, _b) {

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -4,8 +4,15 @@ var Block = require("./block.js");
 var Caml_primitive = require("./caml_primitive.js");
 var Caml_builtin_exceptions = require("./caml_builtin_exceptions.js");
 
-var for_in = (function(o,foo){
-        for (var x in o) { foo(x) }});
+var for_in = (function (o, foo) {
+      if (Array.isArray(o)) {
+        for (var x = 0; x < o.length; x++) {
+          foo(x)
+        }
+      } else {
+        for (var x in o) { foo(x) }
+      }
+    });
 
 function caml_obj_block(tag, size) {
   var v = new Array(size);
@@ -54,11 +61,12 @@ function caml_lazy_make(fn) {
   return block;
 }
 
-var caml_update_dummy = (function(x,y){
-  for (var k in y){
+var caml_update_dummy = (function (x, y) {
+  var set = function (k) {
     x[k] = y[k]
   }
-  });
+  for_in(y, set)
+});
 
 function caml_compare(_a, _b) {
   while(true) {

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -62,10 +62,13 @@ function caml_lazy_make(fn) {
 }
 
 var caml_update_dummy = (function (x, y) {
-  var set = function (k) {
-    x[k] = y[k]
+  if (Array.isArray(y)) {
+    for (var k = 0; k < y.length; k++) {
+      x[k] = y[k]
+    }
+  } else {
+    for (var k in y) { x[k] = y[k] }
   }
-  for_in(y, set)
 });
 
 function caml_compare(_a, _b) {


### PR DESCRIPTION
There are a number of older libraries and polyfills that adjust the prototype of `Array` with fields that are enumerable and can for...in this iteration. While it is typically very rare in modern codebases, it has remained something that we guard against inside of Facebook.

Example of code that this is intended to protect against:
```
Array.prototype.find = "myFindPolyfill"; 
var array = ['a', 'b', 'c'];
for (var i in array) { console.log(array[i]); }
```

I chose Array.isArray and a standard for loop because there is precedent for both of these in this file.