### PR TITLE
Switch to using arg names for calling bsb-native

### DIFF
--- a/jscomp/bsb/bsb_ninja_regen.ml
+++ b/jscomp/bsb/bsb_ninja_regen.ml
@@ -81,7 +81,7 @@ let regenerate_ninja
     end else begin
       let os = Filename.basename Bsb_global_paths.bsc_dir in
       let plugin_path = Bsb_global_paths.cwd // "node_modules" // "bs-platform-native" // os // "bsb.exe" in
-      let status = Sys.command (Printf.sprintf "%s %s %s %s %s %s" plugin_path per_proj_dir lib_bs_dir Bsb_global_paths.cwd Bsb_global_paths.bsc_dir !Bsb_global_backend.backend_string) in
+      let status = Sys.command (Printf.sprintf "%s -project-dir %s -lib-artifacts-dir %s -root-project-dir %s -bsc-dir %s -backend %s" plugin_path per_proj_dir lib_bs_dir Bsb_global_paths.cwd Bsb_global_paths.bsc_dir !Bsb_global_backend.backend_string) in
       if status <> 0 then
         print_endline "Error: native plugin ran into an error";
     end;

--- a/lib/4.06.1/unstable/bsb_native.ml
+++ b/lib/4.06.1/unstable/bsb_native.ml
@@ -14395,7 +14395,7 @@ let regenerate_ninja
     end else begin
       let os = Filename.basename Bsb_global_paths.bsc_dir in
       let plugin_path = Bsb_global_paths.cwd // "node_modules" // "bs-platform-native" // os // "bsb.exe" in
-      let status = Sys.command (Printf.sprintf "%s %s %s %s %s %s" plugin_path per_proj_dir lib_bs_dir Bsb_global_paths.cwd Bsb_global_paths.bsc_dir !Bsb_global_backend.backend_string) in
+      let status = Sys.command (Printf.sprintf "%s -project-dir %s -lib-artifacts-dir %s -root-project-dir %s -bsc-dir %s -backend %s" plugin_path per_proj_dir lib_bs_dir Bsb_global_paths.cwd Bsb_global_paths.bsc_dir !Bsb_global_backend.backend_string) in
       if status <> 0 then
         print_endline "Error: native plugin ran into an error";
     end;


### PR DESCRIPTION
We used positional args to start, but it's getting significantly more complicated now so adding named args seems like a good idea.