### PR TITLE
[Playground] Add new workflow to build an npm-ready package

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,5 +1,8 @@
 name: Build playground
-on: [push]
+on:
+  push:
+    tags:
+    - '*'
 jobs:
   run:
     name: Build
@@ -34,6 +37,6 @@ jobs:
       - name: Archive npm artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: playground
+          name: reason-js-compiler
           path: playground
 

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -29,6 +29,7 @@ jobs:
       - run: ./scripts/ninja.js config && ./scripts/ninja.js build
       - run: mkdir playground && mkdir playground/stdlib
       - run: BS_PLAYGROUND=../playground ./scripts/repl.js -prepublish
+      - run: node -e "require('./playground/exports.js'); eval(ocaml.compile('Js.log Sys.ocaml_version').js_code)"
       - name: Archive npm artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,5 +1,5 @@
 name: Build and publish playground
-on: [push, pull_request]
+on: [push]
 jobs:
   run:
     name: Build
@@ -7,12 +7,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
         ocaml-version: ["4.06.1"]
         node-version: [12.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.0.0
+      - name: Cache .opam folder
+        uses: actions/cache@v1
+        with:
+          path: $HOME/.opam
+          key: ${{ runner.os }}-opam-v1
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1.0
         with:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -28,7 +28,7 @@ jobs:
       - run: git submodule update --init && ./scripts/buildocaml.js
       - run: ./scripts/ninja.js config && ./scripts/ninja.js build
       - run: mkdir playground && mkdir playground/stdlib
-      - run: BS_PLAYGROUND=../playground ./scripts/repl.js
+      - run: BS_PLAYGROUND=../playground ./scripts/repl.js -prepublish
       - name: Archive npm artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -14,15 +14,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2.0.0
       - name: Cache .opam folder
+        id: cache-opam
         uses: actions/cache@v1
         with:
-          path: $HOME/.opam
-          key: ${{ runner.os }}-opam-v1
+          path: ~/.opam
+          key: ${{ runner.os }}-opam-4.06.1-3.5.1-v1
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1.0
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
-      - run: opam install js_of_ocaml.3.5.1
+      - if: steps.cache-opam.outputs.cache-hit != 'true'
+        run: opam install js_of_ocaml.3.5.1
       - run: git submodule update --init && ./scripts/buildocaml.js
       - run: ./scripts/ninja.js config && ./scripts/ninja.js build
       - run: mkdir playground && mkdir playground/stdlib

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,24 @@
+name: Build and publish playground
+on: [push, pull_request]
+jobs:
+  run:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        ocaml-version: ["4.06.1"]
+        node-version: [12.x]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.0.0
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1.0
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+      - run: opam install js_of_ocaml.3.5.1
+      - run: git submodule update --init && ./scripts/buildocaml.js
+      - run: ./scripts/ninja.js config && ./scripts/ninja.js build
+      - run: mkdir playground && mkdir playground/stdlib
+      - run: BS_PLAYGROUND=../playground ./scripts/repl.js

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -4,6 +4,9 @@ jobs:
   run:
     name: Build
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
       - run: opam install js_of_ocaml.3.5.1
+      - run: eval $(opam env)
       - run: git submodule update --init && ./scripts/buildocaml.js
       - run: ./scripts/ninja.js config && ./scripts/ninja.js build
       - run: mkdir playground && mkdir playground/stdlib

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -4,9 +4,6 @@ jobs:
   run:
     name: Build
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +18,6 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
       - run: opam install js_of_ocaml.3.5.1
-      - run: eval $(opam env)
       - run: git submodule update --init && ./scripts/buildocaml.js
       - run: ./scripts/ninja.js config && ./scripts/ninja.js build
       - run: mkdir playground && mkdir playground/stdlib

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,4 +1,4 @@
-name: Build and publish playground
+name: Build playground
 on: [push]
 jobs:
   run:
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.opam
-          key: ${{ runner.os }}-opam-4.06.1-3.5.1-v1
+          key: ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-3.5.1-v1
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1.0
         with:
@@ -29,7 +29,8 @@ jobs:
       - run: ./scripts/ninja.js config && ./scripts/ninja.js build
       - run: mkdir playground && mkdir playground/stdlib
       - run: BS_PLAYGROUND=../playground ./scripts/repl.js -prepublish
-      - run: node -e "require('./playground/exports.js'); eval(ocaml.compile('Js.log Sys.ocaml_version').js_code)"
+      - run: node -e "require('./exports.js'); eval(ocaml.compile('Js.log Sys.ocaml_version').js_code)"
+        working-directory: ./playground
       - name: Archive npm artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -27,3 +27,9 @@ jobs:
       - run: ./scripts/ninja.js config && ./scripts/ninja.js build
       - run: mkdir playground && mkdir playground/stdlib
       - run: BS_PLAYGROUND=../playground ./scripts/repl.js
+      - name: Archive npm artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: playground
+          path: playground
+

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -63,10 +63,10 @@ function prepublish() {
   );
 
   fs.writeFileSync(
-    `${playground}/package.json`,
+    jscompDir + `/${playground}/package.json`,
     packageJson,
     {
-      encoding: "utf8"
+      encoding: "utf8",
     }
   );
 }

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -63,7 +63,7 @@ function prepublish() {
   );
 
   fs.writeFileSync(
-    `${playground}/package.json`),
+    `${playground}/package.json`,
     packageJson,
     {
       encoding: "utf8"

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -43,6 +43,34 @@ function prepare() {
   e(`mv ./exports.js ${playground}`)
 }
 
+function prepublish() {
+  var mainPackageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json')));
+  var packageJson = JSON.stringify(
+    {
+      name: "reason-js-compiler",
+      version: "0.0.1",
+      license: mainPackageJson.license,
+      description: mainPackageJson.description,
+      repository: mainPackageJson.repository,
+      author: mainPackageJson.author,
+      maintainers: mainPackageJson.maintainers,
+      bugs: mainPackageJson.bugs,
+      homepage: mainPackageJson.homepage,
+      main: "exports.js",
+    },
+    null,
+    2
+  );
+
+  fs.writeFileSync(
+    path.join(__dirname, "..", "_release", "package.json"),
+    packageJson,
+    {
+      encoding: "utf8"
+    }
+  );
+}
+
 
 prepare();
 

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -32,11 +32,11 @@ if (!process.env.BS_PLAYGROUND) {
 var playground = process.env.BS_PLAYGROUND;
 
 function prepare() {
-  e(`hash hash js_of_ocaml 2>/dev/null || { echo >&2 "js_of_ocaml not found on path. Please install version 3.5.1 (with opam switch ${ocamlVersion}), and put it on your path."; exit 1; }
+  e(`opam exec -- js_of_ocaml 2>/dev/null || { echo >&2 "js_of_ocaml not found on path. Please install version 3.5.1 (with opam switch ${ocamlVersion}), and put it on your path."; exit 1; }
 `);
 
   e(
-    `ocamlc.opt -w -30-40 -no-check-prims -I ${jsRefmtCompDir} ${jsRefmtCompDir}/js_compiler.mli ${jsRefmtCompDir}/js_compiler.ml -o jsc.byte && js_of_ocaml jsc.byte -o exports.js`
+    `opam exec -- ocamlc.opt -w -30-40 -no-check-prims -I ${jsRefmtCompDir} ${jsRefmtCompDir}/js_compiler.mli ${jsRefmtCompDir}/js_compiler.ml -o jsc.byte && opam exec -- js_of_ocaml jsc.byte -o exports.js`
   );
 
   e(`cp ../lib/js/*.js ${playground}/stdlib`);
@@ -48,7 +48,7 @@ function prepublish() {
   var packageJson = JSON.stringify(
     {
       name: "reason-js-compiler",
-      version: "0.0.1",
+      version: mainPackageJson.version,
       license: mainPackageJson.license,
       description: mainPackageJson.description,
       repository: mainPackageJson.repository,
@@ -63,7 +63,7 @@ function prepublish() {
   );
 
   fs.writeFileSync(
-    path.join(__dirname, "..", "_release", "package.json"),
+    `${playground}/package.json`),
     packageJson,
     {
       encoding: "utf8"

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var p = require("child_process");
-
+var fs = require("fs");
 var path = require("path");
 
 
@@ -36,7 +36,7 @@ function prepare() {
 `);
 
   e(
-    `opam exec -- ocamlc.opt -w -30-40 -no-check-prims -I ${jsRefmtCompDir} ${jsRefmtCompDir}/js_compiler.mli ${jsRefmtCompDir}/js_compiler.ml -o jsc.byte && opam exec -- js_of_ocaml jsc.byte -o exports.js`
+    `opam exec -- ocamlc.opt -w -30-40 -no-check-prims -I ${jsRefmtCompDir} ${jsRefmtCompDir}/js_refmt_compiler.mli ${jsRefmtCompDir}/js_refmt_compiler.ml -o jsc.byte && opam exec -- js_of_ocaml jsc.byte -o exports.js`
   );
 
   e(`cp ../lib/js/*.js ${playground}/stdlib`);
@@ -71,6 +71,7 @@ function prepublish() {
   );
 }
 
-
 prepare();
-
+if (process.argv.includes("-prepublish")) {
+  prepublish();
+}


### PR DESCRIPTION
Adds a new workflow that produces an artifact with `exports.js` in it, as well as stdlib folder.

Some notes:
- It only runs when pushing new tags as I guess there's no point to run it on every push / pr
- It doesn't publish to npm, but it should be quite straightforward to do so:
    ```
    - name: publish
      run: npm publish
      working-directory: ./playground
      env:
        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
    ```
- Includes a small smoke test to make sure bundle works ok
- `avsm/setup-ocaml` doesn't support caching yet, but the workflow stores whole `.opam` folder and this reduces time by half (from ~20min to ~8min).
- Windows build fails for some reason I haven't been able to figure out yet, so it's been left out temporarily

Example run can be seen in https://github.com/jchavarri/bucklescript/actions/runs/88293566.