### PR TITLE
[-bs-g] Avoid override other formatters

### DIFF
--- a/jscomp/runtime/caml_chrome_debugger.ml
+++ b/jscomp/runtime/caml_chrome_debugger.ml
@@ -25,158 +25,157 @@
 
 type obj = Caml_obj_extern.t
 
-let setupChromeDebugger : unit -> unit = [%raw{|function(_){
- 
- // I don't know how to directly refer to the classes that chrome's built-in
- // formatters use. adding "class": "foo" doesn't seem to work
- // tree-outline
- var olStyle = {"style": "list-style-type: none; padding-left: 12px; margin: 0"}
- // object-properties-section-separator
- var colonStyle = {"style": "flex-shrink: 0; padding-right: 5px"}
- 
+let setupChromeDebugger : unit -> unit = [%raw{|
+  function () {
+  // I don't know how to directly refer to the classes that chrome's built-in
+  // formatters use. adding "class": "foo" doesn't seem to work
+  // tree-outline
+  var olStyle = {
+    style: "list-style-type: none; padding-left: 12px; margin: 0",
+  };
+  // object-properties-section-separator
+  var colonStyle = { style: "flex-shrink: 0; padding-right: 5px" };
 
- var showObject = function (value) {
-   if (value == undefined) {
-     return value + ''
-   } else {
-     return ["object", {"object": value}]
-   }
- }
- 
+  var showObject = function (value) {
+    if (value == undefined) {
+      return value + "";
+    } else {
+      return ["object", { object: value }];
+    }
+  };
 
-var listToArray = function (data){
- var result = []
- var cur = data
- var index = 0
- while(typeof cur !== "number"){
-   result.push([
-     "li",
-     {},
-     ["span", {"style": "color: rgb(227, 110, 236)"}, index],
-     ["span", colonStyle, ":"],
-     showObject(cur[0])
-   ]);
-   cur = cur[1]
-   index++
- }
- return result
-};
+  var listToArray = function (data) {
+    var result = [];
+    var cur = data;
+    var index = 0;
+    while (typeof cur !== "number") {
+      result.push([
+        "li",
+        {},
+        ["span", { style: "color: rgb(227, 110, 236)" }, index],
+        ["span", colonStyle, ":"],
+        showObject(cur[0]),
+      ]);
+      cur = cur[1];
+      index++;
+    }
+    return result;
+  };
 
-var variantCustomFormatter = function (data,recordVariant){
- if(recordVariant === "::"){
-   return [
-     "ol",
-     olStyle,
-     ... listToArray(data)
-   ]
- } else {
-    let spacedData = [];
-    data.forEach(cur => {
-      spacedData.push(["span", {"style": "margin-right: 12px"}, showObject(cur)]);
-    })
-     return ["ol", olStyle, ...spacedData]
- }
+  var variantCustomFormatter = function (data, recordVariant) {
+    if (recordVariant === "::") {
+      return ["ol", olStyle, ...listToArray(data)];
+    } else {
+      let spacedData = [];
+      data.forEach((cur) => {
+        spacedData.push([
+          "span",
+          { style: "margin-right: 12px" },
+          showObject(cur),
+        ]);
+      });
+      return ["ol", olStyle, ...spacedData];
+    }
+  };
 
-};
+  var variantPreview = function (x, recordVariant) {
+    if (recordVariant === "::") {
+      // show the length, just like for array
+      var length = listToArray(x).length;
+      return ["span", {}, `List(${length})`];
+    }
+    return ["span", {}, `${recordVariant}(…)`];
+  };
+  var isOCamlExceptionOrExtensionHead = function (x) {
+    return Array.isArray(x) && x.tag === 248 && typeof x[0] === "string";
+  };
+  var isOCamlExceptionOrExtension = function (x) {
+    return (
+      Array.isArray(x) &&
+      x[0] !== undefined &&
+      isOCamlExceptionOrExtensionHead(x[0])
+    );
+  };
+  var Formatter = {
+    header: function (x) {
+      var recordVariant = x[Symbol.for("BsVariant")];
+      var polyVariant = x[Symbol.for("BsPolyVar")];
+      if (recordVariant !== undefined) {
+        return variantPreview(x, recordVariant);
+      } else if (isOCamlExceptionOrExtension(x)) {
+        return ["div", {}, `${x[0][0]}(…)`];
+      } else if (polyVariant !== undefined) {
+        return ["div", {}, `\`${recordPolyVar}#${x[0]}`];
+      }
+      return null;
+    },
+    hasBody: function (x) {
+      var recordVariant = x[Symbol.for("BsVariant")];
+      var polyVariant = x[Symbol.for("BsPolyVar")];
 
-var variantPreview = function (x, recordVariant){
- if(recordVariant === "::") {
-   // show the length, just like for array
-   var length = listToArray(x).length;
-   return ['span', {}, `list(${length})`]
- }
- return ['span', {}, `${recordVariant}(…)`]
-};
-var isOCamlExceptionOrExtensionHead = function(x){
- return Array.isArray(x) && x.tag === 248 && typeof x[0] === "string"
-}
-var isOCamlExceptionOrExtension = function(x){
- return Array.isArray(x) &&
-       x[0] !== undefined &&
-       isOCamlExceptionOrExtensionHead(x[0])
-}
-var formatter = {
- header: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant =  x[Symbol.for('BsVariant')]) !== undefined){
-         return variantPreview(x, recordVariant)
-     } else if (isOCamlExceptionOrExtension(x)){
-       return ['div',{}, `${x[0][0]}(…)`]     
-     } else if ((recordPolyVar = x[Symbol.for('BsPolyVar')] ) !== undefined){
-       return ['div', {}, `\`${recordPolyVar}#${x[0]}`]
-     }
-     return null
- },
- hasBody: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant = x[Symbol.for('BsVariant')] ) !== undefined){
-         return recordVariant
-     } else if(isOCamlExceptionOrExtension(x)){
-       return true
-     } else if( (recordPolyVar = x[Symbol.for('BsPolyVar')]) !== undefined){
-       return true
-     }
-     return false
- },
- body: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant = x[Symbol.for('BsVariant')]) !== undefined) {
-             return variantCustomFormatter(x,recordVariant)
-     }
-     else if ((recordPolyVar = x [Symbol.for('BsPolyVar')]) !== undefined){
-       return showObject(x[1])
-     }
-     else if(isOCamlExceptionOrExtension(x)){
-       return ["ol", olStyle, ... x.slice(1).map(cur => showObject(cur))]
-     }
+      return (
+        recordVariant !== undefined ||
+        isOCamlExceptionOrExtension(x) ||
+        polyVariant !== undefined ||
+        false
+      );
+    },
+    body: function (x) {
+      var recordVariant = x[Symbol.for("BsVariant")];
+      var polyVariant = x[Symbol.for("BsPolyVar")];
 
- }
+      if (recordVariant !== undefined) {
+        return variantCustomFormatter(x, recordVariant);
+      } else if (polyVariant !== undefined) {
+        return showObject(x[1]);
+      } else if (isOCamlExceptionOrExtension(x)) {
+        return ["ol", olStyle, ...x.slice(1).map((cur) => showObject(cur))];
+      }
+    },
+  };
 
-}
-if (typeof window === "undefined"){
- global.devtoolsFormatters = [formatter]
-} else {
- window.devtoolsFormatters = [formatter]
-}
-}
+  if (typeof window === "undefined") {
+    global.devtoolsFormatters = global.devtoolsFormatters || [];
+    global.devtoolsFormatters.push(Formatter);
+  } else {
+    window.devtoolsFormatters = window.devtoolsFormatters || [];
+    window.devtoolsFormatters.push(Formatter);
+  }
 |}]
 
 
-let setup = ref false 
-let setupOnce () = 
-  if not setup.contents then 
-    begin 
+let setup = ref false
+let setupOnce () =
+  if not setup.contents then
+    begin
       setup.contents<- true;
       setupChromeDebugger ()
-    end 
+    end
 
 type symbol
 
-type 'a t = { value : 'a} 
+type 'a t = { value : 'a}
 
 external cacheSymbol : string -> symbol = "for"
  [@@bs.scope "Symbol"] [@@bs.val]
 
-external addProp : 'a -> symbol -> 'b t  -> 'a = 
+external addProp : 'a -> symbol -> 'b t  -> 'a =
   "defineProperty"  [@@bs.scope "Object"] [@@bs.val]
 
 let __ = Block.__
 (* It won't affect [Object.keys] using [Object.defineProperty*)
 
-let variant meta tag xs =     
+let variant meta tag xs =
   setupOnce ();
   xs |. Caml_obj_extern.set_tag tag;
   xs |. addProp (cacheSymbol "BsVariant") {value = meta }
 
-let simpleVariant meta xs =       
+let simpleVariant meta xs =
   setupOnce ();
   xs |. addProp (cacheSymbol "BsVariant") {value = meta }
-  
 
-let polyVar meta xs =   
+
+let polyVar meta xs =
   setupOnce ();
   xs |. addProp (cacheSymbol "BsPolyVar") {value = meta}
 

--- a/jscomp/runtime/caml_chrome_debugger.ml
+++ b/jscomp/runtime/caml_chrome_debugger.ml
@@ -145,7 +145,7 @@ let setupChromeDebugger : unit -> unit = [%raw{|
     window.devtoolsFormatters = window.devtoolsFormatters || [];
     window.devtoolsFormatters.push(Formatter);
   }
-|}]
+}|}]
 
 
 let setup = ref false

--- a/lib/es6/caml_chrome_debugger.js
+++ b/lib/es6/caml_chrome_debugger.js
@@ -1,123 +1,127 @@
 
 
 import * as Block from "./block.js";
+import * as Curry from "./curry.js";
 
-var setupChromeDebugger = (function(_){
- 
- // I don't know how to directly refer to the classes that chrome's built-in
- // formatters use. adding "class": "foo" doesn't seem to work
- // tree-outline
- var olStyle = {"style": "list-style-type: none; padding-left: 12px; margin: 0"}
- // object-properties-section-separator
- var colonStyle = {"style": "flex-shrink: 0; padding-right: 5px"}
- 
+var setupChromeDebugger = (function () {
+  // I don't know how to directly refer to the classes that chrome's built-in
+  // formatters use. adding "class": "foo" doesn't seem to work
+  // tree-outline
+  var olStyle = {
+    style: "list-style-type: none; padding-left: 12px; margin: 0",
+  };
+  // object-properties-section-separator
+  var colonStyle = { style: "flex-shrink: 0; padding-right: 5px" };
 
- var showObject = function (value) {
-   if (value == undefined) {
-     return value + ''
-   } else {
-     return ["object", {"object": value}]
-   }
- }
- 
+  var renderObject = function (value) {
+    if (value == undefined) {
+      return value + "";
+    } else {
+      return ["object", { object: value }];
+    }
+  };
 
-var listToArray = function (data){
- var result = []
- var cur = data
- var index = 0
- while(typeof cur !== "number"){
-   result.push([
-     "li",
-     {},
-     ["span", {"style": "color: rgb(227, 110, 236)"}, index],
-     ["span", colonStyle, ":"],
-     showObject(cur[0])
-   ]);
-   cur = cur[1]
-   index++
- }
- return result
-};
+  var listToArray = function (data) {
+    var result = [];
+    var cur = data;
+    var index = 0;
+    while (typeof cur !== "number") {
+      result.push([
+        "li",
+        {},
+        ["span", { style: "color: rgb(227, 110, 236)" }, index],
+        ["span", colonStyle, ":"],
+        renderObject(cur[0]),
+      ]);
+      cur = cur[1];
+      index++;
+    }
+    return result;
+  };
 
-var variantCustomFormatter = function (data,recordVariant){
- if(recordVariant === "::"){
-   return [
-     "ol",
-     olStyle,
-     ... listToArray(data)
-   ]
- } else {
-    let spacedData = [];
-    data.forEach(cur => {
-      spacedData.push(["span", {"style": "margin-right: 12px"}, showObject(cur)]);
-    })
-     return ["ol", olStyle, ...spacedData]
- }
+  var renderRecord = function (data, recordVariant) {
+    if (recordVariant === "::") {
+      return ["ol", olStyle, ...listToArray(data)];
+    } else {
+      let spacedData = [];
+      data.forEach((cur) => {
+        spacedData.push([
+          "span",
+          { style: "margin-right: 12px" },
+          renderObject(cur),
+        ]);
+      });
+      return ["ol", olStyle, ...spacedData];
+    }
+  };
 
-};
+  var renderVariant = function (x, recordVariant) {
+    if (recordVariant === "::") {
+      // show the length, just like for array
+      var length = listToArray(x).length;
+      return ["span", {}, `List(${length})`];
+    }
+    return ["span", {}, `${recordVariant}(…)`];
+  };
 
-var variantPreview = function (x, recordVariant){
- if(recordVariant === "::") {
-   // show the length, just like for array
-   var length = listToArray(x).length;
-   return ['span', {}, `list(${length})`]
- }
- return ['span', {}, `${recordVariant}(…)`]
-};
-var isOCamlExceptionOrExtensionHead = function(x){
- return Array.isArray(x) && x.tag === 248 && typeof x[0] === "string"
-}
-var isOCamlExceptionOrExtension = function(x){
- return Array.isArray(x) &&
-       x[0] !== undefined &&
-       isOCamlExceptionOrExtensionHead(x[0])
-}
-var formatter = {
- header: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant =  x[Symbol.for('BsVariant')]) !== undefined){
-         return variantPreview(x, recordVariant)
-     } else if (isOCamlExceptionOrExtension(x)){
-       return ['div',{}, `${x[0][0]}(…)`]     
-     } else if ((recordPolyVar = x[Symbol.for('BsPolyVar')] ) !== undefined){
-       return ['div', {}, `\`${recordPolyVar}#${x[0]}`]
-     }
-     return null
- },
- hasBody: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant = x[Symbol.for('BsVariant')] ) !== undefined){
-         return recordVariant
-     } else if(isOCamlExceptionOrExtension(x)){
-       return true
-     } else if( (recordPolyVar = x[Symbol.for('BsPolyVar')]) !== undefined){
-       return true
-     }
-     return false
- },
- body: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant = x[Symbol.for('BsVariant')]) !== undefined) {
-             return variantCustomFormatter(x,recordVariant)
-     }
-     else if ((recordPolyVar = x [Symbol.for('BsPolyVar')]) !== undefined){
-       return showObject(x[1])
-     }
-     else if(isOCamlExceptionOrExtension(x)){
-       return ["ol", olStyle, ... x.slice(1).map(cur => showObject(cur))]
-     }
+  var isOCamlExceptionOrExtensionHead = function (x) {
+    return Array.isArray(x) && x.tag === 248 && typeof x[0] === "string";
+  };
 
- }
+  var isOCamlExceptionOrExtension = function (x) {
+    return (
+      Array.isArray(x) &&
+      x[0] !== undefined &&
+      isOCamlExceptionOrExtensionHead(x[0])
+    );
+  };
 
-}
-if (typeof window === "undefined"){
- global.devtoolsFormatters = [formatter]
-} else {
- window.devtoolsFormatters = [formatter]
-}
+  var Formatter = {
+    header: function (data) {
+      var recordVariant = data[Symbol.for("BsVariant")];
+      var polyVariant = data[Symbol.for("BsPolyVar")];
+
+      if (recordVariant !== undefined) {
+        return renderVariant(data, recordVariant);
+      } else if (isOCamlExceptionOrExtension(data)) {
+        return ["div", {}, `${data[0][0]}(…)`];
+      } else if (polyVariant !== undefined) {
+        return ["div", {}, `\`${recordPolyVar}#${data[0]}`];
+      }
+      return null;
+    },
+    hasBody: function (data) {
+      var recordVariant = data[Symbol.for("BsVariant")];
+      var polyVariant = data[Symbol.for("BsPolyVar")];
+
+      return (
+        recordVariant !== undefined ||
+        isOCamlExceptionOrExtension(data) ||
+        polyVariant !== undefined ||
+        false
+      );
+    },
+    body: function (data) {
+      var recordVariant = data[Symbol.for("BsVariant")];
+      var polyVariant = data[Symbol.for("BsPolyVar")];
+
+      if (recordVariant !== undefined) {
+        return renderRecord(data, recordVariant);
+      } else if (polyVariant !== undefined) {
+        return renderObject(data[1]);
+      } else if (isOCamlExceptionOrExtension(x)) {
+        return ["ol", olStyle, ...data.slice(1).map(renderObject)];
+      }
+    },
+  };
+
+  if (typeof window === "undefined") {
+    global.devtoolsFormatters = global.devtoolsFormatters || [];
+    global.devtoolsFormatters.push(Formatter);
+  } else {
+    window.devtoolsFormatters = window.devtoolsFormatters || [];
+    window.devtoolsFormatters.push(Formatter);
+  }
 });
 
 var setup = {
@@ -127,7 +131,7 @@ var setup = {
 function setupOnce(param) {
   if (!setup.contents) {
     setup.contents = true;
-    return setupChromeDebugger(undefined);
+    return Curry._1(setupChromeDebugger, undefined);
   }
   
 }

--- a/lib/js/caml_chrome_debugger.js
+++ b/lib/js/caml_chrome_debugger.js
@@ -1,123 +1,127 @@
 'use strict';
 
 var Block = require("./block.js");
+var Curry = require("./curry.js");
 
-var setupChromeDebugger = (function(_){
- 
- // I don't know how to directly refer to the classes that chrome's built-in
- // formatters use. adding "class": "foo" doesn't seem to work
- // tree-outline
- var olStyle = {"style": "list-style-type: none; padding-left: 12px; margin: 0"}
- // object-properties-section-separator
- var colonStyle = {"style": "flex-shrink: 0; padding-right: 5px"}
- 
+var setupChromeDebugger = (function () {
+  // I don't know how to directly refer to the classes that chrome's built-in
+  // formatters use. adding "class": "foo" doesn't seem to work
+  // tree-outline
+  var olStyle = {
+    style: "list-style-type: none; padding-left: 12px; margin: 0",
+  };
+  // object-properties-section-separator
+  var colonStyle = { style: "flex-shrink: 0; padding-right: 5px" };
 
- var showObject = function (value) {
-   if (value == undefined) {
-     return value + ''
-   } else {
-     return ["object", {"object": value}]
-   }
- }
- 
+  var renderObject = function (value) {
+    if (value == undefined) {
+      return value + "";
+    } else {
+      return ["object", { object: value }];
+    }
+  };
 
-var listToArray = function (data){
- var result = []
- var cur = data
- var index = 0
- while(typeof cur !== "number"){
-   result.push([
-     "li",
-     {},
-     ["span", {"style": "color: rgb(227, 110, 236)"}, index],
-     ["span", colonStyle, ":"],
-     showObject(cur[0])
-   ]);
-   cur = cur[1]
-   index++
- }
- return result
-};
+  var listToArray = function (data) {
+    var result = [];
+    var cur = data;
+    var index = 0;
+    while (typeof cur !== "number") {
+      result.push([
+        "li",
+        {},
+        ["span", { style: "color: rgb(227, 110, 236)" }, index],
+        ["span", colonStyle, ":"],
+        renderObject(cur[0]),
+      ]);
+      cur = cur[1];
+      index++;
+    }
+    return result;
+  };
 
-var variantCustomFormatter = function (data,recordVariant){
- if(recordVariant === "::"){
-   return [
-     "ol",
-     olStyle,
-     ... listToArray(data)
-   ]
- } else {
-    let spacedData = [];
-    data.forEach(cur => {
-      spacedData.push(["span", {"style": "margin-right: 12px"}, showObject(cur)]);
-    })
-     return ["ol", olStyle, ...spacedData]
- }
+  var renderRecord = function (data, recordVariant) {
+    if (recordVariant === "::") {
+      return ["ol", olStyle, ...listToArray(data)];
+    } else {
+      let spacedData = [];
+      data.forEach((cur) => {
+        spacedData.push([
+          "span",
+          { style: "margin-right: 12px" },
+          renderObject(cur),
+        ]);
+      });
+      return ["ol", olStyle, ...spacedData];
+    }
+  };
 
-};
+  var renderVariant = function (x, recordVariant) {
+    if (recordVariant === "::") {
+      // show the length, just like for array
+      var length = listToArray(x).length;
+      return ["span", {}, `List(${length})`];
+    }
+    return ["span", {}, `${recordVariant}(…)`];
+  };
 
-var variantPreview = function (x, recordVariant){
- if(recordVariant === "::") {
-   // show the length, just like for array
-   var length = listToArray(x).length;
-   return ['span', {}, `list(${length})`]
- }
- return ['span', {}, `${recordVariant}(…)`]
-};
-var isOCamlExceptionOrExtensionHead = function(x){
- return Array.isArray(x) && x.tag === 248 && typeof x[0] === "string"
-}
-var isOCamlExceptionOrExtension = function(x){
- return Array.isArray(x) &&
-       x[0] !== undefined &&
-       isOCamlExceptionOrExtensionHead(x[0])
-}
-var formatter = {
- header: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant =  x[Symbol.for('BsVariant')]) !== undefined){
-         return variantPreview(x, recordVariant)
-     } else if (isOCamlExceptionOrExtension(x)){
-       return ['div',{}, `${x[0][0]}(…)`]     
-     } else if ((recordPolyVar = x[Symbol.for('BsPolyVar')] ) !== undefined){
-       return ['div', {}, `\`${recordPolyVar}#${x[0]}`]
-     }
-     return null
- },
- hasBody: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant = x[Symbol.for('BsVariant')] ) !== undefined){
-         return recordVariant
-     } else if(isOCamlExceptionOrExtension(x)){
-       return true
-     } else if( (recordPolyVar = x[Symbol.for('BsPolyVar')]) !== undefined){
-       return true
-     }
-     return false
- },
- body: function (x) {
-     var recordVariant
-     var recordPolyVar
-     if ((recordVariant = x[Symbol.for('BsVariant')]) !== undefined) {
-             return variantCustomFormatter(x,recordVariant)
-     }
-     else if ((recordPolyVar = x [Symbol.for('BsPolyVar')]) !== undefined){
-       return showObject(x[1])
-     }
-     else if(isOCamlExceptionOrExtension(x)){
-       return ["ol", olStyle, ... x.slice(1).map(cur => showObject(cur))]
-     }
+  var isOCamlExceptionOrExtensionHead = function (x) {
+    return Array.isArray(x) && x.tag === 248 && typeof x[0] === "string";
+  };
 
- }
+  var isOCamlExceptionOrExtension = function (x) {
+    return (
+      Array.isArray(x) &&
+      x[0] !== undefined &&
+      isOCamlExceptionOrExtensionHead(x[0])
+    );
+  };
 
-}
-if (typeof window === "undefined"){
- global.devtoolsFormatters = [formatter]
-} else {
- window.devtoolsFormatters = [formatter]
-}
+  var Formatter = {
+    header: function (data) {
+      var recordVariant = data[Symbol.for("BsVariant")];
+      var polyVariant = data[Symbol.for("BsPolyVar")];
+
+      if (recordVariant !== undefined) {
+        return renderVariant(data, recordVariant);
+      } else if (isOCamlExceptionOrExtension(data)) {
+        return ["div", {}, `${data[0][0]}(…)`];
+      } else if (polyVariant !== undefined) {
+        return ["div", {}, `\`${recordPolyVar}#${data[0]}`];
+      }
+      return null;
+    },
+    hasBody: function (data) {
+      var recordVariant = data[Symbol.for("BsVariant")];
+      var polyVariant = data[Symbol.for("BsPolyVar")];
+
+      return (
+        recordVariant !== undefined ||
+        isOCamlExceptionOrExtension(data) ||
+        polyVariant !== undefined ||
+        false
+      );
+    },
+    body: function (data) {
+      var recordVariant = data[Symbol.for("BsVariant")];
+      var polyVariant = data[Symbol.for("BsPolyVar")];
+
+      if (recordVariant !== undefined) {
+        return renderRecord(data, recordVariant);
+      } else if (polyVariant !== undefined) {
+        return renderObject(data[1]);
+      } else if (isOCamlExceptionOrExtension(x)) {
+        return ["ol", olStyle, ...data.slice(1).map(renderObject)];
+      }
+    },
+  };
+
+  if (typeof window === "undefined") {
+    global.devtoolsFormatters = global.devtoolsFormatters || [];
+    global.devtoolsFormatters.push(Formatter);
+  } else {
+    window.devtoolsFormatters = window.devtoolsFormatters || [];
+    window.devtoolsFormatters.push(Formatter);
+  }
 });
 
 var setup = {
@@ -127,7 +131,7 @@ var setup = {
 function setupOnce(param) {
   if (!setup.contents) {
     setup.contents = true;
-    return setupChromeDebugger(undefined);
+    return Curry._1(setupChromeDebugger, undefined);
   }
   
 }


### PR DESCRIPTION
Hey,

I changed how the runtime on the debug mode was adding the customFormatter in order to not override other formatters.

The only difference is this diff, the rest is JS formatting, let me know if you prefer to keep the old one and I can revert it and keep the PR "clean"

```diff
if (typeof window === "undefined"){
-    global.devtoolsFormatters = [formatter]
+    global.devtoolsFormatters = global.devtoolsFormatters || [];
+    global.devtoolsFormatters.push(Formatter);
} else {
-    window.devtoolsFormatters = [formatter]
+    window.devtoolsFormatters = window.devtoolsFormatters || [];
+    window.devtoolsFormatters.push(Formatter);
}
```