### PR TITLE
Changes needed to compile reason/refmt with bucklescript

### DIFF
--- a/jscomp/stdlib-406/obj.ml
+++ b/jscomp/stdlib-406/obj.ml
@@ -37,7 +37,9 @@ external truncate : t -> int -> unit = "caml_obj_truncate"
 
 
 
-
+let lazy_tag = 246
+let object_tag = 248
+let forward_tag = 250
 
 
 module Ephemeron = struct

--- a/jscomp/stdlib-406/obj.mli
+++ b/jscomp/stdlib-406/obj.mli
@@ -57,6 +57,9 @@ external set_field : t -> int -> t -> unit = "%obj_set_field"
 external dup : t -> t = "caml_obj_dup"
 external truncate : t -> int -> unit = "caml_obj_truncate"
 
+val lazy_tag : int
+val object_tag : int
+val forward_tag : int
 
 module Ephemeron: sig
   (** Ephemeron with arbitrary arity and untyped *)

--- a/jscomp/stdlib-406/sys.ml
+++ b/jscomp/stdlib-406/sys.ml
@@ -26,7 +26,6 @@ type backend_type =
 (* System interface *)
 
 (* external get_config: unit -> string * int * bool = "caml_sys_get_config" *)
-external get_argv: unit -> string * string array = "caml_sys_get_argv"
 external big_endian : unit -> bool = "%big_endian"
 external word_size : unit -> int = "%word_size"
 external int_size : unit -> int = "%int_size"
@@ -36,7 +35,8 @@ external win32 : unit -> bool = "%ostype_win32"
 external cygwin : unit -> bool = "%ostype_cygwin"
 external get_backend_type : unit -> backend_type = "%backend_type"
 
-let (executable_name, argv) = get_argv()
+let (executable_name, argv) = "bs-browser", [||]
+
 #if BS then
 external get_os_type : unit -> string = "#os_type"
 let os_type = get_os_type ()

--- a/lib/es6/obj.js
+++ b/lib/es6/obj.js
@@ -10,6 +10,12 @@ function length(x) {
   return x.length - 2 | 0;
 }
 
+var lazy_tag = 246;
+
+var object_tag = 248;
+
+var forward_tag = 250;
+
 function Ephemeron_create(prim) {
   return Caml_external_polyfill.resolve("caml_ephe_create")(prim);
 }
@@ -81,6 +87,9 @@ var Ephemeron = {
 
 export {
   is_block ,
+  lazy_tag ,
+  object_tag ,
+  forward_tag ,
   Ephemeron ,
   
 }

--- a/lib/es6/sys.js
+++ b/lib/es6/sys.js
@@ -3,7 +3,7 @@
 import * as Caml_sys from "./caml_sys.js";
 import * as Caml_exceptions from "./caml_exceptions.js";
 
-var match = Caml_sys.caml_sys_get_argv(undefined);
+var argv = [];
 
 var os_type = Caml_sys.os_type(undefined);
 
@@ -45,9 +45,7 @@ function runtime_warnings_enabled(param) {
   return false;
 }
 
-var argv = match[1];
-
-var executable_name = match[0];
+var executable_name = "bs-browser";
 
 var cygwin = false;
 

--- a/lib/js/obj.js
+++ b/lib/js/obj.js
@@ -10,6 +10,12 @@ function length(x) {
   return x.length - 2 | 0;
 }
 
+var lazy_tag = 246;
+
+var object_tag = 248;
+
+var forward_tag = 250;
+
 function Ephemeron_create(prim) {
   return Caml_external_polyfill.resolve("caml_ephe_create")(prim);
 }
@@ -80,5 +86,8 @@ var Ephemeron = {
 };
 
 exports.is_block = is_block;
+exports.lazy_tag = lazy_tag;
+exports.object_tag = object_tag;
+exports.forward_tag = forward_tag;
 exports.Ephemeron = Ephemeron;
 /* No side effect */

--- a/lib/js/sys.js
+++ b/lib/js/sys.js
@@ -3,7 +3,7 @@
 var Caml_sys = require("./caml_sys.js");
 var Caml_exceptions = require("./caml_exceptions.js");
 
-var match = Caml_sys.caml_sys_get_argv(undefined);
+var argv = [];
 
 var os_type = Caml_sys.os_type(undefined);
 
@@ -45,9 +45,7 @@ function runtime_warnings_enabled(param) {
   return false;
 }
 
-var argv = match[1];
-
-var executable_name = match[0];
+var executable_name = "bs-browser";
 
 var cygwin = false;
 


### PR DESCRIPTION
I managed to compile `refmt` as a 1st class citizen BuckleScript library and run it in the browser successfully thanks to the bspacked `Js_refmt_compiler` artifact generated by ninja. See https://github.com/jchavarri/bs-refmt.

Some people have mentioned interest to have access to Reason AST using BuckleScript (cc @sgrove) [and also my old self](https://reasonml.chat/t/ocaml-migrate-parsetree-for-bucklescript/1034) 😄 . I know the playground is not critical path, but having a version of BuckleScript that can compile refmt could allow the community to experiment and create more playgrounds & learning tools for Reason and BuckleScript.

These PR includes the changes needed in the compiler to make it work. I understand the `Sys.ml` change is not mergeable as is, maybe we could set `BS_BROWSER` env var when running `ninja build -playground` so the datasets get this change when building the compiler for browser?

https://github.com/BuckleScript/bucklescript/blob/5f7f45a97061b5ed9f249b63f66603506845d44b/scripts/ninja.js#L1778