### PR TITLE
Playground: Bring back load_modules API

### DIFF
--- a/jscomp/core/config_util.ml
+++ b/jscomp/core/config_util.ml
@@ -30,7 +30,7 @@
 let find_in_path_uncap path name =
   let uname = Ext_string.uncapitalize_ascii name in
   let rec try_dir = function
-    | [] -> None
+    | [] -> if Sys.file_exists name then Some name else None
     | dir::rem ->      
       let ufullname = Filename.concat dir uname in
       if Sys.file_exists ufullname then Some ufullname

--- a/jscomp/core/config_util.ml
+++ b/jscomp/core/config_util.ml
@@ -30,7 +30,7 @@
 let find_in_path_uncap path name =
   let uname = Ext_string.uncapitalize_ascii name in
   let rec try_dir = function
-    | [] -> if Sys.file_exists name then Some name else None
+    | [] -> None
     | dir::rem ->      
       let ufullname = Filename.concat dir uname in
       if Sys.file_exists ufullname then Some ufullname

--- a/jscomp/main/jsoo_main.ml
+++ b/jscomp/main/jsoo_main.ml
@@ -103,29 +103,9 @@ let implementation ~use_super_errors impl str  : Js.Unsafe.obj =
 let compile impl ~use_super_errors  =
     implementation ~use_super_errors impl
 
-
-
-
-(* let load_module cmi_path cmi_content cmj_name cmj_content =
-  Js.create_file cmi_path cmi_content;
-  Js_cmj_datasets.data_sets :=
-    Map_string.add !Js_cmj_datasets.data_sets
-      cmj_name (lazy (Js_cmj_format.from_string cmj_content))
-       *)
-
-
 let export (field : string) v =
   Js.Unsafe.set (Js.Unsafe.global) field v
 ;;
-
-(* To add a directory to the load path *)
-
-let dir_directory d =
-  Config.load_path := d :: !Config.load_path
-
-
-let () =
-  dir_directory "/static/cmis"
 
 let make_compiler name impl =
   export name
@@ -141,15 +121,12 @@ let make_compiler name impl =
                       (fun _ code ->
                          (compile impl ~use_super_errors:true (Js.to_string code)));                    
                     "version", Js.Unsafe.inject (Js.string (Bs_version.version));
-                    (* "load_module",
+                    "load_module",
                     inject @@
                     Js.wrap_meth_callback
-                      (fun _ cmi_path cmi_content cmj_name cmj_content ->
-                        let cmj_bytestring = Js.to_bytestring cmj_content in
-                        (* HACK: force string tag to ASCII (9) to avoid
-                         * UTF-8 encoding *)
-                        Js.Unsafe.set cmj_bytestring "t" 9;
-                        load_module cmi_path cmi_content (Js.to_string cmj_name) cmj_bytestring); *)
+                      (fun _ cmi_path cmi_content cmj_path cmj_content ->
+                        Js.create_file cmi_path cmi_content;
+                        Js.create_file cmj_path cmj_content);
                   |]))
 let () = make_compiler "ocaml" Parse.implementation
 

--- a/jscomp/main/jsoo_main.ml
+++ b/jscomp/main/jsoo_main.ml
@@ -107,6 +107,13 @@ let export (field : string) v =
   Js.Unsafe.set (Js.Unsafe.global) field v
 ;;
 
+(* To add a directory to the load path *)
+
+let dir_directory d =
+  Config.load_path := d :: !Config.load_path
+let () =
+  dir_directory "/static"
+
 let make_compiler name impl =
   export name
     (Js.Unsafe.(obj


### PR DESCRIPTION
This patch is the result of an exploration to bring back the `load_modules` API, which was recently disabled.

The proposed approach is to double down on the usage of js_of_ocaml pseudo file system to load these modules. As can be seen, the implementation of `load_modules` API for the playground is really simple, just a couple of calls to `Js.create_file` to load both cmi and cmj files into jsoo pseudo file system.

### Advantages of using pseudo file system

- Because we rely on js_of_ocaml on both "sides" —to consume the modules in the browser, and also to generate them as can be seen in section below— , it is highly unlikely this approach will break, as that would mean js_of_ocaml pseudo file system would be broken.
- Using jsoo pseudo-file system removes the need to update references to compiler functions like `Env.Persistent_signature.load` or `Js_cmj_load.load_unit`, it's just files all the way down.
- Future proof: From what I discussed with @bobzhang, it is very unlikely that bsb will remove support from reading module binaries from files in the future, regardless how the recently added in-memory loading evolves.
- No more need for [hacks](https://github.com/BuckleScript/bucklescript/blob/master/jscomp/main/jsoo_main.ml#L149) to trick jsoo into skipping utf-16=>utf-8 conversions

### Converting from traditional cmi/cmj files to browser-ready files

To complete the process of being able to compile code that references 3rd party BuckleScript libs on the browser, the plan is to have another small program that allows to create "browser-ready cmijs" from `node_modules` folder, a proof of concept of what this package could look like can be seen in https://github.com/jchavarri/bs-playground-bundler.

The generation of resulting scripts relies on js_of_ocaml [pseudo file system](https://github.com/jchavarri/bs-playground-bundler/blob/master/lib/BsEmbed.re#L115-L120) to convert the binary representation of cmis into the utf-16 strings that will be loaded from the browser.

### Remaining work

If this PR gets approved and merged, I will proceed then with other tasks to clean up / update other points:
- Remove support for `-playground` flag in `cmij_main`
- Port changes to `jsoo_refmt_main`