### PR TITLE
[playground] fix jsoo_refmt_main, remove load_modules as not necessary

### DIFF
--- a/jscomp/main/jsoo_main.ml
+++ b/jscomp/main/jsoo_main.ml
@@ -128,12 +128,6 @@ let make_compiler name impl =
                       (fun _ code ->
                          (compile impl ~use_super_errors:true (Js.to_string code)));                    
                     "version", Js.Unsafe.inject (Js.string (Bs_version.version));
-                    "load_module",
-                    inject @@
-                    Js.wrap_meth_callback
-                      (fun _ cmi_path cmi_content cmj_path cmj_content ->
-                        Js.create_file cmi_path cmi_content;
-                        Js.create_file cmj_path cmj_content);
                   |]))
 let () = make_compiler "ocaml" Parse.implementation
 

--- a/jscomp/refmt/jsoo_refmt_main.ml
+++ b/jscomp/refmt/jsoo_refmt_main.ml
@@ -102,23 +102,15 @@ let implementation ~use_super_errors impl str  : Js.Unsafe.obj =
 let compile ~use_super_errors impl =
     implementation ~use_super_errors impl
 
-(* let load_module cmi_path cmi_content cmj_name cmj_content =
-  Js.create_file cmi_path cmi_content;
-  Js_cmj_datasets.data_sets :=
-    Map_string.add !Js_cmj_datasets.data_sets
-      cmj_name (lazy (Js_cmj_format.from_string cmj_content)) *)
-
 let export (field : string) v =
   Js.Unsafe.set (Js.Unsafe.global) field v
 ;;
 
 (* To add a directory to the load path *)
-(* 
 let dir_directory d =
   Config.load_path := d :: !Config.load_path
-
 let () =
-  dir_directory "/static/cmis" *)
+  dir_directory "/static"
 
 module Converter = Refmt_api.Migrate_parsetree.Convert(Refmt_api.Migrate_parsetree.OCaml_404)(Refmt_api.Migrate_parsetree.OCaml_406)
 
@@ -139,15 +131,6 @@ let make_compiler ~name impl=
                       (fun _ code ->
                          (compile impl ~use_super_errors:true (Js.to_string code)));
                     "version", Js.Unsafe.inject (Js.string (match name with | "reason" -> Refmt_api.version | _ -> Bs_version.version));
-                    (* "load_module",
-                    inject @@
-                    Js.wrap_meth_callback
-                      (fun _ cmi_path cmi_content cmj_name cmj_content ->
-                        let cmj_bytestring = Js.to_bytestring cmj_content in
-                        (* HACK: force string tag to ASCII (9) to avoid
-                         * UTF-8 encoding *)
-                        Js.Unsafe.set cmj_bytestring "t" 9;
-                        load_module cmi_path cmi_content (Js.to_string cmj_name) cmj_bytestring); *)
                   |]))
 
 let () = make_compiler ~name:"ocaml" Parse.implementation


### PR DESCRIPTION
Adds `"/static"` to directory in `jsoo_refmt_main` (like `jsoo_main`).

Removes `load_modules` as it's not needed anymore. Using `js_of_ocaml.bc build-fs` creates a JS file that will add a file to jsoo pseudo file system directly when loaded, removing the need for providing an API hook on the compiler.

cc @ryyppy 