### PR TITLE
fix #4413 -- make Some (None) not depending on physical equivalence

### DIFF
--- a/jscomp/runtime/caml_option.mli
+++ b/jscomp/runtime/caml_option.mli
@@ -22,6 +22,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+ type nested = {
+    depth : int ; [@bs.as "BS_PRIVATE_NESTED_SOME_NONE"]
+  } 
 
 val nullable_to_opt : 'a Js.null_undefined -> 'a option
 
@@ -32,6 +35,8 @@ val null_to_opt : 'a Js.null -> 'a option
 val valFromOption : Obj.t -> Obj.t 
 
 val some : Obj.t -> Obj.t 
+
+val isNested : Obj.t -> bool 
 
 val option_get : Obj.t option -> Obj.t Caml_undefined_extern.t 
 

--- a/jscomp/runtime/release.ninja
+++ b/jscomp/runtime/release.ninja
@@ -29,9 +29,9 @@ build runtime/caml_hash_primitive.cmj : cc_cmi runtime/caml_hash_primitive.ml | 
 build runtime/caml_hash_primitive.cmi : cc runtime/caml_hash_primitive.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 build runtime/caml_int32.cmj : cc_cmi runtime/caml_int32.ml | runtime/caml_int32.cmi runtime/caml_nativeint_extern.cmj
 build runtime/caml_int32.cmi : cc runtime/caml_int32.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-build runtime/caml_int64.cmj : cc_cmi runtime/caml_int64.ml | runtime/caml_float.cmj runtime/caml_float_extern.cmj runtime/caml_int64.cmi runtime/caml_nativeint_extern.cmj runtime/caml_string_extern.cmj runtime/js.cmj
+build runtime/caml_int64.cmj : cc_cmi runtime/caml_int64.ml | runtime/caml_float.cmj runtime/caml_float_extern.cmj runtime/caml_int64.cmi runtime/caml_nativeint_extern.cmj runtime/caml_primitive.cmj runtime/caml_string_extern.cmj runtime/js.cmj
 build runtime/caml_int64.cmi : cc runtime/caml_int64.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-build runtime/caml_io.cmj : cc_cmi runtime/caml_io.ml | runtime/caml_io.cmi runtime/caml_string_extern.cmj runtime/caml_undefined_extern.cmj runtime/js.cmj
+build runtime/caml_io.cmj : cc_cmi runtime/caml_io.ml | runtime/caml_io.cmi runtime/caml_string_extern.cmj runtime/caml_undefined_extern.cmj runtime/curry.cmj runtime/js.cmj
 build runtime/caml_io.cmi : cc runtime/caml_io.mli | runtime/bs_stdlib_mini.cmi runtime/caml_undefined_extern.cmj runtime/js.cmi runtime/js.cmj
 build runtime/caml_lexer.cmj : cc_cmi runtime/caml_lexer.ml | runtime/caml_lexer.cmi
 build runtime/caml_lexer.cmi : cc runtime/caml_lexer.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
@@ -39,9 +39,9 @@ build runtime/caml_md5.cmj : cc_cmi runtime/caml_md5.ml | runtime/caml_array_ext
 build runtime/caml_md5.cmi : cc runtime/caml_md5.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 build runtime/caml_module.cmj : cc_cmi runtime/caml_module.ml | runtime/caml_array_extern.cmj runtime/caml_module.cmi runtime/caml_obj.cmj
 build runtime/caml_module.cmi : cc runtime/caml_module.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-build runtime/caml_obj.cmj : cc_cmi runtime/caml_obj.ml | runtime/caml_array_extern.cmj runtime/caml_obj.cmi runtime/js.cmj
+build runtime/caml_obj.cmj : cc_cmi runtime/caml_obj.ml | runtime/caml_array_extern.cmj runtime/caml_obj.cmi runtime/caml_option.cmj runtime/caml_primitive.cmj runtime/js.cmj
 build runtime/caml_obj.cmi : cc runtime/caml_obj.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-build runtime/caml_oo.cmj : cc_cmi runtime/caml_oo.ml | runtime/caml_array_extern.cmj runtime/caml_exceptions.cmj runtime/caml_oo.cmi
+build runtime/caml_oo.cmj : cc_cmi runtime/caml_oo.ml | runtime/caml_array.cmj runtime/caml_array_extern.cmj runtime/caml_exceptions.cmj runtime/caml_oo.cmi
 build runtime/caml_oo.cmi : cc runtime/caml_oo.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 build runtime/caml_option.cmj : cc_cmi runtime/caml_option.ml | runtime/caml_option.cmi runtime/caml_undefined_extern.cmj runtime/js.cmj
 build runtime/caml_option.cmi : cc runtime/caml_option.mli | runtime/bs_stdlib_mini.cmi runtime/caml_undefined_extern.cmj runtime/js.cmi runtime/js.cmj
@@ -63,10 +63,10 @@ build runtime/caml_external_polyfill.cmi runtime/caml_external_polyfill.cmj : cc
 build runtime/caml_float_extern.cmi runtime/caml_float_extern.cmj : cc runtime/caml_float_extern.ml | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 build runtime/caml_int32_extern.cmi runtime/caml_int32_extern.cmj : cc runtime/caml_int32_extern.ml | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 build runtime/caml_int64_extern.cmi runtime/caml_int64_extern.cmj : cc runtime/caml_int64_extern.ml | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-build runtime/caml_js_exceptions.cmi runtime/caml_js_exceptions.cmj : cc runtime/caml_js_exceptions.ml | runtime/bs_stdlib_mini.cmi runtime/caml_exceptions.cmj runtime/js.cmi runtime/js.cmj
+build runtime/caml_js_exceptions.cmi runtime/caml_js_exceptions.cmj : cc runtime/caml_js_exceptions.ml | runtime/bs_stdlib_mini.cmi runtime/caml_exceptions.cmj runtime/caml_option.cmj runtime/js.cmi runtime/js.cmj
 build runtime/caml_nativeint_extern.cmi runtime/caml_nativeint_extern.cmj : cc runtime/caml_nativeint_extern.ml | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 build runtime/caml_oo_curry.cmi runtime/caml_oo_curry.cmj : cc runtime/caml_oo_curry.ml | runtime/bs_stdlib_mini.cmi runtime/caml_oo.cmj runtime/curry.cmj runtime/js.cmi runtime/js.cmj
 build runtime/caml_string_extern.cmi runtime/caml_string_extern.cmj : cc runtime/caml_string_extern.ml | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 build runtime/caml_undefined_extern.cmi runtime/caml_undefined_extern.cmj : cc runtime/caml_undefined_extern.ml | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-build runtime/curry.cmi runtime/curry.cmj : cc runtime/curry.ml | runtime/bs_stdlib_mini.cmi runtime/caml_array_extern.cmj runtime/js.cmi runtime/js.cmj
+build runtime/curry.cmi runtime/curry.cmj : cc runtime/curry.ml | runtime/bs_stdlib_mini.cmi runtime/caml_array.cmj runtime/caml_array_extern.cmj runtime/js.cmi runtime/js.cmj
 build runtime : phony runtime/bs_stdlib_mini.cmi runtime/js.cmj runtime/js.cmi runtime/caml_array.cmi runtime/caml_array.cmj runtime/caml_bytes.cmi runtime/caml_bytes.cmj runtime/caml_float.cmi runtime/caml_float.cmj runtime/caml_format.cmi runtime/caml_format.cmj runtime/caml_gc.cmi runtime/caml_gc.cmj runtime/caml_hash.cmi runtime/caml_hash.cmj runtime/caml_hash_primitive.cmi runtime/caml_hash_primitive.cmj runtime/caml_int32.cmi runtime/caml_int32.cmj runtime/caml_int64.cmi runtime/caml_int64.cmj runtime/caml_io.cmi runtime/caml_io.cmj runtime/caml_lexer.cmi runtime/caml_lexer.cmj runtime/caml_md5.cmi runtime/caml_md5.cmj runtime/caml_module.cmi runtime/caml_module.cmj runtime/caml_obj.cmi runtime/caml_obj.cmj runtime/caml_oo.cmi runtime/caml_oo.cmj runtime/caml_option.cmi runtime/caml_option.cmj runtime/caml_parser.cmi runtime/caml_parser.cmj runtime/caml_primitive.cmi runtime/caml_primitive.cmj runtime/caml_splice_call.cmi runtime/caml_splice_call.cmj runtime/caml_string.cmi runtime/caml_string.cmj runtime/caml_sys.cmi runtime/caml_sys.cmj runtime/caml_array_extern.cmi runtime/caml_array_extern.cmj runtime/caml_bytes_extern.cmi runtime/caml_bytes_extern.cmj runtime/caml_char.cmi runtime/caml_char.cmj runtime/caml_exceptions.cmi runtime/caml_exceptions.cmj runtime/caml_external_polyfill.cmi runtime/caml_external_polyfill.cmj runtime/caml_float_extern.cmi runtime/caml_float_extern.cmj runtime/caml_int32_extern.cmi runtime/caml_int32_extern.cmj runtime/caml_int64_extern.cmi runtime/caml_int64_extern.cmj runtime/caml_js_exceptions.cmi runtime/caml_js_exceptions.cmj runtime/caml_nativeint_extern.cmi runtime/caml_nativeint_extern.cmj runtime/caml_oo_curry.cmi runtime/caml_oo_curry.cmj runtime/caml_string_extern.cmi runtime/caml_string_extern.cmj runtime/caml_undefined_extern.cmi runtime/caml_undefined_extern.cmj runtime/curry.cmi runtime/curry.cmj

--- a/lib/es6/caml_obj.js
+++ b/lib/es6/caml_obj.js
@@ -92,42 +92,42 @@ function caml_compare(a, b) {
         return -1;
       }
       if (a_type === "number") {
-        if (b === null || b.TAG === 256) {
+        if (b === null || b.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
           return 1;
         } else {
           return -1;
         }
       }
       if (b_type === "number") {
-        if (a === null || a.TAG === 256) {
+        if (a === null || a.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
           return -1;
         } else {
           return 1;
         }
       }
       if (a === null) {
-        if (b.TAG === 256) {
+        if (b.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
           return 1;
         } else {
           return -1;
         }
       }
       if (b === null) {
-        if (a.TAG === 256) {
+        if (a.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
           return -1;
         } else {
           return 1;
         }
       }
-      var tag_a = a.TAG | 0;
-      var tag_b = b.TAG | 0;
-      if (tag_a === 256) {
-        if (tag_b === 256) {
-          return Caml_primitive.caml_int_compare(a[1], b[1]);
+      if (a.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
+        if (b.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
+          return aux_obj_compare(a, b);
         } else {
           return -1;
         }
       }
+      var tag_a = a.TAG | 0;
+      var tag_b = b.TAG | 0;
       if (tag_a === 248) {
         return Caml_primitive.caml_int_compare(a[1], b[1]);
       }
@@ -165,57 +165,7 @@ function caml_compare(a, b) {
         } else if ((a instanceof Date && b instanceof Date)) {
           return (a - b);
         } else {
-          var min_key_lhs = {
-            contents: undefined
-          };
-          var min_key_rhs = {
-            contents: undefined
-          };
-          var do_key = function (param, key) {
-            var min_key = param[2];
-            var b = param[1];
-            if (!(!b.hasOwnProperty(key) || caml_compare(param[0][key], b[key]) > 0)) {
-              return ;
-            }
-            var mk = min_key.contents;
-            if (mk !== undefined && key >= mk) {
-              return ;
-            } else {
-              min_key.contents = key;
-              return ;
-            }
-          };
-          var partial_arg = [
-            a,
-            b,
-            min_key_rhs
-          ];
-          var do_key_a = function (param) {
-            return do_key(partial_arg, param);
-          };
-          var partial_arg$1 = [
-            b,
-            a,
-            min_key_lhs
-          ];
-          var do_key_b = function (param) {
-            return do_key(partial_arg$1, param);
-          };
-          for_in(a, do_key_a);
-          for_in(b, do_key_b);
-          var match = min_key_lhs.contents;
-          var match$1 = min_key_rhs.contents;
-          if (match !== undefined) {
-            if (match$1 !== undefined) {
-              return Caml_primitive.caml_string_compare(match, match$1);
-            } else {
-              return -1;
-            }
-          } else if (match$1 !== undefined) {
-            return 1;
-          } else {
-            return 0;
-          }
+          return aux_obj_compare(a, b);
         }
       } else if (len_a < len_b) {
         var _i$1 = 0;
@@ -246,6 +196,60 @@ function caml_compare(a, b) {
           continue ;
         };
       }
+  }
+}
+
+function aux_obj_compare(a, b) {
+  var min_key_lhs = {
+    contents: undefined
+  };
+  var min_key_rhs = {
+    contents: undefined
+  };
+  var do_key = function (param, key) {
+    var min_key = param[2];
+    var b = param[1];
+    if (!(!b.hasOwnProperty(key) || caml_compare(param[0][key], b[key]) > 0)) {
+      return ;
+    }
+    var mk = min_key.contents;
+    if (mk !== undefined && key >= mk) {
+      return ;
+    } else {
+      min_key.contents = key;
+      return ;
+    }
+  };
+  var partial_arg = [
+    a,
+    b,
+    min_key_rhs
+  ];
+  var do_key_a = function (param) {
+    return do_key(partial_arg, param);
+  };
+  var partial_arg$1 = [
+    b,
+    a,
+    min_key_lhs
+  ];
+  var do_key_b = function (param) {
+    return do_key(partial_arg$1, param);
+  };
+  for_in(a, do_key_a);
+  for_in(b, do_key_b);
+  var match = min_key_lhs.contents;
+  var match$1 = min_key_rhs.contents;
+  if (match !== undefined) {
+    if (match$1 !== undefined) {
+      return Caml_primitive.caml_string_compare(match, match$1);
+    } else {
+      return -1;
+    }
+  } else if (match$1 !== undefined) {
+    return 1;
+  } else {
+    return 0;
   }
 }
 
@@ -282,9 +286,6 @@ function caml_equal(a, b) {
   }
   if (tag_a !== tag_b) {
     return false;
-  }
-  if (tag_a === 256) {
-    return a[1] === b[1];
   }
   var len_a = a.length | 0;
   var len_b = b.length | 0;

--- a/lib/es6/caml_option.js
+++ b/lib/es6/caml_option.js
@@ -1,31 +1,26 @@
 
 
 
-var undefinedHeader = [];
+function isNested(x) {
+  return x.BS_PRIVATE_NESTED_SOME_NONE !== undefined;
+}
 
 function some(x) {
   if (x === undefined) {
-    var block = [
-      undefinedHeader,
-      0
-    ];
-    block.TAG = 256;
-    return block;
-  }
-  if (!(x !== null && x[0] === undefinedHeader)) {
+    return {
+            BS_PRIVATE_NESTED_SOME_NONE: 0
+          };
+  } else if (x !== null && x.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
+    return {
+            BS_PRIVATE_NESTED_SOME_NONE: x.BS_PRIVATE_NESTED_SOME_NONE + 1 | 0
+          };
+  } else {
     return x;
   }
-  var nid = x[1] + 1 | 0;
-  var block$1 = [
-    undefinedHeader,
-    nid
-  ];
-  block$1.TAG = 256;
-  return block$1;
 }
 
 function nullable_to_opt(x) {
-  if (x === null || x === undefined) {
+  if (x == null) {
     return ;
   } else {
     return some(x);
@@ -49,17 +44,16 @@ function null_to_opt(x) {
 }
 
 function valFromOption(x) {
-  if (!(x !== null && x[0] === undefinedHeader)) {
+  if (!(x !== null && x.BS_PRIVATE_NESTED_SOME_NONE !== undefined)) {
     return x;
   }
-  var depth = x[1];
+  var depth = x.BS_PRIVATE_NESTED_SOME_NONE;
   if (depth === 0) {
     return ;
   } else {
-    return [
-            undefinedHeader,
-            depth - 1 | 0
-          ];
+    return {
+            BS_PRIVATE_NESTED_SOME_NONE: depth - 1 | 0
+          };
   }
 }
 
@@ -85,6 +79,7 @@ export {
   null_to_opt ,
   valFromOption ,
   some ,
+  isNested ,
   option_get ,
   option_unwrap ,
   

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -92,42 +92,42 @@ function caml_compare(a, b) {
         return -1;
       }
       if (a_type === "number") {
-        if (b === null || b.TAG === 256) {
+        if (b === null || b.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
           return 1;
         } else {
           return -1;
         }
       }
       if (b_type === "number") {
-        if (a === null || a.TAG === 256) {
+        if (a === null || a.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
           return -1;
         } else {
           return 1;
         }
       }
       if (a === null) {
-        if (b.TAG === 256) {
+        if (b.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
           return 1;
         } else {
           return -1;
         }
       }
       if (b === null) {
-        if (a.TAG === 256) {
+        if (a.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
           return -1;
         } else {
           return 1;
         }
       }
-      var tag_a = a.TAG | 0;
-      var tag_b = b.TAG | 0;
-      if (tag_a === 256) {
-        if (tag_b === 256) {
-          return Caml_primitive.caml_int_compare(a[1], b[1]);
+      if (a.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
+        if (b.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
+          return aux_obj_compare(a, b);
         } else {
           return -1;
         }
       }
+      var tag_a = a.TAG | 0;
+      var tag_b = b.TAG | 0;
       if (tag_a === 248) {
         return Caml_primitive.caml_int_compare(a[1], b[1]);
       }
@@ -165,57 +165,7 @@ function caml_compare(a, b) {
         } else if ((a instanceof Date && b instanceof Date)) {
           return (a - b);
         } else {
-          var min_key_lhs = {
-            contents: undefined
-          };
-          var min_key_rhs = {
-            contents: undefined
-          };
-          var do_key = function (param, key) {
-            var min_key = param[2];
-            var b = param[1];
-            if (!(!b.hasOwnProperty(key) || caml_compare(param[0][key], b[key]) > 0)) {
-              return ;
-            }
-            var mk = min_key.contents;
-            if (mk !== undefined && key >= mk) {
-              return ;
-            } else {
-              min_key.contents = key;
-              return ;
-            }
-          };
-          var partial_arg = [
-            a,
-            b,
-            min_key_rhs
-          ];
-          var do_key_a = function (param) {
-            return do_key(partial_arg, param);
-          };
-          var partial_arg$1 = [
-            b,
-            a,
-            min_key_lhs
-          ];
-          var do_key_b = function (param) {
-            return do_key(partial_arg$1, param);
-          };
-          for_in(a, do_key_a);
-          for_in(b, do_key_b);
-          var match = min_key_lhs.contents;
-          var match$1 = min_key_rhs.contents;
-          if (match !== undefined) {
-            if (match$1 !== undefined) {
-              return Caml_primitive.caml_string_compare(match, match$1);
-            } else {
-              return -1;
-            }
-          } else if (match$1 !== undefined) {
-            return 1;
-          } else {
-            return 0;
-          }
+          return aux_obj_compare(a, b);
         }
       } else if (len_a < len_b) {
         var _i$1 = 0;
@@ -246,6 +196,60 @@ function caml_compare(a, b) {
           continue ;
         };
       }
+  }
+}
+
+function aux_obj_compare(a, b) {
+  var min_key_lhs = {
+    contents: undefined
+  };
+  var min_key_rhs = {
+    contents: undefined
+  };
+  var do_key = function (param, key) {
+    var min_key = param[2];
+    var b = param[1];
+    if (!(!b.hasOwnProperty(key) || caml_compare(param[0][key], b[key]) > 0)) {
+      return ;
+    }
+    var mk = min_key.contents;
+    if (mk !== undefined && key >= mk) {
+      return ;
+    } else {
+      min_key.contents = key;
+      return ;
+    }
+  };
+  var partial_arg = [
+    a,
+    b,
+    min_key_rhs
+  ];
+  var do_key_a = function (param) {
+    return do_key(partial_arg, param);
+  };
+  var partial_arg$1 = [
+    b,
+    a,
+    min_key_lhs
+  ];
+  var do_key_b = function (param) {
+    return do_key(partial_arg$1, param);
+  };
+  for_in(a, do_key_a);
+  for_in(b, do_key_b);
+  var match = min_key_lhs.contents;
+  var match$1 = min_key_rhs.contents;
+  if (match !== undefined) {
+    if (match$1 !== undefined) {
+      return Caml_primitive.caml_string_compare(match, match$1);
+    } else {
+      return -1;
+    }
+  } else if (match$1 !== undefined) {
+    return 1;
+  } else {
+    return 0;
   }
 }
 
@@ -282,9 +286,6 @@ function caml_equal(a, b) {
   }
   if (tag_a !== tag_b) {
     return false;
-  }
-  if (tag_a === 256) {
-    return a[1] === b[1];
   }
   var len_a = a.length | 0;
   var len_b = b.length | 0;

--- a/lib/js/caml_option.js
+++ b/lib/js/caml_option.js
@@ -1,31 +1,26 @@
 'use strict';
 
 
-var undefinedHeader = [];
+function isNested(x) {
+  return x.BS_PRIVATE_NESTED_SOME_NONE !== undefined;
+}
 
 function some(x) {
   if (x === undefined) {
-    var block = [
-      undefinedHeader,
-      0
-    ];
-    block.TAG = 256;
-    return block;
-  }
-  if (!(x !== null && x[0] === undefinedHeader)) {
+    return {
+            BS_PRIVATE_NESTED_SOME_NONE: 0
+          };
+  } else if (x !== null && x.BS_PRIVATE_NESTED_SOME_NONE !== undefined) {
+    return {
+            BS_PRIVATE_NESTED_SOME_NONE: x.BS_PRIVATE_NESTED_SOME_NONE + 1 | 0
+          };
+  } else {
     return x;
   }
-  var nid = x[1] + 1 | 0;
-  var block$1 = [
-    undefinedHeader,
-    nid
-  ];
-  block$1.TAG = 256;
-  return block$1;
 }
 
 function nullable_to_opt(x) {
-  if (x === null || x === undefined) {
+  if (x == null) {
     return ;
   } else {
     return some(x);
@@ -49,17 +44,16 @@ function null_to_opt(x) {
 }
 
 function valFromOption(x) {
-  if (!(x !== null && x[0] === undefinedHeader)) {
+  if (!(x !== null && x.BS_PRIVATE_NESTED_SOME_NONE !== undefined)) {
     return x;
   }
-  var depth = x[1];
+  var depth = x.BS_PRIVATE_NESTED_SOME_NONE;
   if (depth === 0) {
     return ;
   } else {
-    return [
-            undefinedHeader,
-            depth - 1 | 0
-          ];
+    return {
+            BS_PRIVATE_NESTED_SOME_NONE: depth - 1 | 0
+          };
   }
 }
 
@@ -84,6 +78,7 @@ exports.undefined_to_opt = undefined_to_opt;
 exports.null_to_opt = null_to_opt;
 exports.valFromOption = valFromOption;
 exports.some = some;
+exports.isNested = isNested;
 exports.option_get = option_get;
 exports.option_unwrap = option_unwrap;
 /* No side effect */


### PR DESCRIPTION
Note the main blocking issue that None is not encoded as null is due to bs.obj
for optional fields, if it is None, we don't set it, which matches the semantics of undefined closely. if we compile it to null, we have to set such field as null even if it does not exist

cc @cristianoc 
