### PR TITLE
Make isNested safe

### DIFF
--- a/jscomp/runtime/caml_option.ml
+++ b/jscomp/runtime/caml_option.ml
@@ -29,7 +29,8 @@ type nested = {
 
 (* INPUT: [x] should not be nullable *)
 let isNested (x : Obj.t) : bool = 
-  Obj.repr ((Obj.magic x : nested).depth) != Obj.repr Js.undefined 
+  try Obj.repr ((Obj.magic x : nested).depth) != Obj.repr Js.undefined with
+  _ -> false
 
 let some ( x : Obj.t) : Obj.t = 
   if Obj.magic x =  None then 


### PR DESCRIPTION
When treating a foreign object (such as a frame window), access throws.