### PR TITLE
Fix building ocaml on FreeBSD

### DIFF
--- a/scripts/buildocaml.js
+++ b/scripts/buildocaml.js
@@ -62,15 +62,16 @@ function build(config) {
     );
 
     if (config) {
+      var { make } = require("./config.js");
       cp.execSync(
         "./configure -flambda -prefix " +
           prefix +
-          " -no-ocamlbuild  -no-curses -no-graph -no-pthread -no-debugger && make clean",
+          ` -no-ocamlbuild  -no-curses -no-graph -no-pthread -no-debugger && ${make} clean`,
         { cwd: ocamlSrcDir, stdio: [0, 1, 2] }
       );
     }
 
-    cp.execSync("make -j9 world.opt && make install ", {
+    cp.execSync(`${make} -j9 world.opt && ${make} install `, {
       cwd: ocamlSrcDir,
       stdio: [0, 1, 2]
     });

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -3,7 +3,7 @@ var os = require('os')
 var os_type = os.type()
 
 var is_windows = !(os_type.indexOf('Windows') < 0)
-// var is_bsd = !(os_type.indexOf('BSD') < 0)
+var is_bsd = !(os_type.indexOf('BSD') < 0)
 
 exports.is_windows = is_windows
 var sys_extension;
@@ -17,7 +17,7 @@ switch (os.type()) {
 }
 
 exports.sys_extension  = sys_extension
-// var make = is_bsd ? 'gmake' : 'make'
-// exports.make  = make
+var make = is_bsd ? 'gmake' : 'make'
+exports.make  = make
 
 


### PR DESCRIPTION
ocaml's Makefile is a GNU Makefile. FreeBSD's make is not GNU make, it's
bsd make. To execute GNU Makefile on FreeBSD one must use gmake.

It seems gmake was introduced at some point, but then got disabled for some reason.