### PR TITLE
Add back dependency module

### DIFF
--- a/jscomp/others/release.ninja
+++ b/jscomp/others/release.ninja
@@ -30,7 +30,7 @@ build others/js_json.cmj : cc_cmi others/js_json.ml | others/js_array2.cmj other
 build others/js_json.cmi : cc others/js_json.mli | others/js_dict.cmi others/js_null.cmi others/js_string.cmj others/js_types.cmi runtime
 build others/js_list.cmj : cc_cmi others/js_list.ml | others/js_array2.cmj others/js_list.cmi others/js_vector.cmj runtime
 build others/js_list.cmi : cc others/js_list.mli | others/js_vector.cmi runtime
-build others/js_mapperRt.cmj : cc_cmi others/js_mapperRt.ml | others/js_mapperRt.cmi runtime
+build others/js_mapperRt.cmj : cc_cmi others/js_mapperRt.ml | others/js_array2.cmj others/js_mapperRt.cmi runtime
 build others/js_mapperRt.cmi : cc others/js_mapperRt.mli | runtime
 build others/js_math.cmi others/js_math.cmj : cc others/js_math.ml | others/js_int.cmj runtime
 build others/js_null.cmj : cc_cmi others/js_null.ml | others/js_exn.cmj others/js_null.cmi runtime


### PR DESCRIPTION
It is still needed as per
https://github.com/BuckleScript/bucklescript/pull/4573/files#diff-e0da68698bb17be133a452a8b717c0e6R43