### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 See [COPYING](./COPYING) and [COPYING.LESSER](./COPYING.LESSER)
 
-The [`ocaml`](ocaml) directory contains the official [OCaml](https://ocaml.org) compiler (version 4.02.3).
+The [`ocaml`](ocaml) directory contains the official [OCaml](https://ocaml.org) compiler (version 4.06.1).
 Refer to its copyright and license notices for information about its licensing.
 
 The `vendor/ninja.tar.gz` contains the vendored [ninja](https://github.com/ninja-build/ninja).


### PR DESCRIPTION
Noting that version 4.0.6.1 of OCaml is used instead of 4.0.2.3.