### PR TITLE
add error if the `lib` dir is included in the sources

### DIFF
--- a/jscomp/bsb/bsb_parse_sources.ml
+++ b/jscomp/bsb/bsb_parse_sources.ml
@@ -298,6 +298,9 @@ and parsing_single_source ({ package_kind; is_dev; cwd } as cxt)
           let dir =
             match map.?(Bsb_build_schemas.dir) with
             | Some (Str { str }) ->
+                if str = Literals.library_file then
+                    Bsb_exception.config_error x (Printf.sprintf "dir field should be different from `%s`" Literals.library_file)
+                else
                 Ext_path.simple_convert_node_path_to_os_path str
             | Some x ->
                 Bsb_exception.config_error x "dir expected to be a string"


### PR DESCRIPTION
Add the following error:

```
File "/home/pedro/Desktop/learning-rescript/bsconfig.json", line 4:
Error: dir field should be different from `lib` 
For more details, please checkout the schema https://rescript-lang.org/docs/manual/latest/build-configuration-schema
```

Close #5440