### PR TITLE
Add error message to @@directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 #### :nail_care: Polish
 
 - Update list of reserved JS keywords. https://github.com/rescript-lang/rescript-compiler/pull/6167
+- Add error message to `@@directive`. https://github.com/rescript-lang/rescript-compiler/pull/6174
 
 # 11.0.0-alpha.3
 

--- a/jscomp/build_tests/super_errors/expected/directive_attr.res.expected
+++ b/jscomp/build_tests/super_errors/expected/directive_attr.res.expected
@@ -1,0 +1,9 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/directive_attr.res[0m:[2m1:1-11[0m
+
+  [1;31m1[0m [2m│[0m [1;31m@@directive[0m
+  2 [2m│[0m 
+  3 [2m│[0m @@directive(2)
+
+  expect string literal

--- a/jscomp/build_tests/super_errors/expected/directive_attr.res.expected
+++ b/jscomp/build_tests/super_errors/expected/directive_attr.res.expected
@@ -4,6 +4,5 @@
 
   [1;31m1[0m [2m│[0m [1;31m@@directive[0m
   2 [2m│[0m 
-  3 [2m│[0m @@directive(2)
 
   expect string literal

--- a/jscomp/build_tests/super_errors/fixtures/directive_attr.res
+++ b/jscomp/build_tests/super_errors/fixtures/directive_attr.res
@@ -1,0 +1,1 @@
+@@directive

--- a/jscomp/frontend/ast_config.ml
+++ b/jscomp/frontend/ast_config.ml
@@ -47,23 +47,9 @@ let process_directives str =
   |> List.iter (fun (item : Parsetree.structure_item) ->
          match item.pstr_desc with
          | Pstr_attribute ({txt = "directive"}, payload) -> (
-           match payload with
-           | PStr structure -> (
-             match structure with
-             | [item] -> (
-               match item.pstr_desc with
-               | Pstr_eval
-                   ({pexp_desc = Pexp_constant (Pconst_string (d, _))}, _) ->
-                 Js_config.directives := !Js_config.directives @ [d]
-               | _ ->
-                 Location.raise_errorf ~loc:item.pstr_loc
-                   "@@@directive argument expect a string")
-             | _ ->
-               Location.raise_errorf ~loc:item.pstr_loc
-                 "@@@directive attribute expect an argument")
-           | _ ->
-             Location.raise_errorf ~loc:item.pstr_loc
-               "@@@directive attribute can only be applied to a string")
+           match Ast_payload.is_single_string payload with
+           | Some (d, _) -> Js_config.directives := !Js_config.directives @ [d]
+           | None -> Bs_syntaxerr.err item.pstr_loc Expect_string_literal)
          | Pstr_attribute ({txt = "uncurried"}, _) ->
            Config.uncurried := Uncurried
          | _ -> ())

--- a/jscomp/frontend/ast_config.ml
+++ b/jscomp/frontend/ast_config.ml
@@ -57,7 +57,7 @@ let process_directives str =
                  Js_config.directives := !Js_config.directives @ [d]
                | _ ->
                  Location.raise_errorf ~loc:item.pstr_loc
-                   "@@@directive argument expect an string")
+                   "@@@directive argument expect a string")
              | _ ->
                Location.raise_errorf ~loc:item.pstr_loc
                  "@@@directive attribute expect an argument")


### PR DESCRIPTION
Currently there is no error message for the `@@directive` attribute

TODO:
- [x] Update CHANGELOG
- [x] Add tests