### PR TITLE
add .res and .resi to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.ml linguist-language=OCaml
 *.mli linguist-language=OCaml
+*.res linguist-language=ReScript
+*.resi linguist-language=ReScript


### PR DESCRIPTION
During https://github.com/rescript-lang/rescript-compiler/pull/6180/, Github didn't show the diff for some files. It was treating as binary.

https://github.com/rescript-lang/rescript-compiler/pull/6180/files#diff-e60cd69d47d201dc2fccf4b051caeb1857f44fc16cb44b7fd49ec6761bbddf65

![image](https://user-images.githubusercontent.com/16160544/233466051-254e6e6f-b7a7-47ff-a929-534cbed0bfbd.png)

Also add highlight to `.resi` files.
