### PR TITLE
Support `-warn-error` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :rocket: New Feature
 
 - Add `%todo` extension for leaving implementation for later. https://github.com/rescript-lang/rescript-compiler/pull/6713
+- Add `-warn-error` argument for generate error on CI. Useful for `%todo` extension. https://github.com/rescript-lang/rescript-compiler/pull/6717
 
 #### :bug: Bug Fix
 

--- a/jscomp/bsb/bsb_ninja_regen.mli
+++ b/jscomp/bsb/bsb_ninja_regen.mli
@@ -27,6 +27,7 @@ val regenerate_ninja :
   forced:bool ->
   per_proj_dir:string ->
   warn_legacy_config:bool ->
+  warn_as_error:string option ->
   Bsb_config_types.t option
 (** Regenerate ninja file by need based on [.bsdeps]
     return None if we dont need regenerate

--- a/jscomp/bsb/bsb_warning.mli
+++ b/jscomp/bsb/bsb_warning.mli
@@ -22,7 +22,16 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type t
+type warning_error =
+  | Warn_error_false
+  (* default [false] to make our changes non-intrusive *)
+  | Warn_error_true
+  | Warn_error_number of string
+
+type t0 = { number : string option; error : warning_error }
+
+type nonrec t = t0 option
+
 
 val to_merlin_string : t -> string
 (** Extra work is need to make merlin happy *)

--- a/jscomp/bsb/bsb_world.ml
+++ b/jscomp/bsb/bsb_world.ml
@@ -71,6 +71,7 @@ let make_world_deps cwd (config : Bsb_config_types.t option)
                    else Dependency { package_specs; jsx; uncurried })
                  ~per_proj_dir:proj_dir ~forced:false
                  ~warn_legacy_config:false
+                 ~warn_as_error:None
              in
              let command =
                { Bsb_unix.cmd = vendor_ninja; cwd = lib_bs_dir; args }

--- a/jscomp/bsb/bsb_world.ml
+++ b/jscomp/bsb/bsb_world.ml
@@ -26,7 +26,7 @@ let ( // ) = Ext_path.combine
 let vendor_ninja = Bsb_global_paths.vendor_ninja
 
 let make_world_deps cwd (config : Bsb_config_types.t option)
-    (ninja_args : string array) =
+    (ninja_args : string array) warn_as_error =
   let package_specs, jsx, uncurried, pinned_dependencies =
     match config with
     | None ->
@@ -71,7 +71,7 @@ let make_world_deps cwd (config : Bsb_config_types.t option)
                    else Dependency { package_specs; jsx; uncurried })
                  ~per_proj_dir:proj_dir ~forced:false
                  ~warn_legacy_config:false
-                 ~warn_as_error:None
+                 ~warn_as_error:(if is_pinned then warn_as_error else None)
              in
              let command =
                { Bsb_unix.cmd = vendor_ninja; cwd = lib_bs_dir; args }

--- a/jscomp/bsb/bsb_world.mli
+++ b/jscomp/bsb/bsb_world.mli
@@ -23,4 +23,4 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 val make_world_deps :
-  string -> Bsb_config_types.t option -> string array -> unit
+  string -> Bsb_config_types.t option -> string array -> string option -> unit

--- a/jscomp/bsb_exe/rescript_main.ml
+++ b/jscomp/bsb_exe/rescript_main.ml
@@ -136,7 +136,7 @@ let build_subcommand ~start argv argv_len =
          Always regenerate build.ninja no matter bsconfig.json is changed or \
          not" );
       ("-no-deps", unit_set_spec no_deps_mode, "*internal* Needed for watcher to build without dependencies on file change");
-      ("-warn-error", string_call (fun s -> warning_as_error := Some s), "Enable warnings as error")
+      ("-warn-error", string_call (fun s -> warning_as_error := Some s), "Warning numbers and whether to turn it into error or not")
     |]
     failed_annon;
 
@@ -148,7 +148,7 @@ let build_subcommand ~start argv argv_len =
   | _ ->
       let warn_as_error = match !warning_as_error with
       | Some s ->
-        Warnings.parse_options true s;
+        let () = try Warnings.parse_options true s with Arg.Bad msg -> Bsb_arg.bad_arg (msg ^ "\n") in
         Some s
       | None -> None in
       let config_opt =

--- a/jscomp/bsb_exe/rescript_main.ml
+++ b/jscomp/bsb_exe/rescript_main.ml
@@ -136,7 +136,7 @@ let build_subcommand ~start argv argv_len =
          Always regenerate build.ninja no matter bsconfig.json is changed or \
          not" );
       ("-no-deps", unit_set_spec no_deps_mode, "*internal* Needed for watcher to build without dependencies on file change");
-      ("-warn-error", string_call (fun s -> warning_as_error := Some s), "Warning numbers and whether to turn it into error or not")
+      ("-warn-error", string_call (fun s -> warning_as_error := Some s), "Warning numbers and whether to turn them into errors, e.g., \"+8+32-102\"")
     |]
     failed_annon;
 

--- a/jscomp/bsb_exe/rescript_main.ml
+++ b/jscomp/bsb_exe/rescript_main.ml
@@ -159,7 +159,7 @@ let build_subcommand ~start argv argv_len =
           ~warn_legacy_config:true
           ~warn_as_error
         in
-      if not !no_deps_mode then Bsb_world.make_world_deps Bsb_global_paths.cwd config_opt ninja_args;
+      if not !no_deps_mode then Bsb_world.make_world_deps Bsb_global_paths.cwd config_opt ninja_args warn_as_error;
       if !do_install then install_target ();
       ninja_command_exit ninja_args
 
@@ -224,7 +224,7 @@ let () =
           ~warn_legacy_config:true
           ~warn_as_error:None
       in
-      Bsb_world.make_world_deps Bsb_global_paths.cwd config_opt [||];
+      Bsb_world.make_world_deps Bsb_global_paths.cwd config_opt [||] None;
       ninja_command_exit [||])
     else
       match argv.(1) with

--- a/jscomp/build_tests/build_warn_as_error/input.js
+++ b/jscomp/build_tests/build_warn_as_error/input.js
@@ -1,0 +1,17 @@
+var p = require("child_process");
+var assert = require("assert");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+
+var o = p.spawnSync(rescript_exe, ["build", "-warn-error", "+110"], {
+  encoding: "utf8",
+  cwd: __dirname,
+});
+
+var error_message = o.stdout
+  .split("\n")
+  .map(s => s.trim())
+  .includes("Warning number 110 (configured as error)");
+
+if (!error_message) {
+  assert.fail(o.stdout);
+}

--- a/jscomp/build_tests/build_warn_as_error/rescript.json
+++ b/jscomp/build_tests/build_warn_as_error/rescript.json
@@ -1,0 +1,5 @@
+{
+  "name": "build_warn_as_error",
+  "version": "0.1.0",
+  "sources": ["src"]
+}

--- a/jscomp/build_tests/build_warn_as_error/src/Demo.res
+++ b/jscomp/build_tests/build_warn_as_error/src/Demo.res
@@ -1,0 +1,1 @@
+let todo = _ => %todo

--- a/jscomp/build_tests/cli_help/input.js
+++ b/jscomp/build_tests/cli_help/input.js
@@ -36,7 +36,7 @@ const buildHelp =
   "  -ws          [host]:port set up host & port for WebSocket build notifications\n" +
   "  -verbose     Set the output to be verbose\n" +
   "  -with-deps   *deprecated* This is the default behavior now. This option will be removed in a future release\n" +
-  "  -warn-error  Enable warnings as error\n";
+  "  -warn-error  Warning numbers and whether to turn it into error or not\n";
 
 const cleanHelp =
   "Usage: rescript clean <options>\n" +

--- a/jscomp/build_tests/cli_help/input.js
+++ b/jscomp/build_tests/cli_help/input.js
@@ -36,7 +36,7 @@ const buildHelp =
   "  -ws          [host]:port set up host & port for WebSocket build notifications\n" +
   "  -verbose     Set the output to be verbose\n" +
   "  -with-deps   *deprecated* This is the default behavior now. This option will be removed in a future release\n" +
-  "  -warn-error  Warning numbers and whether to turn it into error or not\n";
+  '  -warn-error  Warning numbers and whether to turn them into errors, e.g., "+8+32-102"\n';
 
 const cleanHelp =
   "Usage: rescript clean <options>\n" +

--- a/jscomp/build_tests/cli_help/input.js
+++ b/jscomp/build_tests/cli_help/input.js
@@ -32,10 +32,11 @@ const buildHelp =
   "`rescript build -- -h` for Ninja options (internal usage only; unstable)\n" +
   "\n" +
   "Options:\n" +
-  "  -w          Watch mode\n" +
-  "  -ws         [host]:port set up host & port for WebSocket build notifications\n" +
-  "  -verbose    Set the output to be verbose\n" +
-  "  -with-deps  *deprecated* This is the default behavior now. This option will be removed in a future release\n";
+  "  -w           Watch mode\n" +
+  "  -ws          [host]:port set up host & port for WebSocket build notifications\n" +
+  "  -verbose     Set the output to be verbose\n" +
+  "  -with-deps   *deprecated* This is the default behavior now. This option will be removed in a future release\n" +
+  "  -warn-error  Enable warnings as error\n";
 
 const cleanHelp =
   "Usage: rescript clean <options>\n" +

--- a/jscomp/runtime/release.ninja
+++ b/jscomp/runtime/release.ninja
@@ -25,7 +25,7 @@ o runtime/caml_exceptions.cmj : cc_cmi runtime/caml_exceptions.res | runtime/cam
 o runtime/caml_exceptions.cmi : cc runtime/caml_exceptions.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_float.cmj : cc_cmi runtime/caml_float.res | runtime/caml_float.cmi runtime/caml_float_extern.cmj
 o runtime/caml_float.cmi : cc runtime/caml_float.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-o runtime/caml_format.cmj : cc_cmi runtime/caml_format.ml | runtime/caml_float.cmj runtime/caml_float_extern.cmj runtime/caml_format.cmi runtime/caml_int64.cmj runtime/caml_int64_extern.cmj runtime/caml_nativeint_extern.cmj runtime/caml_string_extern.cmj
+o runtime/caml_format.cmj : cc_cmi runtime/caml_format.ml | runtime/caml.cmj runtime/caml_float.cmj runtime/caml_float_extern.cmj runtime/caml_format.cmi runtime/caml_int64.cmj runtime/caml_int64_extern.cmj runtime/caml_nativeint_extern.cmj runtime/caml_string_extern.cmj
 o runtime/caml_format.cmi : cc runtime/caml_format.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_hash.cmj : cc_cmi runtime/caml_hash.res | runtime/caml_hash.cmi runtime/caml_hash_primitive.cmj runtime/caml_nativeint_extern.cmj runtime/js.cmj
 o runtime/caml_hash.cmi : cc runtime/caml_hash.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
@@ -41,7 +41,7 @@ o runtime/caml_md5.cmj : cc_cmi runtime/caml_md5.res | runtime/caml_array_extern
 o runtime/caml_md5.cmi : cc runtime/caml_md5.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_module.cmj : cc_cmi runtime/caml_module.res | runtime/caml_array_extern.cmj runtime/caml_module.cmi runtime/caml_obj.cmj
 o runtime/caml_module.cmi : cc runtime/caml_module.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-o runtime/caml_obj.cmj : cc_cmi runtime/caml_obj.res | runtime/caml_array_extern.cmj runtime/caml_obj.cmi runtime/caml_option.cmj runtime/js.cmj
+o runtime/caml_obj.cmj : cc_cmi runtime/caml_obj.res | runtime/caml.cmj runtime/caml_array_extern.cmj runtime/caml_obj.cmi runtime/caml_option.cmj runtime/js.cmj
 o runtime/caml_obj.cmi : cc runtime/caml_obj.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_option.cmj : cc_cmi runtime/caml_option.res | runtime/caml_option.cmi runtime/caml_undefined_extern.cmj runtime/js.cmj
 o runtime/caml_option.cmi : cc runtime/caml_option.resi | runtime/bs_stdlib_mini.cmi runtime/caml_undefined_extern.cmj runtime/js.cmi runtime/js.cmj
@@ -58,7 +58,7 @@ o runtime/caml_bigint_extern.cmi runtime/caml_bigint_extern.cmj : cc runtime/cam
 o runtime/caml_external_polyfill.cmi runtime/caml_external_polyfill.cmj : cc runtime/caml_external_polyfill.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_float_extern.cmi runtime/caml_float_extern.cmj : cc runtime/caml_float_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_int64_extern.cmi runtime/caml_int64_extern.cmj : cc runtime/caml_int64_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-o runtime/caml_js_exceptions.cmi runtime/caml_js_exceptions.cmj : cc runtime/caml_js_exceptions.res | runtime/bs_stdlib_mini.cmi runtime/caml_exceptions.cmj runtime/js.cmi runtime/js.cmj
+o runtime/caml_js_exceptions.cmi runtime/caml_js_exceptions.cmj : cc runtime/caml_js_exceptions.res | runtime/bs_stdlib_mini.cmi runtime/caml_exceptions.cmj runtime/caml_option.cmj runtime/js.cmi runtime/js.cmj
 o runtime/caml_nativeint_extern.cmi runtime/caml_nativeint_extern.cmj : cc runtime/caml_nativeint_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_string_extern.cmi runtime/caml_string_extern.cmj : cc runtime/caml_string_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_undefined_extern.cmi runtime/caml_undefined_extern.cmj : cc runtime/caml_undefined_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj


### PR DESCRIPTION
Add supoort for `-warn-error` argument. Use for CI only.

If there is already a configuration for warnings as error in `rescript.json` the argument will be added at the end

```json
"warnings": {
  "error": "+27"
}
```

Example: Disable warning 27, run `rescript -warn-error -27` generate `-warn-error +27-27`, the last one wins.




Related #6713