### PR TITLE
Fix bigint div/mod to throw native RangeError

### DIFF
--- a/compiler/core/js_exp_make.ml
+++ b/compiler/core/js_exp_make.ml
@@ -1657,13 +1657,9 @@ let bigint_comp (cmp : Lam_compat.comparison) ?comment (e0 : t) (e1 : t) =
     not (bool (p1 = p2 && String.equal (normalize v1) (normalize v2)))
   | _ -> bin ?comment (Lam_compile_util.jsop_of_comp cmp) e0 e1
 
-let bigint_div ~checked ?comment (e0 : t) (e1 : t) =
-  if checked then runtime_call Primitive_modules.bigint "div" [e0; e1]
-  else bigint_op ?comment Div e0 e1
+let bigint_div ?comment (e0 : t) (e1 : t) = bigint_op ?comment Div e0 e1
 
-let bigint_mod ~checked ?comment (e0 : t) (e1 : t) =
-  if checked then runtime_call Primitive_modules.bigint "mod_" [e0; e1]
-  else bigint_op ?comment Mod e0 e1
+let bigint_mod ?comment (e0 : t) (e1 : t) = bigint_op ?comment Mod e0 e1
 
 (* TODO -- alpha conversion
     remember to add parens..

--- a/compiler/core/js_exp_make.mli
+++ b/compiler/core/js_exp_make.mli
@@ -287,9 +287,9 @@ val bigint_op : ?comment:string -> Js_op.binop -> t -> t -> t
 
 val bigint_comp : Lam_compat.comparison -> ?comment:string -> t -> t -> t
 
-val bigint_div : checked:bool -> ?comment:string -> t -> t -> t
+val bigint_div : ?comment:string -> t -> t -> t
 
-val bigint_mod : checked:bool -> ?comment:string -> t -> t -> t
+val bigint_mod : ?comment:string -> t -> t -> t
 
 val js_comp : Lam_compat.comparison -> ?comment:string -> t -> t -> t
 

--- a/compiler/core/lam_compile_primitive.ml
+++ b/compiler/core/lam_compile_primitive.ml
@@ -240,7 +240,7 @@ let translate output_prefix loc (cxt : Lam_compile_context.t)
     | _ -> assert false)
   | Pdivbigint -> (
     match args with
-    | [e1; e2] -> E.bigint_div ~checked:!Js_config.check_div_by_zero e1 e2
+    | [e1; e2] -> E.bigint_div e1 e2
     | _ -> assert false)
   | Pmodint -> (
     match args with
@@ -248,7 +248,7 @@ let translate output_prefix loc (cxt : Lam_compile_context.t)
     | _ -> assert false)
   | Pmodbigint -> (
     match args with
-    | [e1; e2] -> E.bigint_mod ~checked:!Js_config.check_div_by_zero e1 e2
+    | [e1; e2] -> E.bigint_mod e1 e2
     | _ -> assert false)
   | Ppowbigint -> (
     match args with

--- a/lib/es6/Primitive_bigint.js
+++ b/lib/es6/Primitive_bigint.js
@@ -27,31 +27,9 @@ function max(x, y) {
   }
 }
 
-function div(x, y) {
-  if (y === 0n) {
-    throw {
-      RE_EXN_ID: "Division_by_zero",
-      Error: new Error()
-    };
-  }
-  return x / y;
-}
-
-function mod_(x, y) {
-  if (y === 0n) {
-    throw {
-      RE_EXN_ID: "Division_by_zero",
-      Error: new Error()
-    };
-  }
-  return x % y;
-}
-
 export {
   compare,
   min,
   max,
-  div,
-  mod_,
 }
 /* No side effect */

--- a/lib/js/Primitive_bigint.js
+++ b/lib/js/Primitive_bigint.js
@@ -27,29 +27,7 @@ function max(x, y) {
   }
 }
 
-function div(x, y) {
-  if (y === 0n) {
-    throw {
-      RE_EXN_ID: "Division_by_zero",
-      Error: new Error()
-    };
-  }
-  return x / y;
-}
-
-function mod_(x, y) {
-  if (y === 0n) {
-    throw {
-      RE_EXN_ID: "Division_by_zero",
-      Error: new Error()
-    };
-  }
-  return x % y;
-}
-
 exports.compare = compare;
 exports.min = min;
 exports.max = max;
-exports.div = div;
-exports.mod_ = mod_;
 /* No side effect */

--- a/runtime/Primitive_bigint.res
+++ b/runtime/Primitive_bigint.res
@@ -20,21 +20,3 @@ let max = (x: bigint, y: bigint): bigint =>
   } else {
     y
   }
-
-external div: (bigint, bigint) => bigint = "%divbigint"
-
-let div = (x: bigint, y: bigint) =>
-  if y == 0n {
-    raise(Division_by_zero)
-  } else {
-    div(x, y)
-  }
-
-external mod_: (bigint, bigint) => bigint = "%modbigint"
-
-let mod_ = (x: bigint, y: bigint) =>
-  if y == 0n {
-    raise(Division_by_zero)
-  } else {
-    mod_(x, y)
-  }

--- a/tests/tests/src/core/Core_TempTests.mjs
+++ b/tests/tests/src/core/Core_TempTests.mjs
@@ -8,7 +8,6 @@ import * as Float from "rescript/lib/es6/Float.js";
 import * as $$BigInt from "rescript/lib/es6/BigInt.js";
 import * as Option from "rescript/lib/es6/Option.js";
 import * as Core_IntlTests from "./intl/Core_IntlTests.mjs";
-import * as Primitive_bigint from "rescript/lib/es6/Primitive_bigint.js";
 import * as Primitive_option from "rescript/lib/es6/Primitive_option.js";
 
 console.info("");
@@ -140,7 +139,7 @@ console.info("BigInt");
 
 console.info("---");
 
-console.log(Primitive_bigint.div(BigInt(1), BigInt(12.0)));
+console.log(BigInt(1) / BigInt(12.0));
 
 console.info("");
 


### PR DESCRIPTION
There is no infinity or nan for bigint.

No need to check `int` semantic IMHO, bigint works totally different with number (int & float) anyway