### PR TITLE
Unify check and formatting in one place

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -6,3 +6,5 @@ dune build @fmt --auto-promote
 
 files=$(find runtime tests -type f \( -name "*.res" -o -name "*.resi" \) ! -name "syntaxErrors*" ! -path "tests/syntax_*" ! -path "tests/analysis_tests/tests*" ! -path "tests/gentype_tests/typescript-react-example/node_modules")
 ./cli/rescript format $files
+
+npm run format

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -30,3 +30,5 @@ case "$(uname -s)" in
     echo "Code formatting checks skipped for this platform."
 esac
 
+echo "Biome format check"
+npm run checkFormat

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -38,11 +38,6 @@ if (process.argv.includes("-all")) {
 
 async function runTests() {
   if (formatTest) {
-    cp.execSync("npm run checkFormat", {
-      cwd: path.join(__dirname, ".."),
-      stdio: [0, 1, 2],
-    });
-
     cp.execSync("bash scripts/format_check.sh", {
       cwd: path.join(__dirname, ".."),
       stdio: [0, 1, 2],


### PR DESCRIPTION
Whenever I edit js files and run `make format` the js files are not formatted