### PR TITLE
Fix `index out of bounds` exception in `rescript-editor-analysis codeAction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 #### :bug: Bug fix
 
 - `rescript-tools doc` no longer includes shadowed bindings in its output. https://github.com/rescript-lang/rescript/pull/7497
+- Fix `index out of bounds` exception thrown in rare cases by `rescript-editor-analysis.exe codeAction` command. https://github.com/rescript-lang/rescript/pull/7523
 
 #### :nail_care: Polish
 

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -869,7 +869,8 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
        match
          (Pos.positionToOffset text posStart, Pos.positionToOffset text posEnd)
        with
-       | Some offsetStart, Some offsetEnd ->
+       | Some offsetStart, Some offsetEnd
+         when offsetStart >= 0 && offsetEnd >= offsetStart ->
          (* Can't trust the parser's location
             E.g. @foo. let x... gives as label @foo.let *)
          let label =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -373,7 +373,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
   in
   let posOfDot = Pos.posOfDot text ~pos:posCursor ~offset in
   let charAtCursor =
-    if offset < String.length text then text.[offset] else '\n'
+    if offset >= 0 && offset < String.length text then text.[offset] else '\n'
   in
   let posBeforeCursor = Pos.posBeforeCursor posCursor in
   let charBeforeCursor, blankAfterCursor =

--- a/analysis/src/Pos.ml
+++ b/analysis/src/Pos.ml
@@ -22,8 +22,8 @@ let positionToOffset text (line, character) =
   match offsetOfLine text line with
   | None -> None
   | Some bol ->
-    if bol + character <= String.length text then Some (bol + character)
-    else None
+    let offset = bol + character in
+    if offset >= 0 && offset <= String.length text then Some offset else None
 
 let posBeforeCursor pos = (fst pos, max 0 (snd pos - 1))
 


### PR DESCRIPTION
When editing switch statements in VS Code, I've sometimes been seeing error messages of the form `rescript-editor-analysis codeAction MyFile.res 42 0 42 0 /tmp/xxx.res failed with Fatal error: exception Invalid_argument("index out of bounds")`.

(Since the temporary files generated by the extension were deleted as soon as this command failed, I could not come up with a simple repo. However, by hitting backspace quickly on the first line of switch statements, I was sometimes able to reproduce this error.)

After enabling backtraces with `Printexc.record_backtrace true`, I managed to track this down to line 376 of `CompletionFrontEnd.completionWithParser1`:

```
Fatal error: exception Invalid_argument("index out of bounds") Raised by primitive operation at Analysis__CompletionFrontEnd.completionWithParser1 in file "analysis/src/CompletionFrontEnd.ml", line 376, characters 40-53 Called from Analysis__Xform.extractTypeFromExpr in file "analysis/src/Xform.ml", lines 7-9
```

https://github.com/rescript-lang/rescript/blob/6f4275c478d188f1738a7a367b856445db56205c/analysis/src/CompletionFrontEnd.ml#L376

While we're ensuring that `offset < String.length text`, there was no check that `offset >= 0` and so `text.[-1]` triggered an index out of bounds exception.

I'm not sure exactly why `offset` was negative, but I'm guessing it's because `loc_start.pos_cnum` is initialised as -1 and so `Pos.positionToOffset` is called with args `"..." (line, -1)`.

https://github.com/rescript-lang/rescript/blob/6f4275c478d188f1738a7a367b856445db56205c/analysis/src/Xform.ml#L7-L9

https://github.com/rescript-lang/rescript/blob/6f4275c478d188f1738a7a367b856445db56205c/analysis/src/Pos.ml#L3-L4

https://github.com/rescript-lang/rescript/blob/6f4275c478d188f1738a7a367b856445db56205c/analysis/src/Pos.ml#L21-L26

https://github.com/rescript-lang/rescript/blob/6f4275c478d188f1738a7a367b856445db56205c/analysis/src/CompletionFrontEnd.ml#L1755-L1757

---

In addition to adding bounds checks before using `offset` for `charAtCursor`, I've also [added them for some offset-related logic further down](https://github.com/rescript-lang/rescript/commit/03deb09a7ba5b2bd5171e9f73e3f7a23dab5ed2f).

I've also fixed the root of the issue by [ensuring that `Pos.positionToOffset` does not return negative offsets](https://github.com/rescript-lang/rescript/commit/816565d1d32da52c6d033ca58b5dc28bd49fa652).