### PR TITLE
Add `type: "module"` to `docstring_tests`'s `package.json`

### DIFF
--- a/tests/docstring_tests/package.json
+++ b/tests/docstring_tests/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tests/docstring-tests",
+  "type": "module",
   "private": true,
   "scripts": {
     "build": "rescript",


### PR DESCRIPTION
Fixes the following warning:

```
(node:140026) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///home/mediremi/rescript-compiler/tests/docstring_tests/generated_mocha_test.res.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /home/mediremi/rescript-compiler/tests/docstring_tests/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
```