### PR TITLE
Remove outdated Belt.Array documentation regarding stdlib's Array.get

### DIFF
--- a/runtime/Belt_Array.resi
+++ b/runtime/Belt_Array.resi
@@ -14,15 +14,6 @@
 
 /***
 Utilities for `Array` functions.
-
-### Note about index syntax
-
-Code like `arr[0]` does *not* compile to JavaScript `arr[0]`. Reason transforms
-the `[]` index syntax into a function: `Array.get(arr, 0)`. By default, this
-uses the default standard library's `Array.get` function, which may raise an
-exception if the index isn't found. If you `open Belt`, it will use the
-`Belt.Array.get` function which returns options instead of raising exceptions. 
-[See this for more information](../belt.mdx#array-access-runtime-safety).
 */
 
 type t<'a> = array<'a>

--- a/tests/analysis_tests/tests/src/expected/CompletionResolve.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionResolve.res.txt
@@ -1,5 +1,5 @@
 Completion resolve: Belt_Array
-"\nUtilities for `Array` functions.\n\n### Note about index syntax\n\nCode like `arr[0]` does *not* compile to JavaScript `arr[0]`. Reason transforms\nthe `[]` index syntax into a function: `Array.get(arr, 0)`. By default, this\nuses the default standard library's `Array.get` function, which may raise an\nexception if the index isn't found. If you `open Belt`, it will use the\n`Belt.Array.get` function which returns options instead of raising exceptions. \n[See this for more information](../belt.mdx#array-access-runtime-safety).\n"
+"\nUtilities for `Array` functions.\n"
 
 Completion resolve: ModuleStuff
 " This is a top level module doc. "


### PR DESCRIPTION
Since v12 (or since v11 if using `Core`), the standard library's `Array.get` returns an option instead of throwing an exception if an index isn't found.

I've removed an outdated note from `Belt_Array.resi` that mentions the old behaviour of `Array.get`.

Also, since v11, `arr[0]` in ReScript **is** compiled to `arr[0]` in JavaScript, contrary to what the `Belt_Array.resi` docs said.