### PR TITLE
gentype_tests: clean using `rescript clean` instead `rm` command

### DIFF
--- a/tests/gentype_tests/typescript-react-example/Makefile
+++ b/tests/gentype_tests/typescript-react-example/Makefile
@@ -9,7 +9,7 @@ test:
 		|| exit 1
 
 clean:
-	rm -rf lib src/*.res.js src/*.gen.tsx
+	yarn clean
 
 .DEFAULT_GOAL := test
 


### PR DESCRIPTION
Sometimes I get obsolete output error. `yarn clean` call `rescript clean`