### PR TITLE
Improve completions for inline record fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Better error message for when trying to await something that is not a promise. https://github.com/rescript-lang/rescript/pull/7561
 - Better error messages for object field missing and object field type mismatches. https://github.com/rescript-lang/rescript/pull/7580
 - Better error messages for when polymorphic variants does not match for various reasons. https://github.com/rescript-lang/rescript/pull/7596
+- Improved completions for inline records. https://github.com/rescript-lang/rescript/pull/7601
 
 #### :house: Internal
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1443,6 +1443,48 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
   let emptyCase = emptyCase ~mode in
   let printConstructorArgs = printConstructorArgs ~mode in
   let create = Completion.create ?typeArgContext in
+  let getRecordCompletions ~env ~fields ~extractedType =
+    (* As we're completing for a record, we'll need a hint (completionContext)
+       here to figure out whether we should complete for a record field, or
+       the record body itself. *)
+    match completionContext with
+    | Some (Completable.RecordField {seenFields}) ->
+      fields
+      |> List.filter (fun (field : field) ->
+             List.mem field.fname.txt seenFields = false)
+      |> List.map (fun (field : field) ->
+             match (field.optional, mode) with
+             | true, Pattern Destructuring ->
+               create ("?" ^ field.fname.txt) ?deprecated:field.deprecated
+                 ~docstring:
+                   [
+                     field.fname.txt
+                     ^ " is an optional field, and needs to be destructured \
+                        using '?'.";
+                   ]
+                 ~kind:
+                   (Field (field, TypeUtils.extractedTypeToString extractedType))
+                 ~env
+             | _ ->
+               create field.fname.txt ?deprecated:field.deprecated
+                 ~kind:
+                   (Field (field, TypeUtils.extractedTypeToString extractedType))
+                 ~env)
+      |> filterItems ~prefix
+    | _ ->
+      if prefix = "" then
+        [
+          create "{}" ~includesSnippets:true ~insertText:"{$0}" ~sortText:"A"
+            ~kind:
+              (ExtractedType
+                 ( extractedType,
+                   match mode with
+                   | Pattern _ -> `Type
+                   | Expression -> `Value ))
+            ~env;
+        ]
+      else []
+  in
   match t with
   | TtypeT {env; path} when mode = Expression ->
     if Debug.verbose () then
@@ -1710,88 +1752,13 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
         ~insertText:(printConstructorArgs numExprs ~asSnippet:true)
         ~kind:(Value typ) ~env;
     ]
-  | Trecord {env; fields} as extractedType -> (
+  | Trecord {env; fields} as extractedType ->
     if Debug.verbose () then print_endline "[complete_typed_value]--> Trecord";
-    (* As we're completing for a record, we'll need a hint (completionContext)
-       here to figure out whether we should complete for a record field, or
-       the record body itself. *)
-    match completionContext with
-    | Some (Completable.RecordField {seenFields}) ->
-      fields
-      |> List.filter (fun (field : field) ->
-             List.mem field.fname.txt seenFields = false)
-      |> List.map (fun (field : field) ->
-             match (field.optional, mode) with
-             | true, Pattern Destructuring ->
-               create ("?" ^ field.fname.txt) ?deprecated:field.deprecated
-                 ~docstring:
-                   [
-                     field.fname.txt
-                     ^ " is an optional field, and needs to be destructured \
-                        using '?'.";
-                   ]
-                 ~kind:
-                   (Field (field, TypeUtils.extractedTypeToString extractedType))
-                 ~env
-             | _ ->
-               create field.fname.txt ?deprecated:field.deprecated
-                 ~kind:
-                   (Field (field, TypeUtils.extractedTypeToString extractedType))
-                 ~env)
-      |> filterItems ~prefix
-    | _ ->
-      if prefix = "" then
-        [
-          create "{}" ~includesSnippets:true ~insertText:"{$0}" ~sortText:"A"
-            ~kind:
-              (ExtractedType
-                 ( extractedType,
-                   match mode with
-                   | Pattern _ -> `Type
-                   | Expression -> `Value ))
-            ~env;
-        ]
-      else [])
-  | TinlineRecord {env; fields} as extractedType -> (
+    getRecordCompletions ~env ~fields ~extractedType
+  | TinlineRecord {env; fields} as extractedType ->
     if Debug.verbose () then
       print_endline "[complete_typed_value]--> TinlineRecord";
-    match completionContext with
-    | Some (Completable.RecordField {seenFields}) ->
-      fields
-      |> List.filter (fun (field : field) ->
-             List.mem field.fname.txt seenFields = false)
-      |> List.map (fun (field : field) ->
-             match (field.optional, mode) with
-             | true, Pattern Destructuring ->
-               create ("?" ^ field.fname.txt) ?deprecated:field.deprecated
-                 ~docstring:
-                   [
-                     field.fname.txt
-                     ^ " is an optional field, and needs to be destructured \
-                        using '?'.";
-                   ]
-                 ~kind:
-                   (Field (field, TypeUtils.extractedTypeToString extractedType))
-                 ~env
-             | _ ->
-               create field.fname.txt ?deprecated:field.deprecated
-                 ~kind:
-                   (Field (field, TypeUtils.extractedTypeToString extractedType))
-                 ~env)
-      |> filterItems ~prefix
-    | _ ->
-      if prefix = "" then
-        [
-          create "{}" ~includesSnippets:true ~insertText:"{$0}" ~sortText:"A"
-            ~kind:
-              (ExtractedType
-                 ( extractedType,
-                   match mode with
-                   | Pattern _ -> `Type
-                   | Expression -> `Value ))
-            ~env;
-        ]
-      else [])
+    getRecordCompletions ~env ~fields ~extractedType
   | Tarray (env, typ) ->
     if Debug.verbose () then print_endline "[complete_typed_value]--> Tarray";
     if prefix = "" then

--- a/tests/analysis_tests/tests-incremental-typechecking/src/expected/ConstructorCompletion__Own.res.txt
+++ b/tests/analysis_tests/tests-incremental-typechecking/src/expected/ConstructorCompletion__Own.res.txt
@@ -8,10 +8,10 @@ Resolved opens 1 Stdlib
 ContextPath CTypeAtPos()
 [{
     "label": "{}",
-    "kind": 4,
+    "kind": 12,
     "tags": [],
-    "detail": "Inline record",
-    "documentation": null,
+    "detail": "{miss: bool}",
+    "documentation": {"kind": "markdown", "value": "```rescript\n{miss: bool}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2

--- a/tests/analysis_tests/tests/src/Completion.res
+++ b/tests/analysis_tests/tests/src/Completion.res
@@ -465,3 +465,20 @@ type withUncurried = {fn: int => unit}
 
 // let someRecord = { FAR. }
 //                        ^com
+
+type someRecord = {field1: string, field2: int}
+type someVariantWithRecord = HasRecord(someRecord)
+
+// let v: someVariantWithRecord = HasRecord({})
+//                                           ^com
+
+// let v: someVariantWithRecord = HasRecord({fie})
+//                                              ^com
+
+type someVariantWithInlineRecord = HasInlineRecord({field1: string, field2: int})
+
+// let v: someVariantWithInlineRecord = HasInlineRecord({})
+//                                                       ^com
+
+// let v: someVariantWithInlineRecord = HasInlineRecord({fie})
+//                                                          ^com

--- a/tests/analysis_tests/tests/src/expected/Completion.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Completion.res.txt
@@ -2342,8 +2342,8 @@ Path red
   }]
 
 Complete src/Completion.res 407:22
-posCursor:[407:22] posNoWhite:[407:21] Found expr:[407:11->468:0]
-Pexp_apply ...__ghost__[0:-1->0:-1] (...[407:11->425:17], ...[430:0->468:0])
+posCursor:[407:22] posNoWhite:[407:21] Found expr:[407:11->485:0]
+Pexp_apply ...__ghost__[0:-1->0:-1] (...[407:11->425:17], ...[430:0->485:0])
 posCursor:[407:22] posNoWhite:[407:21] Found expr:[407:11->425:17]
 Pexp_apply ...__ghost__[0:-1->0:-1] (...[407:11->407:19], ...[407:21->425:17])
 posCursor:[407:22] posNoWhite:[407:21] Found expr:[407:21->425:17]
@@ -2745,5 +2745,93 @@ Path FAR.
     "tags": [],
     "detail": "option<int>",
     "documentation": {"kind": "markdown", "value": "```rescript\nsomething: option<int>\n```\n\n```rescript\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}\n```"}
+  }]
+
+Complete src/Completion.res 471:45
+XXX Not found!
+Completable: Cexpression Type[someVariantWithRecord]->variantPayload::HasRecord($0), recordBody
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 3 Stdlib Completion Completion
+ContextPath Type[someVariantWithRecord]
+Path someVariantWithRecord
+[{
+    "label": "field1",
+    "kind": 5,
+    "tags": [],
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfield1: string\n```\n\n```rescript\ntype someRecord = {field1: string, field2: int}\n```"}
+  }, {
+    "label": "field2",
+    "kind": 5,
+    "tags": [],
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfield2: int\n```\n\n```rescript\ntype someRecord = {field1: string, field2: int}\n```"}
+  }]
+
+Complete src/Completion.res 474:48
+XXX Not found!
+Completable: Cexpression Type[someVariantWithRecord]=fie->variantPayload::HasRecord($0), recordBody
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 3 Stdlib Completion Completion
+ContextPath Type[someVariantWithRecord]
+Path someVariantWithRecord
+[{
+    "label": "field1",
+    "kind": 5,
+    "tags": [],
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfield1: string\n```\n\n```rescript\ntype someRecord = {field1: string, field2: int}\n```"}
+  }, {
+    "label": "field2",
+    "kind": 5,
+    "tags": [],
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfield2: int\n```\n\n```rescript\ntype someRecord = {field1: string, field2: int}\n```"}
+  }]
+
+Complete src/Completion.res 479:57
+XXX Not found!
+Completable: Cexpression Type[someVariantWithInlineRecord]->variantPayload::HasInlineRecord($0), recordBody
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 3 Stdlib Completion Completion
+ContextPath Type[someVariantWithInlineRecord]
+Path someVariantWithInlineRecord
+[{
+    "label": "field1",
+    "kind": 5,
+    "tags": [],
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfield1: string\n```\n\n```rescript\n{field1: string, field2: int}\n```"}
+  }, {
+    "label": "field2",
+    "kind": 5,
+    "tags": [],
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfield2: int\n```\n\n```rescript\n{field1: string, field2: int}\n```"}
+  }]
+
+Complete src/Completion.res 482:60
+XXX Not found!
+Completable: Cexpression Type[someVariantWithInlineRecord]=fie->variantPayload::HasInlineRecord($0), recordBody
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 3 Stdlib Completion Completion
+ContextPath Type[someVariantWithInlineRecord]
+Path someVariantWithInlineRecord
+[{
+    "label": "field1",
+    "kind": 5,
+    "tags": [],
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfield1: string\n```\n\n```rescript\n{field1: string, field2: int}\n```"}
+  }, {
+    "label": "field2",
+    "kind": 5,
+    "tags": [],
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfield2: int\n```\n\n```rescript\n{field1: string, field2: int}\n```"}
   }]
 

--- a/tests/analysis_tests/tests/src/expected/CompletionExpressions.res.txt
+++ b/tests/analysis_tests/tests/src/expected/CompletionExpressions.res.txt
@@ -700,10 +700,10 @@ ContextPath Value[fnTakingInlineRecord]
 Path fnTakingInlineRecord
 [{
     "label": "{}",
-    "kind": 4,
+    "kind": 12,
     "tags": [],
-    "detail": "Inline record",
-    "documentation": null,
+    "detail": "{someBoolField: bool, otherField: option<bool>, nestedRecord: otherRecord}",
+    "documentation": {"kind": "markdown", "value": "```rescript\n{someBoolField: bool, otherField: option<bool>, nestedRecord: otherRecord}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -720,22 +720,22 @@ ContextPath Value[fnTakingInlineRecord]
 Path fnTakingInlineRecord
 [{
     "label": "someBoolField",
-    "kind": 4,
+    "kind": 5,
     "tags": [],
-    "detail": "Inline record",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeBoolField: bool\n```\n\n```rescript\n{someBoolField: bool, otherField: option<bool>, nestedRecord: otherRecord}\n```"}
   }, {
     "label": "otherField",
-    "kind": 4,
+    "kind": 5,
     "tags": [],
-    "detail": "Inline record",
-    "documentation": null
+    "detail": "option<bool>",
+    "documentation": {"kind": "markdown", "value": "```rescript\notherField: option<bool>\n```\n\n```rescript\n{someBoolField: bool, otherField: option<bool>, nestedRecord: otherRecord}\n```"}
   }, {
     "label": "nestedRecord",
-    "kind": 4,
+    "kind": 5,
     "tags": [],
-    "detail": "Inline record",
-    "documentation": null
+    "detail": "otherRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnestedRecord: otherRecord\n```\n\n```rescript\n{someBoolField: bool, otherField: option<bool>, nestedRecord: otherRecord}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 132:51
@@ -749,10 +749,10 @@ ContextPath Value[fnTakingInlineRecord]
 Path fnTakingInlineRecord
 [{
     "label": "someBoolField",
-    "kind": 4,
+    "kind": 5,
     "tags": [],
-    "detail": "Inline record",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeBoolField: bool\n```\n\n```rescript\n{someBoolField: bool, otherField: option<bool>, nestedRecord: otherRecord}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 135:63


### PR DESCRIPTION
This change improves inline record completions by:
1) showing the inline record's type when completing constructor payloads 
2) showing each field's type for field completion

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/b70f9607-b083-4d5f-84d6-588a66520bd4) | ![image](https://github.com/user-attachments/assets/20a0aeac-69f0-4c1d-a58f-97afd8f3b827) |
| ![image](https://github.com/user-attachments/assets/fa0c73d3-2b60-4237-b073-ee139a8a1505) | ![image](https://github.com/user-attachments/assets/e7d80d5d-0def-4f56-befe-074b185702b3) |

These changes were implemented by reusing the completion logic used for records.

## Explanation

While we currently show completions for record fields by creating a `Field` field completion for each field...

https://github.com/rescript-lang/rescript/blob/6e6fe0ab220876e5924343cac7d32983a73bac8c/analysis/src/CompletionBackEnd.ml#L1720-L1741

... for inline records we only emit `Label "Inline record"`:

https://github.com/rescript-lang/rescript/blob/6e6fe0ab220876e5924343cac7d32983a73bac8c/analysis/src/CompletionBackEnd.ml#L1763-L1765

In commit 1b0296cbde35a40cf87e3651cb2f196e30436efb, I copied the completion logic for records over to the inline records handler. I also added completion tests for inline records.

Then in commit 2758057dc2a2dcd20974c7d6ad57524de0551551, I extracted the common logic into a helper function called `getRecordCompletions`.
