### PR TITLE
Don't ignore Stdlib_* files when generating docstring tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - Add rust linting to CI with `clippy`. https://github.com/rescript-lang/rescript/pull/7675
 - AST: use `Typ.arrows` for creation, after the refactoring of arrow types. https://github.com/rescript-lang/rescript/pull/7662
+- Don't skip Stdlib docstring tests. https://github.com/rescript-lang/rescript/pull/7694
 
 #### :bug: Bug fix
 

--- a/tests/docstring_tests/DocTest.res
+++ b/tests/docstring_tests/DocTest.res
@@ -65,11 +65,7 @@ let extractExamples = async () => {
   let docFiles = files->Array.filter(f =>
     switch f {
     // Ignore Js modules and RescriptTools for now
-    // Avoid Stdlib modules showing up as both "Stdlib_X" and "Stdlib.X"
-    | f
-      if f->String.startsWith("Js") ||
-      f->String.startsWith("RescriptTools") ||
-      f->String.startsWith("Stdlib_") => false
+    | f if f->String.startsWith("Js") || f->String.startsWith("RescriptTools") => false
     | f if f->String.endsWith(".resi") => true
     | f if f->String.endsWith(".res") && !(files->Array.includes(f ++ "i")) => true
     | _ => false

--- a/tests/docstring_tests/DocTest.res
+++ b/tests/docstring_tests/DocTest.res
@@ -12,22 +12,22 @@ let nodeVersion =
 
 let ignoreRuntimeTests = [
   (
-    // Ignore some tests require Node.js v20+
+    // Ignore tests that require Node.js v20+
     20,
-    ["Stdlib.Array.toReversed", "Stdlib.Array.toSorted"],
+    ["Stdlib_Array.toReversed", "Stdlib_Array.toSorted"],
   ),
   (
-    // Ignore some tests require Node.js v22+
+    // Ignore tests that require Node.js v22+
     22,
     [
-      "Stdlib.Promise.withResolvers",
-      "Stdlib.Set.union",
-      "Stdlib.Set.isSupersetOf",
-      "Stdlib.Set.isSubsetOf",
-      "Stdlib.Set.isDisjointFrom",
-      "Stdlib.Set.intersection",
-      "Stdlib.Set.symmetricDifference",
-      "Stdlib.Set.difference",
+      "Stdlib_Promise.withResolvers",
+      "Stdlib_Set.union",
+      "Stdlib_Set.isSupersetOf",
+      "Stdlib_Set.isSubsetOf",
+      "Stdlib_Set.isDisjointFrom",
+      "Stdlib_Set.intersection",
+      "Stdlib_Set.symmetricDifference",
+      "Stdlib_Set.difference",
     ],
   ),
 ]

--- a/tests/docstring_tests/DocTest.res.js
+++ b/tests/docstring_tests/DocTest.res.js
@@ -68,7 +68,7 @@ let batchSize = Nodeos.cpus().length;
 async function extractExamples() {
   let files = Nodefs.readdirSync("runtime");
   let docFiles = files.filter(f => {
-    if (f.startsWith("Js") || f.startsWith("RescriptTools") || f.startsWith("Stdlib_")) {
+    if (f.startsWith("Js") || f.startsWith("RescriptTools")) {
       return false;
     } else if (f.endsWith(".resi")) {
       return true;

--- a/tests/docstring_tests/DocTest.res.js
+++ b/tests/docstring_tests/DocTest.res.js
@@ -21,21 +21,21 @@ let ignoreRuntimeTests = [
   [
     20,
     [
-      "Stdlib.Array.toReversed",
-      "Stdlib.Array.toSorted"
+      "Stdlib_Array.toReversed",
+      "Stdlib_Array.toSorted"
     ]
   ],
   [
     22,
     [
-      "Stdlib.Promise.withResolvers",
-      "Stdlib.Set.union",
-      "Stdlib.Set.isSupersetOf",
-      "Stdlib.Set.isSubsetOf",
-      "Stdlib.Set.isDisjointFrom",
-      "Stdlib.Set.intersection",
-      "Stdlib.Set.symmetricDifference",
-      "Stdlib.Set.difference"
+      "Stdlib_Promise.withResolvers",
+      "Stdlib_Set.union",
+      "Stdlib_Set.isSupersetOf",
+      "Stdlib_Set.isSubsetOf",
+      "Stdlib_Set.isDisjointFrom",
+      "Stdlib_Set.intersection",
+      "Stdlib_Set.symmetricDifference",
+      "Stdlib_Set.difference"
     ]
   ]
 ];


### PR DESCRIPTION
`DocTest` was not generating docstring tests for Stdlib modules as it was ignoring all files starting with `Stdlib_`.

I discovered this issue while looking into why I couldn't manage to get doctests for a new binding I was writing to fail.

Also, tests that required specific node.js versions to run were not being skipped correctly but this was not an issue in practice as the tests were not being run anyway.