### PR TITLE
Add `RegExp.escape` binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 #### :rocket: New Feature
 
 - Add optional `message` argument to `Result.getOrThrow` and improve default error message. https://github.com/rescript-lang/rescript/pull/7630
+- Add `RegExp.escape` binding. https://github.com/rescript-lang/rescript/pull/7695
 
 #### :nail_care: Polish
 

--- a/runtime/Stdlib_RegExp.res
+++ b/runtime/Stdlib_RegExp.res
@@ -12,6 +12,8 @@ module Result = {
 @new external fromString: (string, ~flags: string=?) => t = "RegExp"
 @new external fromStringWithFlags: (string, ~flags: string) => t = "RegExp"
 
+external escape: string => string = "RegExp.escape"
+
 @send external test: (t, string) => bool = "test"
 @return(nullable) @send external exec: (t, string) => option<Result.t> = "exec"
 

--- a/runtime/Stdlib_RegExp.resi
+++ b/runtime/Stdlib_RegExp.resi
@@ -122,6 +122,25 @@ switch regexp->RegExp.exec("ReScript is pretty cool, right?") {
 external fromStringWithFlags: (string, ~flags: string) => t = "RegExp"
 
 /**
+`escape(string)` escapes any potential regex syntax characters in a string.
+
+See [`RegExp.escape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) on MDN.
+
+## Examples
+```rescript
+let literal = "foo[bar]"
+let regexp = literal->RegExp.escape->RegExp.fromString
+regexp->RegExp.test("foo[bar]") == true
+```
+
+## Remark
+
+Since May 2025, this feature works across the latest devices and browser versions.
+This feature might not work in older devices or browsers.
+*/
+external escape: string => string = "RegExp.escape"
+
+/**
 `test(regexp, string)` tests whether the provided `regexp` matches on the provided string.
 
 See [`RegExp.test`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) on MDN.

--- a/tests/docstring_tests/DocTest.res
+++ b/tests/docstring_tests/DocTest.res
@@ -30,6 +30,11 @@ let ignoreRuntimeTests = [
       "Stdlib_Set.difference",
     ],
   ),
+  (
+    // Ignore tests that require Node.js v24+
+    24,
+    ["Stdlib_RegExp.escape"],
+  ),
 ]
 
 let getOutput = buffer =>

--- a/tests/docstring_tests/DocTest.res.js
+++ b/tests/docstring_tests/DocTest.res.js
@@ -37,6 +37,10 @@ let ignoreRuntimeTests = [
       "Stdlib_Set.symmetricDifference",
       "Stdlib_Set.difference"
     ]
+  ],
+  [
+    24,
+    ["Stdlib_RegExp.escape"]
   ]
 ];
 


### PR DESCRIPTION
Adds bindings for [RegExp.escape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape).

I've added a remark in the docstring regarding [browser compatibility](https://caniuse.com/mdn-javascript_builtins_regexp_escape) since we did so for the recent [Iterator.prototype](https://github.com/rescript-lang/rescript/pull/7506/files#diff-2ec021a7da4717ee92544cf990c17ed4ef8b6ba11b69c1460248301a8e219568R69) bindings.