### PR TITLE
Add rust-version field to Rewatch's Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - AST: use `Typ.arrows` for creation, after the refactoring of arrow types. https://github.com/rescript-lang/rescript/pull/7662
 - Don't skip Stdlib docstring tests. https://github.com/rescript-lang/rescript/pull/7694
 - Remove all leftovers of pinned-dependencies handling. https://github.com/rescript-lang/rescript/pull/7686
+- Add `rust-version` field to Rewatch's `Cargo.toml`. https://github.com/rescript-lang/rescript/pull/7701
 
 #### :bug: Bug fix
 

--- a/rewatch/Cargo.toml
+++ b/rewatch/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rescript"
 version = "12.0.0-beta.3"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 ahash = "0.8.3"


### PR DESCRIPTION
We use Rust edition 2024, which means we require Rust v1.85+.

Attempting to compile Rewatch with an older version of Rust will now show the following error message:

```
$ make
./scripts/copyExes.js --ninja
cargo build --manifest-path rewatch/Cargo.toml --release
error: rustc 1.84.0 is not supported by the following packages:
  rescript@12.0.0-beta.3 requires rustc 1.85
  rescript@12.0.0-beta.3 requires rustc 1.85

make: *** [Makefile:19: rewatch] Error 101
```