### PR TITLE
Add missing details for packages in root rescript json

### DIFF
--- a/rescript.json
+++ b/rescript.json
@@ -1,4 +1,17 @@
 {
   "name": "rescript",
+  "package-specs": [
+    {
+      "module": "esmodule",
+      "in-source": true
+    },
+    {
+      "module": "esmodule",
+      "in-source": false,
+      "suffix": ".res.js"
+    }
+  ],
+  "suffix": ".res.js",
+  "jsx": { "version": 4 },
   "dependencies": ["@tests/gentype-react-example", "playground"]
 }


### PR DESCRIPTION
Monorepos with Rewatch work a little differently.

Certain settings will be taking from the root rescript.json and will no longer be provided by the package rescript.json.

`"package-specs"`, `"jsx"` and `"suffix"` are part of these.

I copied these from the `"@tests/gentype-react-example"` and `"playground"` which will make them build correctly. I think this is a problem that is silently failing because the compiled code in case of the tests is present. And playground will probably only blow up at time of release.

