### PR TITLE
Show doc comments before type expansions in hover information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 #### :rocket: New Feature
 
+- Show docstrings before type expansions on hover. https://github.com/rescript-lang/rescript/pull/7774
+
 #### :bug: Bug fix
 
 #### :memo: Documentation

--- a/tests/analysis_tests/tests/src/expected/Hover.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Hover.res.txt
@@ -295,13 +295,13 @@ Path Hover.someField
 Path someField
 Package opens Stdlib.place holder Pervasives.JsxModules.place holder
 Resolved opens 1 Stdlib
-{"contents": {"kind": "markdown", "value": " Mighty fine field here. \n\n```rescript\nbool\n```"}}
+{"contents": {"kind": "markdown", "value": "```rescript\nbool\n```\n---\n Mighty fine field here. "}}
 
 Hover src/Hover.res 248:19
 {"contents": {"kind": "markdown", "value": "```rescript\nbool\n```\n---\n Mighty fine field here. "}}
 
 Hover src/Hover.res 253:20
-{"contents": {"kind": "markdown", "value": "```rescript\nvariant\nCoolVariant\n```\n\n---\n\n```\n \n```\n```rescript\ntype variant = CoolVariant | OtherCoolVariant\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C251%2C0%5D)\n\n---\n Cool variant! "}}
+{"contents": {"kind": "markdown", "value": "```rescript\nvariant\nCoolVariant\n```\n---\n Cool variant! \n\n---\n\n```\n \n```\n```rescript\ntype variant = CoolVariant | OtherCoolVariant\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C251%2C0%5D)\n"}}
 
 Hover src/Hover.res 258:22
 {"contents": {"kind": "markdown", "value": "```rescript\npayloadVariants\nInlineRecord({field1: int, field2: bool})\n```\n\n---\n\n```\n \n```\n```rescript\ntype payloadVariants =\n  | InlineRecord({field1: int, field2: bool})\n  | Args(int, bool)\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C256%2C0%5D)\n"}}

--- a/tests/analysis_tests/tests/src/expected/JsxV4.res.txt
+++ b/tests/analysis_tests/tests/src/expected/JsxV4.res.txt
@@ -17,7 +17,7 @@ Path M4.make
   }]
 
 Hover src/JsxV4.res 14:9
-{"contents": {"kind": "markdown", "value": "```rescript\nReact.component<M4.props<string, string, string>>\n```\n\n---\n\n```\n \n```\n```rescript\ntype React.component<'props> = Jsx.component<'props>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C12%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype M4.props<'first, 'fun, 'second> = {\n  first: 'first,\n  fun?: 'fun,\n  second?: 'second,\n}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22JsxV4.res%22%2C3%2C2%5D)\n\n---\n Doc Comment For M4 "}}
+{"contents": {"kind": "markdown", "value": "```rescript\nReact.component<M4.props<string, string, string>>\n```\n---\n Doc Comment For M4 \n\n---\n\n```\n \n```\n```rescript\ntype React.component<'props> = Jsx.component<'props>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C12%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype M4.props<'first, 'fun, 'second> = {\n  first: 'first,\n  fun?: 'fun,\n  second?: 'second,\n}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22JsxV4.res%22%2C3%2C2%5D)\n"}}
 
 Create Interface src/JsxV4.res
 module M4: {


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width="770" height="393" alt="image" src="https://github.com/user-attachments/assets/f36e2050-dac2-4b6c-a10a-ba3d19ef60cb" /> | <img width="770" height="303" alt="image" src="https://github.com/user-attachments/assets/7f126b2f-cb31-48cd-b404-aba9c5af1d05" /> |

When generating hover information, we currently show in order:
1. main type
2. expanded types
3. docstrings

A frequent issue I run into is that my expanded types hover information is long enough that the hover preview box must be scrolled to view docstrings.

In this PR, I've changed the order we present this information to:
1. main type
2. docstrings
3. expanded types

