### PR TITLE
Add markdown divider between module doc and module type in hover information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 #### :rocket: New Feature
 
+- Add markdown divider between module doc and module type in hover information. https://github.com/rescript-lang/rescript/pull/7775
+
 #### :bug: Bug fix
 
 #### :memo: Documentation

--- a/analysis/src/Hover.ml
+++ b/analysis/src/Hover.ml
@@ -26,7 +26,8 @@ let showModuleTopLevel ~docstring ~isType ~name (topLevel : Module.item list) =
   let doc =
     match docstring with
     | [] -> ""
-    | _ :: _ -> "\n" ^ (docstring |> String.concat "\n") ^ "\n"
+    | _ :: _ ->
+      "\n" ^ (docstring |> String.concat "\n") ^ Markdown.divider
   in
   Some (doc ^ full)
 

--- a/analysis/src/Hover.ml
+++ b/analysis/src/Hover.ml
@@ -26,8 +26,7 @@ let showModuleTopLevel ~docstring ~isType ~name (topLevel : Module.item list) =
   let doc =
     match docstring with
     | [] -> ""
-    | _ :: _ ->
-      "\n" ^ (docstring |> String.concat "\n") ^ Markdown.divider
+    | _ :: _ -> "\n" ^ (docstring |> String.concat "\n") ^ Markdown.divider
   in
   Some (doc ^ full)
 

--- a/analysis/src/Hover.ml
+++ b/analysis/src/Hover.ml
@@ -26,7 +26,10 @@ let showModuleTopLevel ~docstring ~isType ~name (topLevel : Module.item list) =
   let doc =
     match docstring with
     | [] -> ""
-    | _ :: _ -> "\n" ^ (docstring |> String.concat "\n") ^ Markdown.divider
+    | _ :: _ ->
+      "\n"
+      ^ (docstring |> String.concat "\n")
+      ^ Markdown.divider ^ Markdown.spacing
   in
   Some (doc ^ full)
 

--- a/tests/analysis_tests/tests/src/expected/Hover.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Hover.res.txt
@@ -8,7 +8,7 @@ Hover src/Hover.res 6:7
 {"contents": {"kind": "markdown", "value": "```rescript\nmodule Id: {\n  type x = int\n}\n```"}}
 
 Hover src/Hover.res 19:11
-{"contents": {"kind": "markdown", "value": "\nThis module is commented\n```rescript\nmodule Dep: {\n  let customDouble: int => int\n}\n```"}}
+{"contents": {"kind": "markdown", "value": "\nThis module is commented\n---\n```rescript\nmodule Dep: {\n  let customDouble: int => int\n}\n```"}}
 
 Hover src/Hover.res 22:11
 {"contents": {"kind": "markdown", "value": "```rescript\nint => int\n```\n---\nSome doc comment"}}
@@ -343,7 +343,7 @@ Path x
 {"contents": {"kind": "markdown", "value": "```rescript\nbool\n```"}}
 
 Hover src/Hover.res 278:8
-{"contents": {"kind": "markdown", "value": "\n [`Belt.Array`]()\n\n  **mutable array**: Utilities functions\n\n```rescript\nmodule Array: {\n  module Id\n  module Array\n  module SortArray\n  module MutableQueue\n  module MutableStack\n  module List\n  module Range\n  module Set\n  module Map\n  module MutableSet\n  module MutableMap\n  module HashSet\n  module HashMap\n  module Option\n  module Result\n  module Int\n  module Float\n}\n```"}}
+{"contents": {"kind": "markdown", "value": "\n [`Belt.Array`]()\n\n  **mutable array**: Utilities functions\n\n---\n```rescript\nmodule Array: {\n  module Id\n  module Array\n  module SortArray\n  module MutableQueue\n  module MutableStack\n  module List\n  module Range\n  module Set\n  module Map\n  module MutableSet\n  module MutableMap\n  module HashSet\n  module HashMap\n  module Option\n  module Result\n  module Int\n  module Float\n}\n```"}}
 
 Hover src/Hover.res 281:6
 {"contents": {"kind": "markdown", "value": "```rescript\ntype aliased = variant\n```\n\n---\n\n```\n \n```\n```rescript\ntype variant = CoolVariant | OtherCoolVariant\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C251%2C0%5D)\n"}}

--- a/tests/analysis_tests/tests/src/expected/Hover.res.txt
+++ b/tests/analysis_tests/tests/src/expected/Hover.res.txt
@@ -8,7 +8,7 @@ Hover src/Hover.res 6:7
 {"contents": {"kind": "markdown", "value": "```rescript\nmodule Id: {\n  type x = int\n}\n```"}}
 
 Hover src/Hover.res 19:11
-{"contents": {"kind": "markdown", "value": "\nThis module is commented\n---\n```rescript\nmodule Dep: {\n  let customDouble: int => int\n}\n```"}}
+{"contents": {"kind": "markdown", "value": "\nThis module is commented\n---\n\n```\n \n```\n```rescript\nmodule Dep: {\n  let customDouble: int => int\n}\n```"}}
 
 Hover src/Hover.res 22:11
 {"contents": {"kind": "markdown", "value": "```rescript\nint => int\n```\n---\nSome doc comment"}}
@@ -343,7 +343,7 @@ Path x
 {"contents": {"kind": "markdown", "value": "```rescript\nbool\n```"}}
 
 Hover src/Hover.res 278:8
-{"contents": {"kind": "markdown", "value": "\n [`Belt.Array`]()\n\n  **mutable array**: Utilities functions\n\n---\n```rescript\nmodule Array: {\n  module Id\n  module Array\n  module SortArray\n  module MutableQueue\n  module MutableStack\n  module List\n  module Range\n  module Set\n  module Map\n  module MutableSet\n  module MutableMap\n  module HashSet\n  module HashMap\n  module Option\n  module Result\n  module Int\n  module Float\n}\n```"}}
+{"contents": {"kind": "markdown", "value": "\n [`Belt.Array`]()\n\n  **mutable array**: Utilities functions\n\n---\n\n```\n \n```\n```rescript\nmodule Array: {\n  module Id\n  module Array\n  module SortArray\n  module MutableQueue\n  module MutableStack\n  module List\n  module Range\n  module Set\n  module Map\n  module MutableSet\n  module MutableMap\n  module HashSet\n  module HashMap\n  module Option\n  module Result\n  module Int\n  module Float\n}\n```"}}
 
 Hover src/Hover.res 281:6
 {"contents": {"kind": "markdown", "value": "```rescript\ntype aliased = variant\n```\n\n---\n\n```\n \n```\n```rescript\ntype variant = CoolVariant | OtherCoolVariant\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C251%2C0%5D)\n"}}


### PR DESCRIPTION
I've made hover information for modules more consistent with type hover information by adding a `Markdown.divider` between a module's doc string and its contents.

Thanks to the divider, it's easier to tell where a doctring ends and where the module type definition starts:

```rescript
/**
 My module with a doc comment.

 ## Examples
 ```rescript
 Foo.bar()
 Foo.baz()
 \```
*/
module type Foo = {
  let bar: unit => unit
  let baz: unit => unit
}
```

| Before | After |
| ------ | ----- |
| <img width="369" height="283" alt="image" src="https://github.com/user-attachments/assets/631485ee-73c2-46e0-9e66-8ec934937774" /> | <img width="369" height="283" alt="image" src="https://github.com/user-attachments/assets/73f945e9-3723-4efa-ae09-4806845c94b6" />
