### PR TITLE
Set YARN_NPM_AUTH_TOKEN for publishing again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,6 +703,8 @@ jobs:
         shell: bash
 
       - name: Publish packages on npm with tag "ci"
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
         run: |
           yarn workspaces foreach -W --no-private \
             npm publish --provenance --tolerate-republish --tag ci


### PR DESCRIPTION
Yarn doesn't support OIDC auth for npm publish yet, see https://github.com/yarnpkg/berry/issues/6831.