### PR TITLE
Mitigate potential template injection in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           gh extension install actions/gh-actions-cache
           gh actions-cache delete ${{ steps.compiler-build-state-key.outputs.value }} \
             -R ${{ github.repository }} \
-            -B ${{ github.ref }} \
+            -B "$GITHUB_REF" \
             --confirm || echo "not exist"
         env:
           GH_TOKEN: ${{ github.token }}
@@ -529,7 +529,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions@rescript-lang.org"
           git add data/api
-          git commit -m "Update API docs for ${{ github.ref_name }}"
+          git commit -m "Update API docs for $GITHUB_REF_NAME"
           git push
 
   test-installation-npm:


### PR DESCRIPTION
In GitHub Actions workflows, using template expansions (`${{ ... }}`) in `run` (and other code execution) blocks can lead to [template injection](https://docs.zizmor.sh/audits/#template-injection) vulnerabilities.

From the link above:

> These expansions happen before workflow and job execution, meaning the expansion of a given expression appears verbatim in whatever context it was performed in.
>
> Template expansions aren't syntax-aware, meaning that they can result in unintended shell injection vectors. This is especially true when they're used with attacker-controllable expression contexts

[zizmor](https://docs.zizmor.sh/) identified two locations in `.github/workflows/ci.yml` where code injection via template expansion may be possible:
1. https://github.com/rescript-lang/rescript/blob/f7e334321944d95a1efb51683be1c25ab0b05ff1/.github/workflows/ci.yml#L275
2. https://github.com/rescript-lang/rescript/blob/f7e334321944d95a1efb51683be1c25ab0b05ff1/.github/workflows/ci.yml#L532

[As recommended by GitHub's Security Lab](https://securitylab.github.com/resources/github-actions-untrusted-input/#:~:text=Remediation), I've replaced these template expansions with environmental variables.

The `$GITHUB_REF` and `$GITHUB_REF_NAME` environmental variables [are already defined by default](https://docs.github.com/en/actions/reference/workflows-and-actions/variables), so we don't need to define them with `env:`.