### PR TITLE
Fix fatal compiler error that occurred when an `%ffi` extension point contained invalid JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 #### :bug: Bug fix
 
+- Fix fatal compiler error that occurred when an `%ffi` extension point contained invalid JavaScript https://github.com/rescript-lang/rescript/pull/7998
+
 #### :memo: Documentation
 
 #### :nail_care: Polish

--- a/compiler/ml/code_frame.ml
+++ b/compiler/ml/code_frame.ml
@@ -136,20 +136,25 @@ let print ~is_warning ~src ~(start_pos : Lexing.position)
   (* 3 for separator + the 2 spaces around it *)
   let line_width = 78 - max_line_digits_count - indent - 3 in
   let lines =
-    String.sub src start_line_line_offset
-      (end_line_line_end_offset - start_line_line_offset)
-    |> String.split_on_char '\n'
-    |> filter_mapi (fun i line ->
-           let line_number = i + first_shown_line in
-           if more_than_5_highlighted_lines then
-             if line_number = highlight_line_start_line + 2 then
-               Some (Elided, line)
-             else if
-               line_number > highlight_line_start_line + 2
-               && line_number < highlight_line_end_line - 1
-             then None
-             else Some (Number line_number, line)
-           else Some (Number line_number, line))
+    if
+      start_line_line_offset >= 0
+      && end_line_line_end_offset >= start_line_line_offset
+    then
+      String.sub src start_line_line_offset
+        (end_line_line_end_offset - start_line_line_offset)
+      |> String.split_on_char '\n'
+      |> filter_mapi (fun i line ->
+             let line_number = i + first_shown_line in
+             if more_than_5_highlighted_lines then
+               if line_number = highlight_line_start_line + 2 then
+                 Some (Elided, line)
+               else if
+                 line_number > highlight_line_start_line + 2
+                 && line_number < highlight_line_end_line - 1
+               then None
+               else Some (Number line_number, line)
+             else Some (Number line_number, line))
+    else []
   in
   let leading_space_to_cut =
     lines


### PR DESCRIPTION
When editing invalid JS in an `%ffi`, my compiler would sometimes fail with:

```
FAILED: MyFile.ast

  Warning number 103
  /home/mediremi/MyFile.res:30:9-10
Fatal error: exception Invalid_argument("String.sub / Bytes.sub")
```

Enabling backtraces with `Printexc.record_backtrace true` gave me:

```
Fatal error: exception Invalid_argument("String.sub / Bytes.sub")
Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
Called from Stdlib__String.sub in file "string.ml" (inlined), line 43, characters 2-23
Called from Code_frame.print in file "compiler/ml/code_frame.ml", lines 139-140, characters 4-57
Called from Location.print in file "compiler/ml/location.ml", lines 143-144, characters 8-57
...
```

This PR prevents this fatal error by guarding `String.sub` with a check for its `pos` and `len` arguments (in this case, `start_line_line_offset` and `end_line_line_end_offset - start_line_line_offset`).

With this fix, the compiler now successfully reports the warning triggered by my invalid JS:

```
rescript: [1/6] MyFile.ast

  Warning number 103
  /home/mediremi/MyFile.res:30:9-10


  FFI warning: Unexpected reserved word
```