### PR TITLE
Fix migration to RegExp.Result.captures

### DIFF
--- a/packages/@rescript/runtime/Js_re.res
+++ b/packages/@rescript/runtime/Js_re.res
@@ -44,16 +44,10 @@ type result
 An `array` of the match and captures, the first is the full match and the
 remaining are the substring captures.
 */
-@deprecated({
-  reason: "Use `RegExp.Result.matches` instead.",
-  migrate: RegExp.Result.matches(),
-})
+@deprecated("Use `RegExp.Result.t` instead.")
 external captures: result => array<Js_null_undefined.t<string>> = "%identity"
 
-@deprecated({
-  reason: "Use `RegExp.Result.matches` instead.",
-  migrate: RegExp.Result.matches(),
-})
+@deprecated("Use `RegExp.Result.t` instead.")
 external matches: result => array<string> = "%identity"
 
 /** 0-based index of the match in the input string. */

--- a/packages/@rescript/runtime/Stdlib_RegExp.res
+++ b/packages/@rescript/runtime/Stdlib_RegExp.res
@@ -5,6 +5,7 @@ module Result = {
   type t = array<option<string>>
   @get_index external fullMatch: (t, @as(0) _) => string = ""
   @send external matches: (t, @as(1) _) => array<option<string>> = "slice"
+  @send external captures: (t, @as(1) _) => array<option<string>> = "slice"
   @get external index: t => int = "index"
   @get external input: t => string = "input"
 }

--- a/packages/@rescript/runtime/Stdlib_RegExp.resi
+++ b/packages/@rescript/runtime/Stdlib_RegExp.resi
@@ -34,7 +34,7 @@ module Result: {
   external fullMatch: (t, @as(0) _) => string = ""
 
   /**
-  `matches(regExpResult)` returns all matches for `regExpResult`.
+  `captures(regExpResult)` returns all capture groups for `regExpResult`.
 
   ## Examples
   ```rescript
@@ -45,7 +45,7 @@ module Result: {
   switch regexp->RegExp.exec("ReScript is pretty cool, right?") {
   | None => Console.log("Nope, no match...")
   | Some(result) =>
-    switch result->RegExp.Result.matches->Array.keepSome {
+    switch result->RegExp.Result.captures->Array.keepSome {
     | [firstWord, secondWord] => Console.log2(firstWord, secondWord)
     | _ => Console.log("Didn't find exactly two words...")
     }
@@ -53,7 +53,15 @@ module Result: {
   ```
   */
   @send
+  external captures: (t, @as(1) _) => array<option<string>> = "slice"
+
+  @deprecated({
+    reason: "Use `RegExp.Result.captures` instead.",
+    migrate: RegExp.Result.captures(),
+  })
+  @send
   external matches: (t, @as(1) _) => array<option<string>> = "slice"
+
   @get external index: t => int = "index"
 
   /**


### PR DESCRIPTION
Closing #8029 

This was unsettling me, so I decided to create a PR to fix the binding and remove the broken migraiton.