### PR TITLE
reanalyze: localise dead-code binding and reporting state

### DIFF
--- a/analysis/reanalyze/DEADCODE_REFACTOR_PLAN.md
+++ b/analysis/reanalyze/DEADCODE_REFACTOR_PLAN.md
@@ -200,8 +200,9 @@ Each bullet above should be done as a separate patch touching only a small set o
 Goal: remove `DeadCommon.Current` globals for binding/reporting by threading explicit state.
 
 - [x] Add `Current.state`/helpers in `DeadCommon` and thread it through `DeadValue` (bindings) and `DeadException.markAsUsed` so `last_binding` is no longer a global ref.
-- [x] Replace `Current.maxValuePosEnd` with a per‑reporting `Current.state` in `Decl.report`/`reportDead`.
-- [ ] Follow‑up: remove `Current.state ref` usage by making traversals return an updated state (pure, no mutation). Adjust `addValueReference_state` (or its successor) to be purely functional and always return the new state.
+- [x] Replace `Current.maxValuePosEnd` with a per‑reporting state in `Decl.report`/`reportDead` (now encapsulated in `ReportingContext`).
+- [x] Replace `addValueReference_state` with `addValueReference ~binding` so reference bookkeeping no longer threads `Current.state` or returns a fake “updated state”.
+- [ ] Follow‑up: remove the remaining local `Current.state ref` in `BindingContext` by making traversals return an updated binding context (pure, no mutation). At that point, binding context becomes an explicit input/output of the traversal, not hidden state.
 
 ### 4.4 Make `ProcessDeadAnnotations` state explicit
 

--- a/analysis/reanalyze/src/DeadException.ml
+++ b/analysis/reanalyze/src/DeadException.ml
@@ -22,11 +22,10 @@ let forceDelayedItems () =
          | None -> ()
          | Some locTo ->
            (* Delayed exception references don't need a binding context; use an empty state. *)
-           DeadCommon.addValueReference_state
-             ~current:DeadCommon.Current.empty_state ~addFileReference:true
-             ~locFrom ~locTo)
+           DeadCommon.addValueReference ~binding:Location.none
+             ~addFileReference:true ~locFrom ~locTo)
 
-let markAsUsed ~(current_state : Current.state ref) ~(locFrom : Location.t)
+let markAsUsed ~(binding : Location.t) ~(locFrom : Location.t)
     ~(locTo : Location.t) path_ =
   if locTo.loc_ghost then
     (* Probably defined in another file, delay processing and check at the end *)
@@ -35,5 +34,4 @@ let markAsUsed ~(current_state : Current.state ref) ~(locFrom : Location.t)
     in
     delayedItems := {exceptionPath; locFrom} :: !delayedItems
   else
-    DeadCommon.addValueReference_state ~current:!current_state
-      ~addFileReference:true ~locFrom ~locTo
+    DeadCommon.addValueReference ~binding ~addFileReference:true ~locFrom ~locTo


### PR DESCRIPTION
- Introduce BindingContext in DeadValue to track the current binding location during dead-code traversal, so binding context is explicit and locally encapsulated.
- Introduce ReportingContext in DeadCommon to track, per file, the end position of the last reported value when deciding whether to suppress nested warnings.
- Replace addValueReference_state with addValueReference ~binding, so value-reference bookkeeping is driven by an explicit binding location rather than a threaded analysis state.
- Update dead-code value and exception handling to use the new addValueReference API.
- Refresh DEADCODE_REFACTOR_PLAN.md to mark these state-localisation steps as completed and to narrow the remaining follow-up to making the binding context fully pure.
- Verified with make test-analysis that behaviour and expected outputs remain unchanged.