### PR TITLE
Simplify binding state tracking in DeadValue

### DIFF
--- a/analysis/reanalyze/DEADCODE_REFACTOR_PLAN.md
+++ b/analysis/reanalyze/DEADCODE_REFACTOR_PLAN.md
@@ -202,7 +202,7 @@ Goal: remove `DeadCommon.Current` globals for binding/reporting by threading exp
 - [x] Add `Current.state`/helpers in `DeadCommon` and thread it through `DeadValue` (bindings) and `DeadException.markAsUsed` so `last_binding` is no longer a global ref.
 - [x] Replace `Current.maxValuePosEnd` with a per‑reporting state in `Decl.report`/`reportDead` (now encapsulated in `ReportingContext`).
 - [x] Replace `addValueReference_state` with `addValueReference ~binding` so reference bookkeeping no longer threads `Current.state` or returns a fake “updated state”.
-- [ ] Follow‑up: remove the remaining local `Current.state ref` in `BindingContext` by making traversals return an updated binding context (pure, no mutation). At that point, binding context becomes an explicit input/output of the traversal, not hidden state.
+- [x] Follow‑up: remove the remaining local `Current.state ref` in `BindingContext` by making traversals return an updated binding context (pure, no mutation). At that point, binding context becomes an explicit input/output of the traversal, not hidden state.
 
 ### 4.4 Make `ProcessDeadAnnotations` state explicit
 

--- a/analysis/reanalyze/src/DeadCommon.ml
+++ b/analysis/reanalyze/src/DeadCommon.ml
@@ -18,22 +18,6 @@ module Config = struct
   let warnOnCircularDependencies = false
 end
 
-module Current = struct
-  type state = {last_binding: Location.t; max_value_pos_end: Lexing.position}
-
-  let empty_state =
-    {last_binding = Location.none; max_value_pos_end = Lexing.dummy_pos}
-
-  let get_last_binding (s : state) = s.last_binding
-
-  let with_last_binding (loc : Location.t) (s : state) : state =
-    {s with last_binding = loc}
-
-  let get_max_end (s : state) = s.max_value_pos_end
-
-  let with_max_end (pos : Lexing.position) (s : state) : state =
-    {s with max_value_pos_end = pos}
-end
 
 let rec checkSub s1 s2 n =
   n <= 0


### PR DESCRIPTION
- Remove BindingContext module wrapper (was just forwarding to Current)
- Remove Current module entirely (unnecessary abstraction)
- Simplify to pass Location.t directly instead of record type
- Remove unused max_value_pos_end field
- Refactor traverseStructure to use pure functional mapper creation
- Update DEADCODE_REFACTOR_PLAN.md to mark task 4.3 as complete

This eliminates ~40 lines of wrapper code and makes the binding state tracking pure and simpler to understand.