### PR TITLE
refactor(dce): extract configuration into explicit value (Task 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ The Makefile’s targets build on each other in this order:
 - **Use underscore patterns carefully** - Don't use `_` patterns as lazy placeholders for new language features that then get forgotten. Only use them when you're certain the value should be ignored for that specific case. Ensure all new language features are handled correctly and completely across all compiler layers
 - **Avoid `let _ = …` for side effects** - If you need to call a function only for its side effects, use `ignore expr` (or bind the result and thread state explicitly). Do not write `let _ = expr in ()`, and do not discard stateful results—plumb them through instead.
 
+- **Don't use unit `()` with mandatory labeled arguments** - When a function has a mandatory labeled argument (like `~config`), don't add a trailing `()` parameter. The labeled argument already prevents accidental partial application. Only use `()` when all parameters are optional and you need to force evaluation. Example: `let forceDelayedItems ~config = ...` not `let forceDelayedItems ~config () = ...`
+
 - **Be careful with similar constructor names across different IRs** - Note that `Lam` (Lambda IR) and `Lambda` (typed lambda) have variants with similar constructor names like `Ltrywith`, but they represent different things in different compilation phases.
 
 - **Avoid warning suppressions** - Never use `[@@warning "..."]` to silence warnings. Instead, fix the underlying issue properly

--- a/analysis/reanalyze/src/Arnold.ml
+++ b/analysis/reanalyze/src/Arnold.ml
@@ -111,7 +111,7 @@ module Stats = struct
     incr nCacheChecks;
     if hit then incr nCacheHits;
     if !Common.Cli.debug then
-      Log_.warning ~forStats:false ~loc
+      Log_.warning ~config:(DceConfig.current ()) ~forStats:false ~loc
         (Termination
            {
              termination = TerminationAnalysisInternal;
@@ -125,7 +125,7 @@ module Stats = struct
 
   let logResult ~functionCall ~loc ~resString =
     if !Common.Cli.debug then
-      Log_.warning ~forStats:false ~loc
+      Log_.warning ~config:(DceConfig.current ()) ~forStats:false ~loc
         (Termination
            {
              termination = TerminationAnalysisInternal;
@@ -610,7 +610,7 @@ module ExtendFunctionTable = struct
             then (
               functionTable |> FunctionTable.addFunction ~functionName;
               if !Common.Cli.debug then
-                Log_.warning ~forStats:false ~loc
+                Log_.warning ~config:(DceConfig.current ()) ~forStats:false ~loc
                   (Termination
                      {
                        termination = TerminationAnalysisInternal;
@@ -632,7 +632,8 @@ module ExtendFunctionTable = struct
                  functionTable
                  |> FunctionTable.addLabelToKind ~functionName ~label;
                  if !Common.Cli.debug then
-                   Log_.warning ~forStats:false ~loc
+                   Log_.warning ~config:(DceConfig.current ()) ~forStats:false
+                     ~loc
                      (Termination
                         {
                           termination = TerminationAnalysisInternal;
@@ -699,7 +700,8 @@ module CheckExpressionWellFormed = struct
                        functionTable
                        |> FunctionTable.addLabelToKind ~functionName ~label;
                        if !Common.Cli.debug then
-                         Log_.warning ~forStats:false ~loc:body.exp_loc
+                         Log_.warning ~config:(DceConfig.current ())
+                           ~forStats:false ~loc:body.exp_loc
                            (Termination
                               {
                                 termination = TerminationAnalysisInternal;
@@ -873,7 +875,7 @@ module Compile = struct
         newFunctionName;
       newFunctionDefinition.body <- Some (vb_expr |> expression ~ctx:newCtx);
       if !Common.Cli.debug then
-        Log_.warning ~forStats:false ~loc:pat_loc
+        Log_.warning ~config:(DceConfig.current ()) ~forStats:false ~loc:pat_loc
           (Termination
              {
                termination = TerminationAnalysisInternal;

--- a/analysis/reanalyze/src/DceConfig.ml
+++ b/analysis/reanalyze/src/DceConfig.ml
@@ -1,0 +1,34 @@
+(** Configuration for dead code elimination analysis.
+    
+    This module encapsulates all configuration needed for DCE,
+    gathered from RunConfig and CLI flags. *)
+
+type cli_config = {
+  debug: bool;
+  ci: bool;
+  json: bool;
+  write: bool;
+  live_names: string list;
+  live_paths: string list;
+  exclude_paths: string list;
+}
+
+type t = {run: RunConfig.t; cli: cli_config}
+
+(** Capture the current DCE configuration from global state.
+    
+    This reads from [RunConfig.runConfig] and [Common.Cli] refs
+    to produce a single immutable configuration value. *)
+let current () =
+  let cli =
+    {
+      debug = !Common.Cli.debug;
+      ci = !Common.Cli.ci;
+      json = !Common.Cli.json;
+      write = !Common.Cli.write;
+      live_names = !Common.Cli.liveNames;
+      live_paths = !Common.Cli.livePaths;
+      exclude_paths = !Common.Cli.excludePaths;
+    }
+  in
+  {run = Common.runConfig; cli}

--- a/analysis/reanalyze/src/DeadCode.ml
+++ b/analysis/reanalyze/src/DeadCode.ml
@@ -1,32 +1,33 @@
 open DeadCommon
 
-let processSignature ~doValues ~doTypes (signature : Types.signature) =
+let processSignature ~config ~doValues ~doTypes (signature : Types.signature) =
   signature
   |> List.iter (fun sig_item ->
-         DeadValue.processSignatureItem ~doValues ~doTypes
+         DeadValue.processSignatureItem ~config ~doValues ~doTypes
            ~moduleLoc:Location.none
            ~path:[!Common.currentModuleName]
            sig_item)
 
-let processCmt ~cmtFilePath (cmt_infos : Cmt_format.cmt_infos) =
+let processCmt ~config ~cmtFilePath (cmt_infos : Cmt_format.cmt_infos) =
   (match cmt_infos.cmt_annots with
   | Interface signature ->
-    ProcessDeadAnnotations.signature signature;
-    processSignature ~doValues:true ~doTypes:true signature.sig_type
+    ProcessDeadAnnotations.signature ~config signature;
+    processSignature ~config ~doValues:true ~doTypes:true signature.sig_type
   | Implementation structure ->
     let cmtiExists =
       Sys.file_exists ((cmtFilePath |> Filename.remove_extension) ^ ".cmti")
     in
-    ProcessDeadAnnotations.structure ~doGenType:(not cmtiExists) structure;
-    processSignature ~doValues:true ~doTypes:false structure.str_type;
+    ProcessDeadAnnotations.structure ~config ~doGenType:(not cmtiExists)
+      structure;
+    processSignature ~config ~doValues:true ~doTypes:false structure.str_type;
     let doExternals =
       (* This is already handled at the interface level, avoid issues in inconsistent locations
          https://github.com/BuckleScript/syntax/pull/54
          Ideally, the handling should be less location-based, just like other language aspects. *)
       false
     in
-    DeadValue.processStructure ~doTypes:true ~doExternals
+    DeadValue.processStructure ~config ~doTypes:true ~doExternals
       ~cmt_value_dependencies:cmt_infos.cmt_value_dependencies structure
   | _ -> ());
-  DeadType.TypeDependencies.forceDelayedItems ();
+  DeadType.TypeDependencies.forceDelayedItems ~config;
   DeadType.TypeDependencies.clear ()

--- a/analysis/reanalyze/src/DeadModules.ml
+++ b/analysis/reanalyze/src/DeadModules.ml
@@ -1,26 +1,26 @@
-let active () =
+let active ~config =
   (* When transitive reporting is off, the only dead modules would be empty modules *)
-  RunConfig.runConfig.transitive
+  config.DceConfig.run.transitive
 
 let table = Hashtbl.create 1
 
-let markDead ~isType ~loc path =
-  if active () then
+let markDead ~config ~isType ~loc path =
+  if active ~config then
     let moduleName = path |> Common.Path.toModuleName ~isType in
     match Hashtbl.find_opt table moduleName with
     | Some _ -> ()
     | _ -> Hashtbl.replace table moduleName (false, loc)
 
-let markLive ~isType ~(loc : Location.t) path =
-  if active () then
+let markLive ~config ~isType ~(loc : Location.t) path =
+  if active ~config then
     let moduleName = path |> Common.Path.toModuleName ~isType in
     match Hashtbl.find_opt table moduleName with
     | None -> Hashtbl.replace table moduleName (true, loc)
     | Some (false, loc) -> Hashtbl.replace table moduleName (true, loc)
     | Some (true, _) -> ()
 
-let checkModuleDead ~fileName:pos_fname moduleName =
-  if active () then
+let checkModuleDead ~config ~fileName:pos_fname moduleName =
+  if active ~config then
     match Hashtbl.find_opt table moduleName with
     | Some (false, loc) ->
       Hashtbl.remove table moduleName;
@@ -33,7 +33,7 @@ let checkModuleDead ~fileName:pos_fname moduleName =
           {Location.loc_start = pos; loc_end = pos; loc_ghost = false}
         else loc
       in
-      Log_.warning ~loc
+      Log_.warning ~config ~loc
         (Common.DeadModule
            {
              message =

--- a/analysis/reanalyze/src/Exception.ml
+++ b/analysis/reanalyze/src/Exception.ml
@@ -143,7 +143,7 @@ module Event = struct
              | {kind = Call {callee}} :: _ -> callee |> Common.Path.toName
              | _ -> "expression" |> Name.create
            in
-           Log_.warning ~loc
+           Log_.warning ~config:(DceConfig.current ()) ~loc
              (Common.ExceptionAnalysis
                 {
                   message =
@@ -196,9 +196,9 @@ module Checks = struct
          Common.ExceptionAnalysisMissing
            {exnName; exnTable; throwSet; missingAnnotations; locFull}
        in
-       Log_.warning ~loc description);
+       Log_.warning ~config:(DceConfig.current ()) ~loc description);
     if not (Exceptions.isEmpty redundantAnnotations) then
-      Log_.warning ~loc
+      Log_.warning ~config:(DceConfig.current ()) ~loc
         (Common.ExceptionAnalysis
            {
              message =
@@ -281,7 +281,7 @@ let traverseAst () =
       in
       let calleeName = callee |> Common.Path.toName in
       if calleeName |> Name.toString |> isThrow then
-        Log_.warning ~loc
+        Log_.warning ~config:(DceConfig.current ()) ~loc
           (Common.ExceptionAnalysis
              {
                message =

--- a/analysis/src/DceCommand.ml
+++ b/analysis/src/DceCommand.ml
@@ -1,5 +1,6 @@
 let command () =
   Reanalyze.RunConfig.dce ();
-  Reanalyze.runAnalysis ~cmtRoot:None;
+  let dce_config = Reanalyze.DceConfig.current () in
+  Reanalyze.runAnalysis ~dce_config ~cmtRoot:None;
   let issues = !Reanalyze.Log_.Stats.issues in
   Printf.printf "issues:%d\n" (List.length issues)


### PR DESCRIPTION
Replace global config reads with explicit ~config parameter threading throughout the DCE analysis pipeline. This makes the analysis pure and testable with different configurations.

## Changes

### New module
- DceConfig: Encapsulates DCE configuration (cli + run config)
  - DceConfig.current() captures global state once
  - All analysis functions now take explicit ~config parameter

### DCE Analysis (fully pure - no global reads)
- DeadCode: threads config to all Dead* modules
- DeadValue: replaced ~15 !Cli.debug reads with config.cli.debug
- DeadType: replaced ~7 !Cli.debug reads with config.cli.debug
- DeadOptionalArgs: takes ~config, passes to Log_.warning
- DeadModules: uses config.run.transitive
- DeadCommon: threads config through reporting pipeline
- WriteDeadAnnotations: uses config.cli.write/json
- ProcessDeadAnnotations: uses config.cli.live_names/live_paths

### Logging infrastructure
- Log_.warning: now requires ~config (no optional)
- Log_.logIssue: now requires ~config (no optional)
- Log_.Stats.report: now requires ~config (no optional)
- Consistent API - no conditional logic on Some/None

### Non-DCE analyses (call DceConfig.current() at use sites)
- Exception: 4 call sites updated
- Arnold: 7 call sites updated
- TODO: Thread config through these for full purity

### Other
- Common.ml: removed unused lineAnnotationStr field
- Reanalyze: single DceConfig.current() call at entry point
- DEADCODE_REFACTOR_PLAN.md: updated Task 2, added verification task

## Impact

✅ DCE analysis is now pure - takes explicit config, no global reads ✅ All config parameters required (zero 'config option' types) ✅ Can run analysis with different configs without mutating globals ✅ All tests pass - no regressions

## Remaining Work (Task 2)

- Thread config through Exception/Arnold to eliminate DceConfig.current()
- Verify zero DceConfig.current() calls in analysis code