### PR TITLE
DCE: Remove global file context, thread explicit file_context

### DIFF
--- a/analysis/reanalyze/DEADCODE_REFACTOR_PLAN.md
+++ b/analysis/reanalyze/DEADCODE_REFACTOR_PLAN.md
@@ -21,6 +21,8 @@
 
 **Used by**: `DeadCommon.addDeclaration_`, `DeadType.addTypeDependenciesAcrossFiles`, `DeadValue` path construction.
 
+**Status**: ✅ FIXED in Task 1 - explicit `file_context` now threaded through all analysis functions.
+
 ### P2: Global analysis tables
 **Problem**: All analysis results accumulate in global hashtables:
 - `DeadCommon.decls` - all declarations
@@ -41,6 +43,8 @@
 
 ### P4: Global configuration reads
 **Problem**: Analysis code directly reads `!Common.Cli.debug`, `RunConfig.runConfig.transitive`, etc. scattered throughout. Can't run analysis with different configs without mutating globals.
+
+**Status**: ✅ FIXED in Task 2 - explicit `config` now threaded through all analysis functions.
 
 ### P5: Side effects mixed with analysis
 **Problem**: Analysis functions directly call:
@@ -135,10 +139,13 @@ Each task should:
 **Value**: Makes it possible to process files concurrently or out of order.
 
 **Changes**:
-- [ ] Create `DeadFileContext.t` type with `source_path`, `module_name`, `is_interface` fields
-- [ ] Thread through `DeadCode.processCmt`, `DeadValue`, `DeadType`, `DeadCommon.addDeclaration_`
-- [ ] Remove all reads of `Common.currentSrc`, `currentModule`, `currentModuleName` from DCE code
-- [ ] Delete the globals (or mark as deprecated if still used by Exception/Arnold)
+- [x] Create `DeadCommon.FileContext.t` type with `source_path`, `module_name`, `is_interface` fields
+- [x] Thread through `DeadCode.processCmt`, `DeadValue`, `DeadType`, `DeadCommon.addDeclaration_`
+- [x] Thread through `Exception.processCmt`, `Arnold.processCmt`
+- [x] Remove all reads of `Common.currentSrc`, `currentModule`, `currentModuleName` from DCE code
+- [x] Delete the globals `currentSrc`, `currentModule`, `currentModuleName` from `Common.ml`
+
+**Status**: Complete ✅
 
 **Test**: Run analysis on same files but vary the order - should get identical results.
 
@@ -288,14 +295,15 @@ Each task should:
 
 ## Execution Strategy
 
-**Recommended order**: 1 → 2 (complete all analyses) → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 (verify) → 11 (test)
+**Completed**: Task 1 ✅, Task 2 ✅, Task 10 ✅
+
+**Remaining order**: 3 → 4 → 5 → 6 → 7 → 8 → 9 → 11 (test)
 
 **Why this order?**
-- Tasks 1-2 remove implicit dependencies (file context, config) - these are foundational
-- Task 2 must be **fully complete** (DCE + Exception + Arnold) before proceeding
-- Tasks 3-7 localize global state - can be done incrementally once inputs are explicit
+- Tasks 1-2 remove implicit dependencies (file context, config) - ✅ DONE
+- Tasks 3-7 localize global state - can be done incrementally now that inputs are explicit
 - Tasks 8-9 separate pure/impure - can only do this once state is local
-- Task 10 verifies no global config reads remain
+- Task 10 verifies no global config reads remain - ✅ DONE
 - Task 11 validates everything
 
 **Alternative**: Could do 3-7 in any order (they're mostly independent).

--- a/analysis/reanalyze/src/Arnold.ml
+++ b/analysis/reanalyze/src/Arnold.ml
@@ -111,7 +111,7 @@ module Stats = struct
     incr nCacheChecks;
     if hit then incr nCacheHits;
     if config.DceConfig.cli.debug then
-      Log_.warning ~config ~forStats:false ~loc
+      Log_.warning ~forStats:false ~loc
         (Termination
            {
              termination = TerminationAnalysisInternal;
@@ -125,7 +125,7 @@ module Stats = struct
 
   let logResult ~config ~functionCall ~loc ~resString =
     if config.DceConfig.cli.debug then
-      Log_.warning ~config ~forStats:false ~loc
+      Log_.warning ~forStats:false ~loc
         (Termination
            {
              termination = TerminationAnalysisInternal;
@@ -611,7 +611,7 @@ module ExtendFunctionTable = struct
             then (
               functionTable |> FunctionTable.addFunction ~functionName;
               if config.DceConfig.cli.debug then
-                Log_.warning ~config ~forStats:false ~loc
+                Log_.warning ~forStats:false ~loc
                   (Termination
                      {
                        termination = TerminationAnalysisInternal;
@@ -633,7 +633,7 @@ module ExtendFunctionTable = struct
                  functionTable
                  |> FunctionTable.addLabelToKind ~functionName ~label;
                  if config.DceConfig.cli.debug then
-                   Log_.warning ~config ~forStats:false ~loc
+                   Log_.warning ~forStats:false ~loc
                      (Termination
                         {
                           termination = TerminationAnalysisInternal;
@@ -700,7 +700,7 @@ module CheckExpressionWellFormed = struct
                        functionTable
                        |> FunctionTable.addLabelToKind ~functionName ~label;
                        if config.DceConfig.cli.debug then
-                         Log_.warning ~config ~forStats:false ~loc:body.exp_loc
+                         Log_.warning ~forStats:false ~loc:body.exp_loc
                            (Termination
                               {
                                 termination = TerminationAnalysisInternal;
@@ -879,7 +879,7 @@ module Compile = struct
         newFunctionName;
       newFunctionDefinition.body <- Some (vb_expr |> expression ~ctx:newCtx);
       if config.DceConfig.cli.debug then
-        Log_.warning ~config ~forStats:false ~loc:pat_loc
+        Log_.warning ~forStats:false ~loc:pat_loc
           (Termination
              {
                termination = TerminationAnalysisInternal;
@@ -1410,7 +1410,7 @@ let processStructure ~config (structure : Typedtree.structure) =
   let traverseAst = traverseAst ~config ~valueBindingsTable in
   structure |> traverseAst.structure traverseAst |> ignore
 
-let processCmt ~config (cmt_infos : Cmt_format.cmt_infos) =
+let processCmt ~config ~file:_ (cmt_infos : Cmt_format.cmt_infos) =
   match cmt_infos.cmt_annots with
   | Interface _ -> ()
   | Implementation structure -> processStructure ~config structure

--- a/analysis/reanalyze/src/Common.ml
+++ b/analysis/reanalyze/src/Common.ml
@@ -1,6 +1,3 @@
-let currentSrc = ref ""
-let currentModule = ref ""
-let currentModuleName = ref ("" |> Name.create)
 let runConfig = RunConfig.runConfig
 
 (* Location printer: `filename:line: ' *)

--- a/analysis/reanalyze/src/DeadCode.ml
+++ b/analysis/reanalyze/src/DeadCode.ml
@@ -1,32 +1,35 @@
 open DeadCommon
 
-let processSignature ~config ~doValues ~doTypes (signature : Types.signature) =
+let processSignature ~config ~file ~doValues ~doTypes
+    (signature : Types.signature) =
   signature
   |> List.iter (fun sig_item ->
-         DeadValue.processSignatureItem ~config ~doValues ~doTypes
+         DeadValue.processSignatureItem ~config ~file ~doValues ~doTypes
            ~moduleLoc:Location.none
-           ~path:[!Common.currentModuleName]
+           ~path:[FileContext.module_name_tagged file]
            sig_item)
 
-let processCmt ~config ~cmtFilePath (cmt_infos : Cmt_format.cmt_infos) =
+let processCmt ~config ~file ~cmtFilePath (cmt_infos : Cmt_format.cmt_infos) =
   (match cmt_infos.cmt_annots with
   | Interface signature ->
     ProcessDeadAnnotations.signature ~config signature;
-    processSignature ~config ~doValues:true ~doTypes:true signature.sig_type
+    processSignature ~config ~file ~doValues:true ~doTypes:true
+      signature.sig_type
   | Implementation structure ->
     let cmtiExists =
       Sys.file_exists ((cmtFilePath |> Filename.remove_extension) ^ ".cmti")
     in
     ProcessDeadAnnotations.structure ~config ~doGenType:(not cmtiExists)
       structure;
-    processSignature ~config ~doValues:true ~doTypes:false structure.str_type;
+    processSignature ~config ~file ~doValues:true ~doTypes:false
+      structure.str_type;
     let doExternals =
       (* This is already handled at the interface level, avoid issues in inconsistent locations
          https://github.com/BuckleScript/syntax/pull/54
          Ideally, the handling should be less location-based, just like other language aspects. *)
       false
     in
-    DeadValue.processStructure ~config ~doTypes:true ~doExternals
+    DeadValue.processStructure ~config ~file ~doTypes:true ~doExternals
       ~cmt_value_dependencies:cmt_infos.cmt_value_dependencies structure
   | _ -> ());
   DeadType.TypeDependencies.forceDelayedItems ~config;

--- a/analysis/reanalyze/src/DeadModules.ml
+++ b/analysis/reanalyze/src/DeadModules.ml
@@ -33,7 +33,7 @@ let checkModuleDead ~config ~fileName:pos_fname moduleName =
           {Location.loc_start = pos; loc_end = pos; loc_ghost = false}
         else loc
       in
-      Log_.warning ~config ~loc
+      Log_.warning ~loc
         (Common.DeadModule
            {
              message =

--- a/analysis/reanalyze/src/DeadOptionalArgs.ml
+++ b/analysis/reanalyze/src/DeadOptionalArgs.ml
@@ -81,14 +81,14 @@ let forceDelayedItems () =
            OptionalArgs.combine rFrom.optionalArgs rTo.optionalArgs
          | _ -> ())
 
-let check ~config decl =
+let check ~config:_ decl =
   match decl with
   | {declKind = Value {optionalArgs}}
     when active ()
          && not (ProcessDeadAnnotations.isAnnotatedGenTypeOrLive decl.pos) ->
     optionalArgs
     |> OptionalArgs.iterUnused (fun s ->
-           Log_.warning ~config ~loc:(decl |> declGetLoc)
+           Log_.warning ~loc:(decl |> declGetLoc)
              (DeadOptional
                 {
                   deadOptional = WarningUnusedArgument;
@@ -101,7 +101,7 @@ let check ~config decl =
                 }));
     optionalArgs
     |> OptionalArgs.iterAlwaysUsed (fun s nCalls ->
-           Log_.warning ~config ~loc:(decl |> declGetLoc)
+           Log_.warning ~loc:(decl |> declGetLoc)
              (DeadOptional
                 {
                   deadOptional = WarningRedundantOptionalArgument;

--- a/analysis/reanalyze/src/Log_.ml
+++ b/analysis/reanalyze/src/Log_.ml
@@ -247,7 +247,7 @@ let logIssue ~forStats ~severity ~(loc : Location.t) description =
   if Suppress.filter loc.loc_start then
     if forStats then Stats.addIssue {name; severity; loc; description}
 
-let warning ~config ?(forStats = true) ~loc description =
+let warning ?(forStats = true) ~loc description =
   description |> logIssue ~severity:Warning ~forStats ~loc
 
 let error ~loc description =


### PR DESCRIPTION
Task 1 of the dead code refactor plan: eliminate global mutable state for current file context.

Changes:
- Add DeadCommon.FileContext.t with source_path, module_name, is_interface
- Thread ~file parameter through DeadCode, DeadValue, DeadType, DeadCommon
- Thread ~file through Exception.processCmt and Arnold.processCmt
- Remove Common.currentSrc, currentModule, currentModuleName globals

Design improvement:
- FileContext.module_name is now a raw string (e.g. "ExnB"), not Name.t
- Added FileContext.module_name_tagged helper to create Name.t when needed
- This avoids confusion: raw name for hashtable keys, tagged name for paths
- Previously the interface encoding (+prefix) leaked into code that expected raw names

This makes it possible to process files concurrently or out of order, as analysis no longer depends on hidden global state for file context.