### PR TITLE
DCE: Task 4 - Declarations use map → list → merge pattern

### DIFF
--- a/analysis/reanalyze/DEADCODE_REFACTOR_PLAN.md
+++ b/analysis/reanalyze/DEADCODE_REFACTOR_PLAN.md
@@ -325,12 +325,15 @@ val is_annotated_* : t -> ... -> bool
 **Pattern**: Same as Task 3 - `builder` (mutable) → `builder list` → `merge_all` → `t` (immutable)
 
 **Changes**:
-- [ ] Create `Declarations` module with `builder` and `t` types
-- [ ] `process_cmt_file` returns `Declarations.builder` (local mutable)
-- [ ] `processCmtFiles` collects into `builder list`
-- [ ] `Declarations.merge_all : builder list -> t`
-- [ ] Solver uses immutable `Declarations.t`
-- [ ] Delete global `DeadCommon.decls`
+- [x] Create `Declarations` module with `builder` and `t` types
+- [x] `process_cmt_file` returns `DceFileProcessing.file_data` containing both `annotations` and `decls` builders
+- [x] `processCmtFiles` collects into `file_data list`
+- [x] `Declarations.merge_all : builder list -> t`
+- [x] Solver uses immutable `Declarations.t`
+- [x] Delete global `DeadCommon.decls`
+- [x] Update `DeadOptionalArgs.forceDelayedItems` to take `~decls:Declarations.t`
+
+**Status**: Complete ✅
 
 **Test**: Process files in different orders - results should be identical.
 

--- a/analysis/reanalyze/src/CollectAnnotations.ml
+++ b/analysis/reanalyze/src/CollectAnnotations.ml
@@ -1,0 +1,149 @@
+(** AST traversal to collect source annotations (@dead, @live, @genType).
+    
+    This module traverses the typed AST to find attribute annotations
+    and records them in a FileAnnotations.builder. *)
+
+open DeadCommon
+
+let processAttributes ~state ~config ~doGenType ~name ~pos attributes =
+  let getPayloadFun f = attributes |> Annotation.getAttributePayload f in
+  let getPayload (x : string) =
+    attributes |> Annotation.getAttributePayload (( = ) x)
+  in
+  if
+    doGenType
+    && getPayloadFun Annotation.tagIsOneOfTheGenTypeAnnotations <> None
+  then FileAnnotations.annotate_gentype state pos;
+  if getPayload WriteDeadAnnotations.deadAnnotation <> None then
+    FileAnnotations.annotate_dead state pos;
+  let nameIsInLiveNamesOrPaths () =
+    config.DceConfig.cli.live_names |> List.mem name
+    ||
+    let fname =
+      match Filename.is_relative pos.pos_fname with
+      | true -> pos.pos_fname
+      | false -> Filename.concat (Sys.getcwd ()) pos.pos_fname
+    in
+    let fnameLen = String.length fname in
+    config.DceConfig.cli.live_paths
+    |> List.exists (fun prefix ->
+           String.length prefix <= fnameLen
+           &&
+           try String.sub fname 0 (String.length prefix) = prefix
+           with Invalid_argument _ -> false)
+  in
+  if getPayload liveAnnotation <> None || nameIsInLiveNamesOrPaths () then
+    FileAnnotations.annotate_live state pos;
+  if attributes |> Annotation.isOcamlSuppressDeadWarning then
+    FileAnnotations.annotate_live state pos
+
+let collectExportLocations ~state ~config ~doGenType =
+  let super = Tast_mapper.default in
+  let currentlyDisableWarnings = ref false in
+  let value_binding self
+      ({vb_attributes; vb_pat} as value_binding : Typedtree.value_binding) =
+    (match vb_pat.pat_desc with
+    | Tpat_var (id, {loc = {loc_start = pos}})
+    | Tpat_alias ({pat_desc = Tpat_any}, id, {loc = {loc_start = pos}}) ->
+      if !currentlyDisableWarnings then FileAnnotations.annotate_live state pos;
+      vb_attributes
+      |> processAttributes ~state ~config ~doGenType ~name:(id |> Ident.name)
+           ~pos
+    | _ -> ());
+    super.value_binding self value_binding
+  in
+  let type_kind toplevelAttrs self (typeKind : Typedtree.type_kind) =
+    (match typeKind with
+    | Ttype_record labelDeclarations ->
+      labelDeclarations
+      |> List.iter
+           (fun ({ld_attributes; ld_loc} : Typedtree.label_declaration) ->
+             toplevelAttrs @ ld_attributes
+             |> processAttributes ~state ~config ~doGenType:false ~name:""
+                  ~pos:ld_loc.loc_start)
+    | Ttype_variant constructorDeclarations ->
+      constructorDeclarations
+      |> List.iter
+           (fun
+             ({cd_attributes; cd_loc; cd_args} :
+               Typedtree.constructor_declaration)
+           ->
+             let _process_inline_records =
+               match cd_args with
+               | Cstr_record flds ->
+                 List.iter
+                   (fun ({ld_attributes; ld_loc} : Typedtree.label_declaration)
+                      ->
+                     toplevelAttrs @ cd_attributes @ ld_attributes
+                     |> processAttributes ~state ~config ~doGenType:false
+                          ~name:"" ~pos:ld_loc.loc_start)
+                   flds
+               | Cstr_tuple _ -> ()
+             in
+             toplevelAttrs @ cd_attributes
+             |> processAttributes ~state ~config ~doGenType:false ~name:""
+                  ~pos:cd_loc.loc_start)
+    | _ -> ());
+    super.type_kind self typeKind
+  in
+  let type_declaration self (typeDeclaration : Typedtree.type_declaration) =
+    let attributes = typeDeclaration.typ_attributes in
+    let _ = type_kind attributes self typeDeclaration.typ_kind in
+    typeDeclaration
+  in
+  let value_description self
+      ({val_attributes; val_id; val_val = {val_loc = {loc_start = pos}}} as
+       value_description :
+        Typedtree.value_description) =
+    if !currentlyDisableWarnings then FileAnnotations.annotate_live state pos;
+    val_attributes
+    |> processAttributes ~state ~config ~doGenType ~name:(val_id |> Ident.name)
+         ~pos;
+    super.value_description self value_description
+  in
+  let structure_item self (item : Typedtree.structure_item) =
+    (match item.str_desc with
+    | Tstr_attribute attribute
+      when [attribute] |> Annotation.isOcamlSuppressDeadWarning ->
+      currentlyDisableWarnings := true
+    | _ -> ());
+    super.structure_item self item
+  in
+  let structure self (structure : Typedtree.structure) =
+    let oldDisableWarnings = !currentlyDisableWarnings in
+    super.structure self structure |> ignore;
+    currentlyDisableWarnings := oldDisableWarnings;
+    structure
+  in
+  let signature_item self (item : Typedtree.signature_item) =
+    (match item.sig_desc with
+    | Tsig_attribute attribute
+      when [attribute] |> Annotation.isOcamlSuppressDeadWarning ->
+      currentlyDisableWarnings := true
+    | _ -> ());
+    super.signature_item self item
+  in
+  let signature self (signature : Typedtree.signature) =
+    let oldDisableWarnings = !currentlyDisableWarnings in
+    super.signature self signature |> ignore;
+    currentlyDisableWarnings := oldDisableWarnings;
+    signature
+  in
+  {
+    super with
+    signature;
+    signature_item;
+    structure;
+    structure_item;
+    type_declaration;
+    value_binding;
+    value_description;
+  }
+
+let structure ~state ~config ~doGenType structure =
+  let mapper = collectExportLocations ~state ~config ~doGenType in
+  structure |> mapper.structure mapper |> ignore
+
+let signature ~state ~config signature =
+  let mapper = collectExportLocations ~state ~config ~doGenType:true in
+  signature |> mapper.signature mapper |> ignore

--- a/analysis/reanalyze/src/CollectAnnotations.mli
+++ b/analysis/reanalyze/src/CollectAnnotations.mli
@@ -1,0 +1,18 @@
+(** AST traversal to collect source annotations (@dead, @live, @genType).
+    
+    Traverses the typed AST and records annotations in a FileAnnotations.builder. *)
+
+val structure :
+  state:FileAnnotations.builder ->
+  config:DceConfig.t ->
+  doGenType:bool ->
+  Typedtree.structure ->
+  unit
+(** Traverse a structure and collect annotations. *)
+
+val signature :
+  state:FileAnnotations.builder ->
+  config:DceConfig.t ->
+  Typedtree.signature ->
+  unit
+(** Traverse a signature and collect annotations. *)

--- a/analysis/reanalyze/src/DceFileProcessing.ml
+++ b/analysis/reanalyze/src/DceFileProcessing.ml
@@ -1,7 +1,7 @@
 (** Per-file AST processing for dead code analysis.
     
-    This module uses FileAnnotations.builder during AST traversal
-    and returns it for merging. The caller freezes it before
+    This module coordinates per-file processing using local mutable builders
+    and returns them for merging. The caller freezes them before
     passing to the solver. *)
 
 open DeadCommon
@@ -17,163 +17,9 @@ type file_context = {
 let module_name_tagged (file : file_context) =
   file.module_name |> Name.create ~isInterface:file.is_interface
 
-(* ===== AST Processing (internal) ===== *)
+(* ===== Signature processing ===== *)
 
-module CollectAnnotations = struct
-  let processAttributes ~state ~config ~doGenType ~name ~pos attributes =
-    let getPayloadFun f = attributes |> Annotation.getAttributePayload f in
-    let getPayload (x : string) =
-      attributes |> Annotation.getAttributePayload (( = ) x)
-    in
-    if
-      doGenType
-      && getPayloadFun Annotation.tagIsOneOfTheGenTypeAnnotations <> None
-    then FileAnnotations.annotate_gentype state pos;
-    if getPayload WriteDeadAnnotations.deadAnnotation <> None then
-      FileAnnotations.annotate_dead state pos;
-    let nameIsInLiveNamesOrPaths () =
-      config.DceConfig.cli.live_names |> List.mem name
-      ||
-      let fname =
-        match Filename.is_relative pos.pos_fname with
-        | true -> pos.pos_fname
-        | false -> Filename.concat (Sys.getcwd ()) pos.pos_fname
-      in
-      let fnameLen = String.length fname in
-      config.DceConfig.cli.live_paths
-      |> List.exists (fun prefix ->
-             String.length prefix <= fnameLen
-             &&
-             try String.sub fname 0 (String.length prefix) = prefix
-             with Invalid_argument _ -> false)
-    in
-    if getPayload liveAnnotation <> None || nameIsInLiveNamesOrPaths () then
-      FileAnnotations.annotate_live state pos;
-    if attributes |> Annotation.isOcamlSuppressDeadWarning then
-      FileAnnotations.annotate_live state pos
-
-  let collectExportLocations ~state ~config ~doGenType =
-    let super = Tast_mapper.default in
-    let currentlyDisableWarnings = ref false in
-    let value_binding self
-        ({vb_attributes; vb_pat} as value_binding : Typedtree.value_binding) =
-      (match vb_pat.pat_desc with
-      | Tpat_var (id, {loc = {loc_start = pos}})
-      | Tpat_alias ({pat_desc = Tpat_any}, id, {loc = {loc_start = pos}}) ->
-        if !currentlyDisableWarnings then
-          FileAnnotations.annotate_live state pos;
-        vb_attributes
-        |> processAttributes ~state ~config ~doGenType ~name:(id |> Ident.name)
-             ~pos
-      | _ -> ());
-      super.value_binding self value_binding
-    in
-    let type_kind toplevelAttrs self (typeKind : Typedtree.type_kind) =
-      (match typeKind with
-      | Ttype_record labelDeclarations ->
-        labelDeclarations
-        |> List.iter
-             (fun ({ld_attributes; ld_loc} : Typedtree.label_declaration) ->
-               toplevelAttrs @ ld_attributes
-               |> processAttributes ~state ~config ~doGenType:false ~name:""
-                    ~pos:ld_loc.loc_start)
-      | Ttype_variant constructorDeclarations ->
-        constructorDeclarations
-        |> List.iter
-             (fun
-               ({cd_attributes; cd_loc; cd_args} :
-                 Typedtree.constructor_declaration)
-             ->
-               let _process_inline_records =
-                 match cd_args with
-                 | Cstr_record flds ->
-                   List.iter
-                     (fun ({ld_attributes; ld_loc} :
-                            Typedtree.label_declaration) ->
-                       toplevelAttrs @ cd_attributes @ ld_attributes
-                       |> processAttributes ~state ~config ~doGenType:false
-                            ~name:"" ~pos:ld_loc.loc_start)
-                     flds
-                 | Cstr_tuple _ -> ()
-               in
-               toplevelAttrs @ cd_attributes
-               |> processAttributes ~state ~config ~doGenType:false ~name:""
-                    ~pos:cd_loc.loc_start)
-      | _ -> ());
-      super.type_kind self typeKind
-    in
-    let type_declaration self (typeDeclaration : Typedtree.type_declaration) =
-      let attributes = typeDeclaration.typ_attributes in
-      let _ = type_kind attributes self typeDeclaration.typ_kind in
-      typeDeclaration
-    in
-    let value_description self
-        ({val_attributes; val_id; val_val = {val_loc = {loc_start = pos}}} as
-         value_description :
-          Typedtree.value_description) =
-      if !currentlyDisableWarnings then FileAnnotations.annotate_live state pos;
-      val_attributes
-      |> processAttributes ~state ~config ~doGenType
-           ~name:(val_id |> Ident.name) ~pos;
-      super.value_description self value_description
-    in
-    let structure_item self (item : Typedtree.structure_item) =
-      (match item.str_desc with
-      | Tstr_attribute attribute
-        when [attribute] |> Annotation.isOcamlSuppressDeadWarning ->
-        currentlyDisableWarnings := true
-      | _ -> ());
-      super.structure_item self item
-    in
-    let structure self (structure : Typedtree.structure) =
-      let oldDisableWarnings = !currentlyDisableWarnings in
-      super.structure self structure |> ignore;
-      currentlyDisableWarnings := oldDisableWarnings;
-      structure
-    in
-    let signature_item self (item : Typedtree.signature_item) =
-      (match item.sig_desc with
-      | Tsig_attribute attribute
-        when [attribute] |> Annotation.isOcamlSuppressDeadWarning ->
-        currentlyDisableWarnings := true
-      | _ -> ());
-      super.signature_item self item
-    in
-    let signature self (signature : Typedtree.signature) =
-      let oldDisableWarnings = !currentlyDisableWarnings in
-      super.signature self signature |> ignore;
-      currentlyDisableWarnings := oldDisableWarnings;
-      signature
-    in
-    {
-      super with
-      signature;
-      signature_item;
-      structure;
-      structure_item;
-      type_declaration;
-      value_binding;
-      value_description;
-    }
-
-  let structure ~state ~config ~doGenType structure =
-    let collectExportLocations =
-      collectExportLocations ~state ~config ~doGenType
-    in
-    structure
-    |> collectExportLocations.structure collectExportLocations
-    |> ignore
-
-  let signature ~state ~config signature =
-    let collectExportLocations =
-      collectExportLocations ~state ~config ~doGenType:true
-    in
-    signature
-    |> collectExportLocations.signature collectExportLocations
-    |> ignore
-end
-
-let processSignature ~config ~(file : file_context) ~doValues ~doTypes
+let processSignature ~config ~decls ~(file : file_context) ~doValues ~doTypes
     (signature : Types.signature) =
   let dead_common_file : FileContext.t =
     {
@@ -184,15 +30,20 @@ let processSignature ~config ~(file : file_context) ~doValues ~doTypes
   in
   signature
   |> List.iter (fun sig_item ->
-         DeadValue.processSignatureItem ~config ~file:dead_common_file ~doValues
-           ~doTypes ~moduleLoc:Location.none
+         DeadValue.processSignatureItem ~config ~decls ~file:dead_common_file
+           ~doValues ~doTypes ~moduleLoc:Location.none
            ~path:[module_name_tagged file]
            sig_item)
 
 (* ===== Main entry point ===== *)
 
+type file_data = {
+  annotations: FileAnnotations.builder;
+  decls: Declarations.builder;
+}
+
 let process_cmt_file ~config ~(file : file_context) ~cmtFilePath
-    (cmt_infos : Cmt_format.cmt_infos) : FileAnnotations.builder =
+    (cmt_infos : Cmt_format.cmt_infos) : file_data =
   (* Convert to DeadCommon.FileContext for functions that need it *)
   let dead_common_file : FileContext.t =
     {
@@ -201,27 +52,28 @@ let process_cmt_file ~config ~(file : file_context) ~cmtFilePath
       is_interface = file.is_interface;
     }
   in
-  (* Mutable builder for AST processing *)
-  let builder = FileAnnotations.create_builder () in
+  (* Mutable builders for AST processing *)
+  let annotations = FileAnnotations.create_builder () in
+  let decls = Declarations.create_builder () in
   (match cmt_infos.cmt_annots with
   | Interface signature ->
-    CollectAnnotations.signature ~state:builder ~config signature;
-    processSignature ~config ~file ~doValues:true ~doTypes:true
+    CollectAnnotations.signature ~state:annotations ~config signature;
+    processSignature ~config ~decls ~file ~doValues:true ~doTypes:true
       signature.sig_type
   | Implementation structure ->
     let cmtiExists =
       Sys.file_exists ((cmtFilePath |> Filename.remove_extension) ^ ".cmti")
     in
-    CollectAnnotations.structure ~state:builder ~config
+    CollectAnnotations.structure ~state:annotations ~config
       ~doGenType:(not cmtiExists) structure;
-    processSignature ~config ~file ~doValues:true ~doTypes:false
+    processSignature ~config ~decls ~file ~doValues:true ~doTypes:false
       structure.str_type;
     let doExternals = false in
-    DeadValue.processStructure ~config ~file:dead_common_file ~doTypes:true
-      ~doExternals ~cmt_value_dependencies:cmt_infos.cmt_value_dependencies
-      structure
+    DeadValue.processStructure ~config ~decls ~file:dead_common_file
+      ~doTypes:true ~doExternals
+      ~cmt_value_dependencies:cmt_infos.cmt_value_dependencies structure
   | _ -> ());
   DeadType.TypeDependencies.forceDelayedItems ~config;
   DeadType.TypeDependencies.clear ();
-  (* Return builder - caller will merge and freeze *)
-  builder
+  (* Return builders - caller will merge and freeze *)
+  {annotations; decls}

--- a/analysis/reanalyze/src/DceFileProcessing.mli
+++ b/analysis/reanalyze/src/DceFileProcessing.mli
@@ -1,8 +1,8 @@
 (** Per-file AST processing for dead code analysis.
     
-    This module uses [FileAnnotations.builder] during AST traversal
-    and returns it for merging. The caller freezes the accumulated
-    builder before passing to the solver. *)
+    This module uses mutable builders during AST traversal
+    and returns them for merging. The caller freezes the accumulated
+    builders before passing to the solver. *)
 
 type file_context = {
   source_path: string;
@@ -11,11 +11,17 @@ type file_context = {
 }
 (** File context for processing *)
 
+type file_data = {
+  annotations: FileAnnotations.builder;
+  decls: Declarations.builder;
+}
+(** Result of processing a cmt file - both annotations and declarations *)
+
 val process_cmt_file :
   config:DceConfig.t ->
   file:file_context ->
   cmtFilePath:string ->
   Cmt_format.cmt_infos ->
-  FileAnnotations.builder
-(** Process a cmt file and return mutable builder.
+  file_data
+(** Process a cmt file and return mutable builders.
     Caller should merge builders and freeze before passing to solver. *)

--- a/analysis/reanalyze/src/DeadException.ml
+++ b/analysis/reanalyze/src/DeadException.ml
@@ -6,11 +6,11 @@ type item = {exceptionPath: Path.t; locFrom: Location.t}
 let delayedItems = ref []
 let declarations = Hashtbl.create 1
 
-let add ~config ~file ~path ~loc ~(strLoc : Location.t) name =
+let add ~config ~decls ~file ~path ~loc ~(strLoc : Location.t) name =
   let exceptionPath = name :: path in
   Hashtbl.add declarations exceptionPath loc;
   name
-  |> addDeclaration_ ~config ~file ~posEnd:strLoc.loc_end
+  |> addDeclaration_ ~config ~decls ~file ~posEnd:strLoc.loc_end
        ~posStart:strLoc.loc_start ~declKind:Exception
        ~moduleLoc:(ModulePath.getCurrent ()).loc ~path ~loc
 

--- a/analysis/reanalyze/src/DeadType.ml
+++ b/analysis/reanalyze/src/DeadType.ml
@@ -81,7 +81,7 @@ let addTypeDependenciesInnerModule ~config ~pathToType ~loc ~typeLabelName =
       extendTypeDependencies ~config loc2 loc
   | None -> TypeLabels.add path loc
 
-let addDeclaration ~config ~file ~(typeId : Ident.t)
+let addDeclaration ~config ~decls ~file ~(typeId : Ident.t)
     ~(typeKind : Types.type_kind) =
   let currentModulePath = ModulePath.getCurrent () in
   let pathToType =
@@ -90,7 +90,7 @@ let addDeclaration ~config ~file ~(typeId : Ident.t)
   in
   let processTypeLabel ?(posAdjustment = Nothing) typeLabelName ~declKind
       ~(loc : Location.t) =
-    addDeclaration_ ~config ~file ~declKind ~path:pathToType ~loc
+    addDeclaration_ ~config ~decls ~file ~declKind ~path:pathToType ~loc
       ~moduleLoc:currentModulePath.loc ~posAdjustment typeLabelName;
     addTypeDependenciesAcrossFiles ~config ~file ~pathToType ~loc ~typeLabelName;
     addTypeDependenciesInnerModule ~config ~pathToType ~loc ~typeLabelName;

--- a/analysis/reanalyze/src/Declarations.ml
+++ b/analysis/reanalyze/src/Declarations.ml
@@ -1,0 +1,49 @@
+(** Declarations collected during dead code analysis.
+    
+    Two types are provided:
+    - [builder] - mutable, for AST processing
+    - [t] - immutable, for solver (read-only access) *)
+
+open Common
+
+(* Position-keyed hashtable (same as DeadCommon.PosHash but no dependency) *)
+module PosHash = Hashtbl.Make (struct
+  type t = Lexing.position
+
+  let hash x =
+    let s = Filename.basename x.Lexing.pos_fname in
+    Hashtbl.hash (x.Lexing.pos_cnum, s)
+
+  let equal (x : t) y = x = y
+end)
+
+(* Both types have the same representation, but different semantics *)
+type t = decl PosHash.t
+type builder = decl PosHash.t
+
+(* ===== Builder API ===== *)
+
+let create_builder () : builder = PosHash.create 256
+
+let add (builder : builder) (pos : Lexing.position) (decl : decl) =
+  PosHash.replace builder pos decl
+
+let find_opt_builder (builder : builder) pos = PosHash.find_opt builder pos
+
+let replace_builder (builder : builder) (pos : Lexing.position) (decl : decl) =
+  PosHash.replace builder pos decl
+
+let merge_all (builders : builder list) : t =
+  let result = PosHash.create 256 in
+  builders
+  |> List.iter (fun builder ->
+         PosHash.iter (fun pos decl -> PosHash.replace result pos decl) builder);
+  result
+
+(* ===== Read-only API ===== *)
+
+let find_opt (t : t) pos = PosHash.find_opt t pos
+
+let fold f (t : t) init = PosHash.fold f t init
+
+let iter f (t : t) = PosHash.iter f t

--- a/analysis/reanalyze/src/Declarations.mli
+++ b/analysis/reanalyze/src/Declarations.mli
@@ -1,0 +1,32 @@
+(** Declarations collected during dead code analysis.
+    
+    Two types are provided:
+    - [builder] - mutable, for AST processing
+    - [t] - immutable, for solver (read-only access)
+    
+    Only DceFileProcessing should use [builder].
+    The solver uses [t] which is frozen/immutable. *)
+
+(** {2 Types} *)
+
+type t
+(** Immutable declarations - for solver (read-only) *)
+
+type builder
+(** Mutable builder - for AST processing *)
+
+(** {2 Builder API - for DceFileProcessing only} *)
+
+val create_builder : unit -> builder
+val add : builder -> Lexing.position -> Common.decl -> unit
+val find_opt_builder : builder -> Lexing.position -> Common.decl option
+val replace_builder : builder -> Lexing.position -> Common.decl -> unit
+
+val merge_all : builder list -> t
+(** Merge all builders into one immutable result. Order doesn't matter. *)
+
+(** {2 Read-only API for t - for solver} *)
+
+val find_opt : t -> Lexing.position -> Common.decl option
+val fold : (Lexing.position -> Common.decl -> 'a -> 'a) -> t -> 'a -> 'a
+val iter : (Lexing.position -> Common.decl -> unit) -> t -> unit


### PR DESCRIPTION
Applies the same architectural pattern from Task 3 (annotations) to declarations.

## New modules

- Declarations.ml/.mli: builder (mutable) and t (immutable) types
- CollectAnnotations.ml/.mli: AST traversal for @dead/@live/@genType annotations

## Key changes

1. **Declarations pattern**:
   - process_cmt_file creates local Declarations.builder
   - processCmtFiles collects file_data list (annotations + decls)
   - Declarations.merge_all combines into immutable t
   - Solver uses Declarations.t (read-only)

2. **Global state removed**:
   - Deleted global DeadCommon.decls
   - All declaration access now through explicit ~decls parameter

3. **AST processing separation**:
   - CollectAnnotations.ml: annotation traversal (~150 lines)
   - DceFileProcessing.ml: coordinator (~80 lines, was ~230)

4. **Threading ~decls:builder through AST processing**:
   - addDeclaration_, addValueDeclaration
   - DeadValue.processStructure, processSignatureItem, traverseStructure
   - DeadType.addDeclaration
   - DeadException.add
   - DeadOptionalArgs.addFunctionReference

## Data flow

    process_cmt_file (per-file)
        ├── CollectAnnotations → FileAnnotations.builder
        └── DeadValue/Type/Exception → Declarations.builder

    Merge phase:
        FileAnnotations.merge_all → FileAnnotations.t
        Declarations.merge_all → Declarations.t

    Solver:
        reportDead ~annotations ~decls (both immutable)

## Benefits

- Order independence: files can be processed in any order
- Parallelizable: map phase can run concurrently (future)
- Incremental: replace one file's builders, re-merge (future)
- Type-safe: t types have no mutation functions