### PR TITLE
DCE: Make analysis phase return AnalysisResult.t (Task 8)

### DIFF
--- a/analysis/reanalyze/src/AnalysisResult.ml
+++ b/analysis/reanalyze/src/AnalysisResult.ml
@@ -1,0 +1,52 @@
+(** Analysis result - immutable output from the solver.
+    
+    The solver returns this instead of logging directly.
+    All side effects (logging, JSON output) happen in the reporting phase. *)
+
+open Common
+
+type t = {issues: issue list}
+(** Immutable analysis result *)
+
+let empty = {issues = []}
+
+let add_issue result issue = {issues = issue :: result.issues}
+
+let add_issues result new_issues =
+  {issues = List.rev_append new_issues result.issues}
+
+let get_issues result = result.issues |> List.rev
+
+let issue_count result = List.length result.issues
+
+(** Create a dead code issue *)
+let make_dead_issue ~loc ~deadWarning ~path ~message =
+  {
+    name =
+      (match deadWarning with
+      | WarningDeadException -> "Warning Dead Exception"
+      | WarningDeadType -> "Warning Dead Type"
+      | WarningDeadValue -> "Warning Dead Value"
+      | WarningDeadValueWithSideEffects ->
+        "Warning Dead Value With Side Effects"
+      | IncorrectDeadAnnotation -> "Incorrect Dead Annotation");
+    severity = Warning;
+    loc;
+    description = DeadWarning {deadWarning; path; message};
+  }
+
+(** Create a dead module issue *)
+let make_dead_module_issue ~loc ~moduleName =
+  {
+    name = "Warning Dead Module";
+    severity = Warning;
+    loc;
+    description =
+      DeadModule
+        {
+          message =
+            Format.asprintf "@{<info>%s@} %s"
+              (moduleName |> Name.toInterface |> Name.toString)
+              "is a dead module as all its items are dead.";
+        };
+  }

--- a/analysis/reanalyze/src/AnalysisResult.mli
+++ b/analysis/reanalyze/src/AnalysisResult.mli
@@ -1,0 +1,37 @@
+(** Analysis result - immutable output from the solver.
+    
+    The solver returns this instead of logging directly.
+    All side effects (logging, JSON output) happen in the reporting phase. *)
+
+open Common
+
+type t
+(** Immutable analysis result *)
+
+val empty : t
+(** Empty result with no issues *)
+
+val add_issue : t -> issue -> t
+(** Add a single issue to the result *)
+
+val add_issues : t -> issue list -> t
+(** Add multiple issues to the result *)
+
+val get_issues : t -> issue list
+(** Get all issues in order they were added *)
+
+val issue_count : t -> int
+(** Count of issues *)
+
+(** {2 Issue constructors} *)
+
+val make_dead_issue :
+  loc:Location.t ->
+  deadWarning:deadWarning ->
+  path:string ->
+  message:string ->
+  issue
+(** Create a dead code warning issue *)
+
+val make_dead_module_issue : loc:Location.t -> moduleName:Name.t -> issue
+(** Create a dead module warning issue *)

--- a/analysis/reanalyze/src/Common.ml
+++ b/analysis/reanalyze/src/Common.ml
@@ -133,6 +133,11 @@ module OptionalArgs = struct
 
   let iterUnused f x = StringSet.iter f x.unused
   let iterAlwaysUsed f x = StringSet.iter (fun s -> f s x.count) x.alwaysUsed
+
+  let foldUnused f x init = StringSet.fold f x.unused init
+
+  let foldAlwaysUsed f x init =
+    StringSet.fold (fun s acc -> f s x.count acc) x.alwaysUsed init
 end
 
 module DeclKind = struct


### PR DESCRIPTION
This completes Task 8 of the DCE refactor plan, making the analysis phase return an immutable AnalysisResult.t instead of logging directly.

Key changes:
- Add AnalysisResult module with immutable result type and issue constructors
- makeDeadIssue: pure function to create dead code issues
- Decl.report: returns issue list (includes dead module + dead value issues)
- DeadOptionalArgs.check: returns issue list instead of logging
- DeadModules.checkModuleDead: returns issue option instead of logging
- reportDead: returns AnalysisResult.t, caller logs issues

Architecture after this change:
  merged_view (immutable) │ ▼ reportDead (pure function) │ ▼ AnalysisResult.t (immutable) │ ▼ report (side effects here only)

Note: Optional args and incorrect annotation issues are still logged inline during resolveRecursiveRefs. A future task could collect these as well.