### PR TITLE
Add option to force build before extracting doc

### DIFF
--- a/tools/bin/main.ml
+++ b/tools/bin/main.ml
@@ -63,10 +63,8 @@ let version = Version.version
 let getRescriptBinary () =
   let toolsExePath = Sys.executable_name in
   let binDir = Filename.dirname toolsExePath in
-  let rescriptBin = Filename.concat binDir "rescript" in
-  (* On Windows, try with .exe extension *)
-  if Sys.win32 && not (Sys.file_exists rescriptBin) then rescriptBin ^ ".exe"
-  else rescriptBin
+  (* ReScript binaries use .exe extension on all platforms *)
+  Filename.concat binDir "rescript.exe"
 
 (* Build the project using the rescript binary *)
 let buildProject ~rootPath =


### PR DESCRIPTION
Fix https://github.com/rescript-lang/rescript/issues/8040

The `rescript-tools doc` extracts the docs from `cmt` files. `cmt` files require the source code to be rebuilt to refresh them. This adds an option to run the build before extracting the doc so the `cmt` files are always up to date.

@nojaf @cknitt I'm not sure if this something we want, but I feel this is helpful (or less misleading to the users). Users would expect running the tools will always work without rebuilding.

Another thing to consider is the change in the output when the flag is provided.

```
 rescript-demo main*​
 ❯ npx rescript-tools doc src/Demo.res --build
[1/3] 🧹 Cleaned 0/1 in 0.00s
[2/3] 🧱 Parsed 1 source files in 0.01s
[3/3] 🤺 Compiled 1 modules in 0.01s

✨ Finished Compilation in 0.02s

{
  "name": "Demo",
  "docstrings": [],
  "source": {
    "filepath": "src/Demo.res",
    "line": 1,
    "col": 1
  },
  "items": [
  {
    "id": "Demo.x",
    "kind": "value",
    "name": "x",
    "signature": "let x: int",
    "docstrings": ["Hello world!!!"],
    "source": {
      "filepath": "src/Demo.res",
      "line": 4,
      "col": 5
    },
    "detail":
    {
      "kind": "signature",
      "details": {
      "returnType": {
        "path": "int"
      }
    }
    }
  }]
}
```

If the downstream expects a proper JSON, this will break any downstream CLI tools that depends on this.

Marked this as draft as this needs a bit more polishing.