### PR TITLE
Remove version field from various rescript.json files

### DIFF
--- a/analysis/examples/workspace-project/rescript.json
+++ b/analysis/examples/workspace-project/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "workspace-project",
-  "version": "0.1.0",
   "sources": [],
   "package-specs": {
     "module": "es6",

--- a/packages/playground/rescript.json
+++ b/packages/playground/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "playground",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/build_warn_as_error/rescript.json
+++ b/tests/build_tests/build_warn_as_error/rescript.json
@@ -1,5 +1,4 @@
 {
   "name": "build_warn_as_error",
-  "version": "0.1.0",
   "sources": ["src"]
 }

--- a/tests/build_tests/case/rescript.json
+++ b/tests/build_tests/case/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "case",
-  "version": "0.1.0",
   "sources": ["src"],
   "dependencies": []
 }

--- a/tests/build_tests/case2/rescript.json
+++ b/tests/build_tests/case2/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "case2",
-  "version": "0.1.0",
   "sources": ["src"],
   "dependencies": []
 }

--- a/tests/build_tests/case3/rescript.json
+++ b/tests/build_tests/case3/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "case3",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/cli_compile_status/rescript.json
+++ b/tests/build_tests/cli_compile_status/rescript.json
@@ -1,5 +1,4 @@
 {
   "name": "test",
-  "version": "0.1.0",
   "sources": []
 }

--- a/tests/build_tests/custom_namespace/rescript.json
+++ b/tests/build_tests/custom_namespace/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "namespace",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/cycle/rescript.json
+++ b/tests/build_tests/cycle/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "cycle",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/cycle1/rescript.json
+++ b/tests/build_tests/cycle1/rescript.json
@@ -1,7 +1,6 @@
 {
   "name": "cycle1",
   "namespace": true,
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/deprecated-package-specs/rescript.json
+++ b/tests/build_tests/deprecated-package-specs/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "deprecated-package-specs",
-  "version": "0.1.0",
   "sources": "src",
   "package-specs": {
     "module": "es6-global"

--- a/tests/build_tests/devonly/rescript.json
+++ b/tests/build_tests/devonly/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "devonly",
-  "version": "0.1.0",
   "sources": [
     {
       "dir": "src",

--- a/tests/build_tests/duplicated_symlinked_packages/a/rescript.json
+++ b/tests/build_tests/duplicated_symlinked_packages/a/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "a",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/duplicated_symlinked_packages/b/rescript.json
+++ b/tests/build_tests/duplicated_symlinked_packages/b/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "b",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/duplicated_symlinked_packages/c/rescript.json
+++ b/tests/build_tests/duplicated_symlinked_packages/c/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "c",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/duplicated_symlinked_packages/rescript.json
+++ b/tests/build_tests/duplicated_symlinked_packages/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "duplicated-symlinked-packages",
-  "version": "0.1.0",
   "sources": ["src"],
   "dependencies": ["a", "b", "z"]
 }

--- a/tests/build_tests/exports/rescript.json
+++ b/tests/build_tests/exports/rescript.json
@@ -1,5 +1,4 @@
 {
   "name": "exports",
-  "version": "0.1.0",
   "sources": ["src"]
 }

--- a/tests/build_tests/gpr_978/rescript.json
+++ b/tests/build_tests/gpr_978/rescript.json
@@ -1,5 +1,4 @@
 {
   "name": "gpr_978",
-  "version": "0.0.0",
   "sources": ["src"]
 }

--- a/tests/build_tests/hyphen2/rescript.json
+++ b/tests/build_tests/hyphen2/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "hyphen2",
-  "version": "0.1.0",
   "sources": ["y-src"],
   "namespace": true
 }

--- a/tests/build_tests/install/rescript.json
+++ b/tests/build_tests/install/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "install",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/nested/rescript.json
+++ b/tests/build_tests/nested/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "nested",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/nnest/rescript.json
+++ b/tests/build_tests/nnest/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "nested",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/not_undefined_attribute/rescript.json
+++ b/tests/build_tests/not_undefined_attribute/rescript.json
@@ -1,5 +1,4 @@
 {
   "name": "not_undefined_attribute",
-  "version": "0.1.0",
   "sources": ["."]
 }

--- a/tests/build_tests/ns/rescript.json
+++ b/tests/build_tests/ns/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "ns",
-  "version": "0.1.0",
   "sources": ["src"],
   "package-specs": {
     "module": "commonjs",

--- a/tests/build_tests/post-build/rescript.json
+++ b/tests/build_tests/post-build/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "post-build",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/rerror/rescript.json
+++ b/tests/build_tests/rerror/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "rerror",
-  "version": "0.1.0",
   "sources": ["src"],
   "dependencies": []
 }

--- a/tests/build_tests/unboxed_bool_with_const/rescript.json
+++ b/tests/build_tests/unboxed_bool_with_const/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "unboxed_bool_with_const",
-  "version": "0.1.0",
   "sources": [
     {
       "dir": "src",

--- a/tests/build_tests/uncurried-always/rescript.json
+++ b/tests/build_tests/uncurried-always/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "uncurried",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/weird_deps/rescript.json
+++ b/tests/build_tests/weird_deps/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "weird_devdeps",
-  "version": "0.1.0",
   "sources": [
     {
       "dir": "src",

--- a/tests/build_tests/weird_devdeps/rescript.json
+++ b/tests/build_tests/weird_devdeps/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "weird_devdeps",
-  "version": "0.1.0",
   "sources": [
     {
       "dir": "src",

--- a/tests/build_tests/weird_names/rescript.json
+++ b/tests/build_tests/weird_names/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "weird_names",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/weird_names_not_found_bug/rescript.json
+++ b/tests/build_tests/weird_names_not_found_bug/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "weird_names",
-  "version": "0.1.0",
   "sources": {
     "dir": "src",
     "subdirs": true

--- a/tests/build_tests/x-y/rescript.json
+++ b/tests/build_tests/x-y/rescript.json
@@ -1,5 +1,4 @@
 {
   "name": "x-y",
-  "version": "0.1.0",
   "sources": ["x-src"]
 }

--- a/tests/build_tests/zerocycle/rescript.json
+++ b/tests/build_tests/zerocycle/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "zerocycle",
-  "version": "0.1.0",
   "sources": ["src"],
   "package-specs": {
     "module": "esmodule",

--- a/tools/rescript.json
+++ b/tools/rescript.json
@@ -1,6 +1,5 @@
 {
   "name": "@rescript/tools",
-  "version": "0.6.4",
   "sources": [
     {
       "dir": "npm"


### PR DESCRIPTION
This field doesn't serve any purpose and triggers a warning when building with rewatch.