### PR TITLE
Reanalyze: support rewatch monorepos via root .sourcedirs.json cmt_scan

### DIFF
--- a/analysis/reanalyze/src/Paths.ml
+++ b/analysis/reanalyze/src/Paths.ml
@@ -205,3 +205,72 @@ let readSourceDirs ~configSources =
       Log_.item "Types for cross-references will not be found.\n");
     dirs := readDirsFromConfig ~configSources);
   !dirs
+
+type cmt_scan_entry = {
+  build_root: string;
+  scan_dirs: string list;
+  also_scan_build_root: bool;
+}
+(** Read explicit `.cmt/.cmti` scan plan from `.sourcedirs.json`.
+
+    This is a v2 extension produced by `rewatch` to support monorepos without requiring
+    reanalyze-side package resolution.
+
+    The scan plan is a list of build roots (usually `<pkg>/lib/bs`) relative to the project root,
+    plus a list of subdirectories (relative to that build root) to scan for `.cmt/.cmti`.
+
+    If missing, returns the empty list and callers should fall back to legacy behavior. *)
+
+let readCmtScan () =
+  let sourceDirsFile =
+    ["lib"; "bs"; ".sourcedirs.json"]
+    |> List.fold_left Filename.concat runConfig.bsbProjectRoot
+  in
+  let entries = ref [] in
+  let read_entry (json : Ext_json_types.t) =
+    match json with
+    | Ext_json_types.Obj {map} -> (
+      let build_root =
+        match StringMap.find_opt map "build_root" with
+        | Some (Ext_json_types.Str {str}) -> Some str
+        | _ -> None
+      in
+      let scan_dirs =
+        match StringMap.find_opt map "scan_dirs" with
+        | Some (Ext_json_types.Arr {content = arr}) ->
+          arr |> Array.to_list
+          |> List.filter_map (fun x ->
+                 match x with
+                 | Ext_json_types.Str {str} -> Some str
+                 | _ -> None)
+        | _ -> []
+      in
+      let also_scan_build_root =
+        match StringMap.find_opt map "also_scan_build_root" with
+        | Some (Ext_json_types.True _) -> true
+        | Some (Ext_json_types.False _) -> false
+        | _ -> false
+      in
+      match build_root with
+      | Some build_root ->
+        entries := {build_root; scan_dirs; also_scan_build_root} :: !entries
+      | None -> ())
+    | _ -> ()
+  in
+  let read_cmt_scan (json : Ext_json_types.t) =
+    match json with
+    | Ext_json_types.Obj {map} -> (
+      match StringMap.find_opt map "cmt_scan" with
+      | Some (Ext_json_types.Arr {content = arr}) ->
+        arr |> Array.iter read_entry
+      | _ -> ())
+    | _ -> ()
+  in
+  if sourceDirsFile |> Sys.file_exists then (
+    let jsonOpt = sourceDirsFile |> Ext_json_parse.parse_json_from_file in
+    match jsonOpt with
+    | exception _ -> []
+    | json ->
+      read_cmt_scan json;
+      !entries |> List.rev)
+  else []

--- a/analysis/reanalyze/src/Reanalyze.ml
+++ b/analysis/reanalyze/src/Reanalyze.ml
@@ -102,28 +102,61 @@ let collectCmtFilePaths ~cmtRoot : string list =
     walkSubDirs ""
   | None ->
     Lazy.force Paths.setReScriptProjectRoot;
-    let lib_bs = runConfig.projectRoot +++ ("lib" +++ "bs") in
-    let sourceDirs =
-      Paths.readSourceDirs ~configSources:None |> List.sort String.compare
-    in
-    sourceDirs
-    |> List.iter (fun sourceDir ->
-           let libBsSourceDir = Filename.concat lib_bs sourceDir in
-           let files =
-             match Sys.readdir libBsSourceDir |> Array.to_list with
-             | files -> files
-             | exception Sys_error _ -> []
-           in
-           let cmtFiles =
-             files
-             |> List.filter (fun x ->
-                    Filename.check_suffix x ".cmt"
-                    || Filename.check_suffix x ".cmti")
-           in
-           cmtFiles |> List.sort String.compare
-           |> List.iter (fun cmtFile ->
-                  let cmtFilePath = Filename.concat libBsSourceDir cmtFile in
-                  paths := cmtFilePath :: !paths)));
+    (* Prefer explicit scan plan emitted by rewatch (v2 `.sourcedirs.json`).
+       This supports monorepos without reanalyze-side package resolution. *)
+    let scan_plan = Paths.readCmtScan () in
+    if scan_plan <> [] then
+      let seen = Hashtbl.create 256 in
+      let add_dir (absDir : string) =
+        let files =
+          match Sys.readdir absDir |> Array.to_list with
+          | files -> files
+          | exception Sys_error _ -> []
+        in
+        files
+        |> List.filter (fun x ->
+               Filename.check_suffix x ".cmt" || Filename.check_suffix x ".cmti")
+        |> List.sort String.compare
+        |> List.iter (fun f ->
+               let p = Filename.concat absDir f in
+               if not (Hashtbl.mem seen p) then (
+                 Hashtbl.add seen p ();
+                 paths := p :: !paths))
+      in
+      scan_plan
+      |> List.iter (fun (entry : Paths.cmt_scan_entry) ->
+             let build_root_abs =
+               Filename.concat runConfig.projectRoot entry.build_root
+             in
+             (* Scan configured subdirs. *)
+             entry.scan_dirs
+             |> List.iter (fun d -> add_dir (Filename.concat build_root_abs d));
+             (* Optionally scan build root itself for namespace/mlmap `.cmt`s. *)
+             if entry.also_scan_build_root then add_dir build_root_abs)
+    else
+      (* Legacy behavior: scan `<projectRoot>/lib/bs/<sourceDir>` based on source dirs. *)
+      let lib_bs = runConfig.projectRoot +++ ("lib" +++ "bs") in
+      let sourceDirs =
+        Paths.readSourceDirs ~configSources:None |> List.sort String.compare
+      in
+      sourceDirs
+      |> List.iter (fun sourceDir ->
+             let libBsSourceDir = Filename.concat lib_bs sourceDir in
+             let files =
+               match Sys.readdir libBsSourceDir |> Array.to_list with
+               | files -> files
+               | exception Sys_error _ -> []
+             in
+             let cmtFiles =
+               files
+               |> List.filter (fun x ->
+                      Filename.check_suffix x ".cmt"
+                      || Filename.check_suffix x ".cmti")
+             in
+             cmtFiles |> List.sort String.compare
+             |> List.iter (fun cmtFile ->
+                    let cmtFilePath = Filename.concat libBsSourceDir cmtFile in
+                    paths := cmtFilePath :: !paths)));
   !paths |> List.rev
 
 (** Process files sequentially *)

--- a/rewatch/MonorepoSupport.md
+++ b/rewatch/MonorepoSupport.md
@@ -1,0 +1,245 @@
+# Monorepo Support in `rewatch` (ReScript Build System)
+
+This document describes **how `rewatch` infers monorepo structure**, **what invariants are required**, and **how build scope changes** depending on where you invoke the build.
+
+All statements are derived from:
+- `rewatch/src/project_context.rs` – monorepo context detection
+- `rewatch/src/build/packages.rs` – package discovery and traversal
+- `rewatch/src/helpers.rs` – path resolution utilities
+- `rewatch/src/build/{parse.rs,deps.rs,compile.rs}` – build phases
+
+---
+
+## Terminology
+
+| Term | Definition |
+|------|------------|
+| **Package** | A folder containing `rescript.json` (or legacy `bsconfig.json`). Usually also has `package.json`. |
+| **Root config** | The `rescript.json` used for global build settings (JSX, output format, etc.). |
+| **Local package** | A package whose canonical path is inside the workspace AND not under any `node_modules` path component. |
+| **Current package** | The package where you ran `rescript build` or `rescript watch`. |
+
+---
+
+## Build Modes
+
+`rewatch` does **not** read package manager workspace definitions (e.g., `pnpm-workspace.yaml`). Instead, it infers monorepo structure from:
+
+- `rescript.json` `dependencies` / `dev-dependencies` lists
+- `node_modules/<packageName>` resolution (typically workspace symlinks)
+- Parent `rescript.json` that lists the current package as a dependency
+
+There are **three effective modes**:
+
+### 1. Single Project
+- No parent config references this package
+- No dependencies resolve to local packages
+- The current package is both "root" and only package in scope
+
+### 2. Monorepo Root
+- At least one dependency or dev-dependency resolves via `./node_modules/<dep>` to a **local package**
+- The root `rescript.json` should list workspace packages by name in `dependencies`/`dev-dependencies`
+
+### 3. Monorepo Leaf Package
+- A parent directory contains a `rescript.json` (or `bsconfig.json`)
+- That parent config lists this package's name in its `dependencies` or `dev-dependencies`
+
+---
+
+## Local Package Detection
+
+A resolved dependency path is considered "local" if both conditions are met:
+
+1. Its **canonical path** is within the workspace root path
+2. The canonical path contains **no** `node_modules` segment
+
+This is why workspace symlinks work: `node_modules/<name>` → real path in repo.
+
+```rust
+// From helpers.rs
+pub fn is_local_package(workspace_path: &Path, canonical_package_path: &Path) -> bool {
+    canonical_package_path.starts_with(workspace_path)
+        && !canonical_package_path
+            .components()
+            .any(|c| c.as_os_str() == "node_modules")
+}
+```
+
+---
+
+## Dependency Resolution
+
+All dependencies are resolved via `try_package_path`, which probes in order:
+
+| Priority | Path Probed | When Used |
+|----------|-------------|-----------|
+| 1 | `<packageDir>/node_modules/<dep>` | Always (handles hoisted deps in nested packages) |
+| 2 | `<currentConfigDir>/node_modules/<dep>` | Always (current build context) |
+| 3 | `<rootDir>/node_modules/<dep>` | Always (monorepo root) |
+| 4 | Upward traversal through ancestors | **Only in single-project mode** |
+
+If no path exists, the build fails with: *"are node_modules up-to-date?"*
+
+---
+
+## Build Scope ("Package Graph")
+
+Starting from the current package, `rewatch` builds a **package graph**:
+
+1. **Always includes** the current package (marked as `is_root=true`)
+2. **Recursively includes** transitive `dependencies`
+3. **Includes `dev-dependencies`** only for **local packages**
+
+> External package dev-dependencies are **never** included.
+
+### Practical Effect
+
+| Invocation Location | Packages Built |
+|---------------------|----------------|
+| Monorepo root | All packages reachable from root's `dependencies` + `dev-dependencies` |
+| Leaf package | Only that package + its transitive deps (not unrelated siblings) |
+
+---
+
+## Root Config vs Per-Package Config
+
+Even when building from a leaf package, some settings are inherited from the **root config**:
+
+### From Root Config
+| Setting | Notes |
+|---------|-------|
+| `jsx`, `jsx.mode`, `jsx.module`, `jsx.preserve` | JSX configuration is global |
+| `package-specs`, `suffix` | Output format must be consistent |
+| Experimental features | Runtime feature flags |
+
+### From Per-Package Config
+| Setting | Notes |
+|---------|-------|
+| `namespace`, `namespace-entry` | Each package can have its own namespace |
+| `compiler-flags` (`bsc-flags`) | Package-specific compiler options |
+| `ppx-flags` | PPX transformations are per-package |
+| `warnings` | Warning configuration is per-package |
+| `sources` | Obviously per-package |
+
+---
+
+## Cross-Package Compilation
+
+### Directory Structure
+
+Each package compiles into:
+```
+<package>/
+├── lib/
+│   ├── bs/         # Build working directory (AST files, intermediate outputs)
+│   └── ocaml/      # Published artifacts (.cmi, .cmj, .cmt, .cmti)
+```
+
+### Compilation Process
+
+For package `A` depending on package `B`:
+
+1. **bsc runs with CWD** = `<A>/lib/bs`
+2. **Include path** = `-I <B>/lib/ocaml` for each declared dependency
+3. **Own artifacts** = `-I ../ocaml` (relative path to own lib/ocaml)
+
+### Dependency Filtering
+
+Module dependencies discovered from `.ast` files are **filtered**:
+- A module in another package is only valid if that package is declared in `dependencies` or `dev-dependencies`
+- "It compiles locally because the module exists" is **not** sufficient
+
+---
+
+## Algorithm (Pseudo-code)
+
+```text
+function BUILD(entryFolder):
+  entryFolderAbs = canonicalize(entryFolder)
+  currentConfig = read_config(entryFolderAbs / "rescript.json")
+  
+  # Step 1: Determine monorepo context
+  parentConfigDir = nearest_ancestor_with_config(parent(entryFolderAbs))
+  
+  if parentConfigDir exists:
+    parentConfig = read_config(parentConfigDir / "rescript.json")
+    if currentConfig.name ∈ (parentConfig.dependencies ∪ parentConfig.dev_dependencies):
+      context = MonorepoPackage(parentConfig)
+    else:
+      context = infer_root_or_single(entryFolderAbs, currentConfig)
+  else:
+    context = infer_root_or_single(entryFolderAbs, currentConfig)
+  
+  rootConfig = context.get_root_config()  # parent for MonorepoPackage, else current
+  
+  # Step 2: Build package closure
+  packages = {currentConfig.name: Package(is_root=true, is_local_dep=true)}
+  walk(currentConfig, is_local_dep=true)
+  
+  function walk(config, is_local):
+    deps = config.dependencies
+    if is_local:
+      deps = deps ∪ config.dev_dependencies
+    
+    for depName in deps:
+      if depName already in packages: continue
+      
+      depFolder = canonicalize(resolve_node_modules(config, depName))
+      depConfig = read_config(depFolder)
+      
+      depIsLocal = match context:
+        | SingleProject    → (currentConfig.name == depName)
+        | MonorepoRoot     → depName ∈ context.local_deps
+        | MonorepoPackage  → is_local_package(parentConfig.folder, depFolder)
+      
+      packages[depName] = Package(is_root=false, is_local_dep=depIsLocal)
+      walk(depConfig, depIsLocal)
+  
+  # Step 3: Scan sources
+  for package in packages:
+    scan sources (type:dev only included if package.is_local_dep)
+    compute module names (apply namespace suffix rules)
+    ensure lib/bs + lib/ocaml exist
+    enforce global unique module names
+  
+  # Step 4: Build loop
+  1. Parse dirty sources: bsc -bs-ast, cwd=<pkg>/lib/bs
+  2. Compute module deps from AST; filter by declared package deps
+  3. Compile in dependency-order waves:
+     - bsc cwd=<pkg>/lib/bs
+     - include: -I ../ocaml -I <dep>/lib/ocaml for each declared dep
+     - runtime: -runtime-path <@rescript/runtime resolved>
+     - package specs: from rootConfig
+  4. Copy artifacts to <pkg>/lib/ocaml
+```
+
+---
+
+## Practical Guidance
+
+### Structuring a Monorepo
+
+Each workspace package should have:
+- `rescript.json` with `"name"` matching `package.json` `"name"` (mismatch is warned)
+- Correct `dependencies` for every other ReScript package it imports from
+
+A monorepo root that wants to "build everything" should:
+- Have its own `rescript.json` (can have no sources)
+- List each workspace package in `dependencies` / `dev-dependencies`
+- Ensure package manager creates `node_modules/<pkgName>` symlinks to workspace packages
+
+### Where to Build From
+
+| Goal | Run From |
+|------|----------|
+| Build one leaf package + its deps | That leaf package's folder |
+| Build entire monorepo | Root folder with `rescript.json` listing all packages |
+
+### Common Issues
+
+| Symptom | Likely Cause |
+|---------|--------------|
+| "Package X not found" | Missing from `dependencies` or `node_modules` not linked |
+| Module from sibling package not visible | Sibling not in current package's `dependencies` |
+| Dev sources not compiled | Package is not detected as "local" |
+| Wrong JSX settings | JSX comes from root config, not per-package |

--- a/rewatch/src/sourcedirs.rs
+++ b/rewatch/src/sourcedirs.rs
@@ -13,11 +13,32 @@ type PackageName = String;
 type AbsolutePath = PathBuf;
 type Pkg = (PackageName, AbsolutePath);
 
-#[derive(Serialize, Debug, Clone, PartialEq, Hash)]
-pub struct SourceDirs<'a> {
-    pub dirs: &'a Vec<Dir>,
-    pub pkgs: &'a Vec<Pkg>,
-    pub generated: &'a Vec<String>,
+/// `reanalyze` consumes `.sourcedirs.json` to find `.cmt/.cmti` files.
+///
+/// Historically, this file contained a single `"dirs"` list which was interpreted as being
+/// under the *root* `lib/bs/`. That doesn't hold for `rewatch` monorepos, where each package has
+/// its own `lib/bs/`.
+///
+/// To avoid reanalyze-side "package resolution", v2 includes an explicit `cmt_scan` plan:
+/// a list of build roots (`.../lib/bs`) and the subdirectories within those roots to scan.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CmtScanEntry {
+    /// Path to a `lib/bs` directory, relative to the workspace root.
+    pub build_root: PathBuf,
+    /// Subdirectories (relative to `build_root`) to scan for `.cmt/.cmti`.
+    pub scan_dirs: Vec<PathBuf>,
+    /// Whether to also scan `build_root` itself for `.cmt/.cmti` (namespaces/mlmap often land here).
+    pub also_scan_build_root: bool,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SourceDirs {
+    pub version: u8,
+    pub dirs: Vec<Dir>,
+    pub pkgs: Vec<Pkg>,
+    pub generated: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cmt_scan: Option<Vec<CmtScanEntry>>,
 }
 
 fn package_to_dirs(package: &Package, root_package_path: &Path) -> AHashSet<Dir> {
@@ -54,6 +75,11 @@ fn write_sourcedirs_files(path: &Path, source_dirs: &SourceDirs) -> Result<usize
     source_dirs_json.write(json!(source_dirs).to_string().as_bytes())
 }
 
+fn sort_paths(mut v: Vec<PathBuf>) -> Vec<PathBuf> {
+    v.sort_by(|a, b| a.to_string_lossy().cmp(&b.to_string_lossy()));
+    v
+}
+
 pub fn print(buildstate: &BuildState) {
     // Find Root Package
     let (_name, root_package) = buildstate
@@ -62,10 +88,21 @@ pub fn print(buildstate: &BuildState) {
         .find(|(_name, package)| package.is_root)
         .expect("Could not find root package");
 
+    // We only support a single `.sourcedirs.json` at the workspace root.
+    // Remove any stale per-package `.sourcedirs.json` from older builds to avoid confusion.
+    buildstate
+        .packages
+        .iter()
+        .filter(|(_name, package)| !package.is_root)
+        .for_each(|(_name, package)| {
+            let path = package.get_build_path().join(".sourcedirs.json");
+            let _ = std::fs::remove_file(&path);
+        });
+
     // Take all local packages with source files.
     // In the case of a monorepo, the root package typically won't have any source files.
     // But in the case of a single package, it will be both local, root and have source files.
-    let (dirs, pkgs): (Vec<AHashSet<Dir>>, Vec<AHashMap<PackageName, AbsolutePath>>) = buildstate
+    let collected: Vec<(AHashSet<Dir>, AHashMap<PackageName, AbsolutePath>, CmtScanEntry)> = buildstate
         .packages
         .par_iter()
         .filter(|(_name, package)| package.is_local_dep && package.source_files.is_some())
@@ -78,23 +115,49 @@ pub fn print(buildstate: &BuildState) {
                 .into_iter()
                 .map(|dependencies| deps_to_pkgs(&buildstate.packages, dependencies));
 
-            // Write sourcedirs.json
-            write_sourcedirs_files(
-                &package.get_build_path(),
-                &SourceDirs {
-                    dirs: &dirs.clone().into_iter().collect::<Vec<Dir>>(),
-                    pkgs: &pkgs.clone().flatten().collect::<Vec<Pkg>>(),
-                    generated: &vec![],
-                },
-            )
-            .expect("Could not write sourcedirs.json");
+            // Build scan plan entry for the root `.sourcedirs.json`.
+            // `build_root` is `<pkg_rel_to_root>/lib/bs`.
+            let pkg_rel = package
+                .path
+                .strip_prefix(&root_package.path)
+                .unwrap_or(Path::new(""))
+                .to_path_buf();
+            let build_root = pkg_rel.join("lib").join("bs");
+            let scan_dirs = sort_paths(
+                package
+                    .dirs
+                    .as_ref()
+                    .unwrap_or(&AHashSet::new())
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            );
+
+            // NOTE: We intentionally do NOT write per-package `.sourcedirs.json`.
+            // The root package's `.sourcedirs.json` contains a complete `cmt_scan` plan
+            // and is the only file `reanalyze` needs for root-level monorepo analysis.
 
             (
                 dirs,
                 pkgs.flatten().collect::<AHashMap<PackageName, AbsolutePath>>(),
+                CmtScanEntry {
+                    build_root,
+                    scan_dirs,
+                    // Namespaces/mlmap artifacts can land in `lib/bs` itself; scanning it is cheap and avoids misses.
+                    also_scan_build_root: true,
+                },
             )
         })
-        .unzip();
+        .collect();
+
+    let mut dirs: Vec<AHashSet<Dir>> = Vec::with_capacity(collected.len());
+    let mut pkgs: Vec<AHashMap<PackageName, AbsolutePath>> = Vec::with_capacity(collected.len());
+    let mut cmt_scan_entries: Vec<CmtScanEntry> = Vec::with_capacity(collected.len());
+    for (d, p, s) in collected {
+        dirs.push(d);
+        pkgs.push(p);
+        cmt_scan_entries.push(s);
+    }
 
     let mut merged_dirs: AHashSet<Dir> = AHashSet::new();
     let mut merged_pkgs: AHashMap<PackageName, AbsolutePath> = AHashMap::new();
@@ -102,14 +165,27 @@ pub fn print(buildstate: &BuildState) {
     dirs.into_iter().for_each(|dir_set| merged_dirs.extend(dir_set));
     pkgs.into_iter().for_each(|pkg_set| merged_pkgs.extend(pkg_set));
 
-    // Write sourcedirs.json
-    write_sourcedirs_files(
-        &root_package.get_build_path(),
-        &SourceDirs {
-            dirs: &merged_dirs.into_iter().collect::<Vec<Dir>>(),
-            pkgs: &merged_pkgs.into_iter().collect::<Vec<Pkg>>(),
-            generated: &vec![],
+    // Root `.sourcedirs.json`: merged view + explicit scan plan for reanalyze.
+    let root_sourcedirs = SourceDirs {
+        version: 2,
+        dirs: sort_paths(merged_dirs.into_iter().collect::<Vec<Dir>>()),
+        pkgs: {
+            let mut v = merged_pkgs.into_iter().collect::<Vec<Pkg>>();
+            v.sort_by(|(a, _), (b, _)| a.cmp(b));
+            v
         },
-    )
-    .expect("Could not write sourcedirs.json");
+        generated: vec![],
+        cmt_scan: Some({
+            // Ensure deterministic order (use the serialized string form).
+            let mut v = cmt_scan_entries;
+            v.sort_by(|a, b| {
+                a.build_root
+                    .to_string_lossy()
+                    .cmp(&b.build_root.to_string_lossy())
+            });
+            v
+        }),
+    };
+    write_sourcedirs_files(&root_package.get_build_path(), &root_sourcedirs)
+        .expect("Could not write sourcedirs.json");
 }


### PR DESCRIPTION
- Extend rewatch to emit version:2 .sourcedirs.json with explicit cmt_scan (build roots + scan dirs) for root-level monorepo builds.
- Update reanalyze (editor invocation: rescript-tools reanalyze -json) to prefer cmt_scan when present, with legacy single-project fallback.
- Ensure deterministic output ordering by sorting .cmt/.cmti entries in the cmt_scan path.

Tests: make test-analysis