### PR TITLE
Use rescript.json dir as working dir for js-post-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `Int.fromString` and `Float.fromString` use stricter number parsing and no longer uses an explicit radix argument, but instead supports parsing hexadecimal, binary and exponential notation.
 - Remove `external-stdlib` configuration option from `rescript.json`. This option was rarely used and is no longer supported.
 - `js-post-build` now passes the correct output file path based on `in-source` configuration: when `in-source: true`, the path next to the source file is passed; when `in-source: false`, the path in the `lib/<module>/` directory is passed. Additionally, stdout and stderr from the post-build command are now logged. https://github.com/rescript-lang/rescript/pull/8190
+- `js-post-build` command now runs in the directory containing the `rescript.json` where it is defined, instead of the unpredictable build invocation directory. This provides consistent behavior in monorepos. https://github.com/rescript-lang/rescript/pull/8195
 
 #### :eyeglasses: Spec Compliance
 

--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -125,7 +125,7 @@
       "properties": {
         "cmd": {
           "type": "string",
-          "description": "Shell command to run after each JS file is compiled. The absolute path to the output JS file is appended as an argument. The path respects the `in-source` setting."
+          "description": "Shell command to run after each JS file is compiled. The absolute path to the output JS file is appended as an argument. The path respects the `in-source` setting. The command runs in the directory containing the rescript.json where it is defined."
         }
       }
     },
@@ -454,7 +454,7 @@
     },
     "js-post-build": {
       "$ref": "#/definitions/js-post-build",
-      "description": "Post-processing hook. The build system will invoke `cmd <absolute-path-to-js-file>` after each JS file is compiled. The path respects the `in-source` setting: when true, the path is next to the source file; when false, the path is in the `lib/<module>/` directory. The command runs with the same working directory as the build process (typically the project root)."
+      "description": "Post-processing hook. The build system will invoke `cmd <absolute-path-to-js-file>` after each JS file is compiled. The path respects the `in-source` setting: when true, the path is next to the source file; when false, the path is in the `lib/<module>/` directory. The command runs in the directory containing the rescript.json where it is defined."
     },
     "package-specs": {
       "$ref": "#/definitions/package-specs",


### PR DESCRIPTION

**Problem**

The `js-post-build` command's working directory was unpredictable in monorepo setups. The command would run in whatever directory the build process was invoked from, which could vary depending on whether you're building a specific package or the entire monorepo from the root.

This made it difficult to write reliable post-build scripts that depend on relative paths or need to access files relative to the package.

**Solution**

The `js-post-build` command now always runs in the directory containing the `rescript.json` where it is defined. This provides predictable, consistent behavior:

- If a package defines `js-post-build` in its own `rescript.json`, the command runs in that package's directory
- If defined in the root `rescript.json`, it runs in the root directory

The absolute path to the compiled JS file is still passed as an argument, so scripts can reference the output file unambiguously.

**Example**

```
monorepo/
├── rescript.json          # root config
└── packages/
    └── my-app/
        ├── rescript.json  # defines js-post-build: { "cmd": "./scripts/process.sh" }
        └── scripts/
            └── process.sh
```

Previously, `./scripts/process.sh` would fail if the build was run from `monorepo/`. Now it reliably resolves relative to `packages/my-app/`.

**Breaking Change**

This is a breaking change for users who relied on the previous behavior where the working directory matched the build invocation directory. However, the new behavior is more predictable and aligns with how other per-package configuration options work.