### PR TITLE
Only save formatted files if they changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 #### :nail_care: Polish
 
+- Formatter no longer writes files when contents are already correctly formatted. https://github.com/rescript-lang/rescript/pull/8209
+
 #### :house: Internal
 
 # 12.1.0


### PR DESCRIPTION
Small improvement to only save formatted rescript files if they did change.
Original use-case was a format all a watch was running.
It lead to an entire rebuild while nothing actually changed.