### PR TITLE
Dev container: use node 22, don't install via apt

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
+      "version": "22",
+      "installYarnUsingApt": false
     }
   },
   "customizations": {


### PR DESCRIPTION
Not installing via apt fixes the current CI build issues.

Increased node version to 22 to match .nvmrc.