### PR TITLE
install ocaml in dockerfile instead of postCreate.sh

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,4 +13,4 @@ RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
 ARG OPAM_VERSION=2.5.0
 RUN printf '\n\n' | bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version $OPAM_VERSION"
 
-RUN opam init -y --auto-setup --bare --disable-sandboxing && opam switch create 5.3.0 
+RUN opam init -y --auto-setup --compiler=5.3.0 --disable-sandboxing && echo 'eval $(opam env)' >> ~/.zshrc && echo 'eval $(opam env)' >> ~/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,4 +16,4 @@ RUN printf '\n\n' | bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/o
 USER vscode
 ENV HOME=/home/vscode
 
-RUN opam init -y --shell-setup --enable-shell-hook --compiler=5.3.0 --disable-sandboxing && echo 'eval $(opam env)' >> ~/.zshrc && echo 'eval $(opam env)' >> ~/.bashrc
+RUN opam init -y --shell-setup --enable-shell-hook --compiler=5.3.0 --disable-sandboxing

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,6 +13,4 @@ RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
 ARG OPAM_VERSION=2.5.0
 RUN printf '\n\n' | bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version $OPAM_VERSION"
 
-COPY rescript.opam tools.opam ./
-
-RUN opam init -y --auto-setup --bare --disable-sandboxing && opam switch create 5.3.0 && opam install . --with-test --with-dev-setup -y
+RUN opam init -y --auto-setup --bare --disable-sandboxing && opam switch create 5.3.0 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,7 @@ RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Install OPAM
 ARG OPAM_VERSION=2.5.0
 RUN printf '\n\n' | bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version $OPAM_VERSION"
+
+COPY rescript.opam tools.opam ./
+
+RUN opam init -y --auto-setup --bare --disable-sandboxing && opam switch create 5.3.0 && opam install . --with-test --with-dev-setup -y

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,4 +13,7 @@ RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
 ARG OPAM_VERSION=2.5.0
 RUN printf '\n\n' | bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version $OPAM_VERSION"
 
-RUN opam init -y --auto-setup --compiler=5.3.0 --disable-sandboxing && echo 'eval $(opam env)' >> ~/.zshrc && echo 'eval $(opam env)' >> ~/.bashrc
+USER vscode
+ENV HOME=/home/vscode
+
+RUN opam init -y --shell-setup --enable-shell-hook --compiler=5.3.0 --disable-sandboxing && echo 'eval $(opam env)' >> ~/.zshrc && echo 'eval $(opam env)' >> ~/.bashrc

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -3,7 +3,5 @@
 # Install dev dependencies from OPAM
 opam install . --with-test --with-dev-setup -y
 
-nvm install
-
 corepack enable
 printf "\n" | yarn 

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-# Install dev dependencies from OPAM
-opam init -y --auto-setup --bare --disable-sandboxing
-opam switch create 5.3.0
-opam install . --with-test --with-dev-setup -y
-
-# Add OPAM environment setup to shell startup script
-echo 'eval $(opam env)' >> ~/.zshrc
-echo 'eval $(opam env)' >> ~/.bashrc
-
 nvm install
 
 corepack enable

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-# Add OPAM environment setup to shell startup script
-echo 'eval $(opam env)' >> ~/.zshrc
-echo 'eval $(opam env)' >> ~/.bashrc
-
-eval $(opam env)
-
 # Install dev dependencies from OPAM
 opam install . --with-test --with-dev-setup -y
 

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 
-# Install dev dependencies from OPAM
-opam install . --with-test --with-dev-setup -y
-
 # Add OPAM environment setup to shell startup script
 echo 'eval $(opam env)' >> ~/.zshrc
 echo 'eval $(opam env)' >> ~/.bashrc
+
+eval $(opam env)
+
+# Install dev dependencies from OPAM
+opam install . --with-test --with-dev-setup -y
 
 nvm install
 

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Install dev dependencies from OPAM
+opam install . --with-test --with-dev-setup -y
+
+# Add OPAM environment setup to shell startup script
+echo 'eval $(opam env)' >> ~/.zshrc
+echo 'eval $(opam env)' >> ~/.bashrc
+
 nvm install
 
 corepack enable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 #### :house: Internal
 
+- speed up dev container test by installing ocaml in docker image instead of in `postCreate.sh`. https://github.com/rescript-lang/rescript/pull/8230
+
 # 13.0.0-alpha.1
 
 #### :boom: Breaking Change


### PR DESCRIPTION
it speeds up the test a bit but `opam install` has to be in `postCreate.sh` because there's no access to the repo in the docker build phase.