### PR TITLE
do not setup node/yarn when not needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,6 +488,7 @@ jobs:
           fi
 
       - name: Use Node.js
+        if: steps.diffcheck.outputs.clean == 'false'
         uses: actions/setup-node@v6
         with:
           cache: yarn


### PR DESCRIPTION
This avoids 
```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```
in the post job cleanup
cf https://github.com/rescript-lang/rescript/actions/runs/21551148295/job/62201302974