### PR TITLE
Enable stale branches cleanup

### DIFF
--- a/.github/workflows/branch_cleanup.yml
+++ b/.github/workflows/branch_cleanup.yml
@@ -17,5 +17,5 @@ jobs:
           # ignore-branches: ""
           ignored-prefixes: "maintenance/"
           last-commit-age-days: 90
-          dry-run: true
+          dry-run: false
           rate-limit: true


### PR DESCRIPTION
This has been running on dry-run for a while.

Here is a list of branches that are going to be removed:
https://github.com/rescript-lang/rescript/actions/runs/22422083814/job/64921890771