### PR TITLE
Fix null/array guards dropped for untagged variant switch in statemen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 #### :bug: Bug fix
 
 - Reanalyze server: invalidate cache and recompute results when config changes in `rescript.json`. https://github.com/rescript-lang/rescript/pull/8262
+- Fix `null` and array values incorrectly matching the `Object` branch when pattern matching on `JSON.t` (or other untagged variants with an `Object` case) in statement position. https://github.com/rescript-lang/rescript/pull/8279
 
 #### :memo: Documentation
 

--- a/compiler/core/lam_compile.ml
+++ b/compiler/core/lam_compile.ml
@@ -825,18 +825,27 @@ let compile output_prefix =
             | _ -> false)
           typeof_clauses
       in
-      let has_array_case =
+      let clauses_have_array_case =
         List.exists
           (function
             | Ast_untagged_variants.Untagged (InstanceType Array), _ -> true
             | _ -> false)
           not_typeof_clauses
       in
+      let type_has_array_case =
+        List.exists
+          (function
+            | Ast_untagged_variants.InstanceType Array -> true
+            | _ -> false)
+          block_cases
+      in
       (* When there's an ObjectType typeof case, null and arrays can
          incorrectly match it (typeof null === typeof [] === "object").
          Guard against them when they should fall through to default. *)
       let needs_null_guard = has_object_typeof && has_null_case in
-      let needs_array_guard = has_object_typeof && not has_array_case in
+      let needs_array_guard =
+        has_object_typeof && type_has_array_case && not clauses_have_array_case
+      in
       let rec build_if_chain remaining_clauses =
         match remaining_clauses with
         | ( Ast_untagged_variants.Untagged (InstanceType instance_type),
@@ -860,7 +869,8 @@ let compile output_prefix =
           match (guard, default) with
           | Some guard, Some default_body ->
             S.if_ guard default_body ~else_:[typeof_switch ()]
-          | _ -> typeof_switch ())
+          | Some guard, None -> S.if_ (E.not guard) [typeof_switch ()]
+          | None, _ -> typeof_switch ())
       in
       build_if_chain not_typeof_clauses
     in

--- a/tests/tests/src/js_json_test.mjs
+++ b/tests/tests/src/js_json_test.mjs
@@ -404,24 +404,50 @@ Mocha.describe("Js_json_test", () => {
     Test_utils.eq("File \"js_json_test.res\", line 342, characters 7-14", classifyObjectOnly({}), "Object");
     Test_utils.eq("File \"js_json_test.res\", line 343, characters 7-14", classifyObjectOnly("hi"), "String");
   });
+  Mocha.test("JSON Object switch as statement guards null and array", () => {
+    let result = {
+      contents: "none"
+    };
+    let classifyStatement = json => {
+      if (json === null || Array.isArray(json)) {
+        return;
+      }
+      switch (typeof json) {
+        case "object" :
+          result.contents = "object";
+          return;
+        default:
+          return;
+      }
+    };
+    result.contents = "none";
+    classifyStatement(null);
+    Test_utils.eq("File \"js_json_test.res\", line 359, characters 7-14", result.contents, "none");
+    result.contents = "none";
+    classifyStatement([]);
+    Test_utils.eq("File \"js_json_test.res\", line 363, characters 7-14", result.contents, "none");
+    result.contents = "none";
+    classifyStatement({});
+    Test_utils.eq("File \"js_json_test.res\", line 367, characters 7-14", result.contents, "object");
+  });
   Mocha.test("JSON decodeBoolean", () => {
-    Test_utils.eq("File \"js_json_test.res\", line 347, characters 7-14", Js_json.decodeBoolean("test"), undefined);
-    Test_utils.eq("File \"js_json_test.res\", line 348, characters 7-14", Js_json.decodeBoolean(true), true);
-    Test_utils.eq("File \"js_json_test.res\", line 349, characters 7-14", Js_json.decodeBoolean([]), undefined);
-    Test_utils.eq("File \"js_json_test.res\", line 350, characters 7-14", Js_json.decodeBoolean(null), undefined);
-    Test_utils.eq("File \"js_json_test.res\", line 351, characters 7-14", Js_json.decodeBoolean({}), undefined);
-    Test_utils.eq("File \"js_json_test.res\", line 352, characters 7-14", Js_json.decodeBoolean(1.23), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 371, characters 7-14", Js_json.decodeBoolean("test"), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 372, characters 7-14", Js_json.decodeBoolean(true), true);
+    Test_utils.eq("File \"js_json_test.res\", line 373, characters 7-14", Js_json.decodeBoolean([]), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 374, characters 7-14", Js_json.decodeBoolean(null), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 375, characters 7-14", Js_json.decodeBoolean({}), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 376, characters 7-14", Js_json.decodeBoolean(1.23), undefined);
   });
   Mocha.test("JSON decodeNull", () => {
-    Test_utils.eq("File \"js_json_test.res\", line 356, characters 7-14", Js_json.decodeNull("test"), undefined);
-    Test_utils.eq("File \"js_json_test.res\", line 357, characters 7-14", Js_json.decodeNull(true), undefined);
-    Test_utils.eq("File \"js_json_test.res\", line 358, characters 7-14", Js_json.decodeNull([]), undefined);
-    Test_utils.eq("File \"js_json_test.res\", line 359, characters 7-14", Js_json.decodeNull(null), null);
-    Test_utils.eq("File \"js_json_test.res\", line 360, characters 7-14", Js_json.decodeNull({}), undefined);
-    Test_utils.eq("File \"js_json_test.res\", line 361, characters 7-14", Js_json.decodeNull(1.23), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 380, characters 7-14", Js_json.decodeNull("test"), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 381, characters 7-14", Js_json.decodeNull(true), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 382, characters 7-14", Js_json.decodeNull([]), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 383, characters 7-14", Js_json.decodeNull(null), null);
+    Test_utils.eq("File \"js_json_test.res\", line 384, characters 7-14", Js_json.decodeNull({}), undefined);
+    Test_utils.eq("File \"js_json_test.res\", line 385, characters 7-14", Js_json.decodeNull(1.23), undefined);
   });
   Mocha.test("JSON serialize/deserialize identity", () => {
-    let idtest = obj => Test_utils.eq("File \"js_json_test.res\", line 367, characters 27-34", obj, Js_json.deserializeUnsafe(Js_json.serializeExn(obj)));
+    let idtest = obj => Test_utils.eq("File \"js_json_test.res\", line 391, characters 27-34", obj, Js_json.deserializeUnsafe(Js_json.serializeExn(obj)));
     idtest(undefined);
     idtest({
       hd: [

--- a/tests/tests/src/js_json_test.res
+++ b/tests/tests/src/js_json_test.res
@@ -343,6 +343,30 @@ describe(__MODULE__, () => {
     eq(__LOC__, classifyObjectOnly(J.string("hi")), "String")
   })
 
+  test("JSON Object switch as statement guards null and array", () => {
+    let result = ref("none")
+    let classifyStatement = (json: J.t) => {
+      switch json {
+      | J.Object(_) => result := "object"
+      | J.Array(_) => ()
+      | J.String(_) => ()
+      | _ => ()
+      }
+    }
+
+    result := "none"
+    classifyStatement(J.null)
+    eq(__LOC__, result.contents, "none")
+
+    result := "none"
+    classifyStatement(J.array([]))
+    eq(__LOC__, result.contents, "none")
+
+    result := "none"
+    classifyStatement(J.object_(Js.Dict.empty()))
+    eq(__LOC__, result.contents, "object")
+  })
+
   test("JSON decodeBoolean", () => {
     eq(__LOC__, J.decodeBoolean(J.string("test")), None)
     eq(__LOC__, J.decodeBoolean(J.boolean(true)), Some(true))


### PR DESCRIPTION
…t position

When a switch on an untagged variant (e.g. JSON.t) with an Object case was in statement position (not tail), compile_general_cases would set default=None for empty default bodies, causing the null/array guard to be silently skipped. This let null and arrays fall into the typeof "object" branch at runtime.

Two fixes:
- Handle the Some guard, None default case by emitting if (!(guard)) { ... }
- Use the type's block_cases to determine if arrays can appear at runtime, avoiding unnecessary Array.isArray guards for types without an Array case

Fixes #8251 (comment)