### PR TITLE
Fix directive `@warning("-102")` not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### :bug: Bug fix
 
+- Fix directive `@warning("-102")` not working. https://github.com/rescript-lang/rescript/pull/8322
+
 #### :memo: Documentation
 
 #### :nail_care: Polish

--- a/compiler/core/lam_compile_primitive.ml
+++ b/compiler/core/lam_compile_primitive.ml
@@ -389,23 +389,19 @@ let translate output_prefix loc (cxt : Lam_compile_context.t)
               || E.is_null_undefined_constant e2) ->
       E.neq_null_undefined_boolean e1 e2
     | [e1; e2] ->
-      Location.prerr_warning loc Warnings.Bs_polymorphic_comparison;
       E.runtime_call Primitive_modules.object_
         (Lam_compile_util.runtime_of_comp cmp)
         args
     | _ -> assert false)
   | Pobjorder -> (
-    Location.prerr_warning loc Warnings.Bs_polymorphic_comparison;
     match args with
     | [a; b] -> E.runtime_call Primitive_modules.object_ "compare" args
     | _ -> assert false)
   | Pobjmin -> (
-    Location.prerr_warning loc Warnings.Bs_polymorphic_comparison;
     match args with
     | [a; b] -> E.runtime_call Primitive_modules.object_ "min" args
     | _ -> assert false)
   | Pobjmax -> (
-    Location.prerr_warning loc Warnings.Bs_polymorphic_comparison;
     match args with
     | [a; b] -> E.runtime_call Primitive_modules.object_ "max" args
     | _ -> assert false)

--- a/compiler/ml/translcore.ml
+++ b/compiler/ml/translcore.ml
@@ -439,6 +439,19 @@ let specialize_primitive p env ty (* ~has_constant_constructor *) =
       | None -> table.objcomp
     with Not_found -> find_primitive p.prim_name)
 
+let is_null_undefined_constant = function
+  | Lprim ((Pnull | Pundefined), [], _) -> true
+  | _ -> false
+
+let warn_polymorphic_comparison loc prim args =
+  match (prim, args) with
+  | Pobjcomp (Ceq | Cneq), [arg1; arg2]
+    when is_null_undefined_constant arg1 || is_null_undefined_constant arg2 ->
+    ()
+  | (Pobjcomp _ | Pobjorder | Pobjmin | Pobjmax), _ ->
+    Location.prerr_warning loc Warnings.Bs_polymorphic_comparison
+  | _ -> ()
+
 (* Eta-expand a primitive *)
 
 let transl_primitive loc p env ty =
@@ -447,6 +460,7 @@ let transl_primitive loc p env ty =
     try specialize_primitive p env ty (* ~has_constant_constructor:false *)
     with Not_found -> Pccall p
   in
+  warn_polymorphic_comparison loc prim [];
   match prim with
   | Ploc kind -> (
     let lam = lam_of_loc kind loc in
@@ -653,8 +667,9 @@ let extract_directive_for_fn exp =
          else None)
 
 let rec transl_exp e =
-  List.iter (Translattribute.check_attribute e) e.exp_attributes;
-  transl_exp0 e
+  Builtin_attributes.warning_scope ~ppwarning:false e.exp_attributes (fun () ->
+      List.iter (Translattribute.check_attribute e) e.exp_attributes;
+      transl_exp0 e)
 
 and transl_exp0 (e : Typedtree.expression) : Lambda.lambda =
   match e.exp_desc with
@@ -734,6 +749,7 @@ and transl_exp0 (e : Typedtree.expression) : Lambda.lambda =
     let prim =
       transl_primitive_application e.exp_loc p e.exp_env prim_type args
     in
+    warn_polymorphic_comparison e.exp_loc prim argl;
     match (prim, args) with
     | Praise k, [_] ->
       let targ = List.hd argl in
@@ -1082,7 +1098,10 @@ and transl_let rec_flag pat_expr_list body =
     let rec transl = function
       | [] -> body
       | {vb_pat = pat; vb_expr = expr; vb_attributes = attr; vb_loc} :: rem ->
-        let lam = transl_exp expr in
+        let lam =
+          Builtin_attributes.warning_scope ~ppwarning:false attr (fun () ->
+              transl_exp expr)
+        in
         let lam = Translattribute.add_inline_attribute lam vb_loc attr in
         Matching.for_let pat.pat_loc lam pat (transl rem)
     in
@@ -1098,7 +1117,10 @@ and transl_let rec_flag pat_expr_list body =
            Only variables are allowed as left-hand side of `let rec'
         *)
       in
-      let lam = transl_exp expr in
+      let lam =
+        Builtin_attributes.warning_scope ~ppwarning:false vb_attributes
+          (fun () -> transl_exp expr)
+      in
       let lam = Translattribute.add_inline_attribute lam vb_loc vb_attributes in
       (id, lam)
     in

--- a/tests/build_tests/super_errors/expected/warning102.res.expected
+++ b/tests/build_tests/super_errors/expected/warning102.res.expected
@@ -1,0 +1,20 @@
+
+  [1;33mWarning number 22[0m
+  [36m/.../fixtures/warning102.res[0m:[2m1:32-38[0m
+
+  [1;33m1[0m [2m│[0m let ppwarningOnce = @ppwarning([1;33m"hello"[0m) 1
+  2 [2m│[0m 
+  3 [2m│[0m @warning("-102")
+
+  hello
+
+
+  [1;33mWarning number 102[0m
+  [36m/.../fixtures/warning102.res[0m:[2m11:13-22[0m
+
+   9 [2m│[0m let comparesToNull = x => x == Nullable.null
+  10 [2m│[0m 
+  [1;33m11[0m [2m│[0m let warns = [1;33m[3] == [3][0m
+  12 [2m│[0m 
+
+  Polymorphic comparison introduced (maybe unsafe)

--- a/tests/build_tests/super_errors/fixtures/warning102.res
+++ b/tests/build_tests/super_errors/fixtures/warning102.res
@@ -1,0 +1,11 @@
+let ppwarningOnce = @ppwarning("hello") 1
+
+@warning("-102")
+let suppressedBinding =
+  [1] == [1]
+
+let suppressedExpression = @warning("-102") ([2] == [2])
+
+let comparesToNull = x => x == Nullable.null
+
+let warns = [3] == [3]


### PR DESCRIPTION
## Summary

Fixes #8160, where `@warning("-102")` did not suppress polymorphic comparison warnings.

## Changes

- Moves warning 102 (`Bs_polymorphic_comparison`) emission from JS primitive compilation into lambda translation, where warning scopes are available.
- Allows `@warning("-102")` on bindings and expressions to suppress polymorphic comparison warnings.
- Preserves the existing exemption for direct `==` / `!=` comparisons against `null` or `undefined`.
- Avoids duplicating `@ppwarning` output while applying warning scopes during translation.
- Adds a `super_errors` fixture covering suppression, `@ppwarning`, null comparison, and an unsuppressed warning.

## Testing

- Added `tests/build_tests/super_errors/fixtures/warning102.res`
- Added `tests/build_tests/super_errors/expected/warning102.res.expected`