### PR TITLE
Fix partial application generalization for `...`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### :bug: Bug fix
 
+- Fix partial application generalization for `...`. https://github.com/rescript-lang/rescript/pull/8343
+
 #### :memo: Documentation
 
 #### :nail_care: Polish

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -1803,6 +1803,11 @@ let rec is_nonexpansive exp =
     List.for_all (fun vb -> is_nonexpansive vb.vb_expr) pat_exp_list
     && is_nonexpansive body
   | Texp_function _ -> true
+  | Texp_apply {partial = true; _} ->
+    (* ReScript partial applications (`foo(args, ...)`) lower to wrapper
+       functions in codegen, so creating the partial itself is nonexpansive
+       like an explicit lambda. *)
+    true
   | Texp_apply {funct = e; args = (_, None) :: el} ->
     is_nonexpansive e && List.for_all is_nonexpansive_opt (List.map snd el)
   | Texp_match (e, cases, [], _) ->

--- a/tests/tests/src/PartialApplicationNoRuntimeCurry.mjs
+++ b/tests/tests/src/PartialApplicationNoRuntimeCurry.mjs
@@ -18,9 +18,18 @@ function add5(extra) {
   return 5 + extra | 0;
 }
 
+function addHookPartial(extra) {
+  addHook(hook, extra);
+}
+
+addHook(hook, _x => {});
+
+addHook(hook, _x => {});
+
 export {
   f,
   add$1 as add,
   add5,
+  addHookPartial,
 }
-/* No side effect */
+/*  Not a pure module */

--- a/tests/tests/src/PartialApplicationNoRuntimeCurry.res
+++ b/tests/tests/src/PartialApplicationNoRuntimeCurry.res
@@ -9,3 +9,11 @@ let f = u => {
 type fn2 = (int, int) => int
 let add: fn2 = (a, b) => a + b
 let add5: int => int = add(5, ...)
+
+type hook
+external hook: hook = "hook"
+external addHook: (hook, 'a => unit) => unit = "addHook"
+
+let addHookPartial = addHook(hook, ...)
+let _ = addHookPartial((_x: int) => ())
+let _ = addHookPartial((_x: string) => ())


### PR DESCRIPTION
# Fix partial application generalization for `...`

## Summary

Fixes [#8334](https://github.com/rescript-lang/rescript/issues/8334).

ReScript treated `foo(arg, ...)` differently from `foo(arg, _)` during
generalization:

- `foo(arg, _)` was parsed into an explicit lambda, so it was treated as a
  function value and could be generalized.
- `foo(arg, ...)` stayed as a partial application node in the typed tree, so it
  was treated as expansive and could end up with weak type variables.

That caused code like this to fail:

```rescript
type hook

external hook: hook = "hook"
external addHook: (hook, 'a => unit) => unit = "addHook"

let addHookPartial = addHook(hook, ...)
```

with:

```text
This expression's type contains type variables that cannot be generalized:
('_weak1 => unit) => unit
```

## Fix

Treat ReScript partial applications with `partial = true` as nonexpansive in
the value restriction check.

This matches the runtime/codegen behavior: `foo(arg, ...)` is ultimately lowered
to a wrapper function, so it should be classified like an explicit lambda for
generalization purposes.

## Tests

Added a regression to `tests/tests/src/PartialApplicationNoRuntimeCurry.res`
covering the reported polymorphic callback case:

- create `addHookPartial = addHook(hook, ...)`
- use it at `int`
- use it again at `string`

Updated the expected generated output in the matching `.mjs` fixture.