### PR TITLE
Rewatch: restore backward compatibility for bsconfig.json

### DIFF
--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -439,6 +439,20 @@ fn log_config_warnings(build_state: &BuildCommandState) {
     build_state.packages.iter().for_each(|(_, package)| {
         // Only warn for local dependencies, not external packages
         if package.is_local_dep {
+            package.config.get_deprecations().iter().for_each(
+                |deprecation_warning| match deprecation_warning {
+                    crate::config::DeprecationWarning::BsDependencies => {
+                        log_deprecated_config_field(&package.name, "bs-dependencies", "dependencies");
+                    }
+                    crate::config::DeprecationWarning::BsDevDependencies => {
+                        log_deprecated_config_field(&package.name, "bs-dev-dependencies", "dev-dependencies");
+                    }
+                    crate::config::DeprecationWarning::BscFlags => {
+                        log_deprecated_config_field(&package.name, "bsc-flags", "compiler-flags");
+                    }
+                },
+            );
+
             package
                 .config
                 .get_unsupported_fields()
@@ -452,6 +466,14 @@ fn log_config_warnings(build_state: &BuildCommandState) {
                 .for_each(|field| log_unknown_config_field(&package.name, field));
         }
     });
+}
+
+fn log_deprecated_config_field(package_name: &str, field_name: &str, new_field_name: &str) {
+    let warning = format!(
+        "The field '{field_name}' found in the package config of '{package_name}' is deprecated and will be removed in a future version.\n\
+        Use '{new_field_name}' instead."
+    );
+    eprintln!("\n{}", style(warning).yellow());
 }
 
 fn log_unsupported_config_field(package_name: &str, field_name: &str) {

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -492,6 +492,9 @@ fn log_deprecations(
             crate::config::DeprecationWarning::CjsModule => {
                 "  - module 'cjs' in package-specs — use 'commonjs' instead"
             }
+            crate::config::DeprecationWarning::Es6Module => {
+                "  - module 'es6' in package-specs — use 'esmodule' instead"
+            }
         };
         message.push('\n');
         message.push_str(line);

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -439,53 +439,17 @@ fn log_config_warnings(build_state: &BuildCommandState) {
     let mut packages: Vec<_> = build_state.packages.values().collect();
     packages.sort_by(|a, b| a.name.cmp(&b.name));
     packages.iter().for_each(|package| {
-        // Deprecations affect every package we load (local or external) —
-        // external consumers can't fix them themselves, so we point them at
-        // the package's issue tracker when we can find one.
-        let issue_tracker_url = if package.is_local_dep {
-            None
-        } else {
-            crate::build::packages::read_issue_tracker_url(&package.path)
-        };
-
-        package
-            .config
-            .get_deprecations()
-            .iter()
-            .for_each(|deprecation_warning| match deprecation_warning {
-                crate::config::DeprecationWarning::BsconfigJson => {
-                    log_deprecated_config_filename(
-                        &package.name,
-                        "bsconfig.json",
-                        "rescript.json",
-                        issue_tracker_url.as_deref(),
-                    );
-                }
-                crate::config::DeprecationWarning::BsDependencies => {
-                    log_deprecated_config_field(
-                        &package.name,
-                        "bs-dependencies",
-                        "dependencies",
-                        issue_tracker_url.as_deref(),
-                    );
-                }
-                crate::config::DeprecationWarning::BsDevDependencies => {
-                    log_deprecated_config_field(
-                        &package.name,
-                        "bs-dev-dependencies",
-                        "dev-dependencies",
-                        issue_tracker_url.as_deref(),
-                    );
-                }
-                crate::config::DeprecationWarning::BscFlags => {
-                    log_deprecated_config_field(
-                        &package.name,
-                        "bsc-flags",
-                        "compiler-flags",
-                        issue_tracker_url.as_deref(),
-                    );
-                }
-            });
+        let deprecations = package.config.get_deprecations();
+        if !deprecations.is_empty() {
+            // External consumers can't fix deprecations themselves, so we
+            // point them at the package's issue tracker when we can find one.
+            let issue_tracker_url = if package.is_local_dep {
+                None
+            } else {
+                crate::build::packages::read_issue_tracker_url(&package.path)
+            };
+            log_deprecations(&package.name, deprecations, issue_tracker_url.as_deref());
+        }
 
         if package.is_local_dep {
             package
@@ -503,36 +467,36 @@ fn log_config_warnings(build_state: &BuildCommandState) {
     });
 }
 
-fn log_deprecated_config_field(
+fn log_deprecations(
     package_name: &str,
-    field_name: &str,
-    new_field_name: &str,
+    deprecations: &[crate::config::DeprecationWarning],
     issue_tracker_url: Option<&str>,
 ) {
-    let mut warning = format!(
-        "The field '{field_name}' found in the package config of '{package_name}' is deprecated and will be removed in a future version.\n\
-        Use '{new_field_name}' instead."
+    let mut message = format!(
+        "Package '{package_name}' uses deprecated config (support will be removed in a future version):"
     );
-    if let Some(url) = issue_tracker_url {
-        warning.push_str(&format!("\nPlease report this to the package maintainer: {url}"));
+    for deprecation in deprecations {
+        let line = match deprecation {
+            crate::config::DeprecationWarning::BsconfigJson => {
+                "  - filename 'bsconfig.json' — rename to 'rescript.json'"
+            }
+            crate::config::DeprecationWarning::BsDependencies => {
+                "  - field 'bs-dependencies' — use 'dependencies' instead"
+            }
+            crate::config::DeprecationWarning::BsDevDependencies => {
+                "  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead"
+            }
+            crate::config::DeprecationWarning::BscFlags => {
+                "  - field 'bsc-flags' — use 'compiler-flags' instead"
+            }
+        };
+        message.push('\n');
+        message.push_str(line);
     }
-    eprintln!("\n{}", style(warning).yellow());
-}
-
-fn log_deprecated_config_filename(
-    package_name: &str,
-    filename: &str,
-    new_filename: &str,
-    issue_tracker_url: Option<&str>,
-) {
-    let mut warning = format!(
-        "The config file '{filename}' used by package '{package_name}' is deprecated and support will be removed in a future version.\n\
-        Rename it to '{new_filename}'."
-    );
     if let Some(url) = issue_tracker_url {
-        warning.push_str(&format!("\nPlease report this to the package maintainer: {url}"));
+        message.push_str(&format!("\nPlease report this to the package maintainer: {url}"));
     }
-    eprintln!("\n{}", style(warning).yellow());
+    eprintln!("\n{}", style(message).yellow());
 }
 
 fn log_unsupported_config_field(package_name: &str, field_name: &str) {

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -441,6 +441,9 @@ fn log_config_warnings(build_state: &BuildCommandState) {
         if package.is_local_dep {
             package.config.get_deprecations().iter().for_each(
                 |deprecation_warning| match deprecation_warning {
+                    crate::config::DeprecationWarning::BsconfigJson => {
+                        log_deprecated_config_filename(&package.name, "bsconfig.json", "rescript.json");
+                    }
                     crate::config::DeprecationWarning::BsDependencies => {
                         log_deprecated_config_field(&package.name, "bs-dependencies", "dependencies");
                     }
@@ -472,6 +475,14 @@ fn log_deprecated_config_field(package_name: &str, field_name: &str, new_field_n
     let warning = format!(
         "The field '{field_name}' found in the package config of '{package_name}' is deprecated and will be removed in a future version.\n\
         Use '{new_field_name}' instead."
+    );
+    eprintln!("\n{}", style(warning).yellow());
+}
+
+fn log_deprecated_config_filename(package_name: &str, filename: &str, new_filename: &str) {
+    let warning = format!(
+        "The config file '{filename}' used by package '{package_name}' is deprecated and support will be removed in a future version.\n\
+        Rename it to '{new_filename}'."
     );
     eprintln!("\n{}", style(warning).yellow());
 }

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -489,6 +489,9 @@ fn log_deprecations(
             crate::config::DeprecationWarning::BscFlags => {
                 "  - field 'bsc-flags' — use 'compiler-flags' instead"
             }
+            crate::config::DeprecationWarning::CjsModule => {
+                "  - module 'cjs' in package-specs — use 'commonjs' instead"
+            }
         };
         message.push('\n');
         message.push_str(line);

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -436,7 +436,9 @@ pub fn incremental_build(
 }
 
 fn log_config_warnings(build_state: &BuildCommandState) {
-    build_state.packages.iter().for_each(|(_, package)| {
+    let mut packages: Vec<_> = build_state.packages.values().collect();
+    packages.sort_by(|a, b| a.name.cmp(&b.name));
+    packages.iter().for_each(|package| {
         // Deprecations affect every package we load (local or external) —
         // external consumers can't fix them themselves, so we point them at
         // the package's issue tracker when we can find one.

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -437,25 +437,55 @@ pub fn incremental_build(
 
 fn log_config_warnings(build_state: &BuildCommandState) {
     build_state.packages.iter().for_each(|(_, package)| {
-        // Only warn for local dependencies, not external packages
-        if package.is_local_dep {
-            package.config.get_deprecations().iter().for_each(
-                |deprecation_warning| match deprecation_warning {
-                    crate::config::DeprecationWarning::BsconfigJson => {
-                        log_deprecated_config_filename(&package.name, "bsconfig.json", "rescript.json");
-                    }
-                    crate::config::DeprecationWarning::BsDependencies => {
-                        log_deprecated_config_field(&package.name, "bs-dependencies", "dependencies");
-                    }
-                    crate::config::DeprecationWarning::BsDevDependencies => {
-                        log_deprecated_config_field(&package.name, "bs-dev-dependencies", "dev-dependencies");
-                    }
-                    crate::config::DeprecationWarning::BscFlags => {
-                        log_deprecated_config_field(&package.name, "bsc-flags", "compiler-flags");
-                    }
-                },
-            );
+        // Deprecations affect every package we load (local or external) —
+        // external consumers can't fix them themselves, so we point them at
+        // the package's issue tracker when we can find one.
+        let issue_tracker_url = if package.is_local_dep {
+            None
+        } else {
+            crate::build::packages::read_issue_tracker_url(&package.path)
+        };
 
+        package
+            .config
+            .get_deprecations()
+            .iter()
+            .for_each(|deprecation_warning| match deprecation_warning {
+                crate::config::DeprecationWarning::BsconfigJson => {
+                    log_deprecated_config_filename(
+                        &package.name,
+                        "bsconfig.json",
+                        "rescript.json",
+                        issue_tracker_url.as_deref(),
+                    );
+                }
+                crate::config::DeprecationWarning::BsDependencies => {
+                    log_deprecated_config_field(
+                        &package.name,
+                        "bs-dependencies",
+                        "dependencies",
+                        issue_tracker_url.as_deref(),
+                    );
+                }
+                crate::config::DeprecationWarning::BsDevDependencies => {
+                    log_deprecated_config_field(
+                        &package.name,
+                        "bs-dev-dependencies",
+                        "dev-dependencies",
+                        issue_tracker_url.as_deref(),
+                    );
+                }
+                crate::config::DeprecationWarning::BscFlags => {
+                    log_deprecated_config_field(
+                        &package.name,
+                        "bsc-flags",
+                        "compiler-flags",
+                        issue_tracker_url.as_deref(),
+                    );
+                }
+            });
+
+        if package.is_local_dep {
             package
                 .config
                 .get_unsupported_fields()
@@ -471,19 +501,35 @@ fn log_config_warnings(build_state: &BuildCommandState) {
     });
 }
 
-fn log_deprecated_config_field(package_name: &str, field_name: &str, new_field_name: &str) {
-    let warning = format!(
+fn log_deprecated_config_field(
+    package_name: &str,
+    field_name: &str,
+    new_field_name: &str,
+    issue_tracker_url: Option<&str>,
+) {
+    let mut warning = format!(
         "The field '{field_name}' found in the package config of '{package_name}' is deprecated and will be removed in a future version.\n\
         Use '{new_field_name}' instead."
     );
+    if let Some(url) = issue_tracker_url {
+        warning.push_str(&format!("\nPlease report this to the package maintainer: {url}"));
+    }
     eprintln!("\n{}", style(warning).yellow());
 }
 
-fn log_deprecated_config_filename(package_name: &str, filename: &str, new_filename: &str) {
-    let warning = format!(
+fn log_deprecated_config_filename(
+    package_name: &str,
+    filename: &str,
+    new_filename: &str,
+    issue_tracker_url: Option<&str>,
+) {
+    let mut warning = format!(
         "The config file '{filename}' used by package '{package_name}' is deprecated and support will be removed in a future version.\n\
         Rename it to '{new_filename}'."
     );
+    if let Some(url) = issue_tracker_url {
+        warning.push_str(&format!("\nPlease report this to the package maintainer: {url}"));
+    }
     eprintln!("\n{}", style(warning).yellow());
 }
 

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -462,6 +462,42 @@ pub fn read_package_name(package_dir: &Path) -> Result<String> {
     ))
 }
 
+/// Looks up the best-effort issue tracker URL for a package by reading its
+/// package.json, preferring `bugs.url`, then deriving from `repository`.
+/// Returns None if no tracker could be inferred.
+pub fn read_issue_tracker_url(package_dir: &Path) -> Option<String> {
+    let contents = fs::read_to_string(package_dir.join("package.json")).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&contents).ok()?;
+
+    let extract_url = |v: &serde_json::Value| -> Option<String> {
+        match v {
+            serde_json::Value::String(s) => Some(s.to_owned()),
+            serde_json::Value::Object(o) => o.get("url").and_then(|u| u.as_str()).map(String::from),
+            _ => None,
+        }
+    };
+
+    if let Some(bugs_url) = json.get("bugs").and_then(extract_url) {
+        return Some(bugs_url);
+    }
+
+    json.get("repository")
+        .and_then(extract_url)
+        .map(|repo| issues_url_from_repository(&repo))
+}
+
+fn issues_url_from_repository(repo: &str) -> String {
+    let cleaned = repo.trim_start_matches("git+").trim_end_matches(".git");
+
+    // npm shorthand (no scheme, no user@): treat as github-style "owner/repo"
+    if !cleaned.contains("://") && !cleaned.contains('@') {
+        let path = cleaned.trim_start_matches("github:");
+        return format!("https://github.com/{path}/issues");
+    }
+
+    format!("{cleaned}/issues")
+}
+
 fn make_package(
     config: config::Config,
     package_path: &Path,
@@ -1052,7 +1088,7 @@ pub fn validate_packages_dependencies(packages: &AHashMap<String, Package>) -> b
 mod test {
     use crate::config;
 
-    use super::{Namespace, Package, read_package_name};
+    use super::{Namespace, Package, read_issue_tracker_url, read_package_name};
     use ahash::{AHashMap, AHashSet};
     use std::fs;
     use std::path::PathBuf;
@@ -1185,5 +1221,78 @@ mod test {
                 package_dir.to_string_lossy()
             )
         );
+    }
+
+    fn write_pkg_json(dir: &std::path::Path, body: &str) {
+        fs::write(dir.join("package.json"), body).expect("package.json should be written");
+    }
+
+    #[test]
+    fn issue_tracker_url_prefers_bugs_url_string() {
+        let temp_dir = TempDir::new().unwrap();
+        write_pkg_json(
+            temp_dir.path(),
+            r#"{"name":"x","bugs":"https://example.com/issues"}"#,
+        );
+        assert_eq!(
+            read_issue_tracker_url(temp_dir.path()),
+            Some("https://example.com/issues".to_string())
+        );
+    }
+
+    #[test]
+    fn issue_tracker_url_prefers_bugs_object_url() {
+        let temp_dir = TempDir::new().unwrap();
+        write_pkg_json(
+            temp_dir.path(),
+            r#"{"name":"x","bugs":{"url":"https://example.com/report"}}"#,
+        );
+        assert_eq!(
+            read_issue_tracker_url(temp_dir.path()),
+            Some("https://example.com/report".to_string())
+        );
+    }
+
+    #[test]
+    fn issue_tracker_url_derives_from_repository_git_url() {
+        let temp_dir = TempDir::new().unwrap();
+        write_pkg_json(
+            temp_dir.path(),
+            r#"{"name":"x","repository":"git+https://github.com/owner/repo.git"}"#,
+        );
+        assert_eq!(
+            read_issue_tracker_url(temp_dir.path()),
+            Some("https://github.com/owner/repo/issues".to_string())
+        );
+    }
+
+    #[test]
+    fn issue_tracker_url_derives_from_repository_object() {
+        let temp_dir = TempDir::new().unwrap();
+        write_pkg_json(
+            temp_dir.path(),
+            r#"{"name":"x","repository":{"type":"git","url":"https://github.com/owner/repo.git"}}"#,
+        );
+        assert_eq!(
+            read_issue_tracker_url(temp_dir.path()),
+            Some("https://github.com/owner/repo/issues".to_string())
+        );
+    }
+
+    #[test]
+    fn issue_tracker_url_handles_shorthand() {
+        let temp_dir = TempDir::new().unwrap();
+        write_pkg_json(temp_dir.path(), r#"{"name":"x","repository":"owner/repo"}"#);
+        assert_eq!(
+            read_issue_tracker_url(temp_dir.path()),
+            Some("https://github.com/owner/repo/issues".to_string())
+        );
+    }
+
+    #[test]
+    fn issue_tracker_url_returns_none_without_hints() {
+        let temp_dir = TempDir::new().unwrap();
+        write_pkg_json(temp_dir.path(), r#"{"name":"x"}"#);
+        assert_eq!(read_issue_tracker_url(temp_dir.path()), None);
     }
 }

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -246,7 +246,13 @@ fn get_source_dirs(source: config::Source, sub_path: Option<PathBuf>) -> AHashSe
 
 pub fn read_config(package_dir: &Path) -> Result<Config> {
     let rescript_json_path = package_dir.join("rescript.json");
-    Config::new(&rescript_json_path)
+    let bsconfig_json_path = package_dir.join("bsconfig.json");
+
+    if rescript_json_path.exists() {
+        Config::new(&rescript_json_path)
+    } else {
+        Config::new(&bsconfig_json_path)
+    }
 }
 
 pub fn read_dependency(

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -452,6 +452,10 @@ pub fn read_package_name(package_dir: &Path) -> Result<String> {
         return Ok(name);
     }
 
+    if let Some(name) = read_name("bsconfig.json")? {
+        return Ok(name);
+    }
+
     Err(anyhow!(
         "No name field found in package.json or rescript.json in {}",
         package_dir.to_string_lossy()

--- a/rewatch/src/config.rs
+++ b/rewatch/src/config.rs
@@ -157,7 +157,7 @@ pub struct PackageSpec {
 pub enum PackageModule {
     #[serde(rename = "commonjs", alias = "cjs")]
     CommonJs,
-    #[serde(rename = "esmodule")]
+    #[serde(rename = "esmodule", alias = "es6")]
     EsModule,
 }
 
@@ -250,6 +250,7 @@ pub enum DeprecationWarning {
     BsDevDependencies,
     BscFlags,
     CjsModule,
+    Es6Module,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -498,8 +499,15 @@ impl Config {
             }
         }
 
-        if raw_value.as_ref().is_some_and(uses_cjs_module) {
-            config.deprecation_warnings.push(DeprecationWarning::CjsModule);
+        if let Some(value) = raw_value.as_ref() {
+            for (legacy_module, warning) in [
+                ("cjs", DeprecationWarning::CjsModule),
+                ("es6", DeprecationWarning::Es6Module),
+            ] {
+                if uses_module_alias(value, legacy_module) {
+                    config.deprecation_warnings.push(warning);
+                }
+            }
         }
 
         config.handle_deprecations()?;
@@ -832,19 +840,17 @@ fn resolve_spec_in_source(spec: &serde_json::Value) -> bool {
         .unwrap_or(true)
 }
 
-fn uses_cjs_module(value: &serde_json::Value) -> bool {
+fn uses_module_alias(value: &serde_json::Value, alias: &str) -> bool {
     let specs = match value.get("package-specs") {
         Some(specs) => specs,
         None => return false,
     };
+    let spec_has_alias =
+        |spec: &serde_json::Value| -> bool { spec.get("module").and_then(|m| m.as_str()) == Some(alias) };
     match specs {
-        serde_json::Value::Array(specs) => specs.iter().any(spec_has_cjs_module),
-        _ => spec_has_cjs_module(specs),
+        serde_json::Value::Array(specs) => specs.iter().any(spec_has_alias),
+        _ => spec_has_alias(specs),
     }
-}
-
-fn spec_has_cjs_module(spec: &serde_json::Value) -> bool {
-    spec.get("module").and_then(|m| m.as_str()) == Some("cjs")
 }
 
 fn validate_package_spec_value(value: &serde_json::Value) -> Result<()> {
@@ -859,7 +865,7 @@ fn validate_package_spec_value(value: &serde_json::Value) -> Result<()> {
     };
 
     match module {
-        "commonjs" | "cjs" | "esmodule" => Ok(()),
+        "commonjs" | "cjs" | "esmodule" | "es6" => Ok(()),
         other => Err(anyhow!(
             "Module system \"{other}\" is unsupported. Expected \"commonjs\" or \"esmodule\"."
         )),
@@ -1272,27 +1278,21 @@ pub mod tests {
     }
 
     #[test]
-    fn test_package_specs_es6_deprecation() {
+    fn test_es6_module_alias() {
         let json = r#"
         {
             "name": "testrepo",
-            "sources": {
-                "dir": "src",
-                "subdirs": true
-            },
-            "package-specs": [
-                {
-                "module": "es6",
-                "in-source": true
-                }
-            ],
+            "sources": { "dir": "src", "subdirs": true },
+            "package-specs": [ { "module": "es6", "in-source": true } ],
             "suffix": ".mjs"
         }
         "#;
 
-        let err = Config::new_from_json_string(json).unwrap_err();
-        let message = err.to_string();
-        assert!(message.contains("Module system \"es6\" is unsupported"));
+        let config = Config::new_from_json_string(json).expect("a valid json string");
+        let specs = config.get_package_specs();
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].module, PackageModule::EsModule);
+        assert_eq!(config.get_deprecations(), [DeprecationWarning::Es6Module]);
     }
 
     #[test]

--- a/rewatch/src/config.rs
+++ b/rewatch/src/config.rs
@@ -155,7 +155,7 @@ pub struct PackageSpec {
 
 #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum PackageModule {
-    #[serde(rename = "commonjs")]
+    #[serde(rename = "commonjs", alias = "cjs")]
     CommonJs,
     #[serde(rename = "esmodule")]
     EsModule,
@@ -249,6 +249,7 @@ pub enum DeprecationWarning {
     BsDependencies,
     BsDevDependencies,
     BscFlags,
+    CjsModule,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -495,6 +496,10 @@ impl Config {
                     config.deprecation_warnings.push(warning);
                 }
             }
+        }
+
+        if raw_value.as_ref().is_some_and(uses_cjs_module) {
+            config.deprecation_warnings.push(DeprecationWarning::CjsModule);
         }
 
         config.handle_deprecations()?;
@@ -827,6 +832,21 @@ fn resolve_spec_in_source(spec: &serde_json::Value) -> bool {
         .unwrap_or(true)
 }
 
+fn uses_cjs_module(value: &serde_json::Value) -> bool {
+    let specs = match value.get("package-specs") {
+        Some(specs) => specs,
+        None => return false,
+    };
+    match specs {
+        serde_json::Value::Array(specs) => specs.iter().any(spec_has_cjs_module),
+        _ => spec_has_cjs_module(specs),
+    }
+}
+
+fn spec_has_cjs_module(spec: &serde_json::Value) -> bool {
+    spec.get("module").and_then(|m| m.as_str()) == Some("cjs")
+}
+
 fn validate_package_spec_value(value: &serde_json::Value) -> Result<()> {
     let module = match value.get("module") {
         Some(module) => module,
@@ -839,7 +859,7 @@ fn validate_package_spec_value(value: &serde_json::Value) -> Result<()> {
     };
 
     match module {
-        "commonjs" | "esmodule" => Ok(()),
+        "commonjs" | "cjs" | "esmodule" => Ok(()),
         other => Err(anyhow!(
             "Module system \"{other}\" is unsupported. Expected \"commonjs\" or \"esmodule\"."
         )),
@@ -1366,6 +1386,24 @@ pub mod tests {
             unreachable!("Expected compiler flags to be Some");
         }
         assert!(config.get_deprecations().is_empty());
+    }
+
+    #[test]
+    fn test_cjs_module_alias() {
+        let json = r#"
+        {
+            "name": "testrepo",
+            "sources": { "dir": "src", "subdirs": true },
+            "package-specs": [ { "module": "cjs", "in-source": true } ],
+            "suffix": ".js"
+        }
+        "#;
+
+        let config = Config::new_from_json_string(json).expect("a valid json string");
+        let specs = config.get_package_specs();
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].module, PackageModule::CommonJs);
+        assert_eq!(config.get_deprecations(), [DeprecationWarning::CjsModule]);
     }
 
     #[test]

--- a/rewatch/src/config.rs
+++ b/rewatch/src/config.rs
@@ -244,7 +244,11 @@ pub struct JsPostBuild {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub enum DeprecationWarning {}
+pub enum DeprecationWarning {
+    BsDependencies,
+    BsDevDependencies,
+    BscFlags,
+}
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum ExperimentalFeature {
@@ -293,13 +297,14 @@ pub struct Config {
     pub package_specs: Option<OneOrMore<PackageSpec>>,
     pub warnings: Option<Warnings>,
     pub suffix: Option<String>,
+    #[serde(alias = "bs-dependencies")]
     pub dependencies: Option<Vec<String>>,
-    #[serde(rename = "dev-dependencies")]
+    #[serde(rename = "dev-dependencies", alias = "bs-dev-dependencies")]
     pub dev_dependencies: Option<Vec<String>>,
     #[serde(rename = "ppx-flags")]
     pub ppx_flags: Option<Vec<OneOrMore<String>>>,
 
-    #[serde(rename = "compiler-flags")]
+    #[serde(rename = "compiler-flags", alias = "bsc-flags")]
     pub compiler_flags: Option<Vec<OneOrMore<String>>>,
 
     pub namespace: Option<NamespaceConfig>,
@@ -459,8 +464,9 @@ impl Config {
 
     /// Try to convert a config from a string to a config struct
     pub fn new_from_json_string(config_str: &str) -> Result<Self> {
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(config_str) {
-            validate_package_specs_value(&value)?;
+        let raw_value = serde_json::from_str::<serde_json::Value>(config_str).ok();
+        if let Some(value) = raw_value.as_ref() {
+            validate_package_specs_value(value)?;
         }
 
         let mut deserializer = serde_json::Deserializer::from_str(config_str);
@@ -477,6 +483,18 @@ impl Config {
                         anyhow!("Failed to parse rescript.json at {path}: {err}")
                     }
                 })?;
+
+        if let Some(value) = raw_value.as_ref().and_then(|v| v.as_object()) {
+            for (raw_key, warning) in [
+                ("bs-dependencies", DeprecationWarning::BsDependencies),
+                ("bs-dev-dependencies", DeprecationWarning::BsDevDependencies),
+                ("bsc-flags", DeprecationWarning::BscFlags),
+            ] {
+                if value.contains_key(raw_key) {
+                    config.deprecation_warnings.push(warning);
+                }
+            }
+        }
 
         config.handle_deprecations()?;
         config.unknown_fields = unknown_fields;
@@ -1131,6 +1149,31 @@ pub mod tests {
     }
 
     #[test]
+    fn test_bs_dependencies_alias() {
+        let json = r#"
+        {
+            "name": "testrepo",
+            "sources": {
+                "dir": "src",
+                "subdirs": true
+            },
+            "package-specs": [
+                {
+                "module": "esmodule",
+                "in-source": true
+                }
+            ],
+            "suffix": ".mjs",
+            "bs-dependencies": [ "@testrepo/main" ]
+        }
+        "#;
+
+        let config = Config::new_from_json_string(json).expect("a valid json string");
+        assert_eq!(config.dependencies, Some(vec!["@testrepo/main".to_string()]));
+        assert_eq!(config.get_deprecations(), [DeprecationWarning::BsDependencies]);
+    }
+
+    #[test]
     fn test_dev_dependencies() {
         let json = r#"
         {
@@ -1153,6 +1196,34 @@ pub mod tests {
         let config = Config::new_from_json_string(json).expect("a valid json string");
         assert_eq!(config.dev_dependencies, Some(vec!["@testrepo/main".to_string()]));
         assert!(config.get_deprecations().is_empty());
+    }
+
+    #[test]
+    fn test_bs_dev_dependencies_alias() {
+        let json = r#"
+        {
+            "name": "testrepo",
+            "sources": {
+                "dir": "src",
+                "subdirs": true
+            },
+            "package-specs": [
+                {
+                "module": "esmodule",
+                "in-source": true
+                }
+            ],
+            "suffix": ".mjs",
+            "bs-dev-dependencies": [ "@testrepo/main" ]
+        }
+        "#;
+
+        let config = Config::new_from_json_string(json).expect("a valid json string");
+        assert_eq!(config.dev_dependencies, Some(vec!["@testrepo/main".to_string()]));
+        assert_eq!(
+            config.get_deprecations(),
+            [DeprecationWarning::BsDevDependencies]
+        );
     }
 
     #[test]
@@ -1294,6 +1365,31 @@ pub mod tests {
             unreachable!("Expected compiler flags to be Some");
         }
         assert!(config.get_deprecations().is_empty());
+    }
+
+    #[test]
+    fn test_bsc_flags_alias() {
+        let json = r#"
+        {
+            "name": "testrepo",
+            "sources": {
+                "dir": "src",
+                "subdirs": true
+            },
+            "package-specs": [
+                {
+                "module": "esmodule",
+                "in-source": true
+                }
+            ],
+            "suffix": ".mjs",
+            "bsc-flags": [ "-w" ]
+        }
+        "#;
+
+        let config = Config::new_from_json_string(json).expect("a valid json string");
+        assert!(config.compiler_flags.is_some());
+        assert_eq!(config.get_deprecations(), [DeprecationWarning::BscFlags]);
     }
 
     fn test_find_is_type_dev(source: OneOrMore<Source>, path: &Path, expected: bool) {

--- a/rewatch/src/config.rs
+++ b/rewatch/src/config.rs
@@ -1220,10 +1220,7 @@ pub mod tests {
 
         let config = Config::new_from_json_string(json).expect("a valid json string");
         assert_eq!(config.dev_dependencies, Some(vec!["@testrepo/main".to_string()]));
-        assert_eq!(
-            config.get_deprecations(),
-            [DeprecationWarning::BsDevDependencies]
-        );
+        assert_eq!(config.get_deprecations(), [DeprecationWarning::BsDevDependencies]);
     }
 
     #[test]

--- a/rewatch/src/config.rs
+++ b/rewatch/src/config.rs
@@ -245,6 +245,7 @@ pub struct JsPostBuild {
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum DeprecationWarning {
+    BsconfigJson,
     BsDependencies,
     BsDevDependencies,
     BscFlags,
@@ -503,6 +504,9 @@ impl Config {
     }
 
     fn set_path(&mut self, path: PathBuf) -> Result<()> {
+        if path.file_name().and_then(|n| n.to_str()) == Some("bsconfig.json") {
+            self.deprecation_warnings.push(DeprecationWarning::BsconfigJson);
+        }
         self.path = path;
         Ok(())
     }
@@ -1592,6 +1596,24 @@ pub mod tests {
         assert!(
             error.contains(path.to_string_lossy().as_ref()),
             "Error should include the missing config path, got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_bsconfig_json_filename_deprecation() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("bsconfig.json");
+        std::fs::write(
+            &path,
+            r#"{ "name": "legacy", "sources": { "dir": "src", "subdirs": true } }"#,
+        )
+        .expect("write");
+
+        let config = Config::new(&path).expect("a valid bsconfig.json");
+        assert!(
+            config
+                .get_deprecations()
+                .contains(&DeprecationWarning::BsconfigJson)
         );
     }
 }

--- a/rewatch/src/helpers.rs
+++ b/rewatch/src/helpers.rs
@@ -513,7 +513,7 @@ pub fn compute_file_hash(path: &Path) -> Option<blake3::Hash> {
 }
 
 fn has_rescript_config(path: &Path) -> bool {
-    path.join("rescript.json").exists()
+    path.join("rescript.json").exists() || path.join("bsconfig.json").exists()
 }
 
 // traverse up the directory tree until we find a config.json, if not return None

--- a/rewatch/src/watcher.rs
+++ b/rewatch/src/watcher.rs
@@ -256,17 +256,17 @@ async fn async_watch(
                 return Ok(());
             }
 
-            // Detect rescript.json changes and trigger a full rebuild
-            if event
-                .paths
-                .iter()
-                .any(|p| p.file_name().map(|name| name == "rescript.json").unwrap_or(false))
-                && matches!(
-                    event.kind,
-                    EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
-                )
-            {
-                log::debug!("rescript.json changed -> full compile");
+            // Detect config-file changes and trigger a full rebuild.
+            // Legacy bsconfig.json is accepted for backward compatibility.
+            if event.paths.iter().any(|p| {
+                p.file_name()
+                    .map(|name| name == "rescript.json" || name == "bsconfig.json")
+                    .unwrap_or(false)
+            }) && matches!(
+                event.kind,
+                EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
+            ) {
+                log::debug!("config file changed -> full compile");
                 needs_compile_type = CompileType::Full;
                 continue;
             }

--- a/rewatch/tests/snapshots/clean-rebuild.txt
+++ b/rewatch/tests/snapshots/clean-rebuild.txt
@@ -13,12 +13,30 @@ Compiled 430 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues

--- a/rewatch/tests/snapshots/clean-rebuild.txt
+++ b/rewatch/tests/snapshots/clean-rebuild.txt
@@ -13,30 +13,21 @@ Compiled 430 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues

--- a/rewatch/tests/snapshots/dependency-cycle.txt
+++ b/rewatch/tests/snapshots/dependency-cycle.txt
@@ -13,15 +13,33 @@ Compiled 1 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
 Can't continue... Found a circular dependency in your code:
 Dep01 (packages/dep01/src/Dep01.res)

--- a/rewatch/tests/snapshots/dependency-cycle.txt
+++ b/rewatch/tests/snapshots/dependency-cycle.txt
@@ -13,32 +13,23 @@ Compiled 1 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
 Can't continue... Found a circular dependency in your code:

--- a/rewatch/tests/snapshots/dev-dependency-used-by-non-dev-source.txt
+++ b/rewatch/tests/snapshots/dev-dependency-used-by-non-dev-source.txt
@@ -13,15 +13,33 @@ Compiled 2 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
   [1;31mWe've found a bug for you![0m
   [36m/packages/with-dev-deps/src/FileToTest.res[0m:[2m2:6-11[0m

--- a/rewatch/tests/snapshots/dev-dependency-used-by-non-dev-source.txt
+++ b/rewatch/tests/snapshots/dev-dependency-used-by-non-dev-source.txt
@@ -13,32 +13,23 @@ Compiled 2 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
   [1;31mWe've found a bug for you![0m

--- a/rewatch/tests/snapshots/remove-file.txt
+++ b/rewatch/tests/snapshots/remove-file.txt
@@ -13,15 +13,33 @@ Compiled 2 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
   [1;31mWe've found a bug for you![0m
   [36m/packages/dep01/src/Dep01.res[0m:[2m3:9-17[0m

--- a/rewatch/tests/snapshots/remove-file.txt
+++ b/rewatch/tests/snapshots/remove-file.txt
@@ -13,32 +13,23 @@ Compiled 2 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
   [1;31mWe've found a bug for you![0m

--- a/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
@@ -13,15 +13,33 @@ Compiled 3 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
   [1;31mWe've found a bug for you![0m
   [36m/packages/new-namespace/src/NS_alias.res[0m:[2m2:1-16[0m

--- a/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep-namespace.txt
@@ -13,32 +13,23 @@ Compiled 3 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
   [1;31mWe've found a bug for you![0m

--- a/rewatch/tests/snapshots/rename-file-internal-dep.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep.txt
@@ -13,15 +13,33 @@ Compiled 3 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
   [1;31mWe've found a bug for you![0m
   [36m/packages/main/src/Main.res[0m:[2m4:13-29[0m

--- a/rewatch/tests/snapshots/rename-file-internal-dep.txt
+++ b/rewatch/tests/snapshots/rename-file-internal-dep.txt
@@ -13,32 +13,23 @@ Compiled 3 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues
 
   [1;31mWe've found a bug for you![0m

--- a/rewatch/tests/snapshots/rename-file-with-interface.txt
+++ b/rewatch/tests/snapshots/rename-file-with-interface.txt
@@ -14,30 +14,21 @@ Compiled 2 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues

--- a/rewatch/tests/snapshots/rename-file-with-interface.txt
+++ b/rewatch/tests/snapshots/rename-file-with-interface.txt
@@ -14,12 +14,30 @@ Compiled 2 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues

--- a/rewatch/tests/snapshots/rename-file.txt
+++ b/rewatch/tests/snapshots/rename-file.txt
@@ -13,12 +13,30 @@ Compiled 2 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues

--- a/rewatch/tests/snapshots/rename-file.txt
+++ b/rewatch/tests/snapshots/rename-file.txt
@@ -13,30 +13,21 @@ Compiled 2 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues

--- a/rewatch/tests/snapshots/rename-interface-file.txt
+++ b/rewatch/tests/snapshots/rename-interface-file.txt
@@ -14,30 +14,21 @@ Compiled 2 modules
 
 
 
-The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
-
-The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-
-The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
-Use 'compiler-flags' instead.
+Package '@testrepo/deprecated-config' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - field 'bsc-flags' — use 'compiler-flags' instead
 
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dependencies' instead.
+Package 'rescript-nodejs' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dependencies' — use 'dependencies' instead
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
+  - filename 'bsconfig.json' — rename to 'rescript.json'
 Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
-Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
-
-The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
-Rename it to 'rescript.json'.
-
-The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
-Use 'dev-dependencies' instead.
+Package 'sury' uses deprecated config (support will be removed in a future version):
+  - field 'bs-dev-dependencies' — use 'dev-dependencies' instead
 Please report this to the package maintainer: https://github.com/DZakh/sury/issues

--- a/rewatch/tests/snapshots/rename-interface-file.txt
+++ b/rewatch/tests/snapshots/rename-interface-file.txt
@@ -14,12 +14,30 @@ Compiled 2 modules
 
 
 
+The field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+
+The field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+
+The field 'bsc-flags' found in the package config of '@testrepo/deprecated-config' is deprecated and will be removed in a future version.
+Use 'compiler-flags' instead.
+
 The field 'ignored-dirs' found in the package config of '@testrepo/deprecated-config' is not supported by ReScript 12's new build system.
 
 Unknown field 'some-new-field' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
 
-Unknown field 'bs-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bs-dev-dependencies' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The field 'bs-dev-dependencies' found in the package config of 'rescript-nodejs' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/TheSpyder/rescript-nodejs/issues
 
-Unknown field 'bsc-flags' found in the package config of '@testrepo/deprecated-config'. This option will be ignored.
+The config file 'bsconfig.json' used by package 'rescript-nodejs' is deprecated and support will be removed in a future version.
+Rename it to 'rescript.json'.
+
+The field 'bs-dev-dependencies' found in the package config of 'sury' is deprecated and will be removed in a future version.
+Use 'dev-dependencies' instead.
+Please report this to the package maintainer: https://github.com/DZakh/sury/issues

--- a/rewatch/tests/suite.sh
+++ b/rewatch/tests/suite.sh
@@ -38,7 +38,7 @@ fi
 success "No stale rescript processes found"
 
 bold "Yarn install"
-(cd ../testrepo && yarn && cp node_modules/rescript-nodejs/bsconfig.json node_modules/rescript-nodejs/rescript.json)
+(cd ../testrepo && yarn)
 
 bold "Rescript version"
 (cd ../testrepo && ./node_modules/.bin/rescript --version)

--- a/tests/build_tests/warn_legacy_config/input.js
+++ b/tests/build_tests/warn_legacy_config/input.js
@@ -7,6 +7,6 @@ const { execBuild, execClean } = setup(import.meta.dirname);
 
 const output = await execBuild();
 assert.equal(output.status, 0);
-assert.match(output.stderr, /bsconfig\.json.*deprecated/i);
-assert.match(output.stderr, /rename it to 'rescript\.json'/i);
+assert.match(output.stderr, /uses deprecated config/i);
+assert.match(output.stderr, /filename 'bsconfig\.json' .* rename to 'rescript\.json'/i);
 await execClean();

--- a/tests/build_tests/warn_legacy_config/input.js
+++ b/tests/build_tests/warn_legacy_config/input.js
@@ -8,5 +8,8 @@ const { execBuild, execClean } = setup(import.meta.dirname);
 const output = await execBuild();
 assert.equal(output.status, 0);
 assert.match(output.stderr, /uses deprecated config/i);
-assert.match(output.stderr, /filename 'bsconfig\.json' .* rename to 'rescript\.json'/i);
+assert.match(
+  output.stderr,
+  /filename 'bsconfig\.json' .* rename to 'rescript\.json'/i,
+);
 await execClean();

--- a/tests/build_tests/warn_legacy_config/input.js
+++ b/tests/build_tests/warn_legacy_config/input.js
@@ -6,6 +6,7 @@ import { setup } from "#dev/process";
 const { execBuild, execClean } = setup(import.meta.dirname);
 
 const output = await execBuild();
-assert.notEqual(output.status, 0);
-assert.match(output.stderr, /could not read rescript\.json/i);
+assert.equal(output.status, 0);
+assert.match(output.stderr, /bsconfig\.json.*deprecated/i);
+assert.match(output.stderr, /rename it to 'rescript\.json'/i);
 await execClean();


### PR DESCRIPTION
## Summary

Restores backward compatibility that was removed in #8187 and #8196 so that existing projects using the legacy config name and field aliases continue to build under rewatch.

- `rewatch` again falls back to `bsconfig.json` when `rescript.json` is absent (`read_config`, `has_rescript_config`).
- The config parser accepts `bs-dependencies`, `bs-dev-dependencies`, and `bsc-flags` as aliases for `dependencies`, `dev-dependencies`, and `compiler-flags` (via `#[serde(alias = ...)]`).
- When any of those legacy field names are present in the raw JSON, a deprecation warning is emitted pointing at the modern field name.
- Reverts the `cp bsconfig.json rescript.json` workaround in `rewatch/tests/suite.sh` (no longer needed now that rewatch reads `bsconfig.json` directly).

## Test plan

- [ ] `cargo test --lib config::` — 34 tests pass, including new alias/deprecation tests for `bs-dependencies`, `bs-dev-dependencies`, `bsc-flags`
- [ ] Manual: place a package with a legacy `bsconfig.json` in `node_modules` and confirm rewatch resolves it and prints the deprecation warning
- [ ] CI rewatch integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)