### PR TITLE
Rewatch: don't suppress progress messages under -v/-vv

### DIFF
--- a/rewatch/src/main.rs
+++ b/rewatch/src/main.rs
@@ -36,9 +36,9 @@ fn main() -> Result<()> {
     let is_tty: bool = Term::stdout().is_term() && Term::stderr().is_term();
     let plain_output = !is_tty;
 
-    // The 'normal run' mode will show the 'pretty' formatted progress. But if we turn off the log
-    // level, we should never show that.
-    let show_progress = log_level_filter == LevelFilter::Info;
+    // Show progress messages (e.g. "Finished compilation") as long as logging is at Info level
+    // or more verbose. This way `-v` and `-vv` add debug output without suppressing progress.
+    let show_progress = log_level_filter >= LevelFilter::Info;
 
     match cli.command {
         cli::Command::CompilerArgs { path } => {


### PR DESCRIPTION
## Summary

Change `show_progress` from `log_level_filter == LevelFilter::Info` to `>= LevelFilter::Info` so that `-v` / `-vv` add debug output without also silencing progress messages like "Finished compilation".

Small UX fix split out of #8241.

## Test plan

- [x] `cargo build --release --manifest-path rewatch/Cargo.toml`
- [ ] Manual: run `rewatch build` with and without `-v` / `-vv`, confirm progress line still prints at each verbosity

🤖 Generated with [Claude Code](https://claude.com/claude-code)