### PR TITLE
Rewatch: print 'Finished compilation' in watch plain_output mode

### DIFF
--- a/rewatch/src/watcher.rs
+++ b/rewatch/src/watcher.rs
@@ -452,13 +452,17 @@ async fn async_watch(
                 build::write_build_ninja(&build_state);
 
                 let timing_total_elapsed = timing_total.elapsed();
-                if !plain_output && show_progress {
-                    println!(
-                        "\n{}{}Finished compilation in {:.2}s\n",
-                        LINE_CLEAR,
-                        SPARKLES,
-                        timing_total_elapsed.as_secs_f64()
-                    );
+                if show_progress {
+                    if plain_output {
+                        println!("Finished compilation")
+                    } else {
+                        println!(
+                            "\n{}{}Finished compilation in {:.2}s\n",
+                            LINE_CLEAR,
+                            SPARKLES,
+                            timing_total_elapsed.as_secs_f64()
+                        );
+                    }
                 }
                 needs_compile_type = CompileType::None;
                 initial_build = false;


### PR DESCRIPTION
## Summary

When stdout isn't a TTY during `rewatch watch`, full rebuilds previously produced no completion message. Emit a plain `Finished compilation` line so parent processes and non-TTY log consumers can observe when a rebuild finishes.

Small UX fix split out of #8241.

## Test plan

- [x] `cargo build --release --manifest-path rewatch/Cargo.toml`
- [ ] Manual: pipe `rewatch watch` into `cat`, trigger a rebuild, confirm the line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)