### PR TITLE
Remove Primitive_option.toUndefined; use valFromOption for optional ffi args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 #### :house: Internal
 
+- Remove `Primitive_option.toUndefined`; use `valFromOption` for optional ffi args. https://github.com/rescript-lang/rescript/pull/8380
+
 # 13.0.0-alpha.4
 
 #### :boom: Breaking Change

--- a/compiler/core/js_of_lam_option.ml
+++ b/compiler/core/js_of_lam_option.ml
@@ -79,7 +79,7 @@ let get_default_undefined_from_optional (arg : J.expression) : J.expression =
       if Js_analyzer.is_okay_to_duplicate arg then
         (* FIXME: no need do such inlining*)
         E.econd (is_not_none arg) (val_from_option arg) E.undefined
-      else E.runtime_call Primitive_modules.option "toUndefined" [arg]
+      else E.runtime_call Primitive_modules.option "valFromOption" [arg]
 
 let option_unwrap (arg : J.expression) : J.expression =
   let desc = arg.expression_desc in

--- a/packages/@rescript/runtime/Primitive_option.res
+++ b/packages/@rescript/runtime/Primitive_option.res
@@ -48,8 +48,8 @@ let fromNull = (type t, x: Js.null<t>): option<t> =>
 /* external valFromOption : 'a option -> 'a =
  "#val_from_option" */
 
-/** The input is already of [Some] form, [x] is not None, 
-    make sure [x[0]] will not throw */
+/** Preserves `None`/`undefined` and unwraps one outer option layer.
+    Nested `Some` values stay encoded one level deeper. */
 let valFromOption = (x: Obj.t): Obj.t =>
   if x !== Obj.repr(Js.null) && isNested(x) {
     let {depth}: nested = Obj.magic(x)
@@ -60,13 +60,6 @@ let valFromOption = (x: Obj.t): Obj.t =>
     }
   } else {
     Obj.magic(x)
-  }
-
-let toUndefined = (x: option<'a>) =>
-  if x == None {
-    Js.undefined
-  } else {
-    Obj.magic(valFromOption(Obj.repr(x)))
   }
 
 type poly = {@as("VAL") value: Obj.t}

--- a/packages/@rescript/runtime/Primitive_option.resi
+++ b/packages/@rescript/runtime/Primitive_option.resi
@@ -18,10 +18,6 @@ let some: Primitive_object_extern.t => Primitive_object_extern.t
 
 let isNested: Primitive_object_extern.t => bool
 
-let toUndefined: option<Primitive_object_extern.t> => Primitive_js_extern.undefined<
-  Primitive_object_extern.t,
->
-
 type poly
 
 /** When it is None, return None

--- a/packages/@rescript/runtime/lib/es6/Primitive_option.mjs
+++ b/packages/@rescript/runtime/lib/es6/Primitive_option.mjs
@@ -57,14 +57,6 @@ function valFromOption(x) {
   }
 }
 
-function toUndefined(x) {
-  if (x === undefined) {
-    return;
-  } else {
-    return valFromOption(x);
-  }
-}
-
 function unwrapPolyVar(x) {
   if (x !== undefined) {
     return x.VAL;
@@ -80,7 +72,6 @@ export {
   valFromOption,
   some,
   isNested,
-  toUndefined,
   unwrapPolyVar,
 }
 /* No side effect */

--- a/packages/@rescript/runtime/lib/js/Primitive_option.cjs
+++ b/packages/@rescript/runtime/lib/js/Primitive_option.cjs
@@ -57,14 +57,6 @@ function valFromOption(x) {
   }
 }
 
-function toUndefined(x) {
-  if (x === undefined) {
-    return;
-  } else {
-    return valFromOption(x);
-  }
-}
-
 function unwrapPolyVar(x) {
   if (x !== undefined) {
     return x.VAL;
@@ -79,6 +71,5 @@ exports.fromNull = fromNull;
 exports.valFromOption = valFromOption;
 exports.some = some;
 exports.isNested = isNested;
-exports.toUndefined = toUndefined;
 exports.unwrapPolyVar = unwrapPolyVar;
 /* No side effect */

--- a/tests/tests/src/optional_ffi_test.mjs
+++ b/tests/tests/src/optional_ffi_test.mjs
@@ -24,7 +24,7 @@ function bug_to_fix(f, x) {
 }
 
 function bug_to_fix2(f, x) {
-  return hey(Primitive_option.toUndefined(f(x)), 3);
+  return hey(Primitive_option.valFromOption(f(x)), 3);
 }
 
 let counter2 = {


### PR DESCRIPTION
# Summary

This PR removes `Primitive_option.toUndefined` and switches optional FFI argument lowering to use `Primitive_option.valFromOption` instead.

`valFromOption` already has the right runtime behavior here:

- `None` stays `undefined`
- `Some(v)` becomes `v`
- nested options still unwrap by exactly one outer layer

As a result, the extra `toUndefined` helper is redundant for this code path and can be deleted.

# Changes

- change `compiler/core/js_of_lam_option.ml` so the non-duplicable optional-argument path emits `Primitive_option.valFromOption(...)` instead of `Primitive_option.toUndefined(...)`
- remove `Primitive_option.toUndefined` from the runtime source and interface
- regenerate the JS runtime artifacts
- update the optional FFI generated test output accordingly

# Example

Before:

```js
return hey(Primitive_option.toUndefined(f(x)), 3);
```

After:

```js
return hey(Primitive_option.valFromOption(f(x)), 3);
```
