### PR TITLE
Resolve workspace dependencies in editor analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 #### :nail_care: Polish
 
 - Improve default argument type mismatch errors. https://github.com/rescript-lang/rescript/pull/8389
+- Resolve workspace dependencies in editor analysis. https://github.com/rescript-lang/rescript/pull/8392
 
 #### :house: Internal
 

--- a/analysis/src/FindFiles.ml
+++ b/analysis/src/FindFiles.ml
@@ -135,6 +135,32 @@ let collectFiles directory =
          | None -> None
          | Some res -> Some (modName, SharedTypes.Impl {cmt; res}))
 
+(* Dependency resolution uses the package graph recorded by the build system in
+   .sourcedirs.json when available. If a package is not listed there, analysis
+   falls back to walking up node_modules from the project root. *)
+let readSourcedirsPackageRoots base =
+  let sourceDirsFile = base /+ "lib" /+ "bs" /+ ".sourcedirs.json" in
+  let readPackageEntry = function
+    | Json.Array [Json.String name; Json.String path] ->
+      let path = if Filename.is_relative path then base /+ path else path in
+      Some (name, path)
+    | _ -> None
+  in
+  match Files.readFile sourceDirsFile with
+  | None -> []
+  | Some text -> (
+    match Json.parse text with
+    | None -> []
+    | Some json -> (
+      match json |> Json.get "pkgs" |> bind Json.array with
+      | None -> []
+      | Some packages -> packages |> List.filter_map readPackageEntry))
+
+let findPackageRoot ~base ~sourcedirsPackageRoots name =
+  match List.assoc_opt name sourcedirsPackageRoots with
+  | Some path when Files.exists path -> Some path
+  | _ -> ModuleResolution.resolveNodeModulePath ~startPath:base name
+
 (* returns a list of (absolute path to cmt(i), relative path from base to source file) *)
 let findProjectFiles ~public ~namespace ~path ~sourceDirectories ~libBs =
   let dirs =
@@ -233,12 +259,12 @@ let findDependencyFiles base config =
   in
   let deps = deps @ devDeps in
   Log.log ("Dependencies: " ^ String.concat " " deps);
+  let sourcedirsPackageRoots = readSourcedirsPackageRoots base in
   let depFiles =
     deps
     |> List.map (fun name ->
            let result =
-             Json.bind
-               (ModuleResolution.resolveNodeModulePath ~startPath:base name)
+             Json.bind (findPackageRoot ~base ~sourcedirsPackageRoots name)
                (fun path ->
                  let rescriptJsonPath = path /+ "rescript.json" in
 

--- a/tests/analysis_tests/Makefile
+++ b/tests/analysis_tests/Makefile
@@ -4,6 +4,7 @@ test-analysis-binary:
 	make -C tests test
 	make -C tests-generic-jsx-transform test
 	make -C tests-incremental-typechecking test
+	make -C tests-sourcedirs-dependency test
 
 test-reanalyze:
 	make -C tests-reanalyze test
@@ -14,6 +15,7 @@ clean:
 	make -C tests clean
 	make -C tests-generic-jsx-transform clean
 	make -C tests-incremental-typechecking clean
+	make -C tests-sourcedirs-dependency clean
 	make -C tests-reanalyze clean
 
 .PHONY: test-analysis-binary test-reanalyze clean test

--- a/tests/analysis_tests/tests-sourcedirs-dependency/.gitignore
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/.gitignore
@@ -1,0 +1,2 @@
+lib/
+node_modules/

--- a/tests/analysis_tests/tests-sourcedirs-dependency/Makefile
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/Makefile
@@ -1,0 +1,14 @@
+SHELL = /bin/bash
+
+build:
+	yarn build
+
+test: build
+	./test.sh
+
+clean:
+	yarn clean
+
+.DEFAULT_GOAL := test
+
+.PHONY: clean test

--- a/tests/analysis_tests/tests-sourcedirs-dependency/dependency/package.json
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/dependency/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tests/sourcedirs-dependency-lib",
+  "private": true,
+  "scripts": {
+    "build": "rescript build",
+    "clean": "rescript clean"
+  },
+  "dependencies": {
+    "rescript": "workspace:^"
+  }
+}

--- a/tests/analysis_tests/tests-sourcedirs-dependency/dependency/rescript.json
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/dependency/rescript.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tests/sourcedirs-dependency-lib",
+  "sources": [
+    {
+      "dir": "src",
+      "subdirs": true
+    }
+  ],
+  "package-specs": [{ "module": "commonjs", "in-source": false }],
+  "suffix": ".res.js"
+}

--- a/tests/analysis_tests/tests-sourcedirs-dependency/dependency/src/WorkspaceDep.res
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/dependency/src/WorkspaceDep.res
@@ -1,0 +1,1 @@
+let valueFromDependency = 1

--- a/tests/analysis_tests/tests-sourcedirs-dependency/package.json
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@tests/sourcedirs-dependency",
+  "private": true,
+  "scripts": {
+    "build": "rescript build",
+    "clean": "rescript clean"
+  },
+  "dependencies": {
+    "@tests/sourcedirs-dependency-lib": "workspace:*",
+    "rescript": "workspace:^"
+  }
+}

--- a/tests/analysis_tests/tests-sourcedirs-dependency/rescript.json
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/rescript.json
@@ -1,0 +1,12 @@
+{
+  "name": "@tests/sourcedirs-dependency",
+  "sources": [
+    {
+      "dir": "src",
+      "subdirs": true
+    }
+  ],
+  "dependencies": ["@tests/sourcedirs-dependency-lib"],
+  "package-specs": [{ "module": "commonjs", "in-source": false }],
+  "suffix": ".res.js"
+}

--- a/tests/analysis_tests/tests-sourcedirs-dependency/src/Main.res
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/src/Main.res
@@ -1,0 +1,4 @@
+let _ = WorkspaceDep.valueFromDependency
+
+// WorkspaceDep.value
+//              ^com

--- a/tests/analysis_tests/tests-sourcedirs-dependency/src/expected/Main.res.txt
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/src/expected/Main.res.txt
@@ -1,0 +1,16 @@
+Complete src/Main.res 2:16
+posCursor:[2:16] posNoWhite:[2:15] Found expr:[2:3->2:21]
+Pexp_ident WorkspaceDep.value:[2:3->2:21]
+Completable: Cpath Value[WorkspaceDep, value]
+Package opens Stdlib.place holder Pervasives.JsxModules.place holder
+Resolved opens 1 Stdlib
+ContextPath Value[WorkspaceDep, value]
+Path WorkspaceDep.value
+[{
+    "label": "valueFromDependency",
+    "kind": 12,
+    "tags": [],
+    "detail": "int",
+    "documentation": null
+  }]
+

--- a/tests/analysis_tests/tests-sourcedirs-dependency/test.sh
+++ b/tests/analysis_tests/tests-sourcedirs-dependency/test.sh
@@ -1,0 +1,21 @@
+for file in src/*.res; do
+  output="$(dirname $file)/expected/$(basename $file).txt"
+  ../../../_build/install/default/bin/rescript-editor-analysis test $file &> $output
+  # CI. We use LF, and the CI OCaml fork prints CRLF. Convert.
+  if [ "$RUNNER_OS" == "Windows" ]; then
+    perl -pi -e 's/\r\n/\n/g' -- $output
+  fi
+done
+
+warningYellow='\033[0;33m'
+successGreen='\033[0;32m'
+reset='\033[0m'
+
+diff=$(git ls-files --modified src/expected)
+if [[ $diff = "" ]]; then
+  printf "${successGreen}✅ No unstaged tests difference.${reset}\n"
+else
+  printf "${warningYellow}⚠️ There are unstaged differences in tests/! Did you break a test?\n${diff}\n${reset}"
+  git --no-pager diff src/expected
+  exit 1
+fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,6 +808,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@tests/sourcedirs-dependency-lib@workspace:*, @tests/sourcedirs-dependency-lib@workspace:tests/analysis_tests/tests-sourcedirs-dependency/dependency":
+  version: 0.0.0-use.local
+  resolution: "@tests/sourcedirs-dependency-lib@workspace:tests/analysis_tests/tests-sourcedirs-dependency/dependency"
+  dependencies:
+    rescript: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
+"@tests/sourcedirs-dependency@workspace:tests/analysis_tests/tests-sourcedirs-dependency":
+  version: 0.0.0-use.local
+  resolution: "@tests/sourcedirs-dependency@workspace:tests/analysis_tests/tests-sourcedirs-dependency"
+  dependencies:
+    "@tests/sourcedirs-dependency-lib": "workspace:*"
+    rescript: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@tests/tools@workspace:tests/tools_tests":
   version: 0.0.0-use.local
   resolution: "@tests/tools@workspace:tests/tools_tests"


### PR DESCRIPTION
(This was blocking #7525.)

## Summary

Editor analysis now resolves dependencies from the package graph that the build system records in `lib/bs/.sourcedirs.json`. This makes analysis follow the same resolved dependency roots as compilation for workspace/package-manager layouts.

The existing `node_modules` lookup remains as a fallback for dependencies that are not present in `.sourcedirs.json`.

## Motivation

Workspace dependencies can compile successfully without a package-local `node_modules/<dependency>` entry. Before this change, editor analysis still depended on that `node_modules` layout, so it could skip dependency modules that the build had already resolved.

That mismatch can break completions, hovers, type expansion, and other analysis features even when the project itself builds. Reading the build system's resolved package roots removes that mismatch.

This also avoids reimplementing package-manager-specific workspace resolution in analysis. The build system already knows the dependency roots and writes them to `.sourcedirs.json`; analysis now consumes that information.

## Testing

- `make -C tests/analysis_tests/tests-sourcedirs-dependency test`