### PR TITLE
Fix duplicated comments in for..of formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 #### :bug: Bug fix
 
 - Fix directive `@warning("-102")` not working. https://github.com/rescript-lang/rescript/pull/8322
+- Fix duplicated comments in `for`..`of` formatter. https://github.com/rescript-lang/rescript/pull/8395
 
 #### :memo: Documentation
 

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1825,9 +1825,28 @@ and walk_expression expr t comments =
   | Pexp_await expr -> walk_expression expr t comments
   | Pexp_for_of (pattern, expr1, expr2)
   | Pexp_for_await_of (pattern, expr1, expr2) ->
-    walk_pattern pattern t comments;
-    walk_expression expr1 t comments;
-    walk_expression expr2 t comments
+    let leading, inside, trailing =
+      partition_by_loc comments pattern.ppat_loc
+    in
+    attach t.leading pattern.ppat_loc leading;
+    walk_pattern pattern t inside;
+    let after_pattern, rest =
+      partition_adjacent_trailing pattern.ppat_loc trailing
+    in
+    attach t.trailing pattern.ppat_loc after_pattern;
+    let leading, inside, trailing = partition_by_loc rest expr1.pexp_loc in
+    attach t.leading expr1.pexp_loc leading;
+    walk_expression expr1 t inside;
+    let after_expr, rest =
+      partition_adjacent_trailing expr1.pexp_loc trailing
+    in
+    attach t.trailing expr1.pexp_loc after_expr;
+    if is_block_expr expr2 then walk_expression expr2 t rest
+    else
+      let leading, inside, trailing = partition_by_loc rest expr2.pexp_loc in
+      attach t.leading expr2.pexp_loc leading;
+      walk_expression expr2 t inside;
+      attach t.trailing expr2.pexp_loc trailing
   | Pexp_send _ -> ()
 
 and walk_expr_parameter (_attrs, _argLbl, expr_opt, pattern) t comments =

--- a/tests/syntax_tests/data/printer/comments/expected/expr.res.txt
+++ b/tests/syntax_tests/data/printer/comments/expected/expr.res.txt
@@ -174,6 +174,18 @@ for /* c0 */ i /* c1 */ in /* c2 */ 0 /* c3 */ to /* c4 */ 10 /* c5 */ {
   /* c6 */ doStuff() /* c7 */
 } // trailing
 
+// Pexp_for_of
+for /* c0 */ x /* c1 */ of /* c2 */ xs /* c3 */ {
+  // c4
+  doStuff()
+} // trailing
+
+// Pexp_for_await_of
+for await /* c0 */ x /* c1 */ of /* c2 */ xs /* c3 */ {
+  // c4
+  doStuff()
+} // trailing
+
 // Pexp_pack
 /* c0 */ module(/* c1 */ ModExpr /* c2 */) /* c3 */
 /* c0 */ let /* c1 */ three /* c2 */ = /* c3 */ module(/* c4 */ Three /* c5 */) /* c6 */

--- a/tests/syntax_tests/data/printer/comments/expr.res
+++ b/tests/syntax_tests/data/printer/comments/expr.res
@@ -176,6 +176,18 @@ for /* c0 */ i /* c1 */ in /* c2 */ 0 /* c3 */ to /* c4 */ 10  /* c5 */ {
   /* c6 */ doStuff() /* c7 */
 } // trailing
 
+// Pexp_for_of
+for /* c0 */ x /* c1 */ of /* c2 */ xs /* c3 */ {
+  // c4
+  doStuff()
+} // trailing
+
+// Pexp_for_await_of
+for await /* c0 */ x /* c1 */ of /* c2 */ xs /* c3 */ {
+  // c4
+  doStuff()
+} // trailing
+
 // Pexp_pack
 /* c0 */ module(/* c1 */ ModExpr /* c2 */) /* c3 */
 /* c0 */ let /* c1 */ three /* c2 */ = /* c3 */ module( /* c4 */Three /* c5 */) /* c6 */


### PR DESCRIPTION
## Summary

Fixes #8394.

- Fix comment attachment for `for..of` and `for await..of` loops.
- Add formatter regression coverage for comments in both loop forms.
- Confirm range `for` and `while` loops are not affected by the issue.

## Details

Issue #8394 was caused by the comment walker for `Pexp_for_of` and
`Pexp_for_await_of` passing the same full comment list to the loop pattern,
iterable expression, and body. That allowed a single source comment to attach to
multiple nodes, so formatting duplicated it and repeated formatting compounded
the duplication.

The fix partitions comments through the pattern, iterable expression, and body,
matching the ownership approach already used by normal range `for` loops.

## Verification

- Reproduced the original duplication locally before the fix.
- Checked `for..of`, `for await..of`, range `for`, and `while` with body
  comments after the fix.
- Ran targeted printer fixture diff:

  ```sh
  _build/install/default/bin/res_parser tests/syntax_tests/data/printer/comments/expr.res > /tmp/expr8394.out
  diff -u tests/syntax_tests/data/printer/comments/expected/expr.res.txt /tmp/expr8394.out
  ```

- Ran a two-pass formatter roundtrip for the reproducer.
- Ran `make checkformat`.