### PR TITLE
Avoid warning 56 blowup for dict patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Fix directive `@warning("-102")` not working. https://github.com/rescript-lang/rescript/pull/8322
 - Fix duplicated comments in `for`..`of` formatter. https://github.com/rescript-lang/rescript/pull/8395
+- Fix issue where warning 56 would blow up with `dict{}` patterns. https://github.com/rescript-lang/rescript/pull/8403
 
 #### :memo: Documentation
 

--- a/compiler/ml/parmatch.ml
+++ b/compiler/ml/parmatch.ml
@@ -2017,6 +2017,25 @@ let contains_extension pat =
   loop pat;
   !r
 
+let contains_dict_pattern pat =
+  let r = ref false in
+  let rec loop p =
+    if Dict_type_helpers.has_dict_pattern_attribute p.pat_attributes then
+      r := true
+    else Typedtree.iter_pattern_desc loop p.pat_desc
+  in
+  loop pat;
+  !r
+
+let rec opaque_dict_patterns pat =
+  if Dict_type_helpers.has_dict_pattern_attribute pat.pat_attributes then
+    {pat with pat_desc = Tpat_any; pat_extra = []; pat_attributes = []}
+  else
+    {
+      pat with
+      pat_desc = Typedtree.map_pattern_desc opaque_dict_patterns pat.pat_desc;
+    }
+
 (* Build an untyped or-pattern from its expected type *)
 let ppat_of_type env ty =
   match pats_of_type env ty with
@@ -2192,6 +2211,19 @@ let check_unused pred casel =
              if skip then r
              else
                (* Then look for empty patterns *)
+               let pss, qs =
+                 if
+                   contains_dict_pattern q
+                   || List.exists
+                        (fun ps -> List.exists contains_dict_pattern ps)
+                        pss
+                 then
+                   ( List.filter
+                       (fun ps -> not (List.exists contains_dict_pattern ps))
+                       pss,
+                     List.map opaque_dict_patterns qs )
+                 else (pss, qs)
+               in
                let sfs = satisfiables pss qs in
                if sfs = [] then Unused
                else

--- a/tests/build_tests/super_errors/expected/dict_pattern_unreachable_case.res.expected
+++ b/tests/build_tests/super_errors/expected/dict_pattern_unreachable_case.res.expected
@@ -1,0 +1,57 @@
+
+  [1;33mWarning number 4[0m
+  [36m/.../fixtures/dict_pattern_unreachable_case.res[0m:[2m6:3-11:3[0m
+
+   4 [2m│[0m 
+   5 [2m│[0m let f = (type a, x: kind<a>, y: kind<a>, payload: JSON.t) =>
+   [1;33m6[0m [2m│[0m   [1;33mswitch (x, y, payload) {[0m
+   [1;33m7[0m [2m│[0m [1;33m  | (Int, Int, _) => 0[0m
+   [2m.[0m [2m│[0m [2m...[0m
+  [1;33m10[0m [2m│[0m [1;33m  | _ => 3[0m
+  [1;33m11[0m [2m│[0m [1;33m  }[0m
+  12 [2m│[0m 
+
+  this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type kind.
+
+
+  [1;33mWarning number 4[0m
+  [36m/.../fixtures/dict_pattern_unreachable_case.res[0m:[2m6:3-11:3[0m
+
+   4 [2m│[0m 
+   5 [2m│[0m let f = (type a, x: kind<a>, y: kind<a>, payload: JSON.t) =>
+   [1;33m6[0m [2m│[0m   [1;33mswitch (x, y, payload) {[0m
+   [1;33m7[0m [2m│[0m [1;33m  | (Int, Int, _) => 0[0m
+   [2m.[0m [2m│[0m [2m...[0m
+  [1;33m10[0m [2m│[0m [1;33m  | _ => 3[0m
+  [1;33m11[0m [2m│[0m [1;33m  }[0m
+  12 [2m│[0m 
+
+  this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type Stdlib_JSON.t.
+
+
+  [1;33mWarning number 56[0m
+  [36m/.../fixtures/dict_pattern_unreachable_case.res[0m:[2m9:5-62[0m
+
+   7 [2m┆[0m | (Int, Int, _) => 0
+   8 [2m┆[0m | (String, String, _) => 1
+   [1;33m9[0m [2m┆[0m | [1;33m(_, _, JSON.Object(dict{"operationName": JSON.String(_)}))[0m => 2
+  10 [2m┆[0m | _ => 3
+  11 [2m┆[0m }
+
+  this match case is unreachable.
+Consider replacing it with a refutation case '<pat> -> .'
+
+
+  [1;33mWarning number 56[0m
+  [36m/.../fixtures/dict_pattern_unreachable_case.res[0m:[2m10:5[0m
+
+   8 [2m┆[0m | (String, String, _) => 1
+   9 [2m┆[0m | (_, _, JSON.Object(dict{"operationName": JSON.String(_)})) => 2
+  [1;33m10[0m [2m┆[0m | [1;33m_[0m => 3
+  11 [2m┆[0m }
+  12 [2m┆[0m 
+
+  this match case is unreachable.
+Consider replacing it with a refutation case '<pat> -> .'

--- a/tests/build_tests/super_errors/fixtures/dict_pattern_unreachable_case.res
+++ b/tests/build_tests/super_errors/fixtures/dict_pattern_unreachable_case.res
@@ -1,0 +1,11 @@
+type rec kind<_> =
+  | Int: kind<int>
+  | String: kind<string>
+
+let f = (type a, x: kind<a>, y: kind<a>, payload: JSON.t) =>
+  switch (x, y, payload) {
+  | (Int, Int, _) => 0
+  | (String, String, _) => 1
+  | (_, _, JSON.Object(dict{"operationName": JSON.String(_)})) => 2
+  | _ => 3
+  }

--- a/tests/tests/src/DictPatternMatchingOptimization.mjs
+++ b/tests/tests/src/DictPatternMatchingOptimization.mjs
@@ -78,7 +78,129 @@ function decode(data) {
   }
 }
 
+function decodePayload(data) {
+  let match = JSON.parse(data);
+  if (typeof match !== "object" || match === null || Array.isArray(match)) {
+    return 0;
+  }
+  let exit = 0;
+  let tmp = match.operationName;
+  if (typeof tmp === "string") {
+    let tmp$1 = match.query;
+    if (typeof tmp$1 === "string") {
+      let tmp$2 = match.documentId;
+      if (typeof tmp$2 === "string") {
+        let tmp$3 = match.variables;
+        if (typeof tmp$3 === "object" && tmp$3 !== null && !Array.isArray(tmp$3)) {
+          return 4;
+        }
+        exit = 1;
+      } else {
+        exit = 1;
+      }
+    } else {
+      exit = 1;
+    }
+  } else {
+    exit = 1;
+  }
+  if (exit === 1) {
+    let exit$1 = 0;
+    let tmp$4 = match.operationName;
+    if (typeof tmp$4 === "string") {
+      let tmp$5 = match.query;
+      if (typeof tmp$5 === "string") {
+        let tmp$6 = match.documentId;
+        if (typeof tmp$6 === "string") {
+          return 3;
+        }
+        exit$1 = 2;
+      } else {
+        exit$1 = 2;
+      }
+    } else {
+      exit$1 = 2;
+    }
+    if (exit$1 === 2) {
+      let exit$2 = 0;
+      let tmp$7 = match.operationName;
+      if (typeof tmp$7 === "string") {
+        let tmp$8 = match.query;
+        if (typeof tmp$8 === "string") {
+          let tmp$9 = match.variables;
+          if (typeof tmp$9 === "object" && tmp$9 !== null && !Array.isArray(tmp$9)) {
+            return 3;
+          }
+          exit$2 = 3;
+        } else {
+          exit$2 = 3;
+        }
+      } else {
+        exit$2 = 3;
+      }
+      if (exit$2 === 3) {
+        let exit$3 = 0;
+        let tmp$10 = match.operationName;
+        if (typeof tmp$10 === "string") {
+          let tmp$11 = match.documentId;
+          if (typeof tmp$11 === "string") {
+            let tmp$12 = match.variables;
+            if (typeof tmp$12 === "object" && tmp$12 !== null && !Array.isArray(tmp$12)) {
+              return 3;
+            }
+            exit$3 = 4;
+          } else {
+            exit$3 = 4;
+          }
+        } else {
+          exit$3 = 4;
+        }
+        if (exit$3 === 4) {
+          let exit$4 = 0;
+          let tmp$13 = match.query;
+          if (typeof tmp$13 === "string") {
+            let tmp$14 = match.documentId;
+            if (typeof tmp$14 === "string") {
+              let tmp$15 = match.variables;
+              if (typeof tmp$15 === "object" && tmp$15 !== null && !Array.isArray(tmp$15)) {
+                return 3;
+              }
+              exit$4 = 5;
+            } else {
+              exit$4 = 5;
+            }
+          } else {
+            exit$4 = 5;
+          }
+          if (exit$4 === 5) {
+            let exit$5 = 0;
+            let tmp$16 = match.operationName;
+            if (typeof tmp$16 === "string") {
+              let tmp$17 = match.query;
+              if (typeof tmp$17 === "string") {
+                return 2;
+              }
+              exit$5 = 6;
+            } else {
+              exit$5 = 6;
+            }
+            if (exit$5 === 6) {
+              let tmp$18 = match.operationName;
+              if (typeof tmp$18 === "string") {
+                return 1;
+              } else {
+                return 0;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 export {
   decode,
+  decodePayload,
 }
 /* No side effect */

--- a/tests/tests/src/DictPatternMatchingOptimization.res
+++ b/tests/tests/src/DictPatternMatchingOptimization.res
@@ -13,3 +13,36 @@ let decode = (~data: string): array<inbound> =>
   | JSON.Object(dict{"type": JSON.String("f")}) => [F]
   | _ => []
   }
+
+let decodePayload = data =>
+  switch JSON.parseOrThrow(data) {
+  | JSON.Object(dict{
+      "operationName": JSON.String(_),
+      "query": JSON.String(_),
+      "documentId": JSON.String(_),
+      "variables": JSON.Object(_),
+    }) => 4
+  | JSON.Object(dict{
+      "operationName": JSON.String(_),
+      "query": JSON.String(_),
+      "documentId": JSON.String(_),
+    }) => 3
+  | JSON.Object(dict{
+      "operationName": JSON.String(_),
+      "query": JSON.String(_),
+      "variables": JSON.Object(_),
+    }) => 3
+  | JSON.Object(dict{
+      "operationName": JSON.String(_),
+      "documentId": JSON.String(_),
+      "variables": JSON.Object(_),
+    }) => 3
+  | JSON.Object(dict{
+      "query": JSON.String(_),
+      "documentId": JSON.String(_),
+      "variables": JSON.Object(_),
+    }) => 3
+  | JSON.Object(dict{"operationName": JSON.String(_), "query": JSON.String(_)}) => 2
+  | JSON.Object(dict{"operationName": JSON.String(_)}) => 1
+  | _ => 0
+  }


### PR DESCRIPTION
This fixes a blowup in warning 56 for dict patterns, which would slow down the compiler immensely. Summary by Codex:

 ## Summary

  Avoid exponential work in warning 56 (`Unreachable_case`) refinement for dict patterns.

  Dict patterns are open key/value matches, but they reuse record-pattern machinery. For overlapping `JSON.Object(dict{...})` cases, the warning-56 refinement could materialize a large witness set and spend a long time converting it before deciding whether a case is unreachable.

  This keeps the normal unused-match check intact, but makes dict subpatterns opaque only inside the extra warning-56 refinement path.

  ## Changes

  - Detect typed patterns carrying `res.dictPattern`.
  - Treat current-case dict subpatterns as opaque for warning-56 refinement.
  - Ignore prior compatible rows containing dict patterns in that same refinement.
  - Add an overlapping JSON dict pattern regression.
  - Add a warning snapshot proving warning 56 still fires for unreachable surrounding non-dict/GADT structure.