### PR TITLE
Close remaining rewatch build.lock gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix duplicated comments in `for`..`of` formatter. https://github.com/rescript-lang/rescript/pull/8395
 - Fix issue where warning 56 would blow up with `dict{}` patterns. https://github.com/rescript-lang/rescript/pull/8403
 - Acquire rewatch build lock before initialization. https://github.com/rescript-lang/rescript/pull/8409
+- Close remaining rewatch build.lock gaps. https://github.com/rescript-lang/rescript/pull/8410
 - Rewatch: treat transitive workspace dependencies as local packages in monorepo roots. https://github.com/rescript-lang/rescript/pull/8411
 
 #### :memo: Documentation

--- a/rewatch/src/build.rs
+++ b/rewatch/src/build.rs
@@ -281,7 +281,7 @@ impl fmt::Display for IncrementalBuildError {
     }
 }
 
-fn with_build_lock<T>(path: &Path, f: impl FnOnce() -> T) -> T {
+pub fn with_build_lock<T>(path: &Path, f: impl FnOnce() -> T) -> T {
     let build_folder = path.to_string_lossy().to_string();
     let _lock = get_lock_or_exit(LockKind::Build, &build_folder);
     let result = f();
@@ -316,7 +316,7 @@ pub fn incremental_build(
 // `build` needs to lock before initialization because initialization mutates previous
 // build artifacts. Keep the compile body separate so it can run under that wider lock.
 #[instrument(name = "build.incremental.unlocked", skip_all, fields(module_count = build_state.modules.len()))]
-fn incremental_build_without_lock(
+pub fn incremental_build_without_lock(
     build_state: &mut BuildCommandState,
     default_timing: Option<Duration>,
     initial_build: bool,

--- a/rewatch/src/watcher.rs
+++ b/rewatch/src/watcher.rs
@@ -256,7 +256,7 @@ async fn async_watch(
             if show_progress {
                 println!("\nExiting...");
             }
-            clean::cleanup_after_build(&build_state);
+            build::with_build_lock(path, || clean::cleanup_after_build(&build_state));
             break Ok(());
         }
         let mut events: Vec<Event> = vec![];
@@ -281,7 +281,7 @@ async fn async_watch(
                 if show_progress {
                     println!("\nExiting... (lockfile removed)");
                 }
-                clean::cleanup_after_build(&build_state);
+                build::with_build_lock(path, || clean::cleanup_after_build(&build_state));
                 return Ok(());
             }
 
@@ -468,38 +468,44 @@ async fn async_watch(
                 }
 
                 let timing_total = Instant::now();
-                let mut next_build_state = build::initialize_build(
-                    None,
-                    filter,
-                    show_progress,
-                    path,
-                    plain_output,
-                    build_state.get_warn_error_override(),
-                    prod,
-                    features.clone(),
-                )
-                .expect("Could not initialize build");
+                // Reinitialization runs cleanup for previous build artifacts, so full rebuilds need
+                // the same build lock boundary as regular `rescript build`.
+                let result = build::with_build_lock(path, || {
+                    let mut next_build_state = build::initialize_build(
+                        None,
+                        filter,
+                        show_progress,
+                        path,
+                        plain_output,
+                        build_state.get_warn_error_override(),
+                        prod,
+                        features.clone(),
+                    )
+                    .expect("Could not initialize build");
 
-                // Full rebuilds can be triggered by editor atomic saves that surface as rename events.
-                // Preserve warning state for unchanged modules so their warnings are re-emitted after the
-                // fresh build state replaces the previous one.
-                carry_forward_compile_warnings(&build_state, &mut next_build_state);
-                build_state = next_build_state;
+                    // Full rebuilds can be triggered by editor atomic saves that surface as rename events.
+                    // Preserve warning state for unchanged modules so their warnings are re-emitted after the
+                    // fresh build state replaces the previous one.
+                    carry_forward_compile_warnings(&build_state, &mut next_build_state);
+                    build_state = next_build_state;
 
-                // Re-register watches based on the new build state
-                unregister_watches(watcher, &current_watch_paths);
-                current_watch_paths = compute_watch_paths(&build_state, path);
-                register_watches(watcher, &current_watch_paths);
+                    // Re-register watches based on the new build state
+                    unregister_watches(watcher, &current_watch_paths);
+                    current_watch_paths = compute_watch_paths(&build_state, path);
+                    register_watches(watcher, &current_watch_paths);
 
-                let result = build::incremental_build(
-                    &mut build_state,
-                    None,
-                    initial_build,
-                    show_progress,
-                    false,
-                    create_sourcedirs,
-                    plain_output,
-                );
+                    let result = build::incremental_build_without_lock(
+                        &mut build_state,
+                        None,
+                        initial_build,
+                        show_progress,
+                        false,
+                        create_sourcedirs,
+                        plain_output,
+                    );
+                    build::write_build_ninja(&build_state);
+                    result
+                });
                 match result {
                     Ok(result) => {
                         if let Some(a) = after_build.clone() {
@@ -528,8 +534,6 @@ async fn async_watch(
                         }
                     }
                 }
-
-                build::write_build_ninja(&build_state);
                 needs_compile_type = CompileType::None;
                 initial_build = false;
             }
@@ -565,18 +569,21 @@ pub fn start(
 
         let path = Path::new(folder);
 
-        // Do an initial build to discover packages and source folders
-        let build_state: BuildCommandState = build::initialize_build(
-            None,
-            filter,
-            show_progress,
-            path,
-            plain_output,
-            warn_error.clone(),
-            prod,
-            features.clone(),
-        )
-        .with_context(|| "Could not initialize build")?;
+        // Do an initial build to discover packages and source folders. Initialization can clean
+        // previous build artifacts, so it has to be serialized with other build operations.
+        let build_state: BuildCommandState = build::with_build_lock(path, || {
+            build::initialize_build(
+                None,
+                filter,
+                show_progress,
+                path,
+                plain_output,
+                warn_error.clone(),
+                prod,
+                features.clone(),
+            )
+            .with_context(|| "Could not initialize build")
+        })?;
 
         // Compute and register targeted watches based on source folders
         let current_watch_paths = compute_watch_paths(&build_state, path);


### PR DESCRIPTION
## Motivation

This is a follow-up to the earlier `build.lock` fixes. Those changes covered the main `rescript build` path, but `rescript watch` still had artifact-mutating paths that could run without holding `build.lock`.

That matters because `initialize_build` is not read-only: it reads prior compile state and runs `cleanup_previous_build`, which can remove stale compiler assets and generated JS under `lib/bs`. `cleanup_after_build` and `write_build_ninja` also mutate build artifacts.

Without this follow-up, a watch process could still race with an in-flight `rescript build` during these remaining paths.

## Newly Covered Paths

This PR adds `build.lock` coverage for these remaining watch cases:

- **Watch startup initialization**
  - `watcher::start` calls `initialize_build` to discover packages and source folders before entering the watch loop.
  - This now runs under `build.lock` because initialization may clean previous build artifacts.

- **Watch full rebuild reinitialization**
  - A full rebuild can be triggered by config changes, renames, creates, deletes, or editor atomic-save events.
  - That path calls `initialize_build` again to rebuild package/module state.
  - This now runs under `build.lock`.

- **Watch full rebuild artifact writes**
  - After reinitialization, the full rebuild compiles and writes `build.ninja`.
  - Those operations now stay inside the same `build.lock` boundary.

- **Watch shutdown cleanup**
  - When watch exits via Ctrl-C or because `watch.lock` is removed, it calls `cleanup_after_build`.
  - That cleanup now runs under `build.lock`.

## Locking Model

- `rescript build` holds `build.lock` across initialization, compilation, cleanup, and `build.ninja` writes.
- watch incremental rebuilds call public `incremental_build`, which acquires `build.lock`.
- watch full rebuilds acquire `build.lock` before reinitialization and then call the unlocked incremental build body.
- watch startup initialization and shutdown cleanup now also acquire `build.lock`.
- `rescript clean` already acquires `build.lock` in the CLI entrypoint.

Callers that already hold `build.lock` use `incremental_build_without_lock`, so this avoids duplicate locking and self-deadlocks.