### PR TITLE
Fix rewatch transitive local workspace detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix duplicated comments in `for`..`of` formatter. https://github.com/rescript-lang/rescript/pull/8395
 - Fix issue where warning 56 would blow up with `dict{}` patterns. https://github.com/rescript-lang/rescript/pull/8403
 - Acquire rewatch build lock before initialization. https://github.com/rescript-lang/rescript/pull/8409
+- Rewatch: treat transitive workspace dependencies as local packages in monorepo roots. https://github.com/rescript-lang/rescript/pull/8411
 
 #### :memo: Documentation
 

--- a/rewatch/src/build/packages.rs
+++ b/rewatch/src/build/packages.rs
@@ -389,23 +389,7 @@ fn read_dependencies(
                     }
                 };
 
-            let is_local_dep = {
-                match &project_context.monorepo_context {
-                    None => project_context.current_config.name.as_str() == package_name
-                    ,
-                    Some(MonoRepoContext::MonorepoRoot {
-                             local_dependencies,
-                             local_dev_dependencies,
-                         }) => {
-                        local_dependencies.contains(package_name) || local_dev_dependencies.contains(package_name)
-                    },
-                    Some(MonoRepoContext::MonorepoPackage {
-                             parent_config,
-                         }) => {
-                        helpers::is_local_package(&parent_config.path, &canonical_path)
-                    }
-                }
-            };
+            let is_local_dep = is_local_dependency(project_context, package_name, &canonical_path);
 
             let dependencies = read_dependencies(
                 &mut registered_dependencies_set.to_owned(),
@@ -425,6 +409,18 @@ fn read_dependencies(
             }
         })
         .collect()
+}
+
+fn is_local_dependency(project_context: &ProjectContext, package_name: &str, canonical_path: &Path) -> bool {
+    match &project_context.monorepo_context {
+        None => project_context.current_config.name.as_str() == package_name,
+        Some(MonoRepoContext::MonorepoRoot { .. }) => {
+            helpers::is_local_package(project_context.get_root_path(), canonical_path)
+        }
+        Some(MonoRepoContext::MonorepoPackage { parent_config }) => {
+            helpers::is_local_package(&parent_config.path, canonical_path)
+        }
+    }
 }
 
 fn flatten_dependencies(dependencies: Vec<Dependency>) -> Vec<Dependency> {
@@ -1252,11 +1248,13 @@ pub fn validate_packages_dependencies(packages: &AHashMap<String, Package>) -> b
 #[cfg(test)]
 mod test {
     use crate::config;
+    use crate::project_context::{MonoRepoContext, ProjectContext};
 
     use super::{Namespace, Package, read_issue_tracker_url, read_package_name};
     use ahash::{AHashMap, AHashSet};
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::RwLock;
     use tempfile::TempDir;
 
     pub struct CreatePackageArgs {
@@ -1460,6 +1458,47 @@ mod test {
         let temp_dir = TempDir::new().unwrap();
         write_pkg_json(temp_dir.path(), r#"{"name":"x"}"#);
         assert_eq!(read_issue_tracker_url(temp_dir.path()), None);
+    }
+
+    #[test]
+    fn monorepo_root_marks_transitive_workspace_dependencies_as_local() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let mut local_dependencies = AHashSet::new();
+        local_dependencies.insert("direct".to_string());
+
+        let project_context = ProjectContext {
+            current_config: config::tests::create_config(config::tests::CreateConfigArgs {
+                name: "root".to_string(),
+                bs_deps: vec!["direct".to_string()],
+                build_dev_deps: vec![],
+                allowed_dependents: None,
+                path: root.join("rescript.json"),
+            }),
+            monorepo_context: Some(MonoRepoContext::MonorepoRoot {
+                local_dependencies,
+                local_dev_dependencies: AHashSet::new(),
+            }),
+            node_modules_exist_cache: RwLock::new(AHashMap::new()),
+            packages_cache: RwLock::new(AHashMap::new()),
+        };
+
+        assert!(super::is_local_dependency(
+            &project_context,
+            "direct",
+            &root.join("packages/direct")
+        ));
+        assert!(super::is_local_dependency(
+            &project_context,
+            "transitive",
+            &root.join("packages/transitive")
+        ));
+        assert!(!super::is_local_dependency(
+            &project_context,
+            "external",
+            &root.join("node_modules/external")
+        ));
     }
 
     fn root_package_with_features(


### PR DESCRIPTION
## Summary

Fix rewatch's local workspace detection for monorepo roots so transitive workspace dependencies are treated as local packages.

Previously, when building from a monorepo root, rewatch only marked dependencies as local if their package names appeared directly in the root `rescript.json` dependencies or dev-dependencies. This missed local workspace packages that were only reached transitively, even though they resolve to paths inside the workspace.

The new logic classifies monorepo-root dependencies by their resolved canonical path, matching the existing monorepo-package behavior: packages inside the workspace root and outside `node_modules` are local.

## Why

This affects root-level monorepo builds and analysis workflows. Transitive local workspaces should be:

- watched by rewatch
- built with local package warning/dev-source behavior
- included in the root `.sourcedirs.json` `cmt_scan` plan consumed by reanalyze

Without this, root-level `rescript-tools reanalyze` can miss CMT files for transitive local workspaces in monorepos.

