### PR TITLE
Rewatch: use a single timestamp per compile pass

### DIFF
--- a/rewatch/src/build/compile.rs
+++ b/rewatch/src/build/compile.rs
@@ -1214,7 +1214,7 @@ pub fn mark_modules_with_expired_deps_dirty(build_state: &mut BuildCommandState)
                 let dependent_module = build_state.modules.get(dependent).unwrap();
                 match dependent_module.source_type {
                     SourceType::SourceFile(_) => {
-                        match (module.last_compiled_cmt, module.last_compiled_cmt) {
+                        match (module.last_compiled_cmt, module.last_compiled_cmi) {
                             (None, None) | (Some(_), None) | (None, Some(_)) => {
                                 // println!(
                                 //     "🛑 {} is a dependent of {} but has no cmt/cmi",

--- a/rewatch/src/build/compile.rs
+++ b/rewatch/src/build/compile.rs
@@ -468,10 +468,10 @@ pub fn compile(
     // though modules complete in arbitrary order.
     results_buffer.sort_by(|a, b| a.module_name.cmp(&b.module_name));
 
-    // Use one timestamp for the whole pass. `mark_modules_with_expired_deps_dirty`
-    // compares dependency/dependent timestamps before the next build; assigning
-    // per-result timestamps here would make the sorted result-processing order
-    // look like real staleness and can force unnecessary downstream recompiles.
+    // These timestamps are used as a compile-generation marker by
+    // mark_modules_with_expired_deps_dirty, not as precise wall-clock compile
+    // times. All modules successfully compiled in one pass are mutually
+    // up-to-date for that pass, so they must receive the same timestamp.
     let compile_timestamp = SystemTime::now();
 
     for msg in results_buffer {

--- a/rewatch/src/build/compile.rs
+++ b/rewatch/src/build/compile.rs
@@ -468,6 +468,12 @@ pub fn compile(
     // though modules complete in arbitrary order.
     results_buffer.sort_by(|a, b| a.module_name.cmp(&b.module_name));
 
+    // Use one timestamp for the whole pass. `mark_modules_with_expired_deps_dirty`
+    // compares dependency/dependent timestamps before the next build; assigning
+    // per-result timestamps here would make the sorted result-processing order
+    // look like real staleness and can force unnecessary downstream recompiles.
+    let compile_timestamp = SystemTime::now();
+
     for msg in results_buffer {
         let CompletionMsg {
             module_name,
@@ -558,8 +564,8 @@ pub fn compile(
 
             if result.is_ok() && interface_result.as_ref().is_none_or(|r| r.is_ok()) {
                 module.compile_dirty = false;
-                module.last_compiled_cmi = Some(SystemTime::now());
-                module.last_compiled_cmt = Some(SystemTime::now());
+                module.last_compiled_cmi = Some(compile_timestamp);
+                module.last_compiled_cmt = Some(compile_timestamp);
             }
 
             (compile_warning, compile_error, interface_warning, interface_error)


### PR DESCRIPTION
Fixes #8412

## Summary

Fix unnecessary recompilation/touching of downstream output files in rewatch incremental builds.

The DAG scheduler introduced by #8374 buffers completed module results and then processes them in deterministic module-name order. During that result processing, each successful module previously received fresh `last_compiled_cmi` / `last_compiled_cmt` values via `SystemTime::now()`.

That made the in-memory compile timestamps depend on result processing order rather than dependency order. If a dependency was processed after one of its dependents, the next incremental build could observe:

```text
dependent.last_compiled_cmt < dependency.last_compiled_cmt
```

`mark_modules_with_expired_deps_dirty` interprets that as a stale dependent and marks it dirty. In watch mode this caused unrelated downstream modules, such as app startup/root modules, to be recompiled and their generated `.mjs` files touched. Tools like Vite then saw those touched files and performed a full reload instead of fast refresh.

## Fix

Use a single shared `compile_timestamp` for all successful modules processed in a single compile pass.

This preserves the existing behavior that successful modules are marked current after the pass, including modules that were checked but short-circuited as clean, while removing artificial ordering between modules completed in the same pass.

With a single timestamp, modules processed during the same build no longer make each other look stale on the next incremental rebuild.