### PR TITLE
Improve unclear error and warning messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Refactor analysis to decouple I/O from core logic. https://github.com/rescript-lang/rescript/pull/8426
 - Deprecate `Stdlib_Error` and `Stdlib_Exn` modules in favor of `JsError/JsExn`. https://github.com/rescript-lang/rescript/pull/8404
 - Remove vendored `Json` library and use `yojson` and `lsp` library for analysis. https://github.com/rescript-lang/rescript/pull/8436
+- Improve clarity of various error and warning messages. https://github.com/rescript-lang/rescript/pull/8460
 
 #### :house: Internal
 

--- a/compiler/ext/warnings.ml
+++ b/compiler/ext/warnings.ml
@@ -383,7 +383,7 @@ let message = function
     Printf.sprintf
       "Code should not depend on the actual values of\n\
        this constructor's arguments. They are only for information\n\
-       and may change in future versions. (See manual section 8.5)"
+       and may change in future versions."
   | Unreachable_case ->
     "this match case is unreachable.\n\
      Consider replacing it with a refutation case '<pat> -> .'"
@@ -398,11 +398,11 @@ let message = function
       match vars with
       | [] -> assert false
       | [x] -> "variable " ^ x
-      | _ :: _ -> "variables " ^ String.concat "," vars
+      | _ :: _ -> "variables " ^ String.concat ", " vars
     in
     Printf.sprintf
       "Ambiguous or-pattern variables under guard;\n\
-       %s may match different arguments. (See manual section 8.5)"
+       %s may match different arguments."
       msg
   | Unused_module s -> "unused module " ^ s ^ "."
   | Constraint_on_gadt ->

--- a/compiler/ext/warnings.ml
+++ b/compiler/ext/warnings.ml
@@ -373,7 +373,7 @@ let message = function
     Printf.sprintf "this open statement shadows the %s %s (which is later used)"
       kind s
   | Attribute_payload (a, s) ->
-    Printf.sprintf "illegal payload for attribute '%s'.\n%s" a s
+    Printf.sprintf "illegal payload for attribute @%s.\n%s" a s
   | No_cmi_file (name, None) ->
     "no cmi file was found in path for module " ^ name
   | No_cmi_file (name, Some msg) ->
@@ -388,9 +388,9 @@ let message = function
     "this match case is unreachable.\n\
      Consider replacing it with a refutation case '<pat> -> .'"
   | Misplaced_attribute attr_name ->
-    Printf.sprintf "the %S attribute cannot appear in this context" attr_name
+    Printf.sprintf "the @%s attribute cannot appear in this context" attr_name
   | Duplicated_attribute attr_name ->
-    Printf.sprintf "the %S attribute is used more than once on this expression"
+    Printf.sprintf "the @%s attribute is used more than once on this expression"
       attr_name
   | Ambiguous_pattern vars ->
     let msg =

--- a/compiler/frontend/ast_attributes.ml
+++ b/compiler/frontend/ast_attributes.ml
@@ -161,21 +161,32 @@ let process_derive_type (attrs : t) : derive_attr * t =
 
 (* duplicated attributes not allowed *)
 let iter_process_bs_string_int_unwrap_uncurry (attrs : t) =
-  let st = ref `Nothing in
-  let assign v (({loc; _}, _) as attr : attr) =
-    if !st = `Nothing then (
-      Used_attributes.mark_used_attribute attr;
-      st := v)
-    else Bs_syntaxerr.err loc Conflict_attributes
+  let attr_name = function
+    | `String -> "string"
+    | `Int -> "int"
+    | `Ignore -> "ignore"
+    | `Unwrap -> "unwrap"
+    | `Nothing -> ""
   in
-  Ext_list.iter attrs (fun (({txt; loc = _}, _) as attr) ->
-      match txt with
-      | "string" -> assign `String attr
-      | "int" -> assign `Int attr
-      | "ignore" -> assign `Ignore attr
-      | "unwrap" -> assign `Unwrap attr
-      | _ -> ());
-  !st
+  (* Collect all of @string/@int/@ignore/@unwrap so the conflict error can
+     report every attribute involved, not just the first pair. *)
+  let found =
+    Ext_list.filter_map attrs (fun (({txt; _}, _) as attr) ->
+        match txt with
+        | "string" -> Some (`String, attr)
+        | "int" -> Some (`Int, attr)
+        | "ignore" -> Some (`Ignore, attr)
+        | "unwrap" -> Some (`Unwrap, attr)
+        | _ -> None)
+  in
+  match found with
+  | [] -> `Nothing
+  | [(v, attr)] ->
+    Used_attributes.mark_used_attribute attr;
+    v
+  | (_, ({loc; _}, _)) :: _ as conflicting ->
+    Bs_syntaxerr.err loc
+      (Conflict_attributes (List.map (fun (v, _) -> attr_name v) conflicting))
 
 let iter_process_bs_string_as (attrs : t) : string option =
   let st = ref None in

--- a/compiler/frontend/ast_attributes.ml
+++ b/compiler/frontend/ast_attributes.ml
@@ -166,11 +166,10 @@ let iter_process_bs_string_int_unwrap_uncurry (attrs : t) =
     | `Int -> "int"
     | `Ignore -> "ignore"
     | `Unwrap -> "unwrap"
-    | `Nothing -> ""
   in
   (* Collect all of @string/@int/@ignore/@unwrap so the conflict error can
      report every attribute involved, not just the first pair. *)
-  let found =
+  let found : ([`String | `Int | `Ignore | `Unwrap] * _) list =
     Ext_list.filter_map attrs (fun (({txt; _}, _) as attr) ->
         match txt with
         | "string" -> Some (`String, attr)
@@ -183,7 +182,7 @@ let iter_process_bs_string_int_unwrap_uncurry (attrs : t) =
   | [] -> `Nothing
   | [(v, attr)] ->
     Used_attributes.mark_used_attribute attr;
-    v
+    (v :> [`Nothing | `String | `Int | `Ignore | `Unwrap])
   | (_, ({loc; _}, _)) :: _ as conflicting ->
     Bs_syntaxerr.err loc
       (Conflict_attributes (List.map (fun (v, _) -> attr_name v) conflicting))

--- a/compiler/frontend/ast_external_process.ml
+++ b/compiler/frontend/ast_external_process.ml
@@ -623,7 +623,7 @@ let external_desc_of_non_obj (loc : Location.t) (st : external_desc)
         "Ill defined attribute %@set_index (arity of 3)"
   | {set_index = true} ->
     Bs_syntaxerr.err loc
-      (Conflict_ffi_attribute "Attribute found that conflicts with %@set_index")
+      (Conflict_ffi_attribute "Attribute found that conflicts with @set_index")
   | {
    get_index = true;
    val_name = None;
@@ -649,7 +649,7 @@ let external_desc_of_non_obj (loc : Location.t) (st : external_desc)
         arg_type_specs_length
   | {get_index = true} ->
     Bs_syntaxerr.err loc
-      (Conflict_ffi_attribute "Attribute found that conflicts with %@get_index")
+      (Conflict_ffi_attribute "Attribute found that conflicts with @get_index")
   | {
    module_as_val = Some external_module_name;
    get_index = false;
@@ -750,7 +750,7 @@ let external_desc_of_non_obj (loc : Location.t) (st : external_desc)
     else Js_call {splice; name; external_module_name; scopes; tagged_template}
   | {call_name = Some _} ->
     Bs_syntaxerr.err loc
-      (Conflict_ffi_attribute "Attribute found that conflicts with %@val")
+      (Conflict_ffi_attribute "Attribute found that conflicts with @val")
   | {
    val_name = Some {name; source = _};
    external_module_name;
@@ -777,7 +777,7 @@ let external_desc_of_non_obj (loc : Location.t) (st : external_desc)
     Js_var {name; external_module_name; scopes}
   | {val_name = Some _} ->
     Bs_syntaxerr.err loc
-      (Conflict_ffi_attribute "Attribute found that conflicts with %@val")
+      (Conflict_ffi_attribute "Attribute found that conflicts with @val")
   | {
    splice;
    scopes;
@@ -856,7 +856,7 @@ let external_desc_of_non_obj (loc : Location.t) (st : external_desc)
     Js_new {name; external_module_name; splice; scopes}
   | {new_name = Some _} ->
     Bs_syntaxerr.err loc
-      (Conflict_ffi_attribute "Attribute found that conflicts with %@new")
+      (Conflict_ffi_attribute "Attribute found that conflicts with @new")
   | {
    set_name = Some {name; source = _};
    val_name = None;

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -58,8 +58,8 @@ let pp_error fmt err =
     | Optional_in_uncurried_bs_attribute ->
       "Uncurried function doesn't support optional arguments yet"
     | Expect_opt_in_bs_return_to_opt ->
-      "A @return directive with a `*_to_opt` variant requires the return type \
-       to be written as an option, e.g. `option<int>`."
+      "This @return directive requires the external's return type to be an \
+       option, e.g. `option<int>`."
     | Not_supported_directive_in_bs_return -> "Not supported return directive"
     | Illegal_attribute -> "Illegal attributes"
     | Unsupported_predicates -> "unsupported predicates"
@@ -83,8 +83,7 @@ let pp_error fmt err =
        each constructor must have an argument."
     | Conflict_ffi_attribute str -> "Conflicting attributes: " ^ str
     | Bs_this_simple_pattern ->
-      "@this expects its first parameter to be a simple identifier, not a \
-       destructured pattern."
+      "@this expects its first parameter to be a simple variable (or `_`)."
     | Experimental_feature_not_enabled feature ->
       Printf.sprintf
         "Experimental feature not enabled: %s. Enable it by setting \"%s\" to \

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -83,7 +83,8 @@ let pp_error fmt err =
        each constructor must have an argument."
     | Conflict_ffi_attribute str -> "Conflicting attributes: " ^ str
     | Bs_this_simple_pattern ->
-      "%@this expect its pattern variable to be simple form"
+      "@this expects its first parameter to be a simple identifier, not a \
+       destructured pattern."
     | Experimental_feature_not_enabled feature ->
       Printf.sprintf
         "Experimental feature not enabled: %s. Enable it by setting \"%s\" to \

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -27,7 +27,7 @@ type untagged_variant = OnlyOneUnknown | AtMostOneObject | AtMostOneArray
 type error =
   | Unsupported_predicates
   | Duplicated_bs_deriving
-  | Conflict_attributes
+  | Conflict_attributes of string list
   | Expect_int_literal
   | Expect_string_literal
   | Expect_int_or_string_or_json_literal
@@ -67,9 +67,10 @@ let pp_error fmt err =
     | Unsupported_predicates -> "unsupported predicates"
     | Duplicated_bs_deriving ->
       "Duplicate @deriving attribute; a type can only have one."
-    | Conflict_attributes ->
-      "Conflicting attributes: only one of @string, @int, @ignore, or @unwrap \
-       can be used here."
+    | Conflict_attributes names ->
+      Printf.sprintf
+        "Conflicting attributes: %s cannot be combined; use only one."
+        (String.concat ", " (List.map (fun n -> "@" ^ n) names))
     | Expect_string_literal -> "Expected a string literal."
     | Expect_int_literal ->
       "The @as payload on an @int variant must be an integer literal, e.g. \

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -58,8 +58,8 @@ let pp_error fmt err =
     | Optional_in_uncurried_bs_attribute ->
       "Uncurried function doesn't support optional arguments yet"
     | Expect_opt_in_bs_return_to_opt ->
-      "%@return directive *_to_opt expect return type to be \n\
-       syntax wise `_ option` for safety"
+      "A @return directive with a `*_to_opt` variant requires the return \
+       type to be written as an option, e.g. `option<int>`."
     | Not_supported_directive_in_bs_return -> "Not supported return directive"
     | Illegal_attribute -> "Illegal attributes"
     | Unsupported_predicates -> "unsupported predicates"

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -60,7 +60,9 @@ let pp_error fmt err =
     | Expect_opt_in_bs_return_to_opt ->
       "This @return directive requires the external's return type to be an \
        option, e.g. `option<int>`."
-    | Not_supported_directive_in_bs_return -> "Not supported return directive"
+    | Not_supported_directive_in_bs_return ->
+      "Unsupported @return directive. Supported directives are `null_to_opt`, \
+       `null_undefined_to_opt` (or `nullable`), and `identity`."
     | Illegal_attribute -> "Illegal attributes"
     | Unsupported_predicates -> "unsupported predicates"
     | Duplicated_bs_deriving ->

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -64,7 +64,7 @@ let pp_error fmt err =
       "Unsupported @return directive. Supported directives are `null_to_opt`, \
        `null_undefined_to_opt` (or `nullable`), and `identity`."
     | Illegal_attribute -> "Illegal attributes"
-    | Unsupported_predicates -> "unsupported predicates"
+    | Unsupported_predicates -> "Unsupported predicates"
     | Duplicated_bs_deriving ->
       "Duplicate @deriving attribute; a type can only have one."
     | Conflict_attributes names ->

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -66,7 +66,9 @@ let pp_error fmt err =
     | Duplicated_bs_deriving -> "duplicate @deriving attribute"
     | Conflict_attributes -> "conflicting attributes "
     | Expect_string_literal -> "expect string literal "
-    | Expect_int_literal -> "expect int literal "
+    | Expect_int_literal ->
+      "The @as payload on an @int variant must be an integer literal, e.g. \
+       @as(42)."
     | Expect_int_or_string_or_json_literal ->
       "expect int, string literal or json literal {json|text here|json} "
     | Invalid_underscore_type_in_external ->

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -72,7 +72,7 @@ let pp_error fmt err =
       "The @as payload on an @int variant must be an integer literal, e.g. \
        @as(42)."
     | Expect_int_or_string_or_json_literal ->
-      "expect int, string literal or json literal {json|text here|json} "
+      "The @as payload must be an integer, string, or JSON literal."
     | Invalid_underscore_type_in_external ->
       "_ is not allowed in combination with external optional type"
     | Invalid_bs_string_type -> "Not a valid type for @string"

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -58,8 +58,8 @@ let pp_error fmt err =
     | Optional_in_uncurried_bs_attribute ->
       "Uncurried function doesn't support optional arguments yet"
     | Expect_opt_in_bs_return_to_opt ->
-      "A @return directive with a `*_to_opt` variant requires the return \
-       type to be written as an option, e.g. `option<int>`."
+      "A @return directive with a `*_to_opt` variant requires the return type \
+       to be written as an option, e.g. `option<int>`."
     | Not_supported_directive_in_bs_return -> "Not supported return directive"
     | Illegal_attribute -> "Illegal attributes"
     | Unsupported_predicates -> "unsupported predicates"
@@ -75,10 +75,10 @@ let pp_error fmt err =
       "expect int, string literal or json literal {json|text here|json} "
     | Invalid_underscore_type_in_external ->
       "_ is not allowed in combination with external optional type"
-    | Invalid_bs_string_type -> "Not a valid type for %@string"
-    | Invalid_bs_int_type -> "Not a valid type for %@int"
+    | Invalid_bs_string_type -> "Not a valid type for @string"
+    | Invalid_bs_int_type -> "Not a valid type for @int"
     | Invalid_bs_unwrap_type ->
-      "Not a valid type for %@unwrap. Type must be an inline variant (closed), \
+      "Not a valid type for @unwrap. Type must be an inline variant (closed), \
        and\n\
        each constructor must have an argument."
     | Conflict_ffi_attribute str -> "Conflicting attributes: " ^ str

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -64,7 +64,9 @@ let pp_error fmt err =
     | Illegal_attribute -> "Illegal attributes"
     | Unsupported_predicates -> "unsupported predicates"
     | Duplicated_bs_deriving -> "duplicate @deriving attribute"
-    | Conflict_attributes -> "conflicting attributes "
+    | Conflict_attributes ->
+      "Conflicting attributes: only one of @string, @int, @ignore, or @unwrap \
+       can be used here."
     | Expect_string_literal -> "expect string literal "
     | Expect_int_literal ->
       "The @as payload on an @int variant must be an integer literal, e.g. \

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -63,7 +63,8 @@ let pp_error fmt err =
     | Not_supported_directive_in_bs_return -> "Not supported return directive"
     | Illegal_attribute -> "Illegal attributes"
     | Unsupported_predicates -> "unsupported predicates"
-    | Duplicated_bs_deriving -> "duplicate @deriving attribute"
+    | Duplicated_bs_deriving ->
+      "Duplicate @deriving attribute; a type can only have one."
     | Conflict_attributes ->
       "Conflicting attributes: only one of @string, @int, @ignore, or @unwrap \
        can be used here."

--- a/compiler/frontend/bs_syntaxerr.ml
+++ b/compiler/frontend/bs_syntaxerr.ml
@@ -67,7 +67,7 @@ let pp_error fmt err =
     | Conflict_attributes ->
       "Conflicting attributes: only one of @string, @int, @ignore, or @unwrap \
        can be used here."
-    | Expect_string_literal -> "expect string literal "
+    | Expect_string_literal -> "Expected a string literal."
     | Expect_int_literal ->
       "The @as payload on an @int variant must be an integer literal, e.g. \
        @as(42)."

--- a/compiler/frontend/bs_syntaxerr.mli
+++ b/compiler/frontend/bs_syntaxerr.mli
@@ -27,7 +27,7 @@ type untagged_variant = OnlyOneUnknown | AtMostOneObject | AtMostOneArray
 type error =
   | Unsupported_predicates
   | Duplicated_bs_deriving
-  | Conflict_attributes
+  | Conflict_attributes of string list
   | Expect_int_literal
   | Expect_string_literal
   | Expect_int_or_string_or_json_literal

--- a/compiler/ml/ast_untagged_variants.ml
+++ b/compiler/ml/ast_untagged_variants.ml
@@ -75,7 +75,8 @@ let report_error ppf =
     fprintf ppf
       "A variant case annotation @as(...) must be a string, integer, boolean, \
        null, or undefined."
-  | Duplicated_bs_as -> fprintf ppf "duplicate @as "
+  | Duplicated_bs_as ->
+    fprintf ppf "Duplicate @as annotation; a variant case can only have one."
   | InvalidVariantTagAnnotation ->
     fprintf ppf "A variant tag annotation @tag(...) must be a string"
   | InvalidUntaggedVariantDefinition untagged_variant ->

--- a/compiler/ml/ast_untagged_variants.ml
+++ b/compiler/ml/ast_untagged_variants.ml
@@ -76,7 +76,7 @@ let report_error ppf =
       "A variant case annotation @as(...) must be a string, integer, boolean, \
        null, or undefined."
   | Duplicated_bs_as ->
-    fprintf ppf "Duplicate @as annotation; a variant case can only have one."
+    fprintf ppf "Duplicate @as annotation; only one @as is allowed here."
   | InvalidVariantTagAnnotation ->
     fprintf ppf "A variant tag annotation @tag(...) must be a string"
   | InvalidUntaggedVariantDefinition untagged_variant ->

--- a/compiler/ml/ast_untagged_variants.ml
+++ b/compiler/ml/ast_untagged_variants.ml
@@ -73,8 +73,8 @@ let report_error ppf =
   function
   | InvalidVariantAsAnnotation ->
     fprintf ppf
-      "A variant case annotation @as(...) must be a string or integer, \
-       boolean, null, undefined"
+      "A variant case annotation @as(...) must be a string, integer, boolean, \
+       null, or undefined."
   | Duplicated_bs_as -> fprintf ppf "duplicate @as "
   | InvalidVariantTagAnnotation ->
     fprintf ppf "A variant tag annotation @tag(...) must be a string"

--- a/compiler/ml/rec_check.ml
+++ b/compiler/ml/rec_check.ml
@@ -472,7 +472,7 @@ let check_recursive_bindings valbinds =
 let report_error ppf = function
   | Illegal_letrec_expr ->
     Format.fprintf ppf
-      "This kind of expression is not allowed as right-hand side of `let rec'"
+      "This kind of expression is not allowed as right-hand side of `let rec`"
 
 let () =
   Location.register_error_of_exn (function

--- a/compiler/ml/translattribute.ml
+++ b/compiler/ml/translattribute.ml
@@ -79,10 +79,10 @@ let rec add_inline_attribute (expr : Lambda.lambda) loc attributes =
   | Lprim (((Pjs_fn_make _ | Pjs_fn_make_unit) as p), [e], l), _ ->
     Lambda.Lprim (p, [add_inline_attribute e loc attributes], l)
   | expr, Always_inline ->
-    Location.prerr_warning loc (Warnings.Misplaced_attribute "inline1");
+    Location.prerr_warning loc (Warnings.Misplaced_attribute "inline");
     expr
   | expr, Never_inline ->
-    Location.prerr_warning loc (Warnings.Misplaced_attribute "inline2");
+    Location.prerr_warning loc (Warnings.Misplaced_attribute "inline");
     expr
 
 (* Get the [@inlined] attribute payload (or default if not present).

--- a/compiler/ml/translmod.ml
+++ b/compiler/ml/translmod.ml
@@ -486,7 +486,9 @@ let transl_implementation module_name (str, cc) =
 
 let report_error ppf = function
   | Fragile_pattern_in_toplevel ->
-    Format.fprintf ppf "@[Such fragile pattern not allowed in the toplevel@]"
+    Format.fprintf ppf
+      "@[This pattern can fail to match, so it is not allowed in a top-level \
+       `let` binding.@]"
 
 let () =
   Location.register_error_of_exn (function

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -4974,7 +4974,7 @@ let report_error env loc ppf error =
       name type_expr typ
   | Type_params_not_supported lid ->
     fprintf ppf
-      "The type %a@ has type parameters, but type parameters is not supported \
+      "The type %a@ has type parameters, but type parameters are not supported \
        here."
       longident lid
   | Field_access_on_dict_type ->

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -4791,7 +4791,7 @@ let report_error env loc ppf error =
   | Invalid_for_loop_index ->
     fprintf ppf "@[Invalid for-loop index: only variables and _ are allowed.@]"
   | No_value_clauses ->
-    fprintf ppf "None of the patterns in this 'match' expression match values."
+    fprintf ppf "None of the patterns in this switch match values."
   | Exception_pattern_below_toplevel ->
     fprintf ppf
       "@[Exception patterns must be at the top level of a match case.@]"

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -4782,10 +4782,15 @@ let report_error env loc ppf error =
   | Not_a_packed_module ty ->
     fprintf ppf "This expression is packed module, but the expected type is@ %a"
       type_expr ty
-  | Unexpected_existential -> fprintf ppf "Unexpected existential"
+  | Unexpected_existential ->
+    fprintf ppf
+      "This pattern introduces an existential type from a GADT constructor, \
+       which is not allowed here. Match on it inside a switch instead."
   | Unqualified_gadt_pattern (tpath, name) ->
-    fprintf ppf "@[The GADT constructor %s of type %a@ %s.@]" name Printtyp.path
-      tpath "must be qualified in this pattern"
+    fprintf ppf
+      "@[The GADT constructor %s of type %a@ must be written with its module \
+       prefix in this pattern.@]"
+      name Printtyp.path tpath
   | Invalid_interval ->
     fprintf ppf "@[Only character intervals are supported in patterns.@]"
   | Invalid_for_loop_index ->

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -4823,7 +4823,7 @@ let report_error env loc ppf error =
   | Unknown_literal (n, m) ->
     fprintf ppf "Unknown modifier '%c' for literal %s%c" m n m
   | Illegal_letrec_pat ->
-    fprintf ppf "Only variables are allowed as left-hand side of `let rec'"
+    fprintf ppf "Only variables are allowed as left-hand side of `let rec`"
   | Empty_record_literal ->
     fprintf ppf
       "Empty record literal {} should be type annotated or used in a record \

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -4612,7 +4612,7 @@ let report_error env loc ppf error =
             (Ident.name id))
       (function ppf -> fprintf ppf "but on the right-hand side it has type")
   | Multiply_bound_variable name ->
-    fprintf ppf "Variable %s is bound several times in this matching" name
+    fprintf ppf "Variable %s is bound several times in this pattern" name
   | Orpat_vars (id, valid_idents) ->
     fprintf ppf "Variable %s must occur on both sides of this | pattern"
       (Ident.name id);

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -4663,7 +4663,7 @@ let report_error env loc ppf error =
     | _ ->
       fprintf ppf
         "@[<v>@[<2>This can't be called, it's not a function.@]@,\
-         The function has type: %a@]"
+         It has type: %a@]"
         type_expr typ)
   | Apply_wrong_label (l, ty) ->
     let print_message ppf = function

--- a/compiler/ml/typemod.ml
+++ b/compiler/ml/typemod.ml
@@ -1885,7 +1885,8 @@ let report_error ppf = function
     fprintf ppf "This expression is not a packed module. It has type@ %a"
       type_expr ty
   | Incomplete_packed_module ty ->
-    fprintf ppf "The type of this packed module contains variables:@ %a"
+    fprintf ppf
+      "The type of this first-class module still contains type variables:@ %a"
       type_expr ty
   | Scoping_pack (lid, ty) ->
     fprintf ppf "The type %a in this module cannot be exported.@ " longident lid;

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -828,7 +828,10 @@ let report_error env ppf = function
       Misc.did_you_mean ppf (fun () -> ["`" ^ s])
     | _ -> ())
   | Invalid_variable_name name ->
-    fprintf ppf "The type variable name %s is not allowed in programs" name
+    fprintf ppf
+      "The type variable name %s is not allowed; type variable names cannot \
+       start with an underscore."
+      name
   | Cannot_quantify (name, v) ->
     fprintf ppf
       "@[<hov>The universal type variable '%s cannot be generalized:@ %s.@]"

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -786,18 +786,19 @@ let report_error env ppf = function
   | Unbound_type_constructor_2 p ->
     fprintf ppf "The type constructor@ %a@ is not yet completely defined" path p
   | Type_arity_mismatch (lid, expected, provided) ->
+    let plural n = if n = 1 then "" else "s" in
     if expected == 0 then
       fprintf ppf
         "@[The type %a is not generic so expects no arguments,@ but is here \
-         applied to %i argument(s).@ Have you tried removing the angular \
-         brackets `<` and `>` and the@ arguments within them and just writing \
-         `%a` instead? @]"
-        longident lid provided longident lid
+         given %i argument%s.@ Have you tried removing the angular brackets \
+         `<` and `>` and the@ arguments within them and just writing `%a` \
+         instead? @]"
+        longident lid provided (plural provided) longident lid
     else
       fprintf ppf
-        "@[The type constructor %a@ expects %i argument(s),@ but is here \
-         applied to %i argument(s)@]"
-        longident lid expected provided
+        "@[The type constructor %a@ expects %i type argument%s,@ but is given \
+         %i@]"
+        longident lid expected (plural expected) provided
   | Type_mismatch trace ->
     Printtyp.report_unification_error ppf Env.empty trace
       (function

--- a/compiler/ml/typetexp.ml
+++ b/compiler/ml/typetexp.ml
@@ -789,15 +789,15 @@ let report_error env ppf = function
     let plural n = if n = 1 then "" else "s" in
     if expected == 0 then
       fprintf ppf
-        "@[The type %a is not generic so expects no arguments,@ but is here \
+        "@[The type `%a` is not generic so expects no arguments,@ but is here \
          given %i argument%s.@ Have you tried removing the angular brackets \
          `<` and `>` and the@ arguments within them and just writing `%a` \
          instead? @]"
         longident lid provided (plural provided) longident lid
     else
       fprintf ppf
-        "@[The type constructor %a@ expects %i type argument%s,@ but is given \
-         %i@]"
+        "@[The type constructor `%a`@ expects %i type argument%s,@ but is \
+         given %i@]"
         longident lid expected (plural expected) provided
   | Type_mismatch trace ->
     Printtyp.report_unification_error ppf Env.empty trace

--- a/compiler/syntax/src/res_core.ml
+++ b/compiler/syntax/src/res_core.ml
@@ -6689,7 +6689,7 @@ and parse_newline_or_semicolon_structure p =
     else
       Parser.err ~start_pos:p.prev_end_pos ~end_pos:p.end_pos p
         (Diagnostics.message
-           "consecutive statements on a line must be separated by ';' or a \
+           "Consecutive statements on a line must be separated by ';' or a \
             newline")
   | _ -> ()
 

--- a/tests/analysis_tests/tests/not_compiled/expected/Diagnostics.res.txt
+++ b/tests/analysis_tests/tests/not_compiled/expected/Diagnostics.res.txt
@@ -1,6 +1,6 @@
 [
   {
-    "message": "consecutive statements on a line must be separated by ';' or a newline",
+    "message": "Consecutive statements on a line must be separated by ';' or a newline",
     "range": {
       "end": { "character": 6, "line": 2 },
       "start": { "character": 4, "line": 2 }

--- a/tests/build_tests/super_errors/expected/UntaggedDuplicatedBsAs.res.expected
+++ b/tests/build_tests/super_errors/expected/UntaggedDuplicatedBsAs.res.expected
@@ -6,4 +6,4 @@
   [1;31m2[0m [2m│[0m type t = | @as("x") [1;31m@as[0m("y") A | B
   3 [2m│[0m 
 
-  Duplicate @as annotation; a variant case can only have one.
+  Duplicate @as annotation; only one @as is allowed here.

--- a/tests/build_tests/super_errors/expected/UntaggedDuplicatedBsAs.res.expected
+++ b/tests/build_tests/super_errors/expected/UntaggedDuplicatedBsAs.res.expected
@@ -6,4 +6,4 @@
   [1;31m2[0m [2m│[0m type t = | @as("x") [1;31m@as[0m("y") A | B
   3 [2m│[0m 
 
-  duplicate @as
+  Duplicate @as annotation; a variant case can only have one.

--- a/tests/build_tests/super_errors/expected/UntaggedInvalidVariantAsAnnotation.res.expected
+++ b/tests/build_tests/super_errors/expected/UntaggedInvalidVariantAsAnnotation.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m type t = | [1;31m@as[0m(foo) A | B
   2 [2m│[0m 
 
-  A variant case annotation @as(...) must be a string or integer, boolean, null, undefined
+  A variant case annotation @as(...) must be a string, integer, boolean, null, or undefined.

--- a/tests/build_tests/super_errors/expected/apply_non_function.res.expected
+++ b/tests/build_tests/super_errors/expected/apply_non_function.res.expected
@@ -8,4 +8,4 @@
   4 [2m│[0m 
 
   This can't be called, it's not a function.
-  The function has type: int
+  It has type: int

--- a/tests/build_tests/super_errors/expected/bs_conflict_attributes.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_conflict_attributes.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m 
   3 [2m│[0m let _ = f(#A)
 
-  conflicting attributes
+  Conflicting attributes: only one of @string, @int, @ignore, or @unwrap can be used here.

--- a/tests/build_tests/super_errors/expected/bs_conflict_attributes.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_conflict_attributes.res.expected
@@ -1,9 +1,9 @@
 
   [1;31mWe've found a bug for you![0m
-  [36m/.../fixtures/bs_conflict_attributes.res[0m:[2m1:21-24[0m
+  [36m/.../fixtures/bs_conflict_attributes.res[0m:[2m1:13-19[0m
 
-  [1;31m1[0m [2m│[0m external f: @string [1;31m@int[0m [#A | #B] => unit = "f"
+  [1;31m1[0m [2m│[0m external f: [1;31m@string[0m @int [#A | #B] => unit = "f"
   2 [2m│[0m 
   3 [2m│[0m let _ = f(#A)
 
-  Conflicting attributes: only one of @string, @int, @ignore, or @unwrap can be used here.
+  Conflicting attributes: @string, @int cannot be combined; use only one.

--- a/tests/build_tests/super_errors/expected/bs_conflict_attributes_unwrap.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_conflict_attributes_unwrap.res.expected
@@ -1,0 +1,9 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/bs_conflict_attributes_unwrap.res[0m:[2m1:13-19[0m
+
+  [1;31m1[0m [2m│[0m external f: [1;31m@ignore[0m @unwrap [#A | #B] => unit = "f"
+  2 [2m│[0m 
+  3 [2m│[0m let _ = f(#A)
+
+  Conflicting attributes: @ignore, @unwrap cannot be combined; use only one.

--- a/tests/build_tests/super_errors/expected/bs_expect_int_literal.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_expect_int_literal.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m 
   3 [2m│[0m let _ = f(#A)
 
-  expect int literal
+  The @as payload on an @int variant must be an integer literal, e.g. @as(42).

--- a/tests/build_tests/super_errors/expected/bs_expect_int_or_string_or_json_literal.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_expect_int_or_string_or_json_literal.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m @val external foo: ([1;31m@as[0m(true) _, int) => unit = "foo"
   2 [2m│[0m 
 
-  expect int, string literal or json literal {json|text here|json}
+  The @as payload must be an integer, string, or JSON literal.

--- a/tests/build_tests/super_errors/expected/bs_expect_opt_in_bs_return_to_opt.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_expect_opt_in_bs_return_to_opt.res.expected
@@ -7,5 +7,4 @@
   3 [2m│[0m 
   4 [2m│[0m let _ = f("x")
 
-  %@return directive *_to_opt expect return type to be 
-syntax wise `_ option` for safety
+  A @return directive with a `*_to_opt` variant requires the return type to be written as an option, e.g. `option<int>`.

--- a/tests/build_tests/super_errors/expected/bs_expect_opt_in_bs_return_to_opt.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_expect_opt_in_bs_return_to_opt.res.expected
@@ -7,4 +7,4 @@
   3 [2m│[0m 
   4 [2m│[0m let _ = f("x")
 
-  A @return directive with a `*_to_opt` variant requires the return type to be written as an option, e.g. `option<int>`.
+  This @return directive requires the external's return type to be an option, e.g. `option<int>`.

--- a/tests/build_tests/super_errors/expected/bs_expect_string_literal.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_expect_string_literal.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m 
   3 [2m│[0m let _ = f(#A)
 
-  expect string literal
+  Expected a string literal.

--- a/tests/build_tests/super_errors/expected/bs_invalid_bs_int_type.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_invalid_bs_int_type.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m 
   3 [2m│[0m let _ = f(#A(1))
 
-  Not a valid type for %@int
+  Not a valid type for @int

--- a/tests/build_tests/super_errors/expected/bs_invalid_bs_string_type.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_invalid_bs_string_type.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m 
   3 [2m│[0m let _ = f(#A)
 
-  Not a valid type for %@string
+  Not a valid type for @string

--- a/tests/build_tests/super_errors/expected/bs_invalid_bs_unwrap_type.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_invalid_bs_unwrap_type.res.expected
@@ -6,5 +6,5 @@
   2 [2m│[0m 
   3 [2m│[0m let _ = f(1)
 
-  Not a valid type for %@unwrap. Type must be an inline variant (closed), and
+  Not a valid type for @unwrap. Type must be an inline variant (closed), and
 each constructor must have an argument.

--- a/tests/build_tests/super_errors/expected/bs_not_supported_directive_in_bs_return.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_not_supported_directive_in_bs_return.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m external f: string => int = "f"
   3 [2m│[0m 
 
-  Not supported return directive
+  Unsupported @return directive. Supported directives are `null_to_opt`, `null_undefined_to_opt` (or `nullable`), and `identity`.

--- a/tests/build_tests/super_errors/expected/bs_this_simple_pattern.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_this_simple_pattern.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m let f = @this ([1;31m(a, b)[0m, x) => a + b + x
   2 [2m│[0m 
 
-  @this expects its first parameter to be a simple identifier, not a destructured pattern.
+  @this expects its first parameter to be a simple variable (or `_`).

--- a/tests/build_tests/super_errors/expected/bs_this_simple_pattern.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_this_simple_pattern.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m let f = @this ([1;31m(a, b)[0m, x) => a + b + x
   2 [2m│[0m 
 
-  %@this expect its pattern variable to be simple form
+  @this expects its first parameter to be a simple identifier, not a destructured pattern.

--- a/tests/build_tests/super_errors/expected/bs_unsupported_predicates.res.expected
+++ b/tests/build_tests/super_errors/expected/bs_unsupported_predicates.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m type t = {..@get({[1;31mweird[0m: true}) "x": int}
   2 [2m│[0m 
 
-  unsupported predicates
+  Unsupported predicates

--- a/tests/build_tests/super_errors/expected/conflicting_ffi_attributes.res.expected
+++ b/tests/build_tests/super_errors/expected/conflicting_ffi_attributes.res.expected
@@ -7,4 +7,4 @@
   3 [2m│[0m 
   4 [2m│[0m let _ = doThing("x", 1)
 
-  Conflicting attributes: Attribute found that conflicts with %@val
+  Conflicting attributes: Attribute found that conflicts with @val

--- a/tests/build_tests/super_errors/expected/directive_attr.res.expected
+++ b/tests/build_tests/super_errors/expected/directive_attr.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m [1;31m@@directive[0m
   2 [2m│[0m 
 
-  expect string literal
+  Expected a string literal.

--- a/tests/build_tests/super_errors/expected/duplicate_as_tag_inline_record.res.expected
+++ b/tests/build_tests/super_errors/expected/duplicate_as_tag_inline_record.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m type animal = Cat({@as("catName") [1;31m@as[0m("catName2") name: string})
   2 [2m│[0m 
 
-  duplicate @as
+  Duplicate @as annotation; a variant case can only have one.

--- a/tests/build_tests/super_errors/expected/duplicate_as_tag_inline_record.res.expected
+++ b/tests/build_tests/super_errors/expected/duplicate_as_tag_inline_record.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m type animal = Cat({@as("catName") [1;31m@as[0m("catName2") name: string})
   2 [2m│[0m 
 
-  Duplicate @as annotation; a variant case can only have one.
+  Duplicate @as annotation; only one @as is allowed here.

--- a/tests/build_tests/super_errors/expected/duplicated_bs_deriving.res.expected
+++ b/tests/build_tests/super_errors/expected/duplicated_bs_deriving.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m type t = One | Two
   3 [2m│[0m 
 
-  duplicate @deriving attribute
+  Duplicate @deriving attribute; a type can only have one.

--- a/tests/build_tests/super_errors/expected/fragile_pattern_toplevel.res.expected
+++ b/tests/build_tests/super_errors/expected/fragile_pattern_toplevel.res.expected
@@ -17,4 +17,4 @@
   2 [2m│[0m 
   3 [2m│[0m let _ = x
 
-  Such fragile pattern not allowed in the toplevel
+  This pattern can fail to match, so it is not allowed in a top-level `let` binding.

--- a/tests/build_tests/super_errors/expected/illegal_letrec_expr.res.expected
+++ b/tests/build_tests/super_errors/expected/illegal_letrec_expr.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m let rec x = [1;31mx + 1[0m
   2 [2m│[0m 
 
-  This kind of expression is not allowed as right-hand side of `let rec'
+  This kind of expression is not allowed as right-hand side of `let rec`

--- a/tests/build_tests/super_errors/expected/illegal_letrec_pat.res.expected
+++ b/tests/build_tests/super_errors/expected/illegal_letrec_pat.res.expected
@@ -16,4 +16,4 @@
   2 [2m│[0m let _ = x + y
   3 [2m│[0m 
 
-  Only variables are allowed as left-hand side of `let rec'
+  Only variables are allowed as left-hand side of `let rec`

--- a/tests/build_tests/super_errors/expected/incomplete_packed_module.res.expected
+++ b/tests/build_tests/super_errors/expected/incomplete_packed_module.res.expected
@@ -8,5 +8,5 @@
   8 [2m│[0m   M.v
   9 [2m│[0m }
 
-  The type of this packed module contains variables:
+  The type of this first-class module still contains type variables:
 module(S with type t = 'a)

--- a/tests/build_tests/super_errors/expected/invalid_type_variable_name.res.expected
+++ b/tests/build_tests/super_errors/expected/invalid_type_variable_name.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m type t<'[1;31m_invalid[0m> = list<'_invalid>
   2 [2m│[0m 
 
-  The type variable name '_invalid is not allowed in programs
+  The type variable name '_invalid is not allowed; type variable names cannot start with an underscore.

--- a/tests/build_tests/super_errors/expected/multiply_bound_variable.res.expected
+++ b/tests/build_tests/super_errors/expected/multiply_bound_variable.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m let _ = x
   3 [2m│[0m 
 
-  Variable x is bound several times in this matching
+  Variable x is bound several times in this pattern

--- a/tests/build_tests/super_errors/expected/no_value_clauses.res.expected
+++ b/tests/build_tests/super_errors/expected/no_value_clauses.res.expected
@@ -8,4 +8,4 @@
   [1;31m4[0m [2m│[0m [1;31m  }[0m
   5 [2m│[0m 
 
-  None of the patterns in this 'match' expression match values.
+  None of the patterns in this switch match values.

--- a/tests/build_tests/super_errors/expected/non_function_uncurried_apply.res.expected
+++ b/tests/build_tests/super_errors/expected/non_function_uncurried_apply.res.expected
@@ -7,4 +7,4 @@
   3 [2m│[0m 
 
   This can't be called, it's not a function.
-  The function has type: int
+  It has type: int

--- a/tests/build_tests/super_errors/expected/primitives4.res.expected
+++ b/tests/build_tests/super_errors/expected/primitives4.res.expected
@@ -8,4 +8,4 @@
   4 [2m│[0m 
 
   This can't be called, it's not a function.
-  The function has type: int
+  It has type: int

--- a/tests/build_tests/super_errors/expected/syntaxErrors2.res.expected
+++ b/tests/build_tests/super_errors/expected/syntaxErrors2.res.expected
@@ -6,4 +6,4 @@
   [1;31m2[0m [2m│[0m   I'm[1;31m glad[0m you're looking at this file =)
   3 [2m│[0m 
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline

--- a/tests/build_tests/super_errors/expected/type_arity_mismatch.res.expected
+++ b/tests/build_tests/super_errors/expected/type_arity_mismatch.res.expected
@@ -5,4 +5,4 @@
   [1;31m1[0m [2m│[0m let xs: [1;31marray<int, string>[0m = []
   2 [2m│[0m 
 
-  The type constructor array expects 1 type argument, but is given 2
+  The type constructor `array` expects 1 type argument, but is given 2

--- a/tests/build_tests/super_errors/expected/type_arity_mismatch.res.expected
+++ b/tests/build_tests/super_errors/expected/type_arity_mismatch.res.expected
@@ -5,5 +5,4 @@
   [1;31m1[0m [2m│[0m let xs: [1;31marray<int, string>[0m = []
   2 [2m│[0m 
 
-  The type constructor array expects 1 argument(s),
-  but is here applied to 2 argument(s)
+  The type constructor array expects 1 type argument, but is given 2

--- a/tests/build_tests/super_errors/expected/type_arity_mismatch_non_generic.res.expected
+++ b/tests/build_tests/super_errors/expected/type_arity_mismatch_non_generic.res.expected
@@ -1,0 +1,11 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/type_arity_mismatch_non_generic.res[0m:[2m1:8-24[0m
+
+  [1;31m1[0m [2m│[0m let x: [1;31mint<string, bool>[0m = 1
+  2 [2m│[0m 
+
+  The type `int` is not generic so expects no arguments,
+  but is here given 2 arguments.
+  Have you tried removing the angular brackets `<` and `>` and the
+  arguments within them and just writing `int` instead?

--- a/tests/build_tests/super_errors/expected/variant_spread_pattern_type_params.res.expected
+++ b/tests/build_tests/super_errors/expected/variant_spread_pattern_type_params.res.expected
@@ -9,4 +9,4 @@
   8 [2m│[0m   }
 
   The type a
-has type parameters, but type parameters is not supported here.
+has type parameters, but type parameters are not supported here.

--- a/tests/build_tests/super_errors/expected/warning_47_attribute_payload.res.expected
+++ b/tests/build_tests/super_errors/expected/warning_47_attribute_payload.res.expected
@@ -6,5 +6,5 @@
   2 [2m│[0m let f = x => x + 1
   3 [2m│[0m 
 
-  illegal payload for attribute 'inline'.
+  illegal payload for attribute @inline.
 It must be either empty, 'always' or 'never'

--- a/tests/build_tests/super_errors/expected/warning_52_fragile_literal_pattern.res.expected
+++ b/tests/build_tests/super_errors/expected/warning_52_fragile_literal_pattern.res.expected
@@ -10,4 +10,4 @@
 
   Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 8.5)
+and may change in future versions.

--- a/tests/build_tests/super_errors/expected/warning_53_misplaced_attribute.res.expected
+++ b/tests/build_tests/super_errors/expected/warning_53_misplaced_attribute.res.expected
@@ -10,4 +10,4 @@
   6 [2m│[0m 
   7 [2m│[0m let _ = x
 
-  the "inline1" attribute cannot appear in this context
+  the "inline" attribute cannot appear in this context

--- a/tests/build_tests/super_errors/expected/warning_53_misplaced_attribute.res.expected
+++ b/tests/build_tests/super_errors/expected/warning_53_misplaced_attribute.res.expected
@@ -10,4 +10,4 @@
   6 [2m│[0m 
   7 [2m│[0m let _ = x
 
-  the "inline" attribute cannot appear in this context
+  the @inline attribute cannot appear in this context

--- a/tests/build_tests/super_errors/expected/warning_54_duplicated_attribute.res.expected
+++ b/tests/build_tests/super_errors/expected/warning_54_duplicated_attribute.res.expected
@@ -6,4 +6,4 @@
   2 [2m│[0m let f = x => x + 1
   3 [2m│[0m 
 
-  the "inline" attribute is used more than once on this expression
+  the @inline attribute is used more than once on this expression

--- a/tests/build_tests/super_errors/expected/warning_57_ambiguous_pattern_multi.res.expected
+++ b/tests/build_tests/super_errors/expected/warning_57_ambiguous_pattern_multi.res.expected
@@ -9,4 +9,4 @@
   5 [2m│[0m   }
 
   Ambiguous or-pattern variables under guard;
-variables a,b may match different arguments. (See manual section 8.5)
+variables a, b may match different arguments.

--- a/tests/build_tests/super_errors/expected/warning_57_ambiguous_pattern_single.res.expected
+++ b/tests/build_tests/super_errors/expected/warning_57_ambiguous_pattern_single.res.expected
@@ -9,4 +9,4 @@
   5 [2m│[0m   }
 
   Ambiguous or-pattern variables under guard;
-variable n may match different arguments. (See manual section 8.5)
+variable n may match different arguments.

--- a/tests/build_tests/super_errors/fixtures/bs_conflict_attributes_unwrap.res
+++ b/tests/build_tests/super_errors/fixtures/bs_conflict_attributes_unwrap.res
@@ -1,0 +1,3 @@
+external f: @ignore @unwrap [#A | #B] => unit = "f"
+
+let _ = f(#A)

--- a/tests/build_tests/super_errors/fixtures/type_arity_mismatch_non_generic.res
+++ b/tests/build_tests/super_errors/fixtures/type_arity_mismatch_non_generic.res
@@ -1,0 +1,1 @@
+let x: int<string, bool> = 1

--- a/tests/build_tests/super_errors_multi/expected/Cross_gadt_pattern.expected
+++ b/tests/build_tests/super_errors_multi/expected/Cross_gadt_pattern.expected
@@ -9,4 +9,5 @@
   4 [2m│[0m   | Pair(_, _) => "pair"
   5 [2m│[0m   }
 
-  The GADT constructor Int of type Gadt.t must be qualified in this pattern.
+  The GADT constructor Int of type Gadt.t
+  must be written with its module prefix in this pattern.

--- a/tests/build_tests/super_errors_multi/expected/Unexpected_existential_in_let.expected
+++ b/tests/build_tests/super_errors_multi/expected/Unexpected_existential_in_let.expected
@@ -8,4 +8,4 @@
   [1;31m3[0m [2m│[0m let [1;31mGadt.Pack(_x)[0m = value
   4 [2m│[0m 
 
-  Unexpected existential
+  This pattern introduces an existential type from a GADT constructor, which is not allowed here. Match on it inside a switch instead.

--- a/tests/syntax_tests/data/parsing/errors/expressions/expected/consecutive.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/expressions/expected/consecutive.res.txt
@@ -6,7 +6,7 @@
   2 │ 
   3 │ let f = (g, h) => {
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 
   Syntax error!

--- a/tests/syntax_tests/data/parsing/errors/pattern/expected/missing.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/pattern/expected/missing.res.txt
@@ -41,7 +41,7 @@
   5 │   Js.log("for")
   6 │ }
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 
   Syntax error!

--- a/tests/syntax_tests/data/parsing/errors/scanner/expected/exoticIdent.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/scanner/expected/exoticIdent.res.txt
@@ -90,7 +90,7 @@
    9 │ c" = 1
   10 │ 
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 type nonrec \""
 type nonrec \"" = int

--- a/tests/syntax_tests/data/parsing/errors/structure/expected/consecutive.res.txt
+++ b/tests/syntax_tests/data/parsing/errors/structure/expected/consecutive.res.txt
@@ -5,7 +5,7 @@
   1 │ open Foo exception Bar
   2 │ 
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 open Foo
 exception Bar 

--- a/tests/syntax_tests/data/parsing/grammar/ffi/expected/export.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/ffi/expected/export.res.txt
@@ -6,7 +6,7 @@
   2 │ 
   3 │ export type t = int and export s = string
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 
   Syntax error!
@@ -18,7 +18,7 @@
   4 │ export type t = int and s = string
   5 │ type t = int and export s = string
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 
   Syntax error!
@@ -30,7 +30,7 @@
   6 │ 
   7 │ export let callback = _ => Js.log("Clicked")
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 
   Syntax error!

--- a/tests/syntax_tests/data/parsing/infiniteLoops/expected/jsxChildren.res.txt
+++ b/tests/syntax_tests/data/parsing/infiniteLoops/expected/jsxChildren.res.txt
@@ -6,7 +6,7 @@
   2 │ 
   3 │ let a: action = AddUser("test")
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 
   Syntax error!

--- a/tests/syntax_tests/data/parsing/infiniteLoops/expected/nonRecTypes.res.txt
+++ b/tests/syntax_tests/data/parsing/infiniteLoops/expected/nonRecTypes.res.txt
@@ -21,7 +21,7 @@
   20 ┆ ) =>
   21 ┆ t('value) =
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 
   Syntax error!

--- a/tests/syntax_tests/data/parsing/infiniteLoops/expected/templateEof.res.txt
+++ b/tests/syntax_tests/data/parsing/infiniteLoops/expected/templateEof.res.txt
@@ -6,7 +6,7 @@
   2 │   switch x {
   3 │   | `${
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 
 
   Syntax error!

--- a/tests/syntax_tests/data/parsing/other/expected/gentype.res.txt
+++ b/tests/syntax_tests/data/parsing/other/expected/gentype.res.txt
@@ -18,5 +18,5 @@
   3 │   export x: int
   4 │ } = {
 
-  consecutive statements on a line must be separated by ';' or a newline
+  Consecutive statements on a line must be separated by ';' or a newline
 


### PR DESCRIPTION
## Summary

Improves error and warning messages that were unclear, terse, or used OCaml
terminology. Message text only, no behaviour changes; every change is covered
by an updated super_errors fixture.

## Details

Follow-up to the super_errors fixture coverage work. After reviewing the
fixtures added in that work (including the ones flagged by @cknitt on #8432),
the changes group into:

- The wording @cknitt flagged: non-function application, `@return(*_to_opt)`,
  the `@int`/`@as` payload, and conflicting attributes.
- Render `@` correctly in FFI attribute messages, which printed `%@` literally.
- Use ReScript terms rather than OCaml ones: `switch` (not "match expression"),
  pattern (not "matching"), `let rec` (not `let rec'`), first-class module
  (not "packed module").
- Grammar and clarity: subject-verb agreement, list grammar, singular/plural
  in the type-arity error, and dropping the OCaml-manual references from two
  warnings.
- The conflicting-attributes error now names the attributes actually involved
  (e.g. `@string, @int`) instead of listing every possible one.
- Report the real attribute name in the misplaced-`@inline` warning, which was
  leaking an internal `inline1`.

A few advanced type-system messages (variance, polymorphic-variant
present/conjunction) are left as-is; rewording them needs more care.