### PR TITLE
Include gentype, analysis and syntax tests in coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Convert OCaml codebase to snake case format. https://github.com/rescript-lang/rescript/pull/8456
 - Analysis refactor: remove global state `Shared_types.state`. https://github.com/rescript-lang/rescript/pull/8465
 - Refactor analysis CLI helpers to use source input. https://github.com/rescript-lang/rescript/pull/8466
+- Include syntax, gentype, analysis, tools, and reanalyze tests in coverage reports. https://github.com/rescript-lang/rescript/pull/8467
 
 # 13.0.0-alpha.4
 

--- a/Makefile
+++ b/Makefile
@@ -303,8 +303,10 @@ coverage-lib: coverage-prepare
 # binary via `dune exec`, which would otherwise rebuild it *uninstrumented*.
 # Setting DUNE_INSTRUMENT_WITH=bisect_ppx (the env-var form of
 # `--instrument-with`) makes that `dune exec` match the config coverage-build
-# already used, so it runs the instrumented binary — no rebuild, no coverage
-# gap, and no de-instrumentation of the shared _build artifacts.
+# already used, so it runs the instrumented binary — no rebuild, no
+# de-instrumentation of the shared _build artifacts. (The reanalyze library
+# also carries its own bisect_ppx instrumentation stanza so its source is
+# counted, not just the analysis/tools code it links.)
 .PHONY: coverage-run
 coverage-run: coverage-lib
 	$(COVERAGE_TEST_ENV) node scripts/test.js -all

--- a/Makefile
+++ b/Makefile
@@ -240,9 +240,8 @@ checkformat: | $(YARN_INSTALL_STAMP)
 # Suites covered: the `scripts/test.js -all` suites (mocha/build/ounit/
 # docstrings), the syntax tests (compiler/syntax, via the instrumented
 # res_parser), the gentype tests (compiler/gentype, via the instrumented
-# bsc) and the analysis + tools tests (analysis/, via the instrumented
-# rescript-editor-analysis and rescript-tools). The reanalyze tests are
-# excluded — see the coverage-run target for why.
+# bsc) and the analysis + tools tests, including reanalyze (analysis/, via
+# the instrumented rescript-editor-analysis and rescript-tools).
 #
 # Outputs (under _coverage/):
 #   html/index.html  — human-browsable line-level report
@@ -300,18 +299,19 @@ coverage-lib: coverage-prepare
 #   - analysis tests run the instrumented `rescript-editor-analysis` and tools
 #     tests the instrumented `rescript-tools` (which links analysis + reanalyze),
 #     both from _build/install/default/bin — adding coverage for analysis/.
-# We deliberately run the analysis suite's `test-analysis-binary` target rather
-# than its full `test`: the reanalyze tests invoke the binary via `dune exec`,
-# which would rebuild it *uninstrumented* (and strip instrumentation from the
-# shared _build artifacts mid-run), so they produce no coverage and would
-# corrupt the instrumented build for later suites.
+# The reanalyze tests (run by the analysis suite's full `test`) invoke the
+# binary via `dune exec`, which would otherwise rebuild it *uninstrumented*.
+# Setting DUNE_INSTRUMENT_WITH=bisect_ppx (the env-var form of
+# `--instrument-with`) makes that `dune exec` match the config coverage-build
+# already used, so it runs the instrumented binary — no rebuild, no coverage
+# gap, and no de-instrumentation of the shared _build artifacts.
 .PHONY: coverage-run
 coverage-run: coverage-lib
 	$(COVERAGE_TEST_ENV) node scripts/test.js -all
 	$(COVERAGE_TEST_ENV) ROUNDTRIP_TEST=1 ./scripts/test_syntax.sh
 	$(COVERAGE_TEST_ENV) make -C tests/gentype_tests/typescript-react-example clean test
 	$(COVERAGE_TEST_ENV) make -C tests/gentype_tests/stdlib-no-shims clean test
-	$(COVERAGE_TEST_ENV) make -C tests/analysis_tests clean test-analysis-binary
+	$(COVERAGE_TEST_ENV) DUNE_INSTRUMENT_WITH=bisect_ppx make -C tests/analysis_tests clean test
 	$(COVERAGE_TEST_ENV) make -C tests/tools_tests clean test
 
 .PHONY: coverage-report

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,12 @@ checkformat: | $(YARN_INSTALL_STAMP)
 #   make coverage         # run full test suite, generate report
 #   make clean-coverage   # remove coverage artifacts
 #
+# Suites covered: the `scripts/test.js -all` suites (mocha/build/ounit/
+# docstrings) plus the gentype tests (compiler/gentype, via the instrumented
+# bsc) and the analysis + tools tests (analysis/, via the instrumented
+# rescript-editor-analysis and rescript-tools). The reanalyze tests are
+# excluded — see the coverage-run target for why.
+#
 # Outputs (under _coverage/):
 #   html/index.html  — human-browsable line-level report
 #   coverage.json    — Coveralls-format JSON, queryable with jq:
@@ -253,6 +259,10 @@ COVERAGE_FILES_DIR := $(COVERAGE_DIR)/files
 COVERAGE_HTML_DIR := $(COVERAGE_DIR)/html
 COVERAGE_JSON := $(COVERAGE_DIR)/coverage.json
 COVERAGE_BISECT_PREFIX := $(abspath $(COVERAGE_FILES_DIR))/bisect
+# Env that makes instrumented binaries append their counters to the shared
+# coverage prefix. bisect_ppx adds a unique per-process suffix, so many
+# concurrent `bsc` / analysis processes accumulate without colliding.
+COVERAGE_TEST_ENV := BISECT_FILE=$(COVERAGE_BISECT_PREFIX) BISECT_SILENT=YES
 
 # Re-builds the toolchain with bisect_ppx instrumentation and swaps the
 # instrumented binaries into BIN_DIR so any test runner that shells out to
@@ -278,10 +288,26 @@ coverage-lib: coverage-prepare
 		yarn workspace @rescript/runtime build
 	rm -f $(COVERAGE_BISECT_PREFIX)-discard*.coverage
 
+# Run the test suites that exercise the instrumented toolchain. Each suite
+# shells out to a binary that `coverage-build` instrumented:
+#   - `node scripts/test.js -all` drives bsc (mocha/build/ounit/docstrings).
+#   - gentype tests compile via `rescript build`, i.e. the instrumented bsc in
+#     BIN_DIR, so they add coverage for compiler/gentype.
+#   - analysis tests run the instrumented `rescript-editor-analysis` and tools
+#     tests the instrumented `rescript-tools` (which links analysis + reanalyze),
+#     both from _build/install/default/bin — adding coverage for analysis/.
+# We deliberately run the analysis suite's `test-analysis-binary` target rather
+# than its full `test`: the reanalyze tests invoke the binary via `dune exec`,
+# which would rebuild it *uninstrumented* (and strip instrumentation from the
+# shared _build artifacts mid-run), so they produce no coverage and would
+# corrupt the instrumented build for later suites.
 .PHONY: coverage-run
 coverage-run: coverage-lib
-	BISECT_FILE=$(COVERAGE_BISECT_PREFIX) BISECT_SILENT=YES \
-		node scripts/test.js -all
+	$(COVERAGE_TEST_ENV) node scripts/test.js -all
+	$(COVERAGE_TEST_ENV) make -C tests/gentype_tests/typescript-react-example clean test
+	$(COVERAGE_TEST_ENV) make -C tests/gentype_tests/stdlib-no-shims clean test
+	$(COVERAGE_TEST_ENV) make -C tests/analysis_tests clean test-analysis-binary
+	$(COVERAGE_TEST_ENV) make -C tests/tools_tests clean test
 
 .PHONY: coverage-report
 coverage-report:

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,8 @@ checkformat: | $(YARN_INSTALL_STAMP)
 #   make clean-coverage   # remove coverage artifacts
 #
 # Suites covered: the `scripts/test.js -all` suites (mocha/build/ounit/
-# docstrings) plus the gentype tests (compiler/gentype, via the instrumented
+# docstrings), the syntax tests (compiler/syntax, via the instrumented
+# res_parser), the gentype tests (compiler/gentype, via the instrumented
 # bsc) and the analysis + tools tests (analysis/, via the instrumented
 # rescript-editor-analysis and rescript-tools). The reanalyze tests are
 # excluded — see the coverage-run target for why.
@@ -291,6 +292,9 @@ coverage-lib: coverage-prepare
 # Run the test suites that exercise the instrumented toolchain. Each suite
 # shells out to a binary that `coverage-build` instrumented:
 #   - `node scripts/test.js -all` drives bsc (mocha/build/ounit/docstrings).
+#   - the syntax tests drive the instrumented `res_parser` from
+#     _build/install/default/bin, adding coverage for compiler/syntax.
+#     ROUNDTRIP_TEST=1 matches Linux CI and also exercises the printer paths.
 #   - gentype tests compile via `rescript build`, i.e. the instrumented bsc in
 #     BIN_DIR, so they add coverage for compiler/gentype.
 #   - analysis tests run the instrumented `rescript-editor-analysis` and tools
@@ -304,6 +308,7 @@ coverage-lib: coverage-prepare
 .PHONY: coverage-run
 coverage-run: coverage-lib
 	$(COVERAGE_TEST_ENV) node scripts/test.js -all
+	$(COVERAGE_TEST_ENV) ROUNDTRIP_TEST=1 ./scripts/test_syntax.sh
 	$(COVERAGE_TEST_ENV) make -C tests/gentype_tests/typescript-react-example clean test
 	$(COVERAGE_TEST_ENV) make -C tests/gentype_tests/stdlib-no-shims clean test
 	$(COVERAGE_TEST_ENV) make -C tests/analysis_tests clean test-analysis-binary

--- a/analysis/reanalyze/src/dune
+++ b/analysis/reanalyze/src/dune
@@ -1,5 +1,7 @@
 (library
  (name reanalyze)
+ (instrumentation
+  (backend bisect_ppx))
  (flags
   (-w "+6+26+27+32+33+39"))
  (libraries reactive yojson ml str unix))


### PR DESCRIPTION
I was looking at the coverage report wondering why some parts didn't show tests only to find out that `node scripts/test.js -all` doesn't infact include analysis or gentype or syntax tests 🤦🏼‍♂️  

Since these are run in the CI pipeline I'm including them in coverage.