### PR TITLE
Update coverage.yml to use OIDC for Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   coverage:
     runs-on: ubuntu-24.04-arm
+    permissions:
+      id-token: write
     env:
       OS: ubuntu-24.04-arm
       OCAML_COMPILER: 5.3.0
@@ -200,4 +202,4 @@ jobs:
         with:
           files: _coverage/coverage.json
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,8 @@ jobs:
   coverage:
     runs-on: ubuntu-24.04-arm
     permissions:
-      id-token: write
+      actions: write # For build cache overwriting
+      id-token: write # For CodeCov OIDC
     env:
       OS: ubuntu-24.04-arm
       OCAML_COMPILER: 5.3.0


### PR DESCRIPTION
Always prefer the tokenless method if available. There are no needs to use permanent token here for public repo. It supports verifying repo via OIDC.