### PR TITLE
Tell agents to add a CHANGELOG entry for user-facing changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,8 @@ tests/
    - Unit tests for utility functions
    - Always check JavaScript output quality
 
+4. **Add a `CHANGELOG.md` entry** for any user-facing change (bug fix, feature, or breaking change). Put it under the matching section of the current `(Unreleased)` version and end the line with the PR link. See [CONTRIBUTING.md](CONTRIBUTING.md). PRs are expected to include one.
+
 ### Debugging Techniques
 
 #### View Intermediate Representations


### PR DESCRIPTION
AGENTS.md is the entry point for agents working in this repo, but the changelog requirement only lives in CONTRIBUTING.md. An agent that follows AGENTS.md therefore gets no signal that a CHANGELOG.md entry is expected.

This is not hypothetical. On #8482 the code fix was made by following AGENTS.md, the PR was opened, and the changelog entry was missed because nothing in the agent workflow mentioned it. A reviewer had to ask for it after the fact. Adding the step to the AGENTS.md workflow checklist would have caught it up front, which is why this change is needed.
