### PR TITLE
Add dependabot ignore for awalsh128/cache-apt-pkgs-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Versions >1.4.3 interfere with caching done by our own CI script,
+      # causing the dune binary not to be found anymore.
+      - dependency-name: "awalsh128/cache-apt-pkgs-action"


### PR DESCRIPTION
I have been seeing failing dependabot PRs trying to bump awalsh128/cache-apt-pkgs-action from 1.4.3 to newer versions for many months.

It seems newer versions are completely broken.

~~Dependency installation on the GitHub runners is very fast anyway, so little point in keeping this caching around.~~

Added a dependabot ignore.