### PR TITLE
Reuse node, ocaml, and rewatch setup between ci.yml and coverage.yml

### DIFF
--- a/.github/actions/build-rewatch/action.yml
+++ b/.github/actions/build-rewatch/action.yml
@@ -1,0 +1,93 @@
+name: Build rewatch
+description: Restore or build rewatch and copy its executable into the platform package.
+
+inputs:
+  cache-target:
+    description: Target identifier used in the build cache key.
+    required: true
+  rust-target:
+    description: Explicit Rust compilation target. Empty builds for the runner's native target.
+    required: false
+    default: ""
+  exe-suffix:
+    description: Executable suffix for the target platform.
+    required: false
+    default: ""
+  run-quality-checks:
+    description: Run Clippy and Rust unit tests when populating the cache.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Restore rewatch build cache
+      id: build-cache
+      uses: actions/cache@v6
+      with:
+        path: rewatch/target
+        key: rewatch-build-v4-${{ inputs.cache-target }}-${{ hashFiles('rewatch/src/**', 'rewatch/Cargo.toml', 'rewatch/Cargo.lock', 'rewatch/rust-toolchain.toml', 'rewatch/.cargo/config.toml') }}
+
+    - name: Determine Rust toolchain version
+      id: rust-version
+      shell: bash
+      run: |
+        version="$(awk -F '"' '/^rust-version[[:space:]]*=/ { print $2; exit }' rewatch/Cargo.toml)"
+        if [ -z "$version" ]; then
+          echo "rust-version missing in rewatch/Cargo.toml" >&2
+          exit 1
+        fi
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Install Rust toolchain for native target
+      if: steps.build-cache.outputs.cache-hit != 'true' && inputs.rust-target == ''
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.rust-version.outputs.version }}
+        components: clippy, rustfmt
+
+    - name: Install Rust toolchain for explicit target
+      if: steps.build-cache.outputs.cache-hit != 'true' && inputs.rust-target != ''
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.rust-version.outputs.version }}
+        targets: ${{ inputs.rust-target }}
+        components: clippy, rustfmt
+
+    - name: Build rewatch for native target
+      if: steps.build-cache.outputs.cache-hit != 'true' && inputs.rust-target == ''
+      shell: bash
+      run: cargo build --manifest-path rewatch/Cargo.toml --release
+
+    - name: Build rewatch for explicit target
+      if: steps.build-cache.outputs.cache-hit != 'true' && inputs.rust-target != ''
+      shell: bash
+      run: cargo build --manifest-path rewatch/Cargo.toml --target "${{ inputs.rust-target }}" --release
+
+    - name: Lint rewatch
+      if: steps.build-cache.outputs.cache-hit != 'true' && inputs.run-quality-checks == 'true'
+      shell: bash
+      run: cargo clippy --manifest-path rewatch/Cargo.toml --all-targets --all-features
+
+    - name: Run rewatch unit tests
+      if: steps.build-cache.outputs.cache-hit != 'true' && inputs.run-quality-checks == 'true'
+      shell: bash
+      run: cargo test --manifest-path rewatch/Cargo.toml --release
+
+    - name: Copy rewatch binary
+      shell: bash
+      env:
+        RUST_TARGET: ${{ inputs.rust-target }}
+        EXE_SUFFIX: ${{ inputs.exe-suffix }}
+      run: |
+        if [[ -n "$RUST_TARGET" ]]; then
+          source="rewatch/target/$RUST_TARGET/release/rescript$EXE_SUFFIX"
+        else
+          source="rewatch/target/release/rescript$EXE_SUFFIX"
+        fi
+        cp "$source" rescript
+        if [[ -n "$RUST_TARGET" ]]; then
+          mkdir -p rewatch/target/release
+          cp "$source" rewatch/target/release
+        fi
+        ./scripts/copyExes.js --rewatch

--- a/.github/actions/setup-linux-dependencies/action.yml
+++ b/.github/actions/setup-linux-dependencies/action.yml
@@ -1,0 +1,12 @@
+name: Setup Linux dependencies
+description: Install and cache the system packages required to build ReScript.
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+      with:
+        # Dependencies required by setup-ocaml, plus cmake for OPAM.
+        packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync cmake
+        version: v4

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,16 @@
+name: Setup Node and dependencies
+description: Install the repository Node.js version and immutable Yarn dependencies.
+
+runs:
+  using: composite
+  steps:
+    - name: Use Node.js
+      uses: actions/setup-node@v6
+      with:
+        cache: yarn
+        node-version-file: .nvmrc
+        registry-url: https://registry.npmjs.org
+
+    - name: Install npm packages
+      shell: bash
+      run: yarn install --immutable

--- a/.github/actions/setup-ocaml/action.yml
+++ b/.github/actions/setup-ocaml/action.yml
@@ -32,7 +32,8 @@ runs:
         DEPENDENCY_FLAGS: ${{ inputs.dependency-flags }}
         OS: ${{ inputs.os }}
       run: |
-        dependency_flags_key="${DEPENDENCY_FLAGS// /_}"
+        dependency_flags_key="${DEPENDENCY_FLAGS//--/}"
+        dependency_flags_key="${dependency_flags_key// /_}"
         key="$CACHE_PREFIX-$OS-3.6.0-$COMPILER-$dependency_flags_key-${{ hashFiles('*.opam') }}"
         echo "value=${key//,/-}" >> "$GITHUB_OUTPUT"
         echo "setup-version=3.6.0" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-ocaml/action.yml
+++ b/.github/actions/setup-ocaml/action.yml
@@ -1,0 +1,130 @@
+name: Setup OCaml
+description: Restore or install the repository OPAM environment.
+
+inputs:
+  compiler:
+    description: OCaml compiler switch specification.
+    required: true
+  os:
+    description: Runner identifier used in the cache key.
+    required: true
+  cache-prefix:
+    description: Cache namespace and version.
+    required: true
+  dependency-flags:
+    description: Flags passed to opam install after the package path.
+    required: false
+    default: --deps-only --with-test
+outputs:
+  setup_version:
+    description: Version of ocaml/setup-ocaml used by this action.
+    value: ${{ steps.cache-key.outputs.setup-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get OPAM cache key
+      id: cache-key
+      shell: bash
+      env:
+        CACHE_PREFIX: ${{ inputs.cache-prefix }}
+        COMPILER: ${{ inputs.compiler }}
+        DEPENDENCY_FLAGS: ${{ inputs.dependency-flags }}
+        OS: ${{ inputs.os }}
+      run: |
+        dependency_flags_key="${DEPENDENCY_FLAGS// /_}"
+        key="$CACHE_PREFIX-$OS-3.6.0-$COMPILER-$dependency_flags_key-${{ hashFiles('*.opam') }}"
+        echo "value=${key//,/-}" >> "$GITHUB_OUTPUT"
+        echo "setup-version=3.6.0" >> "$GITHUB_OUTPUT"
+
+    - name: Restore OPAM environment
+      id: cache
+      uses: actions/cache/restore@v6
+      with:
+        path: |
+          ${{ runner.tool_cache }}/opam
+          ~/.opam
+          _opam
+          .opam-path
+          C:\cygwin
+          C:\.opam
+        key: ${{ steps.cache-key.outputs.value }}
+
+    - name: Use OCaml ${{ inputs.compiler }}
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: ocaml/setup-ocaml@v3.6.0
+      with:
+        ocaml-compiler: ${{ inputs.compiler }}
+        opam-pin: false
+
+    - name: Get OPAM executable path
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const opamPath = await io.which('opam', true);
+          console.log('opam executable found: %s', opamPath);
+
+          const fs = require('fs/promises');
+          await fs.writeFile('.opam-path', opamPath, 'utf-8');
+          console.log('stored path to .opam-path');
+
+    - name: Install OPAM dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        DEPENDENCY_FLAGS: ${{ inputs.dependency-flags }}
+      run: |
+        read -ra dependency_flags <<< "$DEPENDENCY_FLAGS"
+        opam install . "${dependency_flags[@]}"
+
+    - name: Cache OPAM environment
+      # Caches created by pull_request runs are scoped to that PR's merge ref
+      # and cannot seed other PRs or branches. Only pushes create shared caches.
+      if: steps.cache.outputs.cache-hit != 'true' && github.event_name == 'push'
+      uses: actions/cache/save@v6
+      with:
+        path: |
+          ${{ runner.tool_cache }}/opam
+          ~/.opam
+          _opam
+          .opam-path
+          C:\cygwin
+          C:\.opam
+        key: ${{ steps.cache-key.outputs.value }}
+
+    - name: Use cached OPAM environment
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        echo "OPAMCOLOR=always"                    >> "$GITHUB_ENV"
+        echo "OPAMCONFIRMLEVEL=unsafe-yes"         >> "$GITHUB_ENV"
+        echo "OPAMDOWNLOADJOBS=4"                  >> "$GITHUB_ENV"
+        echo "OPAMERRLOGLEN=0"                     >> "$GITHUB_ENV"
+        echo "OPAMEXTERNALSOLVER=builtin-0install" >> "$GITHUB_ENV"
+        echo "OPAMPRECISETRACKING=1"               >> "$GITHUB_ENV"
+        echo "OPAMRETRIES=10"                      >> "$GITHUB_ENV"
+        echo "OPAMSOLVERTIMEOUT=600"               >> "$GITHUB_ENV"
+        echo "OPAMYES=1"                           >> "$GITHUB_ENV"
+        echo "CLICOLOR_FORCE=1"                    >> "$GITHUB_ENV"
+
+        if [[ "$RUNNER_OS" != "Windows" ]]; then
+          echo "OPAMROOT=$HOME/.opam" >> "$GITHUB_ENV"
+        else
+          echo "OPAMROOT=C:\\.opam" >> "$GITHUB_ENV"
+        fi
+
+        OPAM_PATH="$(cat .opam-path)"
+        chmod +x "$OPAM_PATH"
+        dirname "$OPAM_PATH" >> "$GITHUB_PATH"
+
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          fsutil behavior query SymlinkEvaluation
+          fsutil behavior set symlinkEvaluation R2L:1 R2R:1
+          fsutil behavior query SymlinkEvaluation
+
+          echo "HOME=$USERPROFILE" >> "$GITHUB_ENV"
+          echo "MSYS=winsymlinks:native" >> "$GITHUB_ENV"
+          echo "CYGWIN=winsymlinks:native" >> "$GITHUB_ENV"
+          echo "BASH_ENV=C:\\cygwin\\bash_env" >> "$GITHUB_ENV"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,6 @@ jobs:
     runs-on: ${{matrix.os}}
 
     env:
-      # When changing the setup-ocaml version, also adjust it in the setup step further below.
-      SETUP_OCAML_VERSION: 3.6.0 # OPAM <2.6.0
       DUNE_PROFILE: ${{ matrix.dune-profile }}
 
     steps:
@@ -98,169 +96,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
+      - name: Setup Node and dependencies
+        uses: ./.github/actions/setup-node
 
-      - name: Install npm packages
-        run: yarn install --immutable
-
-      - name: Install dependencies (Linux)
+      - name: Setup Linux dependencies
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
-        with:
-          # https://github.com/ocaml/setup-ocaml/blob/2f57267f071bc8547dfcb9433ff21d44fffef190/packages/setup-ocaml/src/unix.ts#L48
-          # plus OPAM wants cmake
-          packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync cmake
-          version: v4
-
-      - name: Restore rewatch build cache
-        id: rewatch-build-cache
-        uses: actions/cache@v6
-        with:
-          path: rewatch/target
-          key: rewatch-build-v4-${{ matrix.rust-target }}-${{ hashFiles('rewatch/src/**', 'rewatch/Cargo.toml', 'rewatch/Cargo.lock', 'rewatch/rust-toolchain.toml', 'rewatch/.cargo/config.toml') }}
-
-      - name: Determine Rust toolchain version
-        id: rust-version
-        shell: bash
-        run: |
-          version="$(awk -F '"' '/^rust-version[[:space:]]*=/ { print $2; exit }' rewatch/Cargo.toml)"
-          if [ -z "$version" ]; then
-            echo "rust-version missing in rewatch/Cargo.toml" >&2
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Install rust toolchain
-        if: steps.rewatch-build-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.rust-version.outputs.version }}
-          targets: ${{ matrix.rust-target }}
-          components: clippy, rustfmt
+        uses: ./.github/actions/setup-linux-dependencies
 
       - name: Build rewatch
-        if: steps.rewatch-build-cache.outputs.cache-hit != 'true'
-        run: |
-          cargo build --manifest-path rewatch/Cargo.toml --target ${{ matrix.rust-target }} --release
-
-      - name: Lint rewatch
-        if: steps.rewatch-build-cache.outputs.cache-hit != 'true'
-        run: |
-          cargo clippy --manifest-path rewatch/Cargo.toml --all-targets --all-features
-
-      - name: Run rewatch unit tests
-        if: steps.rewatch-build-cache.outputs.cache-hit != 'true'
-        run: |
-          cargo test --manifest-path rewatch/Cargo.toml --release
-
-      - name: Copy rewatch binary
-        run: |
-          cp rewatch/target/${{ matrix.rust-target }}/release/rescript${{ matrix.exe-suffix }} rescript
-          mkdir -p rewatch/target/release
-          cp rewatch/target/${{ matrix.rust-target }}/release/rescript${{ matrix.exe-suffix }} rewatch/target/release
-          ./scripts/copyExes.js --rewatch
-        shell: bash
-
-      # matrix.ocaml_compiler may contain commas
-      - name: Get OPAM cache key
-        shell: bash
-        run: echo "opam_cache_key=opam-env-v8-${{ matrix.os }}-${{ env.SETUP_OCAML_VERSION }}-${{ matrix.ocaml_compiler }}-${{ hashFiles('*.opam') }}" | sed 's/,/-/g' >> $GITHUB_ENV
-
-      - name: Restore OPAM environment
-        id: cache-opam-env
-        uses: actions/cache/restore@v6
+        uses: ./.github/actions/build-rewatch
         with:
-          path: |
-            ${{ runner.tool_cache }}/opam
-            ~/.opam
-            _opam
-            .opam-path
-            C:\cygwin
-            C:\.opam
-          key: ${{ env.opam_cache_key }}
+          cache-target: ${{ matrix.rust-target }}
+          rust-target: ${{ matrix.rust-target }}
+          exe-suffix: ${{ matrix.exe-suffix }}
+          run-quality-checks: "true"
 
-      - name: Use OCaml ${{matrix.ocaml_compiler}}
-        uses: ocaml/setup-ocaml@v3.6.0
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+      - name: Setup OCaml ${{ matrix.ocaml_compiler }}
+        id: setup_ocaml
+        uses: ./.github/actions/setup-ocaml
         with:
-          ocaml-compiler: ${{matrix.ocaml_compiler}}
-          opam-pin: false
-
-      - name: Get OPAM executable path
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const opamPath = await io.which('opam', true);
-            console.log('opam executable found: %s', opamPath);
-
-            const fs = require('fs/promises');
-            await fs.writeFile('.opam-path', opamPath, 'utf-8');
-            console.log('stored path to .opam-path');
-
-      - name: Install OPAM dependencies
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
-        run: opam install . --deps-only --with-test
-
-      - name: Cache OPAM environment
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: |
-            ${{ runner.tool_cache }}/opam
-            ~/.opam
-            _opam
-            .opam-path
-            C:\cygwin
-            C:\.opam
-          key: ${{ env.opam_cache_key }}
-
-      - name: Use cached OPAM environment
-        if: steps.cache-opam-env.outputs.cache-hit == 'true'
-        run: |
-          # https://github.com/ocaml/setup-ocaml/blob/v3.6.0/packages/setup-ocaml/src/installer.ts
-          echo "OPAMCOLOR=always"                    >> "$GITHUB_ENV"
-          echo "OPAMCONFIRMLEVEL=unsafe-yes"         >> "$GITHUB_ENV"
-          echo "OPAMDOWNLOADJOBS=4"                  >> "$GITHUB_ENV"
-          echo "OPAMERRLOGLEN=0"                     >> "$GITHUB_ENV"
-          echo "OPAMEXTERNALSOLVER=builtin-0install" >> "$GITHUB_ENV"
-          echo "OPAMPRECISETRACKING=1"               >> "$GITHUB_ENV"
-          echo "OPAMRETRIES=10"                      >> "$GITHUB_ENV"
-          echo "OPAMSOLVERTIMEOUT=600"               >> "$GITHUB_ENV"
-          echo "OPAMYES=1"                           >> "$GITHUB_ENV"
-          echo "CLICOLOR_FORCE=1"                    >> "$GITHUB_ENV"
-
-          if [[ "$RUNNER_OS" != "Windows" ]]; then
-            echo "OPAMROOT=$HOME/.opam"      >> "$GITHUB_ENV"
-          else
-            echo "OPAMROOT=C:\\.opam"        >> "$GITHUB_ENV"
-          fi
-
-          OPAM_PATH="$(cat .opam-path)"
-          chmod +x "$OPAM_PATH"
-          dirname "$OPAM_PATH" >> "$GITHUB_PATH"
-
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            fsutil behavior query SymlinkEvaluation
-            fsutil behavior set symlinkEvaluation R2L:1 R2R:1
-            fsutil behavior query SymlinkEvaluation
-
-            echo "HOME=$USERPROFILE" >> "$GITHUB_ENV"
-            echo "MSYS=winsymlinks:native" >> "$GITHUB_ENV"
-            echo "CYGWIN=winsymlinks:native" >> "$GITHUB_ENV"
-            echo "BASH_ENV=C:\\cygwin\\bash_env" >> "$GITHUB_ENV"
-          fi
-        shell: bash
+          compiler: ${{ matrix.ocaml_compiler }}
+          os: ${{ matrix.os }}
+          cache-prefix: opam-env-v8
 
       - name: Compiler build state key
         id: compiler-build-state-key
         shell: bash
         run: |
-          echo "value=compiler-build-state-v1-${{ matrix.os }}-${{ env.SETUP_OCAML_VERSION }}-${{ matrix.ocaml_compiler }}-${{ hashFiles('*.opam') }}" \
+          echo "value=compiler-build-state-v1-${{ matrix.os }}-${{ steps.setup_ocaml.outputs.setup_version }}-${{ matrix.ocaml_compiler }}-${{ hashFiles('*.opam') }}" \
             | sed 's/,/-/g' >> "$GITHUB_OUTPUT"
 
       - name: Restore compiler build state
@@ -476,14 +339,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
-
-      - name: Install npm packages
-        run: yarn install --immutable
+      - name: Setup Node and dependencies
+        uses: ./.github/actions/setup-node
 
       - name: Download dev playground compiler bundle
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install npm packages
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -483,7 +483,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install npm packages
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Download dev playground compiler bundle
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: rewatch/target
-          key: rewatch-build-v3-${{ matrix.rust-target }}-${{ hashFiles('rewatch/src/**', 'rewatch/Cargo.lock') }}
+          key: rewatch-build-v4-${{ matrix.rust-target }}-${{ hashFiles('rewatch/src/**', 'rewatch/Cargo.toml', 'rewatch/Cargo.lock', 'rewatch/rust-toolchain.toml', 'rewatch/.cargo/config.toml') }}
 
       - name: Determine Rust toolchain version
         id: rust-version

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: rewatch/target
-          key: rewatch-build-v3-${{ env.RUST_TARGET }}-${{ hashFiles('rewatch/src/**', 'rewatch/Cargo.lock') }}
+          key: rewatch-build-v4-${{ env.RUST_TARGET }}-${{ hashFiles('rewatch/src/**', 'rewatch/Cargo.toml', 'rewatch/Cargo.lock', 'rewatch/rust-toolchain.toml', 'rewatch/.cargo/config.toml') }}
 
       - name: Determine Rust toolchain version
         id: rust-version

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,9 +12,6 @@ concurrency:
 
 env:
   OCAMLRUNPARAM: b
-  # When changing the setup-ocaml version, also adjust it in the setup step
-  # further below.
-  SETUP_OCAML_VERSION: 3.6.0 # OPAM <2.6.0
 
 jobs:
   coverage:
@@ -30,131 +27,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
+      - name: Setup Node and dependencies
+        uses: ./.github/actions/setup-node
 
-      - name: Install npm packages
-        run: yarn install --immutable
-
-      - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
-        with:
-          packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync cmake
-          version: v4
-
-      # --- rewatch build cache ---------------------------------------------
-      # `make coverage` shells out to `make` which builds rewatch; cache the
-      # cargo target dir so subsequent runs skip the Rust toolchain install
-      # and the cargo build when the rewatch sources haven't changed.
-      - name: Restore rewatch build cache
-        id: rewatch-build-cache
-        uses: actions/cache@v6
-        with:
-          path: rewatch/target
-          key: rewatch-build-v4-${{ env.RUST_TARGET }}-${{ hashFiles('rewatch/src/**', 'rewatch/Cargo.toml', 'rewatch/Cargo.lock', 'rewatch/rust-toolchain.toml', 'rewatch/.cargo/config.toml') }}
-
-      - name: Determine Rust toolchain version
-        id: rust-version
-        run: |
-          version="$(awk -F '"' '/^rust-version[[:space:]]*=/ { print $2; exit }' rewatch/Cargo.toml)"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Install Rust toolchain
-        if: steps.rewatch-build-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.rust-version.outputs.version }}
-          components: clippy, rustfmt
+      - name: Setup Linux dependencies
+        uses: ./.github/actions/setup-linux-dependencies
 
       - name: Build rewatch
-        if: steps.rewatch-build-cache.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path rewatch/Cargo.toml --release
-
-      - name: Copy rewatch binary
-        run: |
-          cp rewatch/target/release/rescript rescript
-          ./scripts/copyExes.js --rewatch
-
-      # --- OPAM environment cache ------------------------------------------
-      # The OPAM install step is the dominant cost on a cold run (often >10
-      # min). Cache the whole opam tree, keyed on the OS, setup-ocaml
-      # version, compiler, and the `.opam` files. The cache also includes
-      # the dev-setup dependencies (e.g. bisect_ppx) so the key is distinct
-      # from the main CI workflow's cache.
-      - name: Get OPAM cache key
-        run: echo "opam_cache_key=opam-coverage-v1-${{ env.OS }}-${{ env.SETUP_OCAML_VERSION }}-${{ env.OCAML_COMPILER }}-${{ hashFiles('*.opam') }}" >> $GITHUB_ENV
-
-      - name: Restore OPAM environment
-        id: cache-opam-env
-        uses: actions/cache/restore@v6
+        uses: ./.github/actions/build-rewatch
         with:
-          path: |
-            ${{ runner.tool_cache }}/opam
-            ~/.opam
-            _opam
-            .opam-path
-          key: ${{ env.opam_cache_key }}
+          cache-target: ${{ env.RUST_TARGET }}
 
-      - name: Use OCaml ${{ env.OCAML_COMPILER }}
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
-        uses: ocaml/setup-ocaml@v3.6.0
+      - name: Setup OCaml ${{ env.OCAML_COMPILER }}
+        id: setup_ocaml
+        uses: ./.github/actions/setup-ocaml
         with:
-          ocaml-compiler: ${{ env.OCAML_COMPILER }}
-          opam-pin: false
-
-      - name: Get OPAM executable path
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const opamPath = await io.which('opam', true);
-            console.log('opam executable found: %s', opamPath);
-
-            const fs = require('fs/promises');
-            await fs.writeFile('.opam-path', opamPath, 'utf-8');
-            console.log('stored path to .opam-path');
-
-      - name: Install OPAM dependencies (incl. bisect_ppx)
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
-        run: opam install . --deps-only --with-test --with-dev-setup
-
-      # Only save on master pushes. PR-scoped caches are tied to
-      # refs/pull/<n>/merge and can't be restored by master or other PRs,
-      # so they'd just consume storage and evict the shared entry. PRs
-      # still get full restore from the latest master-saved cache.
-      - name: Save OPAM environment
-        if: steps.cache-opam-env.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/cache/save@v6
-        with:
-          path: |
-            ${{ runner.tool_cache }}/opam
-            ~/.opam
-            _opam
-            .opam-path
-          key: ${{ env.opam_cache_key }}
-
-      - name: Use cached OPAM environment
-        if: steps.cache-opam-env.outputs.cache-hit == 'true'
-        run: |
-          # https://github.com/ocaml/setup-ocaml/blob/v3.6.0/packages/setup-ocaml/src/installer.ts
-          echo "OPAMCOLOR=always"                    >> "$GITHUB_ENV"
-          echo "OPAMCONFIRMLEVEL=unsafe-yes"         >> "$GITHUB_ENV"
-          echo "OPAMDOWNLOADJOBS=4"                  >> "$GITHUB_ENV"
-          echo "OPAMERRLOGLEN=0"                     >> "$GITHUB_ENV"
-          echo "OPAMEXTERNALSOLVER=builtin-0install" >> "$GITHUB_ENV"
-          echo "OPAMPRECISETRACKING=1"               >> "$GITHUB_ENV"
-          echo "OPAMRETRIES=10"                      >> "$GITHUB_ENV"
-          echo "OPAMSOLVERTIMEOUT=600"               >> "$GITHUB_ENV"
-          echo "OPAMYES=1"                           >> "$GITHUB_ENV"
-          echo "CLICOLOR_FORCE=1"                    >> "$GITHUB_ENV"
-          echo "OPAMROOT=$HOME/.opam"                >> "$GITHUB_ENV"
-
-          OPAM_PATH="$(cat .opam-path)"
-          chmod +x "$OPAM_PATH"
-          dirname "$OPAM_PATH" >> "$GITHUB_PATH"
+          compiler: ${{ env.OCAML_COMPILER }}
+          os: ${{ env.OS }}
+          cache-prefix: opam-coverage-v1
+          dependency-flags: --deps-only --with-test --with-dev-setup
 
       # --- Coverage build cache --------------------------------------------
       # The bisect_ppx-instrumented dune build is a separate artifact from
@@ -163,7 +54,7 @@ jobs:
       # poison it.
       - name: Coverage build state key
         id: coverage-build-state-key
-        run: echo "value=coverage-build-state-v1-${{ env.OS }}-${{ env.SETUP_OCAML_VERSION }}-${{ env.OCAML_COMPILER }}-${{ hashFiles('*.opam', 'compiler/**', 'dune-project') }}" >> $GITHUB_OUTPUT
+        run: echo "value=coverage-build-state-v1-${{ env.OS }}-${{ steps.setup_ocaml.outputs.setup_version }}-${{ env.OCAML_COMPILER }}-${{ hashFiles('*.opam', 'compiler/**', 'dune-project') }}" >> $GITHUB_OUTPUT
 
       - name: Restore coverage build state
         if: github.base_ref == 'master' || github.ref == 'refs/heads/master'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install npm packages
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.4.3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install npm packages
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Validate and display release plan
         id: plan
@@ -115,7 +115,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install npm packages
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,14 +25,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
-
-      - name: Install npm packages
-        run: yarn install --immutable
+      - name: Setup Node and dependencies
+        uses: ./.github/actions/setup-node
 
       - name: Validate and display release plan
         id: plan
@@ -107,15 +101,8 @@ jobs:
           fi
         shell: bash
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
-          registry-url: https://registry.npmjs.org
-
-      - name: Install npm packages
-        run: yarn install --immutable
+      - name: Setup Node and dependencies
+        uses: ./.github/actions/setup-node
 
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

Extract repeated CI environment setup into local composite actions shared by the main CI, coverage, and release workflows.

## What changed

- Add a shared Node setup action that:
  - uses the repository’s configured Node version
  - enables Yarn caching
  - configures the public npm registry
  - installs dependencies with `yarn install --immutable`
- Add a shared OCaml setup action that:
  - restores or creates the OPAM environment
  - supports different compiler switches and dependency flags
  - reconstructs cached OPAM environments on Linux, macOS, and Windows
  - only creates shared caches during push workflows
- Add a shared Rewatch build action that:
  - restores or builds the requested Rust target
  - optionally runs Clippy and unit tests
  - copies the resulting executable into the expected package locations
- Add a shared Linux system-dependency action.
- Reuse these actions from `ci.yml` and `coverage.yml`.
- Reuse the Node action from the playground and publishing jobs.

## Why

The CI and coverage workflows independently implemented nearly identical Node, Rust, Rewatch, OCaml, and OPAM cache setup. Keeping those copies synchronized was error-prone, particularly around:

- cache keys and paths
- Rust toolchain versions and targets
- OPAM environment restoration
- Windows-specific OPAM configuration
- dependency installation flags

Centralizing this setup gives those workflows one implementation while retaining their intentional differences, such as coverage’s additional development dependencies and native Rewatch build.

## Behavior

This is intended as a structural refactoring. Existing build, test, coverage, artifact, and publishing behavior remains unchanged.